### PR TITLE
image: add an example that shows how to get the metadata of an image

### DIFF
--- a/src/image/decode_example_test.go
+++ b/src/image/decode_example_test.go
@@ -21,6 +21,15 @@ import (
 	_ "image/jpeg"
 )
 
+func Example_decodeConfig() {
+	reader := base64.NewDecoder(base64.StdEncoding, strings.NewReader(data))
+	config, format, err := image.DecodeConfig(reader)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("Width:", config.Width, "Height:", config.Height, "Format:", format)
+}
+
 func Example() {
 	// Decode the JPEG data. If reading from file, create a reader with
 	//


### PR DESCRIPTION
This is a simple but everyday use case in image libraries. Currently,
there is one example in this library and it is lengthy and involved.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

