### PR TITLE
cmd/asm: allow methods implemented in assembly

### DIFF
--- a/src/cmd/asm/internal/lex/lex.go
+++ b/src/cmd/asm/internal/lex/lex.go
@@ -107,9 +107,16 @@ func Make(token ScanToken, text string) Token {
 	if token == scanner.Ident && strings.HasPrefix(text, "\u00B7") {
 		text = `""` + text
 	}
-	// Substitute the substitutes for . and /.
+	// If the symbol starts with type··x, rewrite it as type·""·x
+	if token == scanner.Ident && strings.HasPrefix(text, "type\u00B7\u00B7") {
+		text = "type\u00B7" + `""` + text[len("type\u00B7"):]
+	}
+	// Substitute the substitutes for '.', '/', '*', '(' and ')'.
 	text = strings.Replace(text, "\u00B7", ".", -1)
 	text = strings.Replace(text, "\u2215", "/", -1)
+	text = strings.Replace(text, "\u2217", "*", -1)
+	text = strings.Replace(text, "\uFF08", "(", -1)
+	text = strings.Replace(text, "\uFF09", ")", -1)
 	return Token{ScanToken: token, text: text}
 }
 

--- a/src/cmd/asm/internal/lex/tokenizer.go
+++ b/src/cmd/asm/internal/lex/tokenizer.go
@@ -61,6 +61,12 @@ func isIdentRune(ch rune, i int) bool {
 		return true
 	case '\u2215': // Represents the slash in runtime/debug.setGCPercent. U+2215 '∕' division slash
 		return true
+	case '\u2217': // Represents the asterisk in main.(*SomeType).method. U+2217 '∗' asterisk
+		return true
+	case '\uFF08': // Represents the left parentheses in main.(*SomeType).method. U+FF08 '（' left parentheses
+		return true
+	case '\uFF09': // Represents the right parentheses in main.(*SomeType).method. U+FF09 '）' right parentheses
+		return true
 	}
 	// Digits are OK only after the first character.
 	return i > 0 && unicode.IsDigit(ch)


### PR DESCRIPTION
1. allow methods implemented in assembly, identifier name support "main.(*SomeType).method" format
2. if the symbol starts with type··x, rewrite it as type·""·x

fixes #4978
