### PR TITLE
encoding/asn1: to make relax DER unmarshaling.

### DIFF
--- a/src/encoding/asn1/asn1.go
+++ b/src/encoding/asn1/asn1.go
@@ -515,11 +515,6 @@ func parseTagAndLength(bytes []byte, initOffset int) (ret tagAndLength, offset i
 		if err != nil {
 			return
 		}
-		// Tags should be encoded in minimal form.
-		if ret.tag < 0x1f {
-			err = SyntaxError{"non-minimal tag"}
-			return
-		}
 	}
 	if offset >= len(bytes) {
 		err = SyntaxError{"truncated tag or length"}
@@ -553,11 +548,6 @@ func parseTagAndLength(bytes []byte, initOffset int) (ret tagAndLength, offset i
 			}
 			ret.length <<= 8
 			ret.length |= int(b)
-			if ret.length == 0 {
-				// DER requires that lengths be minimal.
-				err = StructuralError{"superfluous leading zeros in length"}
-				return
-			}
 		}
 		// Short lengths must be encoded in short form.
 		if ret.length < 0x80 {


### PR DESCRIPTION
This patch allow to unmarshal with non-minimalized tag and length.
Yes, the currentlly implementation of unmarshaling is faithful to DER specifications.
However, there are many broken encoded data in the world.
I think that the implementation of the encoder and decoder should be relaxing for input data, strict for output data.
Actually, many other ASN.1 implementations allow to unmarshal the non-minimalized encoded data.
