### PR TITLE
net/http: lock the read-only mutex in shouldRedirect

### DIFF
--- a/src/net/http/serve_test.go
+++ b/src/net/http/serve_test.go
@@ -581,6 +581,16 @@ func TestServeWithSlashRedirectForHostPatterns(t *testing.T) {
 	}
 }
 
+func TestShouldRedirectConcurrency(t *testing.T) {
+	setParallel(t)
+	defer afterTest(t)
+
+	mux := NewServeMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	mux.HandleFunc("/", func(w ResponseWriter, r *Request) {})
+}
+
 func BenchmarkServeMux(b *testing.B) {
 
 	type test struct {

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -2223,6 +2223,9 @@ func (mux *ServeMux) redirectToPathSlash(host, path string, u *url.URL) (*url.UR
 // path+"/". This should happen if a handler is registered for path+"/" but
 // not path -- see comments at ServeMux.
 func (mux *ServeMux) shouldRedirect(host, path string) bool {
+	mux.mu.RLock()
+	defer mux.mu.RUnlock()
+
 	p := []string{path, host + path}
 
 	for _, c := range p {


### PR DESCRIPTION
Since that method uses 'mux.m', we need to lock the mutex to avoid data races.
