### PR TITLE
cmd/go: fix typo in test inputs descriptor

### DIFF
--- a/src/cmd/go/internal/test/test.go
+++ b/src/cmd/go/internal/test/test.go
@@ -1487,7 +1487,7 @@ func computeTestInputsID(a *work.Action, testlog []byte) (cache.ActionID, error)
 			fmt.Fprintf(h, "env %s %x\n", name, hashGetenv(name))
 		case "chdir":
 			pwd = name // always absolute
-			fmt.Fprintf(h, "cbdir %s %x\n", name, hashStat(name))
+			fmt.Fprintf(h, "chdir %s %x\n", name, hashStat(name))
 		case "stat":
 			if !filepath.IsAbs(name) {
 				name = filepath.Join(pwd, name)


### PR DESCRIPTION
Presumably each line in the descriptor should match the corresponding operation.
