### PR TITLE
go/vcs: Removed directory check for vcs detection

### DIFF
--- a/src/cmd/go/vcs.go
+++ b/src/cmd/go/vcs.go
@@ -422,7 +422,7 @@ func vcsForDir(p *Package) (vcs *vcsCmd, root string, err error) {
 	origDir := dir
 	for len(dir) > len(srcRoot) {
 		for _, vcs := range vcsList {
-			if fi, err := os.Stat(filepath.Join(dir, "."+vcs.cmd)); err == nil && fi.IsDir() {
+			if _, err := os.Stat(filepath.Join(dir, "."+vcs.cmd)); err == nil {
 				return vcs, dir[len(srcRoot)+1:], nil
 			}
 		}


### PR DESCRIPTION
https://github.com/golang/go/issues/10322

Git uses a file (instead of a directory) for submodule repositories.
