### PR TITLE
Remove "Setting GOROOT" custom install instruction

### DIFF
--- a/doc/install.html
+++ b/doc/install.html
@@ -114,31 +114,6 @@ or execute them from the profile using a command such as
 <code>source $HOME/.profile</code>.
 </p>
 
-<h4 id="tarball_non_standard">Installing to a custom location</h4>
-
-<p>
-The Go binary distributions assume they will be installed in
-<code>/usr/local/go</code> (or <code>c:\Go</code> under Windows),
-but it is possible to install the Go tools to a different location.
-In this case you must set the <code>GOROOT</code> environment variable
-to point to the directory in which it was installed.
-</p>
-
-<p>
-For example, if you installed Go to your home directory you should add
-commands like the following to <code>$HOME/.profile</code>:
-</p>
-
-<pre>
-export GOROOT=$HOME/go1.X
-export PATH=$PATH:$GOROOT/bin
-</pre>
-
-<p>
-<b>Note</b>: <code>GOROOT</code> must be set only when installing to a custom
-location.
-</p>
-
 </div><!-- tarballInstructions -->
 
 <div id="darwinPackageInstructions">


### PR DESCRIPTION
doc: Setting GOROOT is no longer necessary for custom installation as of 1.10 (https://go-review.googlesource.com/c/go/+/42533)

Fixes https://github.com/golang/go/issues/25002

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them