### PR TITLE
cmd/go: fix formatting of file paths under cwd

### DIFF
--- a/src/cmd/go/go_test.go
+++ b/src/cmd/go/go_test.go
@@ -5921,3 +5921,11 @@ echo $* >>`+tg.path("pkg-config.out"))
 		t.Errorf("got %q want %q", out, want)
 	}
 }
+
+// Issue 23982
+func TestFilepathUnderCwdFormat(t *testing.T) {
+	tg := testgo(t)
+	defer tg.cleanup()
+	tg.run("test", "-x", "-cover", "log")
+	tg.grepStderrNot(`\.log\.cover\.go`, "-x output should contain correctly formatted filepath under cwd")
+}

--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -1365,8 +1365,8 @@ func (b *Builder) fmtcmd(dir string, format string, args ...interface{}) string 
 	cmd := fmt.Sprintf(format, args...)
 	if dir != "" && dir != "/" {
 		dot := " ."
-		if dir[len(dir)-1] == '/' {
-			dot += "/"
+		if dir[len(dir)-1] == filepath.Separator {
+			dot += string(filepath.Separator)
 		}
 		cmd = strings.Replace(" "+cmd, " "+dir, dot, -1)[1:]
 		if b.scriptDir != dir {

--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -1364,7 +1364,11 @@ func mayberemovefile(s string) {
 func (b *Builder) fmtcmd(dir string, format string, args ...interface{}) string {
 	cmd := fmt.Sprintf(format, args...)
 	if dir != "" && dir != "/" {
-		cmd = strings.Replace(" "+cmd, " "+dir, " .", -1)[1:]
+		dot := " ."
+		if dir[len(dir)-1] == '/' {
+			dot += "/"
+		}
+		cmd = strings.Replace(" "+cmd, " "+dir, dot, -1)[1:]
 		if b.scriptDir != dir {
 			b.scriptDir = dir
 			cmd = "cd " + dir + "\n" + cmd


### PR DESCRIPTION
The output of go with -x flag is formatted in a manner that file paths
under current directory are modified to start with a dot (.), but when
the directory path ends with a slash (/), the formatting goes wrong.

Fixes #23982