### PR TITLE
Increase _MaxGomaxprocs to support big machines

### DIFF
--- a/src/runtime/runtime2.go
+++ b/src/runtime/runtime2.go
@@ -472,7 +472,7 @@ type p struct {
 const (
 	// The max value of GOMAXPROCS.
 	// There are no fundamental restrictions on the value.
-	_MaxGomaxprocs = 1 << 8
+	_MaxGomaxprocs = 1 << 12
 )
 
 type schedt struct {


### PR DESCRIPTION
Please do not send pull requests to the golang/\* repositories.

We do, however, take contributions gladly.

See https://golang.org/doc/contribute.html

Thanks!

Currently go does not support machines that contains > 256 CPUs, as IBM's E880
that could host 1536 hardware thread, when configured with 192 CPU cores and
SMT (Symmetric Multi Thread) 8.

For example, when running a go program on this machine, I got, the following
problem[1]:

  procresize: invalid arg

This is because of the following code:

  _MaxGomaxprocs = 1 << 8

  if old < 0 || old > _MaxGomaxprocs || nprocs <= 0 || nprocs > _MaxGomaxprocs {
      throw("procresize: invalid arg")
  }

This patch just redefine _MAxGomaxprocs to 1 << 12.
