### PR TITLE
net/rpc: unlock client.mutex as early as possible

### DIFF
--- a/src/net/rpc/client.go
+++ b/src/net/rpc/client.go
@@ -75,8 +75,8 @@ func (client *Client) send(call *Call) {
 	// Register this call.
 	client.mutex.Lock()
 	if client.shutdown || client.closing {
-		call.Error = ErrShutdown
 		client.mutex.Unlock()
+		call.Error = ErrShutdown
 		call.done()
 		return
 	}


### PR DESCRIPTION
Although these changes have no essential influence, I think this is a better point.