### PR TITLE
encoding/asn1: update function "isPrintable" to accept '@' character as printable

### DIFF
--- a/src/encoding/asn1/asn1.go
+++ b/src/encoding/asn1/asn1.go
@@ -430,6 +430,9 @@ func isPrintable(b byte, asterisk asteriskFlag, ampersand ampersandFlag) bool {
 		b == ':' ||
 		b == '=' ||
 		b == '?' ||
+		// x509 certificates issuer or subject may have email address,
+		// so we need '@'.
+		b == '@' ||
 		// This is technically not allowed in a PrintableString.
 		// However, x509 certificates with wildcard strings don't
 		// always use the correct string type so we permit it.


### PR DESCRIPTION
As we know , email address will apear in x.509 certificate, when parse email address ,we need to accept '@' character as printable string.