### PR TITLE
net/http: explain more how Pusher.Push works

### DIFF
--- a/src/net/http/http.go
+++ b/src/net/http/http.go
@@ -135,6 +135,10 @@ type Pusher interface {
 	// data that may trigger a request for URL X. This avoids a race where the
 	// client issues requests for X before receiving the PUSH_PROMISE for X.
 	//
+	// Push will run in a separate goroutine making the order of arrival
+	// non-deterministic. Any required synchronization needs to be implemented
+	// by the caller.
+	//
 	// Push returns ErrNotSupported if the client has disabled push or if push
 	// is not supported on the underlying connection.
 	Push(target string, opts *PushOptions) error


### PR DESCRIPTION
This will clarify that the resources are not completely pushed yet when `Push` returns and that it starts a separate goroutine. This might be implementation dependant but as I believe there is currently only one implementation it should be added to the documentation of the interface which most people will look up first.
