### PR TITLE
fixes #24422 leading double quote in non-quoted \t separated field

### DIFF
--- a/src/encoding/csv/reader.go
+++ b/src/encoding/csv/reader.go
@@ -289,7 +289,7 @@ parseField:
 		if r.TrimLeadingSpace {
 			line = bytes.TrimLeftFunc(line, unicode.IsSpace)
 		}
-		if len(line) == 0 || line[0] != '"' || r.Comma == '\t' {
+		if len(line) == 0 || line[0] != '"' || r.FieldsPerRecord == bytes.Count(line, []byte(string(r.Comma)))+1 {
 			// Non-quoted string field
 			i := bytes.IndexRune(line, r.Comma)
 			field := line

--- a/src/encoding/csv/reader.go
+++ b/src/encoding/csv/reader.go
@@ -289,7 +289,7 @@ parseField:
 		if r.TrimLeadingSpace {
 			line = bytes.TrimLeftFunc(line, unicode.IsSpace)
 		}
-		if len(line) == 0 || line[0] != '"' || r.FieldsPerRecord == bytes.Count(line, []byte(string(r.Comma)))+1 {
+		if len(line) == 0 || line[0] != '"' || (r.LazyQuotes && r.Comma != ',') {
 			// Non-quoted string field
 			i := bytes.IndexRune(line, r.Comma)
 			field := line

--- a/src/encoding/csv/reader.go
+++ b/src/encoding/csv/reader.go
@@ -289,7 +289,7 @@ parseField:
 		if r.TrimLeadingSpace {
 			line = bytes.TrimLeftFunc(line, unicode.IsSpace)
 		}
-		if len(line) == 0 || line[0] != '"' {
+		if len(line) == 0 || line[0] != '"' || r.Comma == '\t' {
 			// Non-quoted string field
 			i := bytes.IndexRune(line, r.Comma)
 			field := line

--- a/src/encoding/csv/reader_test.go
+++ b/src/encoding/csv/reader_test.go
@@ -41,15 +41,16 @@ func TestRead(t *testing.T) {
 		Output: [][]string{{"a", "b\rc", "d"}},
 	}, {
 		Name: "LeadingQuote",
-		Input: `name	age
-"The Rock" Dwayne Johnson	35
+		Input: `name,age
+"The Rock" Dwayne Johnson,35
 `,
 		Output: [][]string{
 			{"name", "age"},
 			{`"The Rock" Dwayne Johnson`, "35"},
 		},
-		Comma:      '\t',
-		LazyQuotes: true,
+		LazyQuotes:         true,
+		UseFieldsPerRecord: true,
+		FieldsPerRecord:    2,
 	}, {
 		Name: "RFC4180test",
 		Input: `#field1,field2,field3

--- a/src/encoding/csv/reader_test.go
+++ b/src/encoding/csv/reader_test.go
@@ -40,6 +40,17 @@ func TestRead(t *testing.T) {
 		Input:  "a,b\rc,d\r\n",
 		Output: [][]string{{"a", "b\rc", "d"}},
 	}, {
+		Name: "LeadingQuote",
+		Input: `name	age
+"The Rock" Dwayne Johnson	35
+`,
+		Output: [][]string{
+			{"name", "age"},
+			{`"The Rock" Dwayne Johnson`, "35"},
+		},
+		Comma:      '\t',
+		LazyQuotes: true,
+	}, {
 		Name: "RFC4180test",
 		Input: `#field1,field2,field3
 "aaa","bb

--- a/src/encoding/csv/reader_test.go
+++ b/src/encoding/csv/reader_test.go
@@ -41,16 +41,15 @@ func TestRead(t *testing.T) {
 		Output: [][]string{{"a", "b\rc", "d"}},
 	}, {
 		Name: "LeadingQuote",
-		Input: `name,age
-"The Rock" Dwayne Johnson,35
+		Input: `name	age
+"The Rock" Dwayne Johnson	35
 `,
 		Output: [][]string{
 			{"name", "age"},
 			{`"The Rock" Dwayne Johnson`, "35"},
 		},
-		LazyQuotes:         true,
-		UseFieldsPerRecord: true,
-		FieldsPerRecord:    2,
+		LazyQuotes: true,
+		Comma:      '\t',
 	}, {
 		Name: "RFC4180test",
 		Input: `#field1,field2,field3


### PR DESCRIPTION
fixes issue https://github.com/golang/go/issues/24422 leading double quote in non-quoted field with \t separator