### PR TITLE
encoding/base32: handle NoPadding when using buffered encoding in Close

### DIFF
--- a/src/encoding/base32/base32.go
+++ b/src/encoding/base32/base32.go
@@ -244,8 +244,9 @@ func (e *encoder) Close() error {
 	// If there's anything left in the buffer, flush it out
 	if e.err == nil && e.nbuf > 0 {
 		e.enc.Encode(e.out[0:], e.buf[0:e.nbuf])
+		encodedLen := e.enc.EncodedLen(e.nbuf)
 		e.nbuf = 0
-		_, e.err = e.w.Write(e.out[0:8])
+		_, e.err = e.w.Write(e.out[0:encodedLen])
 	}
 	return e.err
 }

--- a/src/encoding/base32/base32_test.go
+++ b/src/encoding/base32/base32_test.go
@@ -578,3 +578,31 @@ func TestEncodedDecodedLen(t *testing.T) {
 		})
 	}
 }
+
+func TestWithoutPaddingClose(t *testing.T) {
+	encodings := []*Encoding{
+		StdEncoding,
+		StdEncoding.WithPadding(NoPadding),
+	}
+
+	for _, encoding := range encodings {
+		for _, testpair := range pairs {
+
+			var buf bytes.Buffer
+			encoder := NewEncoder(encoding, &buf)
+			encoder.Write([]byte(testpair.decoded))
+			encoder.Close()
+
+			expected := testpair.encoded
+			if encoding.padChar == NoPadding {
+				expected = strings.Replace(expected, "=", "", -1)
+			}
+
+			res := buf.String()
+
+			if res != expected {
+				t.Errorf("Expected %s got %s; padChar=%d", expected, res, encoding.padChar)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This changes makes encoder.Close aware of how many bytes to write if there
is any data left in the buffer.

Fixes #25295
