### PR TITLE
os/user: obtain a user GID on Windows

### DIFF
--- a/src/internal/syscall/windows/security_windows.go
+++ b/src/internal/syscall/windows/security_windows.go
@@ -83,3 +83,46 @@ const (
 )
 
 //sys	GetProfilesDirectory(dir *uint16, dirLen *uint32) (err error) = userenv.GetProfilesDirectoryW
+
+const (
+	LG_INCLUDE_INDIRECT  = 0x1
+	MAX_PREFERRED_LENGTH = 0xFFFFFFFF
+)
+
+type LocalGroupUserInfo0 struct {
+	Name *uint16
+}
+
+type UserInfo4 struct {
+	Name            *uint16
+	Password        *uint16
+	PasswordAge     uint32
+	Priv            uint32
+	HomeDir         *uint16
+	Comment         *uint16
+	Flags           uint32
+	ScriptPath      *uint16
+	AuthFlags       uint32
+	FullName        *uint16
+	UsrComment      *uint16
+	Parms           *uint16
+	Workstations    *uint16
+	LastLogon       uint32
+	LastLogoff      uint32
+	AcctExpires     uint32
+	MaxStorage      uint32
+	UnitsPerWeek    uint32
+	LogonHours      *byte
+	BadPwCount      uint32
+	NumLogons       uint32
+	LogonServer     *uint16
+	CountryCode     uint32
+	CodePage        uint32
+	UserSid         *syscall.SID
+	PrimaryGroupID  uint32
+	Profile         *uint16
+	HomeDirDrive    *uint16
+	PasswordExpired uint32
+}
+
+//sys	NetUserGetLocalGroups(serverName *uint16, userName *uint16, level uint32, flags uint32, buf **byte, prefMaxLen uint32, entriesRead *uint32, totalEntries *uint32) (neterr error) = netapi32.NetUserGetLocalGroups

--- a/src/internal/syscall/windows/zsyscall_windows.go
+++ b/src/internal/syscall/windows/zsyscall_windows.go
@@ -64,6 +64,7 @@ var (
 	procDuplicateTokenEx          = modadvapi32.NewProc("DuplicateTokenEx")
 	procSetTokenInformation       = modadvapi32.NewProc("SetTokenInformation")
 	procGetProfilesDirectoryW     = moduserenv.NewProc("GetProfilesDirectoryW")
+	procNetUserGetLocalGroups     = modnetapi32.NewProc("NetUserGetLocalGroups")
 	procGetProcessMemoryInfo      = modpsapi.NewProc("GetProcessMemoryInfo")
 )
 
@@ -297,6 +298,14 @@ func GetProfilesDirectory(dir *uint16, dirLen *uint32) (err error) {
 		} else {
 			err = syscall.EINVAL
 		}
+	}
+	return
+}
+
+func NetUserGetLocalGroups(serverName *uint16, userName *uint16, level uint32, flags uint32, buf **byte, prefMaxLen uint32, entriesRead *uint32, totalEntries *uint32) (neterr error) {
+	r0, _, _ := syscall.Syscall9(procNetUserGetLocalGroups.Addr(), 8, uintptr(unsafe.Pointer(serverName)), uintptr(unsafe.Pointer(userName)), uintptr(level), uintptr(flags), uintptr(unsafe.Pointer(buf)), uintptr(prefMaxLen), uintptr(unsafe.Pointer(entriesRead)), uintptr(unsafe.Pointer(totalEntries)), 0)
+	if r0 != 0 {
+		neterr = syscall.Errno(r0)
 	}
 	return
 }

--- a/src/os/user/user_test.go
+++ b/src/os/user/user_test.go
@@ -47,10 +47,6 @@ func compare(t *testing.T, want, got *User) {
 	if want.HomeDir != got.HomeDir {
 		t.Errorf("got HomeDir=%q; want %q", got.HomeDir, want.HomeDir)
 	}
-	// TODO: Gid is not set on Windows
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping Gid comparisons")
-	}
 	if want.Gid != got.Gid {
 		t.Errorf("got Gid=%q; want %q", got.Gid, want.Gid)
 	}


### PR DESCRIPTION
Add the following helpers in lookup_windows.go:
1) lookupGroupName() is used to obtain the SID of a group based
on name.
2) listGroupsForUsernameAndDomain() uses NetUserGetLocalGroups()
as a WINAPI backend to obtain the list of local groups for this
user.
3) lookupUserPrimaryGroup() is now used to populate the User.Gid
field when looking up a user by name.

Implement listGroups(), lookupGroupId(), lookupGroup() and no longer
return unimplemented errors.

Do not skip Windows User.Gid tests in user_test.go.
