### PR TITLE
runtime: fix FreeBSDNumCPU test

### DIFF
--- a/src/runtime/testdata/testprog/numcpu_freebsd.go
+++ b/src/runtime/testdata/testprog/numcpu_freebsd.go
@@ -9,10 +9,15 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
+)
+
+var (
+	cpuSetRE = regexp.MustCompile(`(\d,?)+`)
 )
 
 func init() {
@@ -105,8 +110,12 @@ func checkNCPU(list []string) error {
 		return fmt.Errorf("could not check against an empty CPU list")
 	}
 
+	cListString := cpuSetRE.FindString(listString)
+	if len(cListString) == 0 {
+		return fmt.Errorf("invalid cpuset output '%s'", listString)
+	}
 	// Launch FreeBSDNumCPUHelper() with specified CPUs list.
-	cmd := exec.Command("cpuset", "-l", listString, os.Args[0], "FreeBSDNumCPUHelper")
+	cmd := exec.Command("cpuset", "-l", cListString, os.Args[0], "FreeBSDNumCPUHelper")
 	cmdline := strings.Join(cmd.Args, " ")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -120,7 +129,7 @@ func checkNCPU(list []string) error {
 		return fmt.Errorf("fail to parse output from child '%s', error: %s, output: %s", cmdline, err, output)
 	}
 	if n != len(list) {
-		return fmt.Errorf("runtime.NumCPU() expected to %d, got %d when run with CPU list %s", len(list), n, listString)
+		return fmt.Errorf("runtime.NumCPU() expected to %d, got %d when run with CPU list %s", len(list), n, cListString)
 	}
 	return nil
 }


### PR DESCRIPTION
num cpu unit test fixes for FreeBSD.
cpuset -g can possibly output more
data than expected.

Fixes #25924 