### PR TITLE
.gitattributes: don't CRLF mangle binary files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # see golang.org/issue/9281
-* eol=lf
+text eol=lf


### PR DESCRIPTION
see golang.org/issue/9281
