### PR TITLE
Update HMAC FIPS link to current version

### DIFF
--- a/src/crypto/hmac/hmac.go
+++ b/src/crypto/hmac/hmac.go
@@ -27,7 +27,7 @@ import (
 )
 
 // FIPS 198:
-// http://csrc.nist.gov/publications/fips/fips198/fips-198a.pdf
+// http://csrc.nist.gov/publications/fips/fips198-1/FIPS-198-1_final.pdf
 
 // key is zero padded to the block size of the hash function
 // ipad = 0x36 byte repeated for key length


### PR DESCRIPTION
The link provided was superseded by a new version. This updates the link to the newest version.
