### PR TITLE
net/http,doc: use HTTP status code constants

### DIFF
--- a/doc/progs/error2.go
+++ b/doc/progs/error2.go
@@ -20,11 +20,11 @@ func viewRecord(w http.ResponseWriter, r *http.Request) {
 	key := datastore.NewKey(c, "Record", r.FormValue("id"), 0, nil)
 	record := new(Record)
 	if err := datastore.Get(c, key, record); err != nil {
-		http.Error(w, err.Error(), 500)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	if err := viewTemplate.Execute(w, record); err != nil {
-		http.Error(w, err.Error(), 500)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
 

--- a/doc/progs/error3.go
+++ b/doc/progs/error3.go
@@ -33,7 +33,7 @@ type appHandler func(http.ResponseWriter, *http.Request) error
 
 func (fn appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err := fn(w, r); err != nil {
-		http.Error(w, err.Error(), 500)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
 

--- a/src/net/http/triv.go
+++ b/src/net/http/triv.go
@@ -107,7 +107,7 @@ func DateServer(rw http.ResponseWriter, req *http.Request) {
 
 	date, err := exec.Command("/bin/date").Output()
 	if err != nil {
-		http.Error(rw, err.Error(), 500)
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	rw.Write(date)
@@ -115,7 +115,7 @@ func DateServer(rw http.ResponseWriter, req *http.Request) {
 
 func Logger(w http.ResponseWriter, req *http.Request) {
 	log.Print(req.URL)
-	http.Error(w, "oops", 404)
+	http.Error(w, "oops", http.StatusNotFound)
 }
 
 var webroot = flag.String("root", os.Getenv("HOME"), "web root directory")


### PR DESCRIPTION
There are a few places where the integer value is used.
Use the equivalent constants to improve readability.