### PR TITLE
encoding/json: include property name for marshal errors

### DIFF
--- a/src/encoding/json/encode.go
+++ b/src/encoding/json/encode.go
@@ -695,7 +695,7 @@ func (me *mapEncoder) encode(e *encodeState, v reflect.Value, opts encOpts) {
 	for i, v := range keys {
 		sv[i].v = v
 		if err := sv[i].resolve(); err != nil {
-			e.error(&MarshalerError{v.Type(), v, opts.nest(v.String()).path, err})
+			e.error(&MarshalerError{v.Type(), v, append(opts.path, v.String()), err})
 		}
 	}
 	sort.Slice(sv, func(i, j int) bool { return sv[i].s < sv[j].s })

--- a/src/encoding/json/encode.go
+++ b/src/encoding/json/encode.go
@@ -783,7 +783,7 @@ func (ae *arrayEncoder) encode(e *encodeState, v reflect.Value, opts encOpts) {
 		if i > 0 {
 			e.WriteByte(',')
 		}
-		ae.elemEnc(e, v.Index(i), opts.nest("["+strconv.Itoa(i)+"]"))
+		ae.elemEnc(e, v.Index(i), opts.nest(strconv.Itoa(i)))
 	}
 	e.WriteByte(']')
 }

--- a/src/encoding/json/encode.go
+++ b/src/encoding/json/encode.go
@@ -261,11 +261,16 @@ func (e *InvalidUTF8Error) Error() string {
 
 type MarshalerError struct {
 	Type reflect.Type
+	Path []string
 	Err  error
 }
 
 func (e *MarshalerError) Error() string {
-	return "json: error calling MarshalJSON for type " + e.Type.String() + ": " + e.Err.Error()
+	if len(e.Path) > 0 {
+		return "json: error calling MarshalJSON for " + strings.Join(e.Path, ".") + " (type " + e.Type.String() + "): " + e.Err.Error()
+	} else {
+		return "json: error calling MarshalJSON for type " + e.Type.String() + ": " + e.Err.Error()
+	}
 }
 
 var hex = "0123456789abcdef"
@@ -338,6 +343,16 @@ type encOpts struct {
 	quoted bool
 	// escapeHTML causes '<', '>', and '&' to be escaped in JSON strings.
 	escapeHTML bool
+	// path keeps breadcrumbs of properties being marshaled for complex types.
+	path []string
+}
+
+// nest returns a copy of the original encOpts with an addition member added to
+// the path list, to indicate the hierarchy of the encoding process. (this is
+// copied to prevent clobbering path among siblings)
+func (opts encOpts) nest(path string) encOpts {
+	opts.path = append(opts.path, path)
+	return opts
 }
 
 type encoderFunc func(e *encodeState, v reflect.Value, opts encOpts)
@@ -456,11 +471,11 @@ func marshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 		err = compact(&e.Buffer, b, opts.escapeHTML)
 	}
 	if err != nil {
-		e.error(&MarshalerError{v.Type(), err})
+		e.error(&MarshalerError{v.Type(), opts.path, err})
 	}
 }
 
-func addrMarshalerEncoder(e *encodeState, v reflect.Value, _ encOpts) {
+func addrMarshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 	va := v.Addr()
 	if va.IsNil() {
 		e.WriteString("null")
@@ -473,7 +488,7 @@ func addrMarshalerEncoder(e *encodeState, v reflect.Value, _ encOpts) {
 		err = compact(&e.Buffer, b, true)
 	}
 	if err != nil {
-		e.error(&MarshalerError{v.Type(), err})
+		e.error(&MarshalerError{v.Type(), opts.path, err})
 	}
 }
 
@@ -485,7 +500,7 @@ func textMarshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 	m := v.Interface().(encoding.TextMarshaler)
 	b, err := m.MarshalText()
 	if err != nil {
-		e.error(&MarshalerError{v.Type(), err})
+		e.error(&MarshalerError{v.Type(), opts.path, err})
 	}
 	e.stringBytes(b, opts.escapeHTML)
 }
@@ -499,7 +514,7 @@ func addrTextMarshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 	m := va.Interface().(encoding.TextMarshaler)
 	b, err := m.MarshalText()
 	if err != nil {
-		e.error(&MarshalerError{v.Type(), err})
+		e.error(&MarshalerError{v.Type(), opts.path, err})
 	}
 	e.stringBytes(b, opts.escapeHTML)
 }
@@ -643,8 +658,9 @@ func (se *structEncoder) encode(e *encodeState, v reflect.Value, opts encOpts) {
 		}
 		e.string(f.name, opts.escapeHTML)
 		e.WriteByte(':')
-		opts.quoted = f.quoted
-		se.fieldEncs[i](e, fv, opts)
+		o := opts.nest(f.name)
+		o.quoted = f.quoted
+		se.fieldEncs[i](e, fv, o)
 	}
 	e.WriteByte('}')
 }
@@ -678,7 +694,7 @@ func (me *mapEncoder) encode(e *encodeState, v reflect.Value, opts encOpts) {
 	for i, v := range keys {
 		sv[i].v = v
 		if err := sv[i].resolve(); err != nil {
-			e.error(&MarshalerError{v.Type(), err})
+			e.error(&MarshalerError{v.Type(), opts.nest(v.String()).path, err})
 		}
 	}
 	sort.Slice(sv, func(i, j int) bool { return sv[i].s < sv[j].s })
@@ -689,7 +705,7 @@ func (me *mapEncoder) encode(e *encodeState, v reflect.Value, opts encOpts) {
 		}
 		e.string(kv.s, opts.escapeHTML)
 		e.WriteByte(':')
-		me.elemEnc(e, v.MapIndex(kv.v), opts)
+		me.elemEnc(e, v.MapIndex(kv.v), opts.nest(kv.s))
 	}
 	e.WriteByte('}')
 }
@@ -766,7 +782,7 @@ func (ae *arrayEncoder) encode(e *encodeState, v reflect.Value, opts encOpts) {
 		if i > 0 {
 			e.WriteByte(',')
 		}
-		ae.elemEnc(e, v.Index(i), opts)
+		ae.elemEnc(e, v.Index(i), opts.nest("["+strconv.Itoa(i)+"]"))
 	}
 	e.WriteByte(']')
 }

--- a/src/encoding/json/encode.go
+++ b/src/encoding/json/encode.go
@@ -260,9 +260,10 @@ func (e *InvalidUTF8Error) Error() string {
 }
 
 type MarshalerError struct {
-	Type reflect.Type
-	Path []string
-	Err  error
+	Type  reflect.Type
+	Value reflect.Value
+	Path  []string
+	Err   error
 }
 
 func (e *MarshalerError) Error() string {
@@ -471,7 +472,7 @@ func marshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 		err = compact(&e.Buffer, b, opts.escapeHTML)
 	}
 	if err != nil {
-		e.error(&MarshalerError{v.Type(), opts.path, err})
+		e.error(&MarshalerError{v.Type(), v, opts.path, err})
 	}
 }
 
@@ -488,7 +489,7 @@ func addrMarshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 		err = compact(&e.Buffer, b, true)
 	}
 	if err != nil {
-		e.error(&MarshalerError{v.Type(), opts.path, err})
+		e.error(&MarshalerError{v.Type(), v, opts.path, err})
 	}
 }
 
@@ -500,7 +501,7 @@ func textMarshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 	m := v.Interface().(encoding.TextMarshaler)
 	b, err := m.MarshalText()
 	if err != nil {
-		e.error(&MarshalerError{v.Type(), opts.path, err})
+		e.error(&MarshalerError{v.Type(), v, opts.path, err})
 	}
 	e.stringBytes(b, opts.escapeHTML)
 }
@@ -514,7 +515,7 @@ func addrTextMarshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 	m := va.Interface().(encoding.TextMarshaler)
 	b, err := m.MarshalText()
 	if err != nil {
-		e.error(&MarshalerError{v.Type(), opts.path, err})
+		e.error(&MarshalerError{v.Type(), v, opts.path, err})
 	}
 	e.stringBytes(b, opts.escapeHTML)
 }
@@ -694,7 +695,7 @@ func (me *mapEncoder) encode(e *encodeState, v reflect.Value, opts encOpts) {
 	for i, v := range keys {
 		sv[i].v = v
 		if err := sv[i].resolve(); err != nil {
-			e.error(&MarshalerError{v.Type(), opts.nest(v.String()).path, err})
+			e.error(&MarshalerError{v.Type(), v, opts.nest(v.String()).path, err})
 		}
 	}
 	sort.Slice(sv, func(i, j int) bool { return sv[i].s < sv[j].s })

--- a/src/encoding/json/encode_test.go
+++ b/src/encoding/json/encode_test.go
@@ -1029,7 +1029,7 @@ func TestMarshalErrorMessage(t *testing.T) {
 		// checking slice indexes
 		{
 			in:   []time.Time{badTime},
-			want: "json: error calling MarshalJSON for [0] (type time.Time): Time.MarshalJSON: year outside of range [0,9999]",
+			want: "json: error calling MarshalJSON for 0 (type time.Time): Time.MarshalJSON: year outside of range [0,9999]",
 		},
 		// checking complex values (mixing slice, struct and map)
 		{
@@ -1046,7 +1046,7 @@ func TestMarshalErrorMessage(t *testing.T) {
 					},
 				},
 			},
-			want: "json: error calling MarshalJSON for [0].m.t (type time.Time): Time.MarshalJSON: year outside of range [0,9999]",
+			want: "json: error calling MarshalJSON for 0.m.t (type time.Time): Time.MarshalJSON: year outside of range [0,9999]",
 		},
 	}
 

--- a/src/encoding/json/encode_test.go
+++ b/src/encoding/json/encode_test.go
@@ -999,13 +999,17 @@ func TestMarshalPanic(t *testing.T) {
 
 func TestMarshalErrorMessage(t *testing.T) {
 	// values that cannot be encoded in JSON
-	// ch := make(chan int)
 	badTime := time.Date(-1, 0, 0, 0, 0, 0, 0, time.UTC)
 
 	tests := []struct {
 		in   interface{}
 		want string
 	}{
+		// check simple value
+		{
+			in:   badTime,
+			want: "json: error calling MarshalJSON for type time.Time: Time.MarshalJSON: year outside of range [0,9999]",
+		},
 		// checking map properties
 		{
 			in: map[string]interface{}{


### PR DESCRIPTION
When a marshal error is encountered, the error message (and underlying `MarshalerError`) does not include any context about where the error was encountered, even if the value is complex like a map, slice or struct.

This change will include that metadata in both places, allowing a caller to have more context in the event of a JSON marshal error.

Fixes #25153