### PR TITLE
misc/git: check formatting for staged changes only

### DIFF
--- a/misc/git/pre-commit
+++ b/misc/git/pre-commit
@@ -13,7 +13,21 @@
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$')
 [ -z "$gofiles" ] && exit 0
 
-unformatted=$(gofmt -l $gofiles)
+tempdir=$(mktemp -d "${TMPDIR}go_precommit.XXXXX")
+unformatted=""
+
+for file in $gofiles; do
+    tempname="$tempdir/$file"
+    relative_dir=$(dirname "$file")
+
+    mkdir -p "$tempdir/$relative_dir"
+    git show ":$file" > "$tempname"
+
+    output=$(gofmt -l "$tempname")
+
+    [ -n "$output" ] && unformatted="$unformatted $file"
+done
+
 [ -z "$unformatted" ] && exit 0
 
 # Some files are not gofmt'd. Print message and fail.

--- a/misc/git/pre-commit
+++ b/misc/git/pre-commit
@@ -30,6 +30,8 @@ done
 
 [ -z "$unformatted" ] && exit 0
 
+rm -rf $tempdir
+
 # Some files are not gofmt'd. Print message and fail.
 
 echo >&2 "Go files must be formatted with gofmt. Please run:"

--- a/misc/git/pre-commit
+++ b/misc/git/pre-commit
@@ -14,7 +14,7 @@ gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$')
 [ -z "$gofiles" ] && exit 0
 
 tempdir=$(mktemp -d "${TMPDIR}go_precommit.XXXXX")
-unformatted=""
+tempfiles=""
 
 for file in $gofiles; do
     tempname="$tempdir/$file"
@@ -23,20 +23,21 @@ for file in $gofiles; do
     mkdir -p "$tempdir/$relative_dir"
     git show ":$file" > "$tempname"
 
-    output=$(gofmt -l "$tempname")
-
-    [ -n "$output" ] && unformatted="$unformatted $file"
+    tempfiles="$tempfiles $tempname"
 done
 
-[ -z "$unformatted" ] && exit 0
+output=$(gofmt -l $tempfiles)
+output=$(echo "$output" | sed "s|$tempdir|$PWD|g")
 
 rm -rf $tempdir
+
+[ -z "$output" ] && exit 0
 
 # Some files are not gofmt'd. Print message and fail.
 
 echo >&2 "Go files must be formatted with gofmt. Please run:"
-for fn in $unformatted; do
-	echo >&2 "  gofmt -w $PWD/$fn"
+for fn in $output; do
+	echo >&2 "  gofmt -w $fn"
 done
 
 exit 1


### PR DESCRIPTION
Use case:

* Start with a correctly-formatted `.go` file
* Make some changes that are formatted correctly
* Make some other changes that are formatted incorrectly
* Use `git add -p` to stage only the correctly-formatted changes
* Commit

Since the unstaged changes won't be committed, they're outside the remit of
a pre-commit hook. With this change, the pre-commit hook will only examine
the staged version of the file.

Fixes #23136 