### PR TITLE
os/exec: fix Win32 tests missing 'chcp'

### DIFF
--- a/src/os/exec/lp_windows_test.go
+++ b/src/os/exec/lp_windows_test.go
@@ -117,7 +117,7 @@ func createEnv(dir, PATH, PATHEXT string) []string {
 		dirs[i] = filepath.Join(dir, dirs[i])
 	}
 	path := strings.Join(dirs, ";")
-	env = updateEnv(env, "PATH", path)
+	env = updateEnv(env, "PATH", os.Getenv("SystemRoot") + "/System32;" + path)
 	return env
 }
 


### PR DESCRIPTION
'%SystemRoot%/System32/chcp.com' is a tool on Windows that
is used to change the active code page in the console.

'go test os/exec' can fail with:
"'chcp' is not recognized as an internal or external command"

The test uses a custom PATH variable but does not include
'%SystemRoot%/System32'. Always append that to PATH.

Updates #24709
