### PR TITLE
cmd/go: Update vcs.go

### DIFF
--- a/src/cmd/go/vcs.go
+++ b/src/cmd/go/vcs.go
@@ -116,7 +116,7 @@ var vcsGit = &vcsCmd{
 	tagSyncCmd:     "checkout {tag}",
 	tagSyncDefault: "checkout master",
 
-	scheme:     []string{"git", "https", "http", "git+ssh"},
+	scheme:     []string{"git", "https", "git+ssh"},
 	pingCmd:    "ls-remote {scheme}://{repo}",
 	remoteRepo: gitRemoteRepo,
 }


### PR DESCRIPTION
Never use HTTP for git.

This is a dangerous security flaw, but easily fixed.
- https://twitter.com/wiretapped/status/573173567728308224
