### PR TITLE
net/http: correct use of byte slice in js syscall

### DIFF
--- a/src/net/http/roundtrip_js.go
+++ b/src/net/http/roundtrip_js.go
@@ -60,7 +60,9 @@ func (t *Transport) RoundTrip(req *Request) (*Response, error) {
 			return nil, err
 		}
 		req.Body.Close()
-		opt.Set("body", body)
+		a := js.TypedArrayOf(body)
+		defer a.Release()
+		opt.Set("body", a)
 	}
 	respPromise := js.Global().Call("fetch", req.URL.String(), opt)
 	var (


### PR DESCRIPTION
syscall/js does not allow []byte to be used in direct inputs to
its JavaScript manipulation methods since
https://github.com/golang/go/commit/bafe466a9537d8ea5ac5767504628803302ebb12.
Unfortunately, this use of a byte slice was missed, so any
uses of the WASM Roundtripper with a body will panic.
This ensures the byte slice is appropriately converted
before being passed to syscall.

Fixes #26349