### PR TITLE
Fix /bin/bash shebangs to /bin/sh

### DIFF
--- a/misc/benchcmp
+++ b/misc/benchcmp
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo 'misc/benchcmp has moved:' >&2
 echo '	go get -u golang.org/x/tools/cmd/benchcmp' >&2

--- a/misc/nacl/go_nacl_386_exec
+++ b/misc/nacl/go_nacl_386_exec
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 eval $(go env)
 

--- a/misc/nacl/go_nacl_amd64p32_exec
+++ b/misc/nacl/go_nacl_amd64p32_exec
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 eval $(go env)
 

--- a/misc/nacl/go_nacl_arm_exec
+++ b/misc/nacl/go_nacl_arm_exec
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 eval $(go env)
 

--- a/src/bootstrap.bash
+++ b/src/bootstrap.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Copyright 2015 The Go Authors.  All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.

--- a/src/cmd/dist/mkdeps.bash
+++ b/src/cmd/dist/mkdeps.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 

--- a/src/cmd/go/mkalldocs.sh
+++ b/src/cmd/go/mkalldocs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Copyright 2012 The Go Authors.  All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.

--- a/src/nacltest.bash
+++ b/src/nacltest.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Copyright 2014 The Go Authors.  All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.

--- a/src/runtime/mknacl.sh
+++ b/src/runtime/mknacl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Copyright 2013 The Go Authors.  All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.


### PR DESCRIPTION
These scripts do not require any bash features and should work well
with any posix-compatible shell. Bash though is not available on all
systems (*BSDs, for instance) by default, so /bin/bash shebang will
bring extra unneeded dependency.
