### PR TITLE
When subject have a Email (E), the '@' should deal

### DIFF
--- a/src/encoding/asn1/asn1.go
+++ b/src/encoding/asn1/asn1.go
@@ -407,6 +407,7 @@ func isPrintable(b byte, asterisk asteriskFlag) bool {
 		b == ':' ||
 		b == '=' ||
 		b == '?' ||
+                b == '@' ||
 		// This is technically not allowed in a PrintableString.
 		// However, x509 certificates with wildcard strings don't
 		// always use the correct string type so we permit it.


### PR DESCRIPTION
When subject have a Email (E), the '@' should consider as a printablestring

Please do not send pull requests to the golang/* repositories.

We do, however, take contributions gladly.

See https://golang.org/doc/contribute.html

Thanks!
