### PR TITLE
crypto/tls: add support for AES_256_GCM_SHA384 cipher suites as specified in RFC5289

### DIFF
--- a/src/crypto/tls/cipher_suites.go
+++ b/src/crypto/tls/cipher_suites.go
@@ -71,6 +71,8 @@ var cipherSuites = []*cipherSuite{
 	// and RC4 comes before AES (because of the Lucky13 attack).
 	{TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, 16, 0, 4, ecdheRSAKA, suiteECDHE | suiteTLS12, nil, nil, aeadAESGCM},
 	{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, 16, 0, 4, ecdheECDSAKA, suiteECDHE | suiteECDSA | suiteTLS12, nil, nil, aeadAESGCM},
+	{TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, 32, 0, 4, ecdheECDSAKA, suiteECDHE | suiteTLS12, nil, nil, aeadAESGCM},
+	{TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, 32, 0, 4, ecdheRSAKA, suiteECDHE | suiteECDSA | suiteTLS12, nil, nil, aeadAESGCM},
 	{TLS_ECDHE_RSA_WITH_RC4_128_SHA, 16, 20, 0, ecdheRSAKA, suiteECDHE, cipherRC4, macSHA1, nil},
 	{TLS_ECDHE_ECDSA_WITH_RC4_128_SHA, 16, 20, 0, ecdheECDSAKA, suiteECDHE | suiteECDSA, cipherRC4, macSHA1, nil},
 	{TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, 16, 20, 16, ecdheRSAKA, suiteECDHE, cipherAES, macSHA1, nil},
@@ -251,6 +253,17 @@ func mutualCipherSuite(have []uint16, want uint16) *cipherSuite {
 	return nil
 }
 
+func hashId(ciphersuite uint16) uint8 {
+	switch ciphersuite {
+	case TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:
+		return hashSHA384
+	case TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:
+		return hashSHA256
+	default:
+		return hashSHA1
+	}
+}
+
 // A list of the possible cipher suite ids. Taken from
 // http://www.iana.org/assignments/tls-parameters/tls-parameters.xml
 const (
@@ -267,6 +280,8 @@ const (
 	TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA      uint16 = 0xc014
 	TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256   uint16 = 0xc02f
 	TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 uint16 = 0xc02b
+	TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384   uint16 = 0xc032
+	TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 uint16 = 0xc02c
 
 	// TLS_FALLBACK_SCSV isn't a standard cipher suite but an indicator
 	// that the client is doing version fallback. See

--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -123,6 +123,7 @@ const (
 const (
 	hashSHA1   uint8 = 2
 	hashSHA256 uint8 = 4
+	hashSHA384 uint8 = 8 // TODO: find spec
 )
 
 // Signature algorithms for TLS 1.2 (See RFC 5246, section A.4.1)
@@ -142,6 +143,8 @@ type signatureAndHash struct {
 var supportedSKXSignatureAlgorithms = []signatureAndHash{
 	{hashSHA256, signatureRSA},
 	{hashSHA256, signatureECDSA},
+	{hashSHA384, signatureRSA},
+	{hashSHA384, signatureECDSA},
 	{hashSHA1, signatureRSA},
 	{hashSHA1, signatureECDSA},
 }
@@ -152,6 +155,8 @@ var supportedSKXSignatureAlgorithms = []signatureAndHash{
 var supportedClientCertSignatureAlgorithms = []signatureAndHash{
 	{hashSHA256, signatureRSA},
 	{hashSHA256, signatureECDSA},
+	{hashSHA384, signatureRSA},
+	{hashSHA384, signatureECDSA},
 }
 
 // ConnectionState records basic TLS details about the connection.

--- a/src/crypto/tls/handshake_client.go
+++ b/src/crypto/tls/handshake_client.go
@@ -168,7 +168,7 @@ NextCipherSuite:
 		serverHello:  serverHello,
 		hello:        hello,
 		suite:        suite,
-		finishedHash: newFinishedHash(c.vers),
+		finishedHash: newFinishedHash(c.vers, hashId(suite.id)),
 		session:      session,
 	}
 
@@ -457,7 +457,7 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 		c.writeRecord(recordTypeHandshake, certVerify.marshal())
 	}
 
-	hs.masterSecret = masterFromPreMasterSecret(c.vers, preMasterSecret, hs.hello.random, hs.serverHello.random)
+	hs.masterSecret = masterFromPreMasterSecret(c.vers, hashId(hs.suite.id), preMasterSecret, hs.hello.random, hs.serverHello.random)
 	return nil
 }
 
@@ -465,7 +465,7 @@ func (hs *clientHandshakeState) establishKeys() error {
 	c := hs.c
 
 	clientMAC, serverMAC, clientKey, serverKey, clientIV, serverIV :=
-		keysFromMasterSecret(c.vers, hs.masterSecret, hs.hello.random, hs.serverHello.random, hs.suite.macLen, hs.suite.keyLen, hs.suite.ivLen)
+		keysFromMasterSecret(c.vers, hashId(hs.suite.id), hs.masterSecret, hs.hello.random, hs.serverHello.random, hs.suite.macLen, hs.suite.keyLen, hs.suite.ivLen)
 	var clientCipher, serverCipher interface{}
 	var clientHash, serverHash macFunction
 	if hs.suite.cipher != nil {

--- a/src/crypto/tls/handshake_client_test.go
+++ b/src/crypto/tls/handshake_client_test.go
@@ -311,6 +311,16 @@ func TestHandshakeClientECDHEECDSAAESGCM(t *testing.T) {
 	runClientTestTLS12(t, test)
 }
 
+func TestHandshakeClientECDHEECDSAAES256GCM384(t *testing.T) {
+	test := &clientTest{
+		name:    "ECDHE-ECDSA-AES-256-GCM-384",
+		command: []string{"openssl", "s_server", "-cipher", "ECDHE-ECDSA-AES256-GCM-SHA384"},
+		cert:    testECDSACertificate,
+		key:     testECDSAPrivateKey,
+	}
+	runClientTestTLS12(t, test)
+}
+
 func TestHandshakeClientCertRSA(t *testing.T) {
 	config := *testConfig
 	cert, _ := X509KeyPair([]byte(clientCertificatePEM), []byte(clientKeyPEM))

--- a/src/crypto/tls/handshake_server.go
+++ b/src/crypto/tls/handshake_server.go
@@ -47,6 +47,8 @@ func (c *Conn) serverHandshake() error {
 	if err != nil {
 		return err
 	}
+	hs.finishedHash = newFinishedHash(c.vers, hashId(hs.suite.id))
+	hs.finishedHash.Write(hs.clientHello.marshal())
 
 	// For an overview of TLS handshaking, see https://tools.ietf.org/html/rfc5246#section-7.3
 	if isResume {
@@ -110,9 +112,6 @@ func (hs *serverHandshakeState) readClientHello() (isResume bool, err error) {
 		return false, fmt.Errorf("tls: client offered an unsupported, maximum protocol version of %x", hs.clientHello.vers)
 	}
 	c.haveVers = true
-
-	hs.finishedHash = newFinishedHash(c.vers)
-	hs.finishedHash.Write(hs.clientHello.marshal())
 
 	hs.hello = new(serverHelloMsg)
 
@@ -463,13 +462,12 @@ func (hs *serverHandshakeState) doFullHandshake() error {
 
 		hs.finishedHash.Write(certVerify.marshal())
 	}
-
 	preMasterSecret, err := keyAgreement.processClientKeyExchange(config, hs.cert, ckx, c.vers)
 	if err != nil {
 		c.sendAlert(alertHandshakeFailure)
 		return err
 	}
-	hs.masterSecret = masterFromPreMasterSecret(c.vers, preMasterSecret, hs.clientHello.random, hs.hello.random)
+	hs.masterSecret = masterFromPreMasterSecret(c.vers, hashId(hs.suite.id), preMasterSecret, hs.clientHello.random, hs.hello.random)
 
 	return nil
 }
@@ -478,7 +476,7 @@ func (hs *serverHandshakeState) establishKeys() error {
 	c := hs.c
 
 	clientMAC, serverMAC, clientKey, serverKey, clientIV, serverIV :=
-		keysFromMasterSecret(c.vers, hs.masterSecret, hs.clientHello.random, hs.hello.random, hs.suite.macLen, hs.suite.keyLen, hs.suite.ivLen)
+		keysFromMasterSecret(c.vers, hashId(hs.suite.id), hs.masterSecret, hs.clientHello.random, hs.hello.random, hs.suite.macLen, hs.suite.keyLen, hs.suite.ivLen)
 
 	var clientCipher, serverCipher interface{}
 	var clientHash, serverHash macFunction

--- a/src/crypto/tls/key_agreement.go
+++ b/src/crypto/tls/key_agreement.go
@@ -12,6 +12,7 @@ import (
 	"crypto/rsa"
 	"crypto/sha1"
 	"crypto/sha256"
+	"crypto/sha512"
 	"crypto/x509"
 	"encoding/asn1"
 	"errors"
@@ -119,6 +120,14 @@ func sha256Hash(slices [][]byte) []byte {
 	return h.Sum(nil)
 }
 
+func sha384Hash(slices [][]byte) []byte {
+	h := sha512.New384()
+	for _, slice := range slices {
+		h.Write(slice)
+	}
+	return h.Sum(nil)
+}
+
 // hashForServerKeyExchange hashes the given slices and returns their digest
 // and the identifier of the hash function used. The hashFunc argument is only
 // used for >= TLS 1.2 and precisely identifies the hash function to use.
@@ -127,6 +136,8 @@ func hashForServerKeyExchange(sigType, hashFunc uint8, version uint16, slices ..
 		switch hashFunc {
 		case hashSHA256:
 			return sha256Hash(slices), crypto.SHA256, nil
+		case hashSHA384:
+			return sha384Hash(slices), crypto.SHA384, nil
 		case hashSHA1:
 			return sha1Hash(slices), crypto.SHA1, nil
 		default:
@@ -155,7 +166,7 @@ func pickTLS12HashForSignature(sigType uint8, clientSignatureAndHashes []signatu
 			continue
 		}
 		switch sigAndHash.hash {
-		case hashSHA1, hashSHA256:
+		case hashSHA1, hashSHA256, hashSHA384:
 			return sigAndHash.hash, nil
 		}
 	}

--- a/src/crypto/tls/prf.go
+++ b/src/crypto/tls/prf.go
@@ -10,6 +10,7 @@ import (
 	"crypto/md5"
 	"crypto/sha1"
 	"crypto/sha256"
+	"crypto/sha512"
 	"hash"
 )
 
@@ -73,6 +74,16 @@ func prf12(result, secret, label, seed []byte) {
 	pHash(result, secret, labelAndSeed, sha256.New)
 }
 
+// prf12sha384 implements the TLS 1.2 pseudo-random function, as defined in RFC 5246, section 5,
+// but using the SHA-384 hash function as specified in RFC 5289, section 3.
+func prf12sha384(result, secret, label, seed []byte) {
+	labelAndSeed := make([]byte, len(label)+len(seed))
+	copy(labelAndSeed, label)
+	copy(labelAndSeed[len(label):], seed)
+
+	pHash(result, secret, labelAndSeed, sha512.New384)
+}
+
 // prf30 implements the SSL 3.0 pseudo-random function, as defined in
 // www.mozilla.org/projects/security/pki/nss/ssl/draft302.txt section 6.
 func prf30(result, secret, label, seed []byte) {
@@ -117,14 +128,18 @@ var keyExpansionLabel = []byte("key expansion")
 var clientFinishedLabel = []byte("client finished")
 var serverFinishedLabel = []byte("server finished")
 
-func prfForVersion(version uint16) func(result, secret, label, seed []byte) {
+func prfForVersion(version uint16, hashId uint8) func(result, secret, label, seed []byte) {
 	switch version {
 	case VersionSSL30:
 		return prf30
 	case VersionTLS10, VersionTLS11:
 		return prf10
 	case VersionTLS12:
-		return prf12
+		if hashId == hashSHA384 {
+			return prf12sha384
+		} else {
+			return prf12
+		}
 	default:
 		panic("unknown version")
 	}
@@ -132,26 +147,26 @@ func prfForVersion(version uint16) func(result, secret, label, seed []byte) {
 
 // masterFromPreMasterSecret generates the master secret from the pre-master
 // secret. See http://tools.ietf.org/html/rfc5246#section-8.1
-func masterFromPreMasterSecret(version uint16, preMasterSecret, clientRandom, serverRandom []byte) []byte {
+func masterFromPreMasterSecret(version uint16, hashId uint8, preMasterSecret, clientRandom, serverRandom []byte) []byte {
 	var seed [tlsRandomLength * 2]byte
 	copy(seed[0:len(clientRandom)], clientRandom)
 	copy(seed[len(clientRandom):], serverRandom)
 	masterSecret := make([]byte, masterSecretLength)
-	prfForVersion(version)(masterSecret, preMasterSecret, masterSecretLabel, seed[0:])
+	prfForVersion(version, hashId)(masterSecret, preMasterSecret, masterSecretLabel, seed[0:])
 	return masterSecret
 }
 
 // keysFromMasterSecret generates the connection keys from the master
 // secret, given the lengths of the MAC key, cipher key and IV, as defined in
 // RFC 2246, section 6.3.
-func keysFromMasterSecret(version uint16, masterSecret, clientRandom, serverRandom []byte, macLen, keyLen, ivLen int) (clientMAC, serverMAC, clientKey, serverKey, clientIV, serverIV []byte) {
+func keysFromMasterSecret(version uint16, hashId uint8, masterSecret, clientRandom, serverRandom []byte, macLen, keyLen, ivLen int) (clientMAC, serverMAC, clientKey, serverKey, clientIV, serverIV []byte) {
 	var seed [tlsRandomLength * 2]byte
 	copy(seed[0:len(clientRandom)], serverRandom)
 	copy(seed[len(serverRandom):], clientRandom)
 
 	n := 2*macLen + 2*keyLen + 2*ivLen
 	keyMaterial := make([]byte, n)
-	prfForVersion(version)(keyMaterial, masterSecret, keyExpansionLabel, seed[0:])
+	prfForVersion(version, hashId)(keyMaterial, masterSecret, keyExpansionLabel, seed[0:])
 	clientMAC = keyMaterial[:macLen]
 	keyMaterial = keyMaterial[macLen:]
 	serverMAC = keyMaterial[:macLen]
@@ -166,11 +181,17 @@ func keysFromMasterSecret(version uint16, masterSecret, clientRandom, serverRand
 	return
 }
 
-func newFinishedHash(version uint16) finishedHash {
+func newFinishedHash(version uint16, hashId uint8) finishedHash {
 	if version >= VersionTLS12 {
-		return finishedHash{sha256.New(), sha256.New(), nil, nil, version}
+		var newHash func() hash.Hash
+		if hashId == hashSHA384 {
+			newHash = sha512.New384
+		} else {
+			newHash = sha256.New
+		}
+		return finishedHash{newHash(), newHash(), nil, nil, version, prfForVersion(version, hashId)}
 	}
-	return finishedHash{sha1.New(), sha1.New(), md5.New(), md5.New(), version}
+	return finishedHash{sha1.New(), sha1.New(), md5.New(), md5.New(), version, prfForVersion(version, hashId)}
 }
 
 // A finishedHash calculates the hash of a set of handshake messages suitable
@@ -184,6 +205,7 @@ type finishedHash struct {
 	serverMD5 hash.Hash
 
 	version uint16
+	prf     func(result, secret, label, seed []byte)
 }
 
 func (h finishedHash) Write(msg []byte) (n int, err error) {
@@ -242,12 +264,12 @@ func (h finishedHash) clientSum(masterSecret []byte) []byte {
 	out := make([]byte, finishedVerifyLength)
 	if h.version >= VersionTLS12 {
 		seed := h.client.Sum(nil)
-		prf12(out, masterSecret, clientFinishedLabel, seed)
+		h.prf(out, masterSecret, clientFinishedLabel, seed)
 	} else {
 		seed := make([]byte, 0, md5.Size+sha1.Size)
 		seed = h.clientMD5.Sum(seed)
 		seed = h.client.Sum(seed)
-		prf10(out, masterSecret, clientFinishedLabel, seed)
+		h.prf(out, masterSecret, clientFinishedLabel, seed)
 	}
 	return out
 }
@@ -262,12 +284,12 @@ func (h finishedHash) serverSum(masterSecret []byte) []byte {
 	out := make([]byte, finishedVerifyLength)
 	if h.version >= VersionTLS12 {
 		seed := h.server.Sum(nil)
-		prf12(out, masterSecret, serverFinishedLabel, seed)
+		h.prf(out, masterSecret, serverFinishedLabel, seed)
 	} else {
 		seed := make([]byte, 0, md5.Size+sha1.Size)
 		seed = h.serverMD5.Sum(seed)
 		seed = h.server.Sum(seed)
-		prf10(out, masterSecret, serverFinishedLabel, seed)
+		h.prf(out, masterSecret, serverFinishedLabel, seed)
 	}
 	return out
 }

--- a/src/crypto/tls/prf_test.go
+++ b/src/crypto/tls/prf_test.go
@@ -35,6 +35,7 @@ func TestSplitPreMasterSecret(t *testing.T) {
 
 type testKeysFromTest struct {
 	version                    uint16
+	hashId                     uint8
 	preMasterSecret            string
 	clientRandom, serverRandom string
 	masterSecret               string
@@ -49,13 +50,13 @@ func TestKeysFromPreMasterSecret(t *testing.T) {
 		clientRandom, _ := hex.DecodeString(test.clientRandom)
 		serverRandom, _ := hex.DecodeString(test.serverRandom)
 
-		masterSecret := masterFromPreMasterSecret(test.version, in, clientRandom, serverRandom)
+		masterSecret := masterFromPreMasterSecret(test.version, test.hashId, in, clientRandom, serverRandom)
 		if s := hex.EncodeToString(masterSecret); s != test.masterSecret {
 			t.Errorf("#%d: bad master secret %s, want %s", i, s, test.masterSecret)
 			continue
 		}
 
-		clientMAC, serverMAC, clientKey, serverKey, _, _ := keysFromMasterSecret(test.version, masterSecret, clientRandom, serverRandom, test.macLen, test.keyLen, 0)
+		clientMAC, serverMAC, clientKey, serverKey, _, _ := keysFromMasterSecret(test.version, test.hashId, masterSecret, clientRandom, serverRandom, test.macLen, test.keyLen, 0)
 		clientMACString := hex.EncodeToString(clientMAC)
 		serverMACString := hex.EncodeToString(serverMAC)
 		clientKeyString := hex.EncodeToString(clientKey)
@@ -73,6 +74,7 @@ func TestKeysFromPreMasterSecret(t *testing.T) {
 var testKeysFromTests = []testKeysFromTest{
 	{
 		VersionTLS10,
+		hashSHA1,
 		"0302cac83ad4b1db3b9ab49ad05957de2a504a634a386fc600889321e1a971f57479466830ac3e6f468e87f5385fa0c5",
 		"4ae66303755184a3917fcb44880605fcc53baa01912b22ed94473fc69cebd558",
 		"4ae663020ec16e6bb5130be918cfcafd4d765979a3136a5d50c593446e4e44db",
@@ -86,6 +88,7 @@ var testKeysFromTests = []testKeysFromTest{
 	},
 	{
 		VersionTLS10,
+		hashSHA1,
 		"03023f7527316bc12cbcd69e4b9e8275d62c028f27e65c745cfcddc7ce01bd3570a111378b63848127f1c36e5f9e4890",
 		"4ae66364b5ea56b20ce4e25555aed2d7e67f42788dd03f3fee4adae0459ab106",
 		"4ae66363ab815cbf6a248b87d6b556184e945e9b97fbdf247858b0bdafacfa1c",
@@ -99,6 +102,7 @@ var testKeysFromTests = []testKeysFromTest{
 	},
 	{
 		VersionTLS10,
+		hashSHA1,
 		"832d515f1d61eebb2be56ba0ef79879efb9b527504abb386fb4310ed5d0e3b1f220d3bb6b455033a2773e6d8bdf951d278a187482b400d45deb88a5d5a6bb7d6a7a1decc04eb9ef0642876cd4a82d374d3b6ff35f0351dc5d411104de431375355addc39bfb1f6329fb163b0bc298d658338930d07d313cd980a7e3d9196cac1",
 		"4ae663b2ee389c0de147c509d8f18f5052afc4aaf9699efe8cb05ece883d3a5e",
 		"4ae664d503fd4cff50cfc1fb8fc606580f87b0fcdac9554ba0e01d785bdf278e",
@@ -112,6 +116,7 @@ var testKeysFromTests = []testKeysFromTest{
 	},
 	{
 		VersionSSL30,
+		hashSHA1,
 		"832d515f1d61eebb2be56ba0ef79879efb9b527504abb386fb4310ed5d0e3b1f220d3bb6b455033a2773e6d8bdf951d278a187482b400d45deb88a5d5a6bb7d6a7a1decc04eb9ef0642876cd4a82d374d3b6ff35f0351dc5d411104de431375355addc39bfb1f6329fb163b0bc298d658338930d07d313cd980a7e3d9196cac1",
 		"4ae663b2ee389c0de147c509d8f18f5052afc4aaf9699efe8cb05ece883d3a5e",
 		"4ae664d503fd4cff50cfc1fb8fc606580f87b0fcdac9554ba0e01d785bdf278e",


### PR DESCRIPTION
Support for  SHA-384 ciphersuites inside of `crypto/tls`, requiring changes to the derivation of PRF (`prfForVersion` can't be based just on version)

Tests still incomplete, run with `go test -update` to regenerate flows  for future testing (Not so much help if the original flows are wrong...)
