### PR TITLE
path/filepath: change example to print the correct path on failure

### DIFF
--- a/src/path/filepath/example_unix_test.go
+++ b/src/path/filepath/example_unix_test.go
@@ -80,13 +80,14 @@ func ExampleJoin() {
 	// a/b/c
 	// a/b/c
 }
+
 func ExampleWalk() {
 	dir := "dir/to/walk"
 	subDirToSkip := "skip" // dir/to/walk/skip
 
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			fmt.Printf("prevent panic by handling failure accessing a path %q: %v\n", dir, err)
+			fmt.Printf("prevent panic by handling failure accessing a path %q: %v\n", path, err)
 			return err
 		}
 		if info.IsDir() && info.Name() == subDirToSkip {


### PR DESCRIPTION
This change makes errors in the example code a bit better, as it's no use to show the root dir when an error occurs walking a subdirectory or file.