### PR TITLE
net/http/cookiejar: unescape cookie paths

### DIFF
--- a/src/net/http/cookiejar/jar.go
+++ b/src/net/http/cookiejar/jar.go
@@ -369,6 +369,9 @@ func defaultPath(path string) string {
 	if i == 0 {
 		return "/" // Path has the form "/abc".
 	}
+	if s, err := url.PathUnescape(path[:i]); err == nil {
+		return s
+	}
 	return path[:i] // Path is either of form "/abc/xyz" or "/abc/xyz/".
 }
 
@@ -386,6 +389,8 @@ func (j *Jar) newEntry(c *http.Cookie, now time.Time, defPath, host string) (e e
 
 	if c.Path == "" || c.Path[0] != '/' {
 		e.Path = defPath
+	} else if path, err := url.PathUnescape(c.Path); err == nil {
+		e.Path = path
 	} else {
 		e.Path = c.Path
 	}

--- a/src/net/http/cookiejar/jar_test.go
+++ b/src/net/http/cookiejar/jar_test.go
@@ -1320,3 +1320,22 @@ func TestIssue19384(t *testing.T) {
 		}
 	}
 }
+
+func TestIssue26247(t *testing.T) {
+	cookies := []*http.Cookie{{Name: "name", Value: "value", Path: "/a%20path"}}
+	jar, _ := New(nil)
+	u := &url.URL{Scheme: "http", Host: "example.com"}
+	jar.SetCookies(u, cookies)
+	for _, path := range []string{"", "/", "/a", "/a/path", "/a/path/", "/a/path/here"} {
+		u.Path = path
+		if got := jar.Cookies(u); len(got) != 0 {
+			t.Errorf("path %q, got %v", path, got)
+		}
+	}
+	for _, path := range []string{"/a path", "/a path/", "/a path/here"} {
+		u.Path = path
+		if got := jar.Cookies(u); len(got) != 1 {
+			t.Errorf("path %q, got %v", path, got)
+		}
+	}
+}


### PR DESCRIPTION
Unescape path's in cookies for when servers send back Cookie headers with %20 in place of space Fixes #26247 