### PR TITLE
all: fix top-level comment, BUG needs a (who) part

### DIFF
--- a/src/bytes/bytes.go
+++ b/src/bytes/bytes.go
@@ -442,7 +442,7 @@ func isSeparator(r rune) bool {
 // Title returns a copy of s with all Unicode letters that begin words
 // mapped to their title case.
 //
-// BUG: The rule Title uses for word boundaries does not handle Unicode punctuation properly.
+// BUG(rsc): The rule Title uses for word boundaries does not handle Unicode punctuation properly.
 func Title(s []byte) []byte {
 	// Use a closure here to remember state.
 	// Hackish but effective. Depends on Map scanning in order and calling

--- a/src/os/exec/exec.go
+++ b/src/os/exec/exec.go
@@ -80,7 +80,7 @@ type Cmd struct {
 	// new process. It does not include standard input, standard output, or
 	// standard error. If non-nil, entry i becomes file descriptor 3+i.
 	//
-	// BUG: on OS X 10.6, child processes may sometimes inherit unwanted fds.
+	// BUG(rsc): on OS X 10.6, child processes may sometimes inherit unwanted fds.
 	// http://golang.org/issue/2603
 	ExtraFiles []*os.File
 

--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -519,7 +519,7 @@ func isSeparator(r rune) bool {
 // Title returns a copy of the string s with all Unicode letters that begin words
 // mapped to their title case.
 //
-// BUG: The rule Title uses for word boundaries does not handle Unicode punctuation properly.
+// BUG(rsc): The rule Title uses for word boundaries does not handle Unicode punctuation properly.
 func Title(s string) string {
 	// Use a closure here to remember state.
 	// Hackish but effective. Depends on Map scanning in order and calling


### PR DESCRIPTION
Reference to noteMarker here: https://github.com/golang/go/blob/master/src/go/doc/reader.go#L403
We also need to fix the link on the bytes packages in the post blog here: http://blog.golang.org/godoc-documenting-go-code
