### PR TITLE
path/filepath: fix Win32 tests missing 'chcp'

### DIFF
--- a/src/path/filepath/path_windows_test.go
+++ b/src/path/filepath/path_windows_test.go
@@ -79,7 +79,7 @@ func testWinSplitListTestIsValid(t *testing.T, ti int, tt SplitListTest,
 		cmd := &exec.Cmd{
 			Path: comspec,
 			Args: []string{`/c`, cmdfile},
-			Env:  []string{`Path=` + tt.list, `SystemRoot=` + systemRoot},
+			Env:  []string{`Path=` + systemRoot + "/System32;" + tt.list, `SystemRoot=` + systemRoot},
 			Dir:  tmp,
 		}
 		out, err := cmd.CombinedOutput()


### PR DESCRIPTION
'%SystemRoot%/System32/chcp.com' is a tool on Windows that
is used to change the active code page in the console.

'go test path/filepath' can fail with:
"'chcp' is not recognized as an internal or external command"

The test uses a custom PATH variable but does not include
'%SystemRoot%/System32'. Always append that to PATH.

Updates #24709
