### PR TITLE
os/signal: disable loading of history during test

### DIFF
--- a/src/os/signal/signal_cgo_test.go
+++ b/src/os/signal/signal_cgo_test.go
@@ -89,6 +89,7 @@ func TestTerminalSignal(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, bash, "--norc", "--noprofile", "-i")
+	// Clear HISTFILE so that we don't read or clobber the user's bash history.
 	cmd.Env = append(os.Environ(), "HISTFILE=")
 	cmd.Stdin = slave
 	cmd.Stdout = slave

--- a/src/os/signal/signal_cgo_test.go
+++ b/src/os/signal/signal_cgo_test.go
@@ -89,6 +89,7 @@ func TestTerminalSignal(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, bash, "--norc", "--noprofile", "-i")
+	cmd.Env = append(os.Environ(), "HISTFILE=")
 	cmd.Stdin = slave
 	cmd.Stdout = slave
 	cmd.Stderr = slave


### PR DESCRIPTION
This change modifies Go to disable loading of users' shell history for 
TestTerminalSignal tests. TestTerminalSignal, as part of its workload, 
will execute a new interactive bash shell. Bash will attempt to load the 
user's history from the file pointed to by the HISTFILE environment 
variable. For users with large histories that may take up to several 
seconds, pushing the whole test past the 5 second timeout and causing 
it to fail.