### PR TITLE
net: Add GetSysfd to conn type of net for getting sysfd for further use

### DIFF
--- a/src/net/net.go
+++ b/src/net/net.go
@@ -168,6 +168,11 @@ func (c *conn) ok() bool { return c != nil && c.fd != nil }
 
 // Implementation of the Conn interface.
 
+//Return sysfd for further use,like: syscall.SetsockoptTimeval
+func (c *conn) GetSysfd() int {
+	return c.fd.pfd.Sysfd
+}
+
 // Read implements the Conn Read method.
 func (c *conn) Read(b []byte) (int, error) {
 	if !c.ok() {


### PR DESCRIPTION
fix https://github.com/golang/go/issues/25729
SetDeadline have a poor performance in the benchmark, maybe because of the timmer.
So I add a function to get the sysfd of the socket, that I can set the specify socket options.   I use the following code to set timeout in the socket:
    fd = conn.(*net.UDPConn).GetSysfd()
    var tv syscall.Timeval
    tv.Sec = 1
    tv.Usec = 0 
    err := syscall.SetsockoptTimeval(fd, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &tv)
