### PR TITLE
fix hello command with reversed output

### DIFF
--- a/doc/code.html
+++ b/doc/code.html
@@ -415,7 +415,7 @@ Running the new version of the program, you should see a new, reversed message:
 
 <pre>
 $ <b>hello</b>
-Hello, Go!
+.dlrow ,olleH
 </pre>
 
 <p>


### PR DESCRIPTION
Hello world is defined by: `fmt.Printf("Hello, world.\n")` so it prints: `Hello, world.`

After using `stringutils.Reversed` the output of the command should be: `.dlrow ,olleH`

Please do not send pull requests to the golang/* repositories.

We do, however, take contributions gladly.

See https://golang.org/doc/contribute.html

Thanks!
