### PR TITLE
image/gif: support non-looping animated gifs (LoopCount=-1)

### DIFF
--- a/src/image/gif/reader.go
+++ b/src/image/gif/reader.go
@@ -570,10 +570,11 @@ func Decode(r io.Reader) (image.Image, error) {
 type GIF struct {
 	Image []*image.Paletted // The successive images.
 	Delay []int             // The successive delay times, one per frame, in 100ths of a second.
-	// LoopCount is the number of times an animation will be restarted
-	// during display. This means for LoopCount=N, each frame will be
-	// displayed N+1 times. Use 0 for infinite looping, -1 to show each
-	// frame once.
+	// LoopCount controls the number of times an animation will be
+	// restarted during display.
+	// A LoopCount of 0 means to loop forever.
+	// A LoopCount of -1 means to show each frame only once.
+	// Otherwise, the animation is looped LoopCount+1 times.
 	LoopCount int
 	// Disposal is the successive disposal methods, one per frame. For
 	// backwards compatibility, a nil Disposal is valid to pass to EncodeAll,

--- a/src/image/gif/reader.go
+++ b/src/image/gif/reader.go
@@ -224,6 +224,8 @@ func (d *decoder) decode(r io.Reader, configOnly, keepAllFrames bool) error {
 		d.r = bufio.NewReader(r)
 	}
 
+	d.loopCount = -1
+
 	err := d.readHeaderAndScreenDescriptor()
 	if err != nil {
 		return err
@@ -566,9 +568,13 @@ func Decode(r io.Reader) (image.Image, error) {
 
 // GIF represents the possibly multiple images stored in a GIF file.
 type GIF struct {
-	Image     []*image.Paletted // The successive images.
-	Delay     []int             // The successive delay times, one per frame, in 100ths of a second.
-	LoopCount int               // The loop count.
+	Image []*image.Paletted // The successive images.
+	Delay []int             // The successive delay times, one per frame, in 100ths of a second.
+	// LoopCount is the number of times an animation will be restarted
+	// during display. This means for LoopCount=N, each frame will be
+	// displayed N+1 times. Use 0 for infinite looping, -1 to show each
+	// frame once.
+	LoopCount int
 	// Disposal is the successive disposal methods, one per frame. For
 	// backwards compatibility, a nil Disposal is valid to pass to EncodeAll,
 	// and implies that each frame's disposal method is 0 (no disposal

--- a/src/image/gif/reader_test.go
+++ b/src/image/gif/reader_test.go
@@ -318,23 +318,56 @@ func TestTransparentPixelOutsidePaletteRange(t *testing.T) {
 }
 
 func TestLoopCount(t *testing.T) {
-	data := []byte("GIF89a000\x00000,0\x00\x00\x00\n\x00" +
-		"\n\x00\x80000000\x02\b\xf01u\xb9\xfdal\x05\x00;")
-	img, err := DecodeAll(bytes.NewReader(data))
-	if err != nil {
-		t.Fatal("DecodeAll:", err)
+	tests := []struct {
+		data      []byte
+		loopCount int
+	}{
+		{
+			[]byte("GIF89a000\x00000" +
+				",0\x00\x00\x00\n\x00\n\x00\x80000000" + // image 0 descriptor & color table
+				"\x02\b\xf01u\xb9\xfdal\x05\x00;"), // image 0 image data & trailer
+			-1,
+		},
+		{
+			[]byte("GIF89a000\x00000" +
+				"!\xff\vNETSCAPE2.0\x03\x01\x00\x00\x00" + // loop count = 0
+				",0\x00\x00\x00\n\x00\n\x00\x80000000" + // image 0 descriptor & color table
+				"\x02\b\xf01u\xb9\xfdal\x05\x00" + // image 0 image data
+				",0\x00\x00\x00\n\x00\n\x00\x80000000" + // image 1 descriptor & color table
+				"\x02\b\xf01u\xb9\xfdal\x05\x00;"), // image 1 image data & trailer
+			0,
+		},
+		{
+			[]byte("GIF89a000\x00000" +
+				"!\xff\vNETSCAPE2.0\x03\x01\x01\x00\x00" + // loop count = 1
+				",0\x00\x00\x00\n\x00\n\x00\x80000000" + // image 0 descriptor & color table
+				"\x02\b\xf01u\xb9\xfdal\x05\x00" + // image 0 image data
+				",0\x00\x00\x00\n\x00\n\x00\x80000000" + // image 1 descriptor & color table
+				"\x02\b\xf01u\xb9\xfdal\x05\x00;"), // image 1 image data & trailer
+			1,
+		},
 	}
-	w := new(bytes.Buffer)
-	err = EncodeAll(w, img)
-	if err != nil {
-		t.Fatal("EncodeAll:", err)
-	}
-	img1, err := DecodeAll(w)
-	if err != nil {
-		t.Fatal("DecodeAll:", err)
-	}
-	if img.LoopCount != img1.LoopCount {
-		t.Errorf("loop count mismatch: %d vs %d", img.LoopCount, img1.LoopCount)
+
+	for _, tt := range tests {
+		img, err := DecodeAll(bytes.NewReader(tt.data))
+		if err != nil {
+			t.Fatal("DecodeAll:", err)
+		}
+		w := new(bytes.Buffer)
+		err = EncodeAll(w, img)
+		if err != nil {
+			t.Fatal("EncodeAll:", err)
+		}
+		img1, err := DecodeAll(w)
+		if err != nil {
+			t.Fatal("DecodeAll:", err)
+		}
+		if img.LoopCount != tt.loopCount {
+			t.Errorf("loop count mismatch: %d vs %d", img.LoopCount, tt.loopCount)
+		}
+		if img.LoopCount != img1.LoopCount {
+			t.Errorf("loop count failed round-trip: %d vs %d", img.LoopCount, img1.LoopCount)
+		}
 	}
 }
 

--- a/src/image/gif/reader_test.go
+++ b/src/image/gif/reader_test.go
@@ -318,17 +318,20 @@ func TestTransparentPixelOutsidePaletteRange(t *testing.T) {
 }
 
 func TestLoopCount(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
+		name      string
 		data      []byte
 		loopCount int
 	}{
 		{
+			"loopcount-missing",
 			[]byte("GIF89a000\x00000" +
 				",0\x00\x00\x00\n\x00\n\x00\x80000000" + // image 0 descriptor & color table
 				"\x02\b\xf01u\xb9\xfdal\x05\x00;"), // image 0 image data & trailer
 			-1,
 		},
 		{
+			"loopcount-0",
 			[]byte("GIF89a000\x00000" +
 				"!\xff\vNETSCAPE2.0\x03\x01\x00\x00\x00" + // loop count = 0
 				",0\x00\x00\x00\n\x00\n\x00\x80000000" + // image 0 descriptor & color table
@@ -338,6 +341,7 @@ func TestLoopCount(t *testing.T) {
 			0,
 		},
 		{
+			"loopcount-1",
 			[]byte("GIF89a000\x00000" +
 				"!\xff\vNETSCAPE2.0\x03\x01\x01\x00\x00" + // loop count = 1
 				",0\x00\x00\x00\n\x00\n\x00\x80000000" + // image 0 descriptor & color table
@@ -348,26 +352,28 @@ func TestLoopCount(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		img, err := DecodeAll(bytes.NewReader(tt.data))
-		if err != nil {
-			t.Fatal("DecodeAll:", err)
-		}
-		w := new(bytes.Buffer)
-		err = EncodeAll(w, img)
-		if err != nil {
-			t.Fatal("EncodeAll:", err)
-		}
-		img1, err := DecodeAll(w)
-		if err != nil {
-			t.Fatal("DecodeAll:", err)
-		}
-		if img.LoopCount != tt.loopCount {
-			t.Errorf("loop count mismatch: %d vs %d", img.LoopCount, tt.loopCount)
-		}
-		if img.LoopCount != img1.LoopCount {
-			t.Errorf("loop count failed round-trip: %d vs %d", img.LoopCount, img1.LoopCount)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			img, err := DecodeAll(bytes.NewReader(tc.data))
+			if err != nil {
+				t.Fatal("DecodeAll:", err)
+			}
+			w := new(bytes.Buffer)
+			err = EncodeAll(w, img)
+			if err != nil {
+				t.Fatal("EncodeAll:", err)
+			}
+			img1, err := DecodeAll(w)
+			if err != nil {
+				t.Fatal("DecodeAll:", err)
+			}
+			if img.LoopCount != tc.loopCount {
+				t.Errorf("loop count mismatch: %d vs %d", img.LoopCount, tc.loopCount)
+			}
+			if img.LoopCount != img1.LoopCount {
+				t.Errorf("loop count failed round-trip: %d vs %d", img.LoopCount, img1.LoopCount)
+			}
+		})
 	}
 }
 

--- a/src/image/gif/writer.go
+++ b/src/image/gif/writer.go
@@ -178,7 +178,7 @@ func (e *encoder) writeHeader() {
 	}
 
 	// Add animation info if necessary.
-	if len(e.g.Image) > 1 {
+	if len(e.g.Image) > 1 && e.g.LoopCount >= 0 {
 		e.buf[0] = 0x21 // Extension Introducer.
 		e.buf[1] = 0xff // Application Label.
 		e.buf[2] = 0x0b // Block Size.
@@ -376,9 +376,6 @@ func EncodeAll(w io.Writer, g *GIF) error {
 
 	if len(g.Image) != len(g.Delay) {
 		return errors.New("gif: mismatched image and delay lengths")
-	}
-	if g.LoopCount < 0 {
-		g.LoopCount = 0
 	}
 
 	e := encoder{g: *g}


### PR DESCRIPTION
The Netscape looping application extension encodes how many
times the animation should restart, and if it's present
there is no way to signal that a GIF should play only once.

Use LoopCount=-1 to signal when a decoded GIF had no looping
extension, and update the encoder to omit that extension
block when LoopCount=-1.

Fixes #15768