### PR TITLE
Add a Delta() method to determine how many are waiting

### DIFF
--- a/src/sync/waitgroup.go
+++ b/src/sync/waitgroup.go
@@ -136,3 +136,11 @@ func (wg *WaitGroup) Wait() {
 		}
 	}
 }
+
+// Return the net delta added to the wait counter.
+func (wg *WaitGroup) Delta() int {
+	statep := wg.state()
+	state := atomic.AddUint64(statep, uint64(0)<<32)
+	v := int32(state >> 32)
+	return v
+}


### PR DESCRIPTION
This is my first crack at improving go core. I'm not a pro C programmer, so I suspect this might be able to be simplified to remote the atomic operation. This patch is useful so that when you pass a WaitGroup struct you can also examine it easily and know the net delta.
