### PR TITLE
Fix socket leak on failed connections

### DIFF
--- a/src/net/sock_posix.go
+++ b/src/net/sock_posix.go
@@ -75,12 +75,14 @@ func socket(net string, family, sotype, proto int, ipv6only bool, laddr, raddr s
 		case syscall.SOCK_STREAM, syscall.SOCK_SEQPACKET:
 			if err := fd.listenStream(laddr, listenerBacklog); err != nil {
 				fd.Close()
+				closeFunc(s)
 				return nil, err
 			}
 			return fd, nil
 		case syscall.SOCK_DGRAM:
 			if err := fd.listenDatagram(laddr); err != nil {
 				fd.Close()
+				closeFunc(s)
 				return nil, err
 			}
 			return fd, nil
@@ -88,6 +90,7 @@ func socket(net string, family, sotype, proto int, ipv6only bool, laddr, raddr s
 	}
 	if err := fd.dial(laddr, raddr, deadline); err != nil {
 		fd.Close()
+		closeFunc(s)
 		return nil, err
 	}
 	return fd, nil


### PR DESCRIPTION
It seems that this issue was fixed in 2011 (https://code.google.com/p/go/issues/detail?id=2349) but the code was refactored since and this bug may be back.  We are seeing the same exact problem.  The fix here is to close socket on failures.  Please verify that this is an issue.  Thanks.
