### PR TITLE
cmd/go/internal/work: add -w compiler flag to the whitelist for cgo

### DIFF
--- a/src/cmd/go/internal/work/security.go
+++ b/src/cmd/go/internal/work/security.go
@@ -75,6 +75,7 @@ var validCompilerFlags = []*regexp.Regexp{
 	re(`-pipe`),
 	re(`-pthread`),
 	re(`-?-std=([^@\-].*)`),
+	re(`-w`),
 	re(`-x([^@\-].*)`),
 }
 


### PR DESCRIPTION
See wellington/go-libsass#54
