### PR TITLE
net/url: Fixed url parsing with invalid slashes.

### DIFF
--- a/src/net/url/url.go
+++ b/src/net/url/url.go
@@ -14,6 +14,17 @@ import (
 	"strings"
 )
 
+// Given a web protocol prefix as a key,
+// the value is whether the host needs a "//"
+// formatting and padding
+var webProtocolPrefixes = map[string]bool{
+	"ftp":    true,
+	"git":    false,
+	"http":   true,
+	"mailto": false,
+	"ssh":    true,
+}
+
 // Error reports an error and the operation and URL that caused it.
 type Error struct {
 	Op  string
@@ -361,6 +372,7 @@ func ParseRequestURI(rawurl string) (url *URL, err error) {
 // If viaRequest is false, all forms of relative URLs are allowed.
 func parse(rawurl string, viaRequest bool) (url *URL, err error) {
 	var rest string
+	var isWebProtocol, needSlashFmt bool
 
 	if rawurl == "" && viaRequest {
 		err = errors.New("empty url")
@@ -378,6 +390,18 @@ func parse(rawurl string, viaRequest bool) (url *URL, err error) {
 	if url.Scheme, rest, err = getscheme(rawurl); err != nil {
 		goto Error
 	}
+
+	// needsSlashFmt when set: clean up 'rest': Make sure all
+	// left most slashes are trimmed off after the scheme
+	isWebProtocol, needSlashFmt = hostSlashFormatting(url.Scheme)
+
+	if isWebProtocol && strings.HasPrefix(rest, "/") {
+		rest = strings.TrimLeft(rest, "/")
+		if needSlashFmt {
+			rest = strings.Join([]string{"//", rest}, "")
+		}
+	}
+
 	url.Scheme = strings.ToLower(url.Scheme)
 
 	rest, url.RawQuery = split(rest, "?", true)
@@ -413,6 +437,18 @@ func parse(rawurl string, viaRequest bool) (url *URL, err error) {
 
 Error:
 	return nil, &Error{"parse", rawurl, err}
+}
+
+func hostSlashFormatting(q string) (bool, bool) {
+	if q == "" {
+		return false, false
+	}
+	for prefix, slashFormatting := range webProtocolPrefixes {
+		if strings.HasPrefix(q, prefix) {
+			return true, slashFormatting
+		}
+	}
+	return false, false
 }
 
 func parseAuthority(authority string) (user *Userinfo, host string, err error) {

--- a/src/net/url/url_test.go
+++ b/src/net/url/url_test.go
@@ -112,6 +112,39 @@ var urltests = []URLTest{
 		},
 		"http:www.google.com/?q=go+language",
 	},
+	// path with extra leading ////, expected formatting
+	{
+		"http:///www.google.com/?q=go+language",
+		&URL{
+			Scheme:   "http",
+			Path:     "/",
+			Opaque:   "",
+			Host:     "www.google.com",
+			RawQuery: "q=go+language",
+		},
+		"http://www.google.com/?q=go+language",
+	},
+
+	// ssh checks
+	{
+		"ssh://///gobot:foo@github.com/go.git",
+		&URL{
+			Scheme: "ssh",
+			User:   UserPassword("gobot", "foo"),
+			Host:   "github.com",
+			Path:   "/go.git",
+		},
+		"ssh://gobot:foo@github.com/go.git",
+	},
+	{
+		"http:/localhost:9999/a",
+		&URL{
+			Scheme: "http",
+			Host:   "localhost:9999",
+			Path:   "/a",
+		},
+		"http://localhost:9999/a",
+	},
 	// path without leading /, so no parsing
 	{
 		"http:%2f%2fwww.google.com/?q=go+language",
@@ -127,9 +160,9 @@ var urltests = []URLTest{
 		"mailto:/webmaster@golang.org",
 		&URL{
 			Scheme: "mailto",
-			Path:   "/webmaster@golang.org",
+			Opaque: "webmaster@golang.org",
 		},
-		"mailto:///webmaster@golang.org", // unfortunate compromise
+		"mailto:webmaster@golang.org",
 	},
 	// non-authority
 	{


### PR DESCRIPTION
This PR addresses issue #9216, as well as updates a test for which
a compromise had to have been made earlier on.
