### PR TITLE
Prevent rare case crash in conn.serve when fetching remote address

### DIFF
--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -1691,7 +1691,6 @@ func isCommonNetReadError(err error) bool {
 
 // Serve a new connection.
 func (c *conn) serve(ctx context.Context) {
-	c.remoteAddr = c.rwc.RemoteAddr().String()
 	ctx = context.WithValue(ctx, LocalAddrContextKey, c.rwc.LocalAddr())
 	defer func() {
 		if err := recover(); err != nil && err != ErrAbortHandler {
@@ -1705,6 +1704,8 @@ func (c *conn) serve(ctx context.Context) {
 			c.setState(c.rwc, StateClosed)
 		}
 	}()
+
+	c.remoteAddr = c.rwc.RemoteAddr().String()
 
 	if tlsConn, ok := c.rwc.(*tls.Conn); ok {
 		if d := c.server.ReadTimeout; d != 0 {


### PR DESCRIPTION
https://github.com/golang/go/issues/23022

Original recover process does not cover the case,
and it will crash the whole server.

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x2fcaf4]

    goroutine 207644 [running]:
    net/http.(*conn).serve(0x15ee4120, 0x31fbbc0, 0x154af2c0)
	    /usr/local/go/src/net/http/server.go:1691 +0x34
    created by net/http.(*Server).Serve
	    /usr/local/go/src/net/http/server.go:2720 +0x208

Please do not send pull requests to the golang/* repositories.

We do, however, take contributions gladly.

See https://golang.org/doc/contribute.html

Thanks!
