### PR TITLE
Add `Remove` method to expvar

### DIFF
--- a/src/expvar/expvar.go
+++ b/src/expvar/expvar.go
@@ -148,6 +148,17 @@ func (v *Map) Set(key string, av Var) {
 	v.updateKeys()
 }
 
+func (v *Map) Remove(key string) Var {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	val, ok := v.m[key]
+	if ok {
+	    delete(v.m, key)
+	    v.updateKeys()
+    }
+    return val
+}
+
 func (v *Map) Add(key string, delta int64) {
 	v.mu.RLock()
 	av, ok := v.m[key]


### PR DESCRIPTION
expvar currently has no mechanism to remove a value from a Map. This exposes a simple `Remove` method which returns the `Var` associated with `key`-- or nil.
