### PR TITLE
/net/textproto/reader.go alter c/CanonicalMIMEHeaderKey

### DIFF
--- a/src/net/textproto/reader.go
+++ b/src/net/textproto/reader.go
@@ -561,29 +561,17 @@ func (r *Reader) upcomingHeaderNewlines() (n int) {
 	return
 }
 
-// CanonicalMIMEHeaderKey returns the canonical format of the
-// MIME header key s. The canonicalization converts the first
-// letter and any letter following a hyphen to upper case;
-// the rest are converted to lowercase. For example, the
-// canonical key for "accept-encoding" is "Accept-Encoding".
-// MIME header keys are assumed to be ASCII only.
-// If s contains a space or invalid header field bytes, it is
-// returned without modifications.
+// CanonicalMIMEHeaderKey returns MIME header key s.
+//Each header field consists of a case-insensitive field name
+//followed by a colon (":"), optional leading whitespace,
+//the field value, and optional trailing whitespace. RFC 7230
 func CanonicalMIMEHeaderKey(s string) string {
 	// Quick check for canonical encoding.
-	upper := true
 	for i := 0; i < len(s); i++ {
 		c := s[i]
 		if !validHeaderFieldByte(c) {
 			return s
 		}
-		if upper && 'a' <= c && c <= 'z' {
-			return canonicalMIMEHeaderKey([]byte(s))
-		}
-		if !upper && 'A' <= c && c <= 'Z' {
-			return canonicalMIMEHeaderKey([]byte(s))
-		}
-		upper = c == '-'
 	}
 	return s
 }
@@ -609,34 +597,6 @@ func validHeaderFieldByte(b byte) bool {
 // is unchanged and a string copy is returned.
 func canonicalMIMEHeaderKey(a []byte) string {
 	// See if a looks like a header key. If not, return it unchanged.
-	for _, c := range a {
-		if validHeaderFieldByte(c) {
-			continue
-		}
-		// Don't canonicalize.
-		return string(a)
-	}
-
-	upper := true
-	for i, c := range a {
-		// Canonicalize: first letter upper case
-		// and upper case after each dash.
-		// (Host, User-Agent, If-Modified-Since).
-		// MIME headers are ASCII only, so no Unicode issues.
-		if upper && 'a' <= c && c <= 'z' {
-			c -= toLower
-		} else if !upper && 'A' <= c && c <= 'Z' {
-			c += toLower
-		}
-		a[i] = c
-		upper = c == '-' // for next time
-	}
-	// The compiler recognizes m[string(byteSlice)] as a special
-	// case, so a copy of a's bytes into a new string does not
-	// happen in this map lookup:
-	if v := commonHeader[string(a)]; v != "" {
-		return v
-	}
 	return string(a)
 }
 


### PR DESCRIPTION
Each header field consists of a case-insensitive field name
followed by a colon (":"), optional leading whitespace, the
field value, and optional trailing whitespace.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
