### PR TITLE
net/url: Catch URL Parse error with port and no scheme

### DIFF
--- a/src/net/url/url_test.go
+++ b/src/net/url/url_test.go
@@ -369,6 +369,14 @@ var urltests = []URLTest{
 		},
 		"http://[fe80::1%25en01-._~]:8080/",
 	},
+	// host with port and no scheme
+	{
+		"www.whitehouse.gov:443", 
+		&URL {
+			Scheme : "",
+			Host: "www.whitehouse.gov:443"
+		}
+	},
 }
 
 // more useful string for debugging than fmt's struct printer


### PR DESCRIPTION
I found that when parsing URLs with a port and no scheme, the parser would return the hostname in the Scheme field, and an empty string in the host field. This test should catch that.
