### PR TITLE
cmd/cgo: provides directly calling a c function without runtime thread pool involved.

### DIFF
--- a/src/cmd/cgo/ast.go
+++ b/src/cmd/cgo/ast.go
@@ -73,7 +73,7 @@ func (f *File) ReadGo(name string) {
 		}
 		for _, spec := range d.Specs {
 			s, ok := spec.(*ast.ImportSpec)
-			if !ok || string(s.Path.Value) != `"C"` {
+			if !ok || (string(s.Path.Value) != `"C"` && string(s.Path.Value) != `"c"`) {
 				continue
 			}
 			sawC = true
@@ -106,7 +106,7 @@ func (f *File) ReadGo(name string) {
 		ws := 0
 		for _, spec := range d.Specs {
 			s, ok := spec.(*ast.ImportSpec)
-			if !ok || string(s.Path.Value) != `"C"` {
+			if !ok || (string(s.Path.Value) != `"C"` && string(s.Path.Value) != `"c"`) {
 				d.Specs[ws] = spec
 				ws++
 			}
@@ -175,7 +175,7 @@ func (f *File) saveRef(x interface{}, context string) {
 		// The parser should take care of scoping in the future,
 		// so that we will be able to distinguish a "top-level C"
 		// from a local C.
-		if l, ok := sel.X.(*ast.Ident); ok && l.Name == "C" {
+		if l, ok := sel.X.(*ast.Ident); ok && (l.Name == "C" || l.Name == "c") {
 			if context == "as2" {
 				context = "expr"
 			}
@@ -194,12 +194,14 @@ func (f *File) saveRef(x interface{}, context string) {
 			if goname == "malloc" {
 				goname = "_CMalloc"
 			}
-			name := f.Name[goname]
+			key := l.Name + "." + goname
+			name := f.Name[key]
 			if name == nil {
 				name = &Name{
 					Go: goname,
+					Direct: l.Name == "c",
 				}
-				f.Name[goname] = name
+				f.Name[key] = name
 			}
 			f.Ref = append(f.Ref, &Ref{
 				Name:    name,

--- a/src/cmd/cgo/gcc.go
+++ b/src/cmd/cgo/gcc.go
@@ -577,6 +577,9 @@ func (p *Package) mangleName(n *Name) {
 	if *gccgo && n.IsVar() {
 		prefix = "C"
 	}
+	if n.Direct {
+		prefix+= "asm"
+	}
 	n.Mangle = prefix + n.Kind + "_" + n.Go
 }
 

--- a/src/cmd/cgo/main.go
+++ b/src/cmd/cgo/main.go
@@ -84,6 +84,7 @@ type Name struct {
 	Type     *Type  // the type of xxx
 	FuncType *FuncType
 	AddError bool
+	Direct   bool
 	Const    string // constant definition
 }
 

--- a/src/cmd/cgo/out.go
+++ b/src/cmd/cgo/out.go
@@ -428,7 +428,11 @@ func (p *Package) writeDefsFunc(fc, fgo2 *os.File, n *Name) {
 	if n.AddError {
 		prefix = "errno := "
 	}
-	fmt.Fprintf(fgo2, "\t%s_cgo_runtime_cgocall_errno(%s, %s)\n", prefix, cname, arg)
+	if n.Direct { 
+		fmt.Fprintf(fgo2, "\t%s_cgo_runtime_asmcgocall_errno(%s, %s)\n", prefix, cname, arg)
+	} else {
+		fmt.Fprintf(fgo2, "\t%s_cgo_runtime_cgocall_errno(%s, %s)\n", prefix, cname, arg)
+	}
 	if n.AddError {
 		fmt.Fprintf(fgo2, "\tif errno != 0 { r2 = syscall.Errno(errno) }\n")
 	}
@@ -1175,6 +1179,11 @@ static void *cgocall_errno = runtime·cgocall_errno;
 void *·_cgo_runtime_cgocall_errno = &cgocall_errno;
 
 #pragma dataflag NOPTR
+static void *asmcgocall_errno = runtime·asmcgocall_errno;
+#pragma dataflag NOPTR
+void *·_cgo_runtime_asmcgocall_errno = &asmcgocall_errno;
+
+#pragma dataflag NOPTR
 static void *runtime_gostring = runtime·gostring;
 #pragma dataflag NOPTR
 void *·_cgo_runtime_gostring = &runtime_gostring;
@@ -1199,6 +1208,7 @@ void ·_Cerrno(void*, int32);
 
 const goProlog = `
 var _cgo_runtime_cgocall_errno func(unsafe.Pointer, uintptr) int32
+var _cgo_runtime_asmcgocall_errno func(unsafe.Pointer, uintptr) int32
 var _cgo_runtime_cmalloc func(uintptr) unsafe.Pointer
 `
 


### PR DESCRIPTION
currently using c.func_call() instead of C.func_call() to perform a direct cgo call.
