### PR TITLE
text/html: MIME type "application/ld+json: should be escaped as JS

### DIFF
--- a/src/html/template/js.go
+++ b/src/html/template/js.go
@@ -391,6 +391,7 @@ func isJSType(mimeType string) bool {
 		"application/ecmascript",
 		"application/javascript",
 		"application/json",
+		"application/ld+json",
 		"application/x-ecmascript",
 		"application/x-javascript",
 		"text/ecmascript",

--- a/src/html/template/js_test.go
+++ b/src/html/template/js_test.go
@@ -343,6 +343,7 @@ func TestIsJsMimeType(t *testing.T) {
 		{"application/javascript/version=1.8", false},
 		{"text/javascript", true},
 		{"application/json", true},
+		{"application/ld+json", true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Teach the text/html package to understand the "application/ld+json" MIME
type (used for JSON-LD data) as JS, so it can be apply the correct contextual
escaping.

Fixes #26053