### PR TITLE
bytes: re-slice buffer to its previous length after call to grow()

### DIFF
--- a/src/bytes/buffer.go
+++ b/src/bytes/buffer.go
@@ -202,6 +202,7 @@ func (b *Buffer) ReadFrom(r io.Reader) (n int64, err error) {
 	b.lastRead = opInvalid
 	for {
 		i := b.grow(MinRead)
+		b.buf = b.buf[:i]
 		m, e := r.Read(b.buf[i:cap(b.buf)])
 		if m < 0 {
 			panic(errNegativeRead)

--- a/src/bytes/buffer_test.go
+++ b/src/bytes/buffer_test.go
@@ -275,7 +275,6 @@ func (r slowReader) Read(p []byte) (int, error) {
 	r.ch <- struct{}{}
 	<-r.ch
 	p = p[:0]
-	r.ch <- struct{}{}
 	return 0, io.EOF
 }
 
@@ -285,7 +284,10 @@ func TestSlowReadFrom(t *testing.T) {
 	var buf Buffer
 	r := slowReader{make(chan struct{}, 0)}
 
-	go buf.ReadFrom(r)
+	go func() {
+		buf.ReadFrom(r)
+		r.ch <- struct{}{}
+	}()
 
 	<-r.ch
 	check(t, "TestSlowReadFrom (1)", &buf, "")

--- a/src/bytes/buffer_test.go
+++ b/src/bytes/buffer_test.go
@@ -299,7 +299,7 @@ func TestReadFromPanicReader(t *testing.T) {
 		recover()
 		check(t, "TestReadFromPanicReader (2)", &buf2, "")
 	}()
-	i, err = buf2.ReadFrom(panicReader{panic: true})
+	buf2.ReadFrom(panicReader{panic: true})
 }
 
 func TestReadFromNegativeReader(t *testing.T) {


### PR DESCRIPTION
Fixes #25435 

The added test fails without the re-slice and passes with it.