### PR TITLE
cmd/go/internal/load: ignore vendor imports from testdata

### DIFF
--- a/src/cmd/go/go_test.go
+++ b/src/cmd/go/go_test.go
@@ -6042,3 +6042,28 @@ func TestNoRelativeTmpdir(t *testing.T) {
 		tg.grepStderr("relative tmpdir", "wrong error")
 	}
 }
+
+// Issue 24854
+func TestGoListOntestdata(t *testing.T) {
+	tg := testgo(t)
+	defer tg.cleanup()
+
+	tg.tempFile("src/testdata/f1.go", `package testdata
+		import "p"
+		
+		func foo() {
+			p.bar()
+		}
+	`)
+
+	tg.tempFile("src/vendor/p/f2.go", `package p
+		import "fmt"
+		
+		func bar() {
+			fmt.Println("Hello World!")
+		}
+	`)
+	tg.setenv("GOPATH", tg.path("."))
+	tg.cd(tg.path("src/testdata"))
+	tg.run("list")
+}

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -1077,16 +1077,16 @@ func (p *Package) load(stk *ImportStack, bp *build.Package, err error) {
 
 	// Build list of imported packages and full dependency list.
 	imports := make([]*Package, 0, len(p.Imports))
+	var mode int
+	if p.Root == "" {
+		// may be in testdata
+		mode = 0
+	} else {
+		mode = UseVendor
+	}
 	for i, path := range importPaths {
 		if path == "C" {
 			continue
-		}
-		var mode int
-		if p.ImportPath == "" {
-			// may be in testdata
-			mode = 0
-		} else {
-			mode = UseVendor
 		}
 		p1 := LoadImport(path, p.Dir, p, stk, p.Internal.Build.ImportPos[path], mode)
 		if p.Standard && p.Error == nil && !p1.Standard && p1.Error == nil {

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -1081,7 +1081,14 @@ func (p *Package) load(stk *ImportStack, bp *build.Package, err error) {
 		if path == "C" {
 			continue
 		}
-		p1 := LoadImport(path, p.Dir, p, stk, p.Internal.Build.ImportPos[path], UseVendor)
+		var mode int
+		if p.ImportPath == "" {
+			// may be in testdata
+			mode = 0
+		} else {
+			mode = UseVendor
+		}
+		p1 := LoadImport(path, p.Dir, p, stk, p.Internal.Build.ImportPos[path], mode)
 		if p.Standard && p.Error == nil && !p1.Standard && p1.Error == nil {
 			p.Error = &PackageError{
 				ImportStack: stk.Copy(),


### PR DESCRIPTION
This is an alternative fix to #24854 

As the issue only occurs when a testdata package imports a vendor package, this PR disallows such an import. Without touching go/build package, it is hoped to avoid the controversy arising from #24868 concerning to what extent go tool should ignore testdata. If any, this PR makes go tool further ignore testdata by disallowing its vendor imports.

cc @VitalyArbuzov 

