### PR TITLE
doc: correct statement in go1.10 release notes

### DIFF
--- a/doc/go1.10.html
+++ b/doc/go1.10.html
@@ -45,7 +45,7 @@ There are no significant changes to the language specification.
 <p><!-- CL 60230 -->
 A corner case involving shifts by untyped constants has been clarified,
 and as a result the compilers have been updated to allow the index expression
-<code>x[1.0</code>&nbsp;<code>&lt;&lt;</code>&nbsp;<code>s]</code> where <code>s</code> is an untyped constant;
+<code>x[1.0</code>&nbsp;<code>&lt;&lt;</code>&nbsp;<code>s]</code> where <code>s</code> is an unsigned integer;
 the <a href="/pkg/go/types/">go/types</a> package already did.
 </p>
 


### PR DESCRIPTION
The language spec requires the RHS operand of shift expressions to be unsigned integers.

The changes in CL 60230 and the related CL 81277 refer to a variable s of type uint.
The "untyped constant" here refers to 1.0, not s.