### PR TITLE
cmd/go/internal/get: fix regexes for "any" character matching

### DIFF
--- a/src/cmd/go/internal/get/vcs.go
+++ b/src/cmd/go/internal/get/vcs.go
@@ -971,7 +971,7 @@ var vcsPaths = []*vcsPath{
 	// IBM DevOps Services (JazzHub)
 	{
 		prefix: "hub.jazz.net/git/",
-		re:     `^(?P<root>hub.jazz.net/git/[a-z0-9]+/[A-Za-z0-9_.\-]+)(/[A-Za-z0-9_.\-]+)*$`,
+		re:     `^(?P<root>hub\.jazz\.net/git/[a-z0-9]+/[A-Za-z0-9_.\-]+)(/[A-Za-z0-9_.\-]+)*$`,
 		vcs:    "git",
 		repo:   "https://{root}",
 		check:  noVCSSuffix,
@@ -980,7 +980,7 @@ var vcsPaths = []*vcsPath{
 	// Git at Apache
 	{
 		prefix: "git.apache.org/",
-		re:     `^(?P<root>git.apache.org/[a-z0-9_.\-]+\.git)(/[A-Za-z0-9_.\-]+)*$`,
+		re:     `^(?P<root>git\.apache\.org/[a-z0-9_.\-]+\.git)(/[A-Za-z0-9_.\-]+)*$`,
 		vcs:    "git",
 		repo:   "https://{root}",
 	},

--- a/src/cmd/go/internal/get/vcs_test.go
+++ b/src/cmd/go/internal/get/vcs_test.go
@@ -60,6 +60,10 @@ func TestRepoRootForImportPath(t *testing.T) {
 			nil,
 		},
 		{
+			"hubajazz.net",
+			nil,
+		},
+		{
 			"hub2.jazz.net",
 			nil,
 		},
@@ -138,6 +142,10 @@ func TestRepoRootForImportPath(t *testing.T) {
 		// Should have ".git" suffix
 		{
 			"git.apache.org/package-name/path/to/lib",
+			nil,
+		},
+		{
+			"gitbapache.org",
 			nil,
 		},
 		{


### PR DESCRIPTION
Minor bug: `hubajazz.net` and `gitbapache.org` would match, probably shouldn't