### PR TITLE
http: Capitalization of HTTP 418 I'm a Teapot

### DIFF
--- a/src/net/http/status.go
+++ b/src/net/http/status.go
@@ -117,7 +117,7 @@ var statusText = map[int]string{
 	StatusUnsupportedMediaType:         "Unsupported Media Type",
 	StatusRequestedRangeNotSatisfiable: "Requested Range Not Satisfiable",
 	StatusExpectationFailed:            "Expectation Failed",
-	StatusTeapot:                       "I'm a teapot",
+	StatusTeapot:                       "I'm a Teapot",
 	StatusMisdirectedRequest:           "Misdirected Request",
 	StatusUnprocessableEntity:          "Unprocessable Entity",
 	StatusLocked:                       "Locked",


### PR DESCRIPTION
In [rfc2324](https://tools.ietf.org/html/rfc2324) (1998), the HTTP 418 message reads I'm a teapot, whereas in the latter [rfc7168](https://tools.ietf.org/html/rfc7168) (2014) it's spelled I'm a Teapot — note that capital T.

This is consistent with other canonical status messages, all of which have Every Word Capitalized.