### PR TITLE
flag: removed the colon after "Usage" in the documentation

### DIFF
--- a/src/flag/flag.go
+++ b/src/flag/flag.go
@@ -5,7 +5,7 @@
 /*
 	Package flag implements command-line flag parsing.
 
-	Usage:
+	Usage
 
 	Define flags using flag.String(), Bool(), Int(), etc.
 

--- a/src/flag/flag.go
+++ b/src/flag/flag.go
@@ -35,7 +35,7 @@
 	slice flag.Args() or individually as flag.Arg(i).
 	The arguments are indexed from 0 through flag.NArg()-1.
 
-	Command line flag syntax:
+	Command line flag syntax
 		-flag
 		-flag=x
 		-flag x  // non-boolean flags only


### PR DESCRIPTION
Removing the colon will make the "Usage" and "Command line flag syntax" in the docs, a header when interpreted by godoc.

Fixes #25749 
