### PR TITLE
testing/iotest: fix typo, s/written/read/

### DIFF
--- a/src/testing/iotest/logger.go
+++ b/src/testing/iotest/logger.go
@@ -48,7 +48,7 @@ func (l *readLogger) Read(p []byte) (n int, err error) {
 
 // NewReadLogger returns a reader that behaves like r except
 // that it logs (using log.Print) each read to standard error,
-// printing the prefix and the hexadecimal data written.
+// printing the prefix and the hexadecimal data read.
 func NewReadLogger(prefix string, r io.Reader) io.Reader {
 	return &readLogger{prefix, r}
 }


### PR DESCRIPTION
I think this was a copy paste error.
