### PR TITLE
doc: add link to the Go Discord forum

### DIFF
--- a/doc/help.html
+++ b/doc/help.html
@@ -27,6 +27,11 @@ The <a href="https://forum.golangbridge.org/">Go Forum</a> is a discussion
 forum for Go programmers.
 </p>
 
+<h3 id="discord"><a href="https://discord.gg/64C346U">Gophers Discord</a></h3>
+<p>
+Get live support and talk with other gophers on the Go Discord.
+</p>
+
 <h3 id="slack"><a href="https://blog.gopheracademy.com/gophers-slack-community/">Gopher Slack</a></h3>
 <p>Get live support from other users in the Go slack channel.</p>
 


### PR DESCRIPTION
I've linked the  gophers discord. It's a well administered discord which already got many members, but it was never officially linked. For many people it's a quality proof if a discord is linked on the official page. I think there are much more people out there, who would prefer to use discord instead of slack or irc.

The discord already got many users without even being promoted, so it's very likely there are many people who are interested in a discord, but they don't want to use unofficial discords. This discord shouldn't be seen as a competitor for the slack, it's a platform for those, who don't want to use slack.