### PR TITLE
time: Update docstring for Format in format.go

### DIFF
--- a/src/time/format.go
+++ b/src/time/format.go
@@ -401,7 +401,7 @@ func (t Time) String() string {
 // Format returns a textual representation of the time value formatted
 // according to layout, which defines the format by showing how the reference
 // time, defined to be
-//	Mon Jan 2 15:04:05 -0700 MST 2006
+//	Mon Jan 2 15:04:05.000000000 -0700 MST 2006
 // would be displayed if it were the value; it serves as an example of the
 // desired output. The same display rules will then be applied to the time
 // value.


### PR DESCRIPTION
The reference time described in the docstring for Format doesn't provide a value for nanoseconds. This hides the functionality provided by the Format function to render milli, micro and nanoseconds.

This has led to some confusion that Format can't handle sub-second precision: https://groups.google.com/forum/#!topic/golang-nuts/TIinEnPu5wE
