### PR TITLE
cmd/cgo: clarify implicit "cgo" build constraint

### DIFF
--- a/src/cmd/cgo/doc.go
+++ b/src/cmd/cgo/doc.go
@@ -109,7 +109,9 @@ it is expected to work. It is disabled by default when
 cross-compiling. You can control this by setting the CGO_ENABLED
 environment variable when running the go tool: set it to 1 to enable
 the use of cgo, and to 0 to disable it. The go tool will set the
-build constraint "cgo" if cgo is enabled.
+build constraint "cgo" if cgo is enabled. When the Go tool sees the
+special import "C", the "cgo" build constraint will be implied, causing
+the tool to skip the file if CGO_ENABLED is set to 0.
 
 When cross-compiling, you must specify a C cross-compiler for cgo to
 use. You can do this by setting the generic CC_FOR_TARGET or the

--- a/src/cmd/cgo/doc.go
+++ b/src/cmd/cgo/doc.go
@@ -112,8 +112,8 @@ the use of cgo, and to 0 to disable it. The go tool will set the
 build constraint "cgo" if cgo is enabled. The special import "C"
 implies the "cgo" build constraint, as though the file also said
 "// +build cgo".  Therefore, if cgo is disabled, files that import
-"C" will not be built by the go tool. 
-(For more about build constraints see https://golang.org/pkg/go/build/#hdr-Build_Constraints).
+"C" will not be built by the go tool. (For more about build constraints
+see https://golang.org/pkg/go/build/#hdr-Build_Constraints).
 
 When cross-compiling, you must specify a C cross-compiler for cgo to
 use. You can do this by setting the generic CC_FOR_TARGET or the

--- a/src/cmd/cgo/doc.go
+++ b/src/cmd/cgo/doc.go
@@ -109,9 +109,11 @@ it is expected to work. It is disabled by default when
 cross-compiling. You can control this by setting the CGO_ENABLED
 environment variable when running the go tool: set it to 1 to enable
 the use of cgo, and to 0 to disable it. The go tool will set the
-build constraint "cgo" if cgo is enabled. When the Go tool sees the
-special import "C", the "cgo" build constraint will be implied, causing
-the tool to skip the file if CGO_ENABLED is set to 0.
+build constraint "cgo" if cgo is enabled. The special import "C"
+implies the "cgo" build constraint, as though the file also said
+"// +build cgo".  Therefore, if cgo is disabled, files that import
+"C" will not be built by the go tool. 
+(For more about build constraints see https://golang.org/pkg/go/build/#hdr-Build_Constraints).
 
 When cross-compiling, you must specify a C cross-compiler for cgo to
 use. You can do this by setting the generic CC_FOR_TARGET or the


### PR DESCRIPTION
When using the special import "C", the "cgo" build constraint is implied for the go file, potentially triggering unclear "undefined" error messages. The documentation so far did not yet mention this.

Updates #24068, adds the instructed "quick win" as a more helpful message from the compiler is non-trivial.