### PR TITLE
container/list: make MoveBefore and MoveAfter a bit more flexible

### DIFF
--- a/src/container/list/list.go
+++ b/src/container/list/list.go
@@ -182,7 +182,7 @@ func (l *List) MoveToBack(e *Element) {
 // MoveBefore moves element e to its new position before mark.
 // If e or mark is not an element of l, or e == mark, the list is not modified.
 func (l *List) MoveBefore(e, mark *Element) {
-	if e.list != l || e == mark || mark.list != l {
+	if e == mark || e == mark.prev || e.list != l || mark.list != l {
 		return
 	}
 	l.insert(l.remove(e), mark.prev)
@@ -191,7 +191,7 @@ func (l *List) MoveBefore(e, mark *Element) {
 // MoveAfter moves element e to its new position after mark.
 // If e or mark is not an element of l, or e == mark, the list is not modified.
 func (l *List) MoveAfter(e, mark *Element) {
-	if e.list != l || e == mark || mark.list != l {
+	if e == mark || e == mark.next || e.list != l || mark.list != l {
 		return
 	}
 	l.insert(l.remove(e), mark)


### PR DESCRIPTION
for MoveBefore, if e == mark.prev, wo can return directly, same as above to MoveAfter.

see MoveToFront or MoveToBack
