### PR TITLE
runtime: rename the TestGcHashmapIndirection to TestGcMapIndirection

### DIFF
--- a/src/runtime/gc_test.go
+++ b/src/runtime/gc_test.go
@@ -43,7 +43,7 @@ func TestGcDeepNesting(t *testing.T) {
 	}
 }
 
-func TestGcHashmapIndirection(t *testing.T) {
+func TestGcMapIndirection(t *testing.T) {
 	defer debug.SetGCPercent(debug.SetGCPercent(1))
 	runtime.GC()
 	type T struct {


### PR DESCRIPTION
The hashmap was renamed with map few days ago. 

But there is still 'Hashmap' word on gc_test.go, so I renamed this with just 'Map'

Related commit: f4bb25c937cffb277e5ba87708d286ea7fd1b6ed
