### PR TITLE
Shemeless URLs support in net/http::Redirect()

### DIFF
--- a/src/net/http/serve_test.go
+++ b/src/net/http/serve_test.go
@@ -1693,6 +1693,62 @@ func TestRedirectBadPath(t *testing.T) {
 	}
 }
 
+// Test different URL formats and schemes
+func TestRedirectURLFormat(t *testing.T) {
+	req, _ := NewRequest("GET", "http://example.com/", nil)
+
+	var resp ResponseWriter
+
+	// normal http
+	resp = httptest.NewRecorder()
+	Redirect(resp, req, "http://foobar.com/baz", 302)
+	if g, e := resp.Header().Get("Location"), "http://foobar.com/baz"; g != e {
+		t.Errorf("Location header was %q; want %q", g, e)
+	}
+
+	// normal https
+	resp = httptest.NewRecorder()
+	Redirect(resp, req, "https://foobar.com/baz", 302)
+	if g, e := resp.Header().Get("Location"), "https://foobar.com/baz"; g != e {
+		t.Errorf("Location header was %q; want %q", g, e)
+	}
+
+	// custom scheme
+	resp = httptest.NewRecorder()
+	Redirect(resp, req, "test://foobar.com/baz", 302)
+	if g, e := resp.Header().Get("Location"), "test://foobar.com/baz"; g != e {
+		t.Errorf("Location header was %q; want %q", g, e)
+	}
+
+	// schemeless
+	resp = httptest.NewRecorder()
+	Redirect(resp, req, "//foobar.com/baz", 302)
+	if g, e := resp.Header().Get("Location"), "//foobar.com/baz"; g != e {
+		t.Errorf("Location header was %q; want %q", g, e)
+	}
+
+	// relative with slash
+	resp = httptest.NewRecorder()
+	Redirect(resp, req, "/foobar.com/baz", 302)
+	if g, e := resp.Header().Get("Location"), "/foobar.com/baz"; g != e {
+		t.Errorf("Location header was %q; want %q", g, e)
+	}
+
+	// relative without slash
+	resp = httptest.NewRecorder()
+	Redirect(resp, req, "foobar.com/baz", 302)
+	if g, e := resp.Header().Get("Location"), "/foobar.com/baz"; g != e {
+		t.Errorf("Location header was %q; want %q", g, e)
+	}
+
+	// too many slashes
+	resp = httptest.NewRecorder()
+	Redirect(resp, req, "///foobar.com/baz", 302)
+	if g, e := resp.Header().Get("Location"), "/foobar.com/baz"; g != e {
+		t.Errorf("Location header was %q; want %q", g, e)
+	}
+}
+
 // TestZeroLengthPostAndResponse exercises an optimization done by the Transport:
 // when there is no body (either because the method doesn't permit a body, or an
 // explicit Content-Length of zero is present), then the transport can re-use the

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -1479,11 +1479,12 @@ func Redirect(w ResponseWriter, r *Request, urlStr string, code int) {
 		// Because of this problem, no one pays attention
 		// to the RFC; they all send back just a new path.
 		// So do we.
-		oldpath := r.URL.Path
-		if oldpath == "" { // should not happen, but avoid a crash if it does
-			oldpath = "/"
-		}
-		if u.Scheme == "" {
+		if u.Scheme == "" && u.Host == "" {
+			oldpath := r.URL.Path
+			if oldpath == "" { // should not happen, but avoid a crash if it does
+				oldpath = "/"
+			}
+
 			// no leading http://server
 			if urlStr == "" || urlStr[0] != '/' {
 				// make relative path absolute


### PR DESCRIPTION
Many browsers now support schemeless URLs in the Location headers and also it is allowed in the draft HTTP/1.1 specification (see http://stackoverflow.com/questions/4831741/can-i-change-all-my-http-links-to-just#comment25926312_4831741), but Go standard library lacks support for them.

I've made a patch to implement schemeless URLs support in `net/http::Redirect()`. Since `net/url::Parse()` correctly handles schemeless URL's, I've just added an extra condition to verify URL's Host part in the absoulute/relative check in the `Redirect()` function.

Also I've moved `oldpath` variable initialization inside the block of code where it is used. 
