### PR TITLE
net/http: use HTTP methods constants

### DIFF
--- a/misc/linkcheck/linkcheck.go
+++ b/misc/linkcheck/linkcheck.go
@@ -120,7 +120,7 @@ func crawlLoop() {
 func doCrawl(url string) error {
 	defer wg.Done()
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/vet/testdata/httpresponse.go
+++ b/src/cmd/vet/testdata/httpresponse.go
@@ -58,7 +58,7 @@ func badClientGet() {
 
 func badClientPtrDo() {
 	client := http.DefaultClient
-	req, err := http.NewRequest("GET", "http://foo.com", nil)
+	req, err := http.NewRequest(http.MethodGet, "http://foo.com", nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func badClientPtrDo() {
 
 func badClientDo() {
 	var client http.Client
-	req, err := http.NewRequest("GET", "http://foo.com", nil)
+	req, err := http.NewRequest(http.MethodGet, "http://foo.com", nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/src/net/http/cgi/host_test.go
+++ b/src/net/http/cgi/host_test.go
@@ -382,7 +382,7 @@ func TestCopyError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req, _ := http.NewRequest("GET", "http://example.com/test.cgi?bigresponse=1", nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com/test.cgi?bigresponse=1", nil)
 	err = req.Write(conn)
 	if err != nil {
 		t.Fatalf("Write: %v", err)
@@ -524,7 +524,7 @@ func TestEnvOverride(t *testing.T) {
 			"PATH=/wibble"},
 	}
 	expectedMap := map[string]string{
-		"cwd":                 cwd,
+		"cwd": cwd,
 		"env-SCRIPT_FILENAME": cgifile,
 		"env-REQUEST_URI":     "/foo/bar",
 		"env-PATH":            "/wibble",

--- a/src/net/http/cgi/matryoshka_test.go
+++ b/src/net/http/cgi/matryoshka_test.go
@@ -104,7 +104,7 @@ func TestKillChildAfterCopyError(t *testing.T) {
 		Root: "/test.go",
 		Args: []string{"-test.run=TestBeChildCGIProcess"},
 	}
-	req, _ := http.NewRequest("GET", "http://example.com/test.cgi?write-forever=1", nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com/test.cgi?write-forever=1", nil)
 	rec := httptest.NewRecorder()
 	var out bytes.Buffer
 	const writeLen = 50 << 10

--- a/src/net/http/client.go
+++ b/src/net/http/client.go
@@ -389,7 +389,7 @@ func Get(url string) (resp *Response, err error) {
 //
 // To make a request with custom headers, use NewRequest and Client.Do.
 func (c *Client) Get(url string) (resp *Response, err error) {
-	req, err := NewRequest("GET", url, nil)
+	req, err := NewRequest(MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -734,7 +734,7 @@ func Post(url, contentType string, body io.Reader) (resp *Response, err error) {
 // See the Client.Do method documentation for details on how redirects
 // are handled.
 func (c *Client) Post(url, contentType string, body io.Reader) (resp *Response, err error) {
-	req, err := NewRequest("POST", url, body)
+	req, err := NewRequest(MethodPost, url, body)
 	if err != nil {
 		return nil, err
 	}
@@ -799,7 +799,7 @@ func Head(url string) (resp *Response, err error) {
 //    307 (Temporary Redirect)
 //    308 (Permanent Redirect)
 func (c *Client) Head(url string) (resp *Response, err error) {
-	req, err := NewRequest("HEAD", url, nil)
+	req, err := NewRequest(MethodPost, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/src/net/http/clientserver_test.go
+++ b/src/net/http/clientserver_test.go
@@ -530,7 +530,7 @@ func testCancelRequestMidBody(t *testing.T, h2 bool) {
 	defer cst.close()
 	defer close(unblock)
 
-	req, _ := NewRequest("GET", cst.ts.URL, nil)
+	req, _ := NewRequest(MethodGet, cst.ts.URL, nil)
 	cancel := make(chan struct{})
 	req.Cancel = cancel
 
@@ -594,7 +594,7 @@ func testTrailersClientToServer(t *testing.T, h2 bool) {
 	defer cst.close()
 
 	var req *Request
-	req, _ = NewRequest("POST", cst.ts.URL, io.MultiReader(
+	req, _ = NewRequest(MethodPost, cst.ts.URL, io.MultiReader(
 		eofReaderFunc(func() {
 			req.Trailer["Client-Trailer-A"] = []string{"valuea"}
 		}),
@@ -752,7 +752,7 @@ func testConcurrentReadWriteReqBody(t *testing.T, h2 bool) {
 		wg.Wait()
 	}))
 	defer cst.close()
-	req, _ := NewRequest("POST", cst.ts.URL, strings.NewReader(reqBody))
+	req, _ := NewRequest(MethodPost, cst.ts.URL, strings.NewReader(reqBody))
 	req.Header.Add("Expect", "100-continue") // just to complicate things
 	res, err := cst.c.Do(req)
 	if err != nil {
@@ -868,7 +868,7 @@ func testTransportUserAgent(t *testing.T, h2 bool) {
 		},
 	}
 	for i, tt := range tests {
-		req, _ := NewRequest("GET", cst.ts.URL, nil)
+		req, _ := NewRequest(MethodGet, cst.ts.URL, nil)
 		tt.setup(req)
 		res, err := cst.c.Do(req)
 		if err != nil {
@@ -1056,7 +1056,7 @@ func testTransportGCRequest(t *testing.T, h2, body bool) {
 	didGC := make(chan struct{})
 	(func() {
 		body := strings.NewReader("some body")
-		req, _ := NewRequest("POST", cst.ts.URL, body)
+		req, _ := NewRequest(MethodPost, cst.ts.URL, body)
 		runtime.SetFinalizer(req, func(*Request) { close(didGC) })
 		res, err := cst.c.Do(req)
 		if err != nil {
@@ -1118,7 +1118,7 @@ func testTransportRejectsInvalidHeaders(t *testing.T, h2 bool) {
 			dialedc <- true
 			return net.Dial(netw, addr)
 		}
-		req, _ := NewRequest("GET", cst.ts.URL, nil)
+		req, _ := NewRequest(MethodGet, cst.ts.URL, nil)
 		req.Header[tt.key] = []string{tt.val}
 		res, err := cst.c.Do(req)
 		var body []byte
@@ -1314,7 +1314,7 @@ func testNoSniffExpectRequestBody(t *testing.T, h2 bool) {
 	// Set ExpectContinueTimeout non-zero so RoundTrip won't try to write it.
 	cst.tr.ExpectContinueTimeout = 10 * time.Second
 
-	req, err := NewRequest("POST", cst.ts.URL, testErrorReader{t})
+	req, err := NewRequest(MethodPost, cst.ts.URL, testErrorReader{t})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/net/http/cookie_test.go
+++ b/src/net/http/cookie_test.go
@@ -187,7 +187,7 @@ var addCookieTests = []struct {
 
 func TestAddCookie(t *testing.T) {
 	for i, tt := range addCookieTests {
-		req, _ := NewRequest("GET", "http://example.com/", nil)
+		req, _ := NewRequest(MethodGet, "http://example.com/", nil)
 		for _, c := range tt.Cookies {
 			req.AddCookie(c)
 		}

--- a/src/net/http/doc.go
+++ b/src/net/http/doc.go
@@ -34,7 +34,7 @@ settings, create a Client:
 	resp, err := client.Get("http://example.com")
 	// ...
 
-	req, err := http.NewRequest("GET", "http://example.com", nil)
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
 	// ...
 	req.Header.Add("If-None-Match", `W/"wyzzy"`)
 	resp, err := client.Do(req)

--- a/src/net/http/fs_test.go
+++ b/src/net/http/fs_test.go
@@ -254,7 +254,7 @@ func TestFileServerCleans(t *testing.T) {
 		{"//foo.txt", "/foo.txt"},
 		{"/../foo.txt", "/foo.txt"},
 	}
-	req, _ := NewRequest("GET", "http://example.com", nil)
+	req, _ := NewRequest(MethodGet, "http://example.com", nil)
 	for n, test := range tests {
 		rec := httptest.NewRecorder()
 		req.URL.Path = test.reqPath
@@ -702,7 +702,7 @@ func TestDirectoryIfNotModified(t *testing.T) {
 		t.Fatalf("initial Last-Modified = %q; want %q", lastMod, fileModStr)
 	}
 
-	req, _ := NewRequest("GET", ts.URL, nil)
+	req, _ := NewRequest(MethodGet, ts.URL, nil)
 	req.Header.Set("If-Modified-Since", lastMod)
 
 	c := ts.Client()
@@ -1037,7 +1037,7 @@ func TestServeContent(t *testing.T) {
 // Issue 12991
 func TestServerFileStatError(t *testing.T) {
 	rec := httptest.NewRecorder()
-	r, _ := NewRequest("GET", "http://foo/", nil)
+	r, _ := NewRequest(MethodGet, "http://foo/", nil)
 	redirect := false
 	name := "file.txt"
 	fs := issue12991FS{}
@@ -1240,7 +1240,7 @@ func TestFileServerCleanPath(t *testing.T) {
 	for _, tt := range tests {
 		var log []string
 		rr := httptest.NewRecorder()
-		req, _ := NewRequest("GET", "http://foo.localhost"+tt.path, nil)
+		req, _ := NewRequest(MethodGet, "http://foo.localhost"+tt.path, nil)
 		FileServer(fileServerCleanPathDir{&log}).ServeHTTP(rr, req)
 		if !reflect.DeepEqual(log, tt.wantOpen) {
 			t.Logf("For %s: Opens = %q; want %q", tt.path, log, tt.wantOpen)

--- a/src/net/http/httptest/example_test.go
+++ b/src/net/http/httptest/example_test.go
@@ -18,7 +18,7 @@ func ExampleResponseRecorder() {
 		io.WriteString(w, "<html><body>Hello World!</body></html>")
 	}
 
-	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/foo", nil)
 	w := httptest.NewRecorder()
 	handler(w, req)
 

--- a/src/net/http/httptest/recorder_test.go
+++ b/src/net/http/httptest/recorder_test.go
@@ -274,7 +274,7 @@ func TestRecorder(t *testing.T) {
 			check(hasStatus(200), hasContents("Some body"), hasContentLength(9)),
 		},
 	}
-	r, _ := http.NewRequest("GET", "http://foo.com/", nil)
+	r, _ := http.NewRequest(http.MethodGet, "http://foo.com/", nil)
 	for _, tt := range tests {
 		h := http.HandlerFunc(tt.h)
 		rec := NewRecorder()

--- a/src/net/http/httptrace/example_test.go
+++ b/src/net/http/httptrace/example_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Example() {
-	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
 	trace := &httptrace.ClientTrace{
 		GotConn: func(connInfo httptrace.GotConnInfo) {
 			fmt.Printf("Got Conn: %+v\n", connInfo)

--- a/src/net/http/httputil/dump_test.go
+++ b/src/net/http/httputil/dump_test.go
@@ -67,7 +67,7 @@ var dumpTests = []dumpTest{
 	},
 
 	{
-		Req: *mustNewRequest("GET", "http://example.com/foo", nil),
+		Req: *mustNewRequest(http.MethodGet, "http://example.com/foo", nil),
 
 		WantDumpOut: "GET /foo HTTP/1.1\r\n" +
 			"Host: example.com\r\n" +
@@ -79,7 +79,7 @@ var dumpTests = []dumpTest{
 	// with a bytes.Buffer and hang with all goroutines not
 	// runnable.
 	{
-		Req: *mustNewRequest("GET", "https://example.com/foo", nil),
+		Req: *mustNewRequest(http.MethodGet, "https://example.com/foo", nil),
 
 		WantDumpOut: "GET /foo HTTP/1.1\r\n" +
 			"Host: example.com\r\n" +
@@ -187,7 +187,7 @@ var dumpTests = []dumpTest{
 	// Issue 18506: make drainBody recognize NoBody. Otherwise
 	// this was turning into a chunked request.
 	{
-		Req: *mustNewRequest("POST", "http://example.com/foo", http.NoBody),
+		Req: *mustNewRequest(http.MethodPost, "http://example.com/foo", http.NoBody),
 
 		WantDumpOut: "POST /foo HTTP/1.1\r\n" +
 			"Host: example.com\r\n" +

--- a/src/net/http/httputil/example_test.go
+++ b/src/net/http/httputil/example_test.go
@@ -28,7 +28,7 @@ func ExampleDumpRequest() {
 	defer ts.Close()
 
 	const body = "Go is a general-purpose language designed with systems programming in mind."
-	req, err := http.NewRequest("POST", ts.URL, strings.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, ts.URL, strings.NewReader(body))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func ExampleDumpRequest() {
 
 func ExampleDumpRequestOut() {
 	const body = "Go is a general-purpose language designed with systems programming in mind."
-	req, err := http.NewRequest("PUT", "http://www.example.org", strings.NewReader(body))
+	req, err := http.NewRequest(http.MethodPut, "http://www.example.org", strings.NewReader(body))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/src/net/http/httputil/reverseproxy_test.go
+++ b/src/net/http/httputil/reverseproxy_test.go
@@ -82,7 +82,7 @@ func TestReverseProxy(t *testing.T) {
 	defer frontend.Close()
 	frontendClient := frontend.Client()
 
-	getReq, _ := http.NewRequest("GET", frontend.URL, nil)
+	getReq, _ := http.NewRequest(http.MethodGet, frontend.URL, nil)
 	getReq.Host = "some-name"
 	getReq.Header.Set("Connection", "close")
 	getReq.Header.Set("Proxy-Connection", "should be deleted")
@@ -129,7 +129,7 @@ func TestReverseProxy(t *testing.T) {
 
 	// Test that a backend failing to be reached or one which doesn't return
 	// a response results in a StatusBadGateway.
-	getReq, _ = http.NewRequest("GET", frontend.URL+"/?mode=hangup", nil)
+	getReq, _ = http.NewRequest(http.MethodGet, frontend.URL+"/?mode=hangup", nil)
 	getReq.Close = true
 	res, err = frontendClient.Do(getReq)
 	if err != nil {
@@ -173,7 +173,7 @@ func TestReverseProxyStripHeadersPresentInConnection(t *testing.T) {
 	}))
 	defer frontend.Close()
 
-	getReq, _ := http.NewRequest("GET", frontend.URL, nil)
+	getReq, _ := http.NewRequest(http.MethodGet, frontend.URL, nil)
 	getReq.Header.Set("Connection", "Upgrade, "+fakeConnectionToken)
 	getReq.Header.Set("Upgrade", "original value")
 	getReq.Header.Set(fakeConnectionToken, "should be deleted")
@@ -220,7 +220,7 @@ func TestXForwardedFor(t *testing.T) {
 	frontend := httptest.NewServer(proxyHandler)
 	defer frontend.Close()
 
-	getReq, _ := http.NewRequest("GET", frontend.URL, nil)
+	getReq, _ := http.NewRequest(http.MethodGet, frontend.URL, nil)
 	getReq.Host = "some-name"
 	getReq.Header.Set("Connection", "close")
 	getReq.Header.Set("X-Forwarded-For", prevForwardedFor)
@@ -262,7 +262,7 @@ func TestReverseProxyQuery(t *testing.T) {
 			t.Fatal(err)
 		}
 		frontend := httptest.NewServer(NewSingleHostReverseProxy(backendURL))
-		req, _ := http.NewRequest("GET", frontend.URL+tt.reqSuffix, nil)
+		req, _ := http.NewRequest(http.MethodGet, frontend.URL+tt.reqSuffix, nil)
 		req.Close = true
 		res, err := frontend.Client().Do(req)
 		if err != nil {
@@ -298,7 +298,7 @@ func TestReverseProxyFlushInterval(t *testing.T) {
 	frontend := httptest.NewServer(proxyHandler)
 	defer frontend.Close()
 
-	req, _ := http.NewRequest("GET", frontend.URL, nil)
+	req, _ := http.NewRequest(http.MethodGet, frontend.URL, nil)
 	req.Close = true
 	res, err := frontend.Client().Do(req)
 	if err != nil {
@@ -356,7 +356,7 @@ func TestReverseProxyCancelation(t *testing.T) {
 	defer frontend.Close()
 	frontendClient := frontend.Client()
 
-	getReq, _ := http.NewRequest("GET", frontend.URL, nil)
+	getReq, _ := http.NewRequest(http.MethodGet, frontend.URL, nil)
 	go func() {
 		<-reqInFlight
 		frontendClient.Transport.(*http.Transport).CancelRequest(getReq)
@@ -436,7 +436,7 @@ func TestUserAgentHeader(t *testing.T) {
 	defer frontend.Close()
 	frontendClient := frontend.Client()
 
-	getReq, _ := http.NewRequest("GET", frontend.URL, nil)
+	getReq, _ := http.NewRequest(http.MethodGet, frontend.URL, nil)
 	getReq.Header.Set("User-Agent", explicitUA)
 	getReq.Close = true
 	res, err := frontendClient.Do(getReq)
@@ -445,7 +445,7 @@ func TestUserAgentHeader(t *testing.T) {
 	}
 	res.Body.Close()
 
-	getReq, _ = http.NewRequest("GET", frontend.URL+"/noua", nil)
+	getReq, _ = http.NewRequest(http.MethodGet, frontend.URL+"/noua", nil)
 	getReq.Header.Set("User-Agent", "")
 	getReq.Close = true
 	res, err = frontendClient.Do(getReq)
@@ -498,7 +498,7 @@ func TestReverseProxyGetPutBuffer(t *testing.T) {
 	frontend := httptest.NewServer(rp)
 	defer frontend.Close()
 
-	req, _ := http.NewRequest("GET", frontend.URL, nil)
+	req, _ := http.NewRequest(http.MethodGet, frontend.URL, nil)
 	req.Close = true
 	res, err := frontend.Client().Do(req)
 	if err != nil {
@@ -546,7 +546,7 @@ func TestReverseProxy_Post(t *testing.T) {
 	frontend := httptest.NewServer(proxyHandler)
 	defer frontend.Close()
 
-	postReq, _ := http.NewRequest("POST", frontend.URL, bytes.NewReader(requestBody))
+	postReq, _ := http.NewRequest(http.MethodPost, frontend.URL, bytes.NewReader(requestBody))
 	res, err := frontend.Client().Do(postReq)
 	if err != nil {
 		t.Fatalf("Do: %v", err)
@@ -695,7 +695,7 @@ func BenchmarkServeHTTP(b *testing.B) {
 	}
 
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "/", nil)
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -744,7 +744,7 @@ func TestServeHTTPDeepCopy(t *testing.T) {
 // Issue 18327: verify we always do a deep copy of the Request.Header map
 // before any mutations.
 func TestClonesRequestHeaders(t *testing.T) {
-	req, _ := http.NewRequest("GET", "http://foo.tld/", nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://foo.tld/", nil)
 	req.RemoteAddr = "1.2.3.4:56789"
 	rp := &ReverseProxy{
 		Director: func(req *http.Request) {
@@ -775,7 +775,7 @@ func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) 
 }
 
 func TestModifyResponseClosesBody(t *testing.T) {
-	req, _ := http.NewRequest("GET", "http://foo.tld/", nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://foo.tld/", nil)
 	req.RemoteAddr = "1.2.3.4:56789"
 	closeCheck := new(checkCloser)
 	logBuf := new(bytes.Buffer)
@@ -846,6 +846,6 @@ func TestReverseProxy_PanicBodyError(t *testing.T) {
 			t.Fatal("expected ErrAbortHandler, got", err)
 		}
 	}()
-	req, _ := http.NewRequest("GET", "http://foo.tld/", nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://foo.tld/", nil)
 	rproxy.ServeHTTP(httptest.NewRecorder(), req)
 }

--- a/src/net/http/npn_test.go
+++ b/src/net/http/npn_test.go
@@ -116,7 +116,7 @@ func handleTLSProtocol09(srv *Server, conn *tls.Conn, h Handler) {
 	if path == line {
 		return
 	}
-	req, _ := NewRequest("GET", path, nil)
+	req, _ := NewRequest(MethodGet, path, nil)
 	req.Proto = "HTTP/0.9"
 	req.ProtoMajor = 0
 	req.ProtoMinor = 9

--- a/src/net/http/pprof/pprof_test.go
+++ b/src/net/http/pprof/pprof_test.go
@@ -31,7 +31,7 @@ func TestHandlers(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.path, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "http://example.com"+tc.path, nil)
+			req := httptest.NewRequest(http.MethodGet, "http://example.com"+tc.path, nil)
 			w := httptest.NewRecorder()
 			tc.handler(w, req)
 

--- a/src/net/http/requestwrite_test.go
+++ b/src/net/http/requestwrite_test.go
@@ -716,7 +716,7 @@ func (rc *closeChecker) Close() error {
 // inside a NopCloser, and that it serializes it correctly.
 func TestRequestWriteClosesBody(t *testing.T) {
 	rc := &closeChecker{Reader: strings.NewReader("my body")}
-	req, err := NewRequest("POST", "http://foo.com/", rc)
+	req, err := NewRequest(MethodPost, "http://foo.com/", rc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -778,7 +778,7 @@ func TestRequestWriteError(t *testing.T) {
 		}),
 	}
 
-	req, _ := NewRequest("GET", "http://example.com/", nil)
+	req, _ := NewRequest(MethodGet, "http://example.com/", nil)
 	const writeCalls = 4 // number of Write calls in current implementation
 	sawGood := false
 	for n := 0; n <= writeCalls+2; n++ {

--- a/src/net/http/transport_internal_test.go
+++ b/src/net/http/transport_internal_test.go
@@ -30,7 +30,7 @@ func TestTransportPersistConnReadLoopEOF(t *testing.T) {
 	}()
 
 	tr := new(Transport)
-	req, _ := NewRequest("GET", "http://"+ln.Addr().String(), nil)
+	req, _ := NewRequest(MethodGet, "http://"+ln.Addr().String(), nil)
 	req = req.WithT(t)
 	treq := &transportRequest{Request: req}
 	cm := connectMethod{targetScheme: "http", targetAddr: ln.Addr().String()}


### PR DESCRIPTION
There are few places where http method literal is used.
I think that it's better to use constants in terms of readability.