### PR TITLE
cmd/go/internal/version: fixes version arg

### DIFF
--- a/src/cmd/go/internal/version/version.go
+++ b/src/cmd/go/internal/version/version.go
@@ -14,7 +14,7 @@ import (
 
 var CmdVersion = &base.Command{
 	Run:       runVersion,
-	UsageLine: "version",
+	UsageLine: "-v",
 	Short:     "print Go version",
 	Long:      `Version prints the Go version, as reported by runtime.Version.`,
 }


### PR DESCRIPTION
Fixes https://github.com/adamgj/go/issues/1

Expected `go -v` to return version