### PR TITLE
mime/multipart: test for presence of filename instead of content-type

### DIFF
--- a/src/mime/multipart/formdata.go
+++ b/src/mime/multipart/formdata.go
@@ -58,8 +58,7 @@ func (r *Reader) readForm(maxMemory int64) (_ *Form, err error) {
 
 		var b bytes.Buffer
 
-		_, hasContentTypeHeader := p.Header["Content-Type"]
-		if !hasContentTypeHeader && filename == "" {
+		if !p.hasFileName() {
 			// value, store as string in memory
 			n, err := io.CopyN(&b, p, maxValueBytes+1)
 			if err != nil && err != io.EOF {

--- a/src/mime/multipart/formdata_test.go
+++ b/src/mime/multipart/formdata_test.go
@@ -55,6 +55,21 @@ func TestReadFormWithNamelessFile(t *testing.T) {
 
 }
 
+func TestReadFormWithTextContentType(t *testing.T) {
+	// From https://github.com/golang/go/issues/24041
+	b := strings.NewReader(strings.Replace(messageWithTextContentType, "\n", "\r\n", -1))
+	r := NewReader(b, boundary)
+	f, err := r.ReadForm(25)
+	if err != nil {
+		t.Fatal("ReadForm:", err)
+	}
+	defer f.RemoveAll()
+
+	if g, e := f.Value["texta"][0], textaValue; g != e {
+		t.Errorf("texta value = %q, want %q", g, e)
+	}
+}
+
 func testFile(t *testing.T, fh *FileHeader, efn, econtent string) File {
 	if fh.Filename != efn {
 		t.Errorf("filename = %q, want %q", fh.Filename, efn)
@@ -92,6 +107,15 @@ Content-Type: text/plain
 
 ` + filebContents + `
 --MyBoundary--
+`
+
+const messageWithTextContentType = `
+--MyBoundary
+Content-Disposition: form-data; name="texta"
+Content-Type: text/plain
+
+` + textaValue + `
+--MyBoundary
 `
 
 const message = `

--- a/src/mime/multipart/multipart.go
+++ b/src/mime/multipart/multipart.go
@@ -81,6 +81,16 @@ func (p *Part) FileName() string {
 	return p.dispositionParams["filename"]
 }
 
+// hasFileName determines if a (empty or otherwise)
+// filename parameter was included in the Content-Disposition header
+func (p *Part) hasFileName() bool {
+	if p.dispositionParams == nil {
+		p.parseContentDisposition()
+	}
+	_, ok := p.dispositionParams["filename"]
+	return ok
+}
+
 func (p *Part) parseContentDisposition() {
 	v := p.Header.Get("Content-Disposition")
 	var err error


### PR DESCRIPTION
Fixes #24041 

Preserving the intended fix in https://go.googlesource.com/go/+/81ec7256072ed5e20b8827c583193258769aebc0