### PR TITLE
Add `Remove` method to expvar

### DIFF
--- a/src/expvar/expvar.go
+++ b/src/expvar/expvar.go
@@ -148,6 +148,16 @@ func (v *Map) Set(key string, av Var) {
 	v.updateKeys()
 }
 
+func (v *Map) Remove(key string) Var {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	val, ok := v.m[key]
+	if ok {
+	    delete(v.m, key)
+    }
+    return val
+}
+
 func (v *Map) Add(key string, delta int64) {
 	v.mu.RLock()
 	av, ok := v.m[key]


### PR DESCRIPTION
I've been using expvar for a few metrics related cases, and its great. The one thing I really see as missing is that there is no mechanism to remove items from an expvar.Map. This exposes a simple `Remove` method which returns the `Var` associated with `key`-- or nil.
