### PR TITLE
cmd/go/internal/load: assign .ImportPath and .Root for a testdata package in GOPATH properly

### DIFF
--- a/src/cmd/go/go_test.go
+++ b/src/cmd/go/go_test.go
@@ -6042,3 +6042,28 @@ func TestNoRelativeTmpdir(t *testing.T) {
 		tg.grepStderr("relative tmpdir", "wrong error")
 	}
 }
+
+// Issue 24854
+func TestGoListOntestdata(t *testing.T) {
+	tg := testgo(t)
+	defer tg.cleanup()
+
+	tg.tempFile("src/testdata/f1.go", `package testdata
+		import "p"
+		
+		func foo() {
+			p.bar()
+		}
+	`)
+
+	tg.tempFile("src/vendor/p/f2.go", `package p
+		import "fmt"
+		
+		func bar() {
+			fmt.Println("Hello World!")
+		}
+	`)
+	tg.setenv("GOPATH", tg.path("."))
+	tg.cd(tg.path("src/testdata"))
+	tg.run("list")
+}

--- a/src/cmd/go/main.go
+++ b/src/cmd/go/main.go
@@ -68,7 +68,7 @@ func init() {
 }
 
 func main() {
-	_ = go11tag
+	//_ = go11tag
 	flag.Usage = base.Usage
 	flag.Parse()
 	log.SetFlags(0)

--- a/src/cmd/go/main.go
+++ b/src/cmd/go/main.go
@@ -68,7 +68,7 @@ func init() {
 }
 
 func main() {
-	//_ = go11tag
+	_ = go11tag
 	flag.Usage = base.Usage
 	flag.Parse()
 	log.SetFlags(0)

--- a/src/go/build/build.go
+++ b/src/go/build/build.go
@@ -551,7 +551,7 @@ func (ctxt *Context) Import(path string, srcDir string, mode ImportMode) (*Packa
 		all := ctxt.gopath()
 		for i, root := range all {
 			rootsrc := ctxt.joinPath(root, "src")
-			if sub, ok := ctxt.hasSubdir(rootsrc, p.Dir); ok && !inTestdata(sub) {
+			if sub, ok := ctxt.hasSubdir(rootsrc, p.Dir); ok {
 				// We found a potential import path for dir,
 				// but check that using it wouldn't find something
 				// else first.


### PR DESCRIPTION
go/build.Import failed to assign values .ImportPath and .Root if a package is a local import and is a sub package of testdata. Then in cmd/go/internal/load.VendoredImportPath, the vendored import path is not expanded if the parent.Root is empty. Without the "vendor" part in the parent package, the check `filepath.Join(root, parent.ImportPath) != dir` in cmd/go/internal/load.VendoredImportPath succeeds in child imports, leading to #24854.

This PR makes go/build assign .ImportPath and .Root for a testdata package in GOPATH properly, and fixes #24854.