### PR TITLE
runtime: support all as parameter in gdb goroutine commands.

### DIFF
--- a/doc/debugging_with_gdb.html
+++ b/doc/debugging_with_gdb.html
@@ -149,6 +149,9 @@ Inspecting goroutines:
 (gdb) <b>help goroutine</b></pre>
 For example:
 <pre>(gdb) <b>goroutine 12 bt</b></pre>
+You can inspect all goroutines by passing <code>all</code> instead of a specific goroutine's ID.
+For example:
+<pre>(gdb) <b>goroutine all bt</b></pre>
 </li>
 </ul>
 

--- a/src/runtime/runtime-gdb_test.go
+++ b/src/runtime/runtime-gdb_test.go
@@ -217,6 +217,9 @@ func testGdbPython(t *testing.T, cgo bool) {
 		"-ex", "echo BEGIN goroutine 2 bt\n",
 		"-ex", "goroutine 2 bt",
 		"-ex", "echo END\n",
+		"-ex", "echo BEGIN goroutine all bt\n",
+		"-ex", "goroutine all bt",
+		"-ex", "echo END\n",
 		"-ex", "clear main.go:15", // clear the previous break point
 		"-ex", fmt.Sprintf("br main.go:%d", nLines), // new break point at the end of main
 		"-ex", "c",
@@ -301,6 +304,10 @@ func testGdbPython(t *testing.T, cgo bool) {
 	btGoroutine2Re := regexp.MustCompile(`(?m)^#0\s+(0x[0-9a-f]+\s+in\s+)?runtime.+at`)
 	if bl := blocks["goroutine 2 bt"]; !btGoroutine2Re.MatchString(bl) {
 		t.Fatalf("goroutine 2 bt failed: %s", bl)
+	}
+
+	if bl := blocks["goroutine all bt"]; !btGoroutine1Re.MatchString(bl) || !btGoroutine2Re.MatchString(bl) {
+		t.Fatalf("goroutine all bt failed: %s", bl)
 	}
 
 	btGoroutine1AtTheEndRe := regexp.MustCompile(`(?m)^#0\s+(0x[0-9a-f]+\s+in\s+)?main\.main.+at`)


### PR DESCRIPTION
For example, can use `goroutine all bt` to dump all goroutines'
information.