### PR TITLE
cmd/dist: explicit option for crosscompilation

### DIFF
--- a/src/cmd/dist/build.go
+++ b/src/cmd/dist/build.go
@@ -292,12 +292,13 @@ func xinit() {
 // $CC_FOR_goos_goarch, if set, applies only to goos/goarch.
 func compilerEnv(envName, def string) map[string]string {
 	m := map[string]string{"": def}
+	crosscompiling := os.Getenv("GO_ASSUME_CROSSCOMPILING")
 
 	if env := os.Getenv(envName); env != "" {
 		m[""] = env
 	}
 	if env := os.Getenv(envName + "_FOR_TARGET"); env != "" {
-		if gohostos != goos || gohostarch != goarch {
+		if gohostos != goos || gohostarch != goarch || crosscompiling == "1" {
 			m[gohostos+"/"+gohostarch] = m[""]
 		}
 		m[""] = env

--- a/src/cmd/go/internal/help/helpdoc.go
+++ b/src/cmd/go/internal/help/helpdoc.go
@@ -682,6 +682,9 @@ Additional information available from 'go env' but not read from the environment
 		The directory where the go tools (compile, cover, doc, etc...) are installed.
 	GOVERSION
 		The version of the installed Go tree, as reported by runtime.Version.
+	GO_ASSUME_CROSSCOMPILING
+		Force the go build system to honor the different CC_FOR_TARGET even
+		if the architecture is the same, useful when cross compiling.
 	`,
 }
 

--- a/src/make.bash
+++ b/src/make.bash
@@ -72,6 +72,10 @@
 # that name even though they put newer Go toolchains there.
 
 bootgo=1.20.6
+#
+# GO_ASSUME_CROSSCOMPILING: Used to explicitly tell to the go build
+# system that a cross compilation is happening and it should honor the
+# different CC_FOR_TARGET even if architecture is the same.
 
 set -e
 


### PR DESCRIPTION
If GOHOSTOS == GOOS || GOHOSTARCH == GOARCH the go build system assume
it's not cross compiling and uses the same compiler for both
CC_FOR_TARGET and CC even if they are declared different. During go
compilation, this produces the error:

fork/exec
/accts/mlweber1/rclinux/rc-buildroot-test/scripts/instance-2/output/build/host-go-1.10/bin/go:
no such file or directory

cause the go binary produced is linked against a different libc and
cannot be run on the host machine.

This is a problem in case the cross compilation mandates a different
toolchain for host and target like happens in cross compilation
environments like buildroot. This patch adds GO_ASSUME_CROSSCOMPILING
varible to assure that in case of cross compilation CC_FOR_TARGET can be
different from CC.

Fixes #25177