### PR TITLE
net/http: Update Request documentation to include detail about Form population.

### DIFF
--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -167,6 +167,12 @@ type Request struct {
 	// field's query parameters and the POST or PUT form data.
 	// This field is only available after ParseForm is called.
 	// The HTTP client ignores Form and uses Body instead.
+	//
+	// The way that Form is populated is dependent on the header
+	// "Content-Type". For example, the header must be set to
+	// "application/x-www-form-urlencoded" for URL encoded values.
+	// An empty Content-Type results in the form being treated as
+	// application/octet-stream
 	Form url.Values
 
 	// PostForm contains the parsed form data from POST or PUT


### PR DESCRIPTION
The documentation lacks in the semantics of how the Form field is populated on http.Request. This updates the Form field on Request to talk about the business logic behind population.
