### PR TITLE
os: respect setuid and setgid bit in Mkdir() on *nix

### DIFF
--- a/src/os/file.go
+++ b/src/os/file.go
@@ -219,9 +219,20 @@ func Mkdir(name string, perm FileMode) error {
 		return &PathError{"mkdir", name, e}
 	}
 
+	var bits FileMode
+
 	// mkdir(2) itself won't handle the sticky bit on *BSD and Solaris
 	if !supportsCreateWithStickyBit && perm&ModeSticky != 0 {
-		addPermBits(name, ModeSticky)
+		bits |= ModeSticky
+	}
+
+	// mkdir(2) itself won't handle the setuid or setgid bit on *nix
+	if !supportsMkdirWithSetuidSetgid {
+		bits |= perm&(ModeSetuid|ModeSetgid)
+	}
+
+	if bits != 0 {
+		addPermBits(name, bits)
 	}
 
 	return nil

--- a/src/os/file.go
+++ b/src/os/file.go
@@ -221,19 +221,19 @@ func Mkdir(name string, perm FileMode) error {
 
 	// mkdir(2) itself won't handle the sticky bit on *BSD and Solaris
 	if !supportsCreateWithStickyBit && perm&ModeSticky != 0 {
-		setStickyBit(name)
+		addPermBits(name, ModeSticky)
 	}
 
 	return nil
 }
 
-// setStickyBit adds ModeSticky to the permision bits of path, non atomic.
-func setStickyBit(name string) error {
-	fi, err := Stat(name)
+// addPermBits adds bits to the permission bits of path, non atomic.
+func addPermBits(path string, bits FileMode) error {
+	fi, err := Stat(path)
 	if err != nil {
 		return err
 	}
-	return Chmod(name, fi.Mode()|ModeSticky)
+	return Chmod(path, fi.Mode()|bits)
 }
 
 // Chdir changes the current working directory to the named directory.

--- a/src/os/file_nounix.go
+++ b/src/os/file_nounix.go
@@ -1,0 +1,16 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !darwin
+// +build !dragonfly
+// +build !freebsd
+// +build !linux
+// +build !nacl
+// +build !netbsd
+// +build !openbsd
+// +build !solaris
+
+package os
+
+const supportsMkdirWithSetuidSetgid = true

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 )
 
+const supportsMkdirWithSetuidSetgid = false
+
 // fixLongPath is a noop on non-Windows platforms.
 func fixLongPath(path string) string {
 	return path

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -193,7 +193,7 @@ func openFileNolog(name string, flag int, perm FileMode) (*File, error) {
 
 	// open(2) itself won't handle the sticky bit on *BSD and Solaris
 	if setSticky {
-		setStickyBit(name)
+		addPermBits(name, ModeSticky)
 	}
 
 	// There's a race here with fork/exec, which we are

--- a/src/os/os_unix_test.go
+++ b/src/os/os_unix_test.go
@@ -226,6 +226,26 @@ func TestMkdirStickyUmask(t *testing.T) {
 	}
 }
 
+// Issue 25539: respect setuid and setgid bit in Mkdir()
+func TestMkdirSetuidSetgid(t *testing.T) {
+	dir := newDir("TestMkdirSetuidSetgid", t)
+	defer RemoveAll(dir)
+
+	p := filepath.Join(dir, "dir1")
+	if err := Mkdir(p, ModeSetuid|ModeSetgid|0755); err != nil {
+		t.Fatal(err)
+	}
+
+	fi, err := Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if mode := fi.Mode(); mode&ModeSetuid == 0 || mode&ModeSetgid == 0 {
+		t.Errorf("unexpected mode %s", mode)
+	}
+}
+
 // See also issues: 22939, 24331
 func newFileTest(t *testing.T, blocking bool) {
 	p := make([]int, 2)


### PR DESCRIPTION
fixes #25539