### PR TITLE
Add new day duration.

### DIFF
--- a/src/time/time.go
+++ b/src/time/time.go
@@ -452,6 +452,7 @@ const (
 	Second               = 1000 * Millisecond
 	Minute               = 60 * Second
 	Hour                 = 60 * Minute
+	Day                  = 24 * Hour
 )
 
 // String returns a string representing the duration in the form "72h3m0.5s".


### PR DESCRIPTION
Unlike a Month or Year which might vary, a day duration is always 24 hours, so unsure why this isn't in the time package.
