### PR TITLE
cmd/compile: reset branch prediction when deleting a branch

### DIFF
--- a/src/cmd/compile/internal/ssa/check.go
+++ b/src/cmd/compile/internal/ssa/check.go
@@ -98,7 +98,7 @@ func checkFunc(f *Func) {
 				f.Fatalf("plain/dead block %s has a control value", b)
 			}
 		}
-		if len(b.Succs) > 2 && b.Likely != BranchUnknown {
+		if len(b.Succs) != 2 && b.Likely != BranchUnknown {
 			f.Fatalf("likeliness prediction %d for block %s with %d successors", b.Likely, b, len(b.Succs))
 		}
 

--- a/src/cmd/compile/internal/ssa/fuse.go
+++ b/src/cmd/compile/internal/ssa/fuse.go
@@ -92,6 +92,7 @@ func fuseBlockIf(b *Block) bool {
 		b.removeEdge(1)
 	}
 	b.Kind = BlockPlain
+	b.Likely = BranchUnknown
 	b.SetControl(nil)
 
 	// Trash the empty blocks s0 & s1.

--- a/test/fixedbugs/issue23504.go
+++ b/test/fixedbugs/issue23504.go
@@ -1,0 +1,15 @@
+// compile
+
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package p
+
+func f() {
+	var B bool
+	B2 := (B || B && !B) && !B
+	B3 := B2 || B
+	for (B3 || B2) && !B2 && B {
+	}
+}


### PR DESCRIPTION
(backport / cherry-pick)

When we go from a branch block to a plain block, reset the
branch prediction bit. Downstream passes asssume that if the
branch prediction is set, then the block has 2 successors.

Fixes #23504

Change-Id: I2898ec002228b2e34fe80ce420c6939201c0a5aa
Reviewed-on: https://go-review.googlesource.com/88955
Reviewed-by: Josh Bleecher Snyder <josharian@gmail.com>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.