### PR TITLE
fmt: fix incorrect format of whole-number floats when using %#v

### DIFF
--- a/src/fmt/fmt_test.go
+++ b/src/fmt/fmt_test.go
@@ -690,6 +690,14 @@ var fmtTests = []struct {
 	{"%#v", []int32(nil), "[]int32(nil)"},
 	{"%#v", 1.2345678, "1.2345678"},
 	{"%#v", float32(1.2345678), "1.2345678"},
+
+	// Whole number floats should have a single trailing zero added, but not
+	// for exponent notation.
+	{"%#v", 1.0, "1.0"},
+	{"%#v", 1000000.0, "1e+06"},
+	{"%#v", float32(1.0), "1.0"},
+	{"%#v", float32(1000000.0), "1e+06"},
+
 	// Only print []byte and []uint8 as type []byte if they appear at the top level.
 	{"%#v", []byte(nil), "[]byte(nil)"},
 	{"%#v", []uint8(nil), "[]byte(nil)"},

--- a/test/switch5.go
+++ b/test/switch5.go
@@ -24,8 +24,8 @@ func f0(x int) {
 func f1(x float32) {
 	switch x {
 	case 5:
-	case 5: // ERROR "duplicate case 5 in switch"
-	case 5.0: // ERROR "duplicate case 5 in switch"
+	case 5: // ERROR "duplicate case 5 .value 5\.0. in switch"
+	case 5.0: // ERROR "duplicate case 5 .value 5\.0. in switch"
 	}
 }
 
@@ -44,9 +44,9 @@ func f3(e interface{}) {
 	case 0: // ERROR "duplicate case 0 in switch"
 	case int64(0):
 	case float32(10):
-	case float32(10): // ERROR "duplicate case float32\(10\) .value 10. in switch"
+	case float32(10): // ERROR "duplicate case float32\(10\) .value 10\.0. in switch"
 	case float64(10):
-	case float64(10): // ERROR "duplicate case float64\(10\) .value 10. in switch"
+	case float64(10): // ERROR "duplicate case float64\(10\) .value 10\.0. in switch"
 	}
 }
 


### PR DESCRIPTION
This fixes the unwanted behaviour where printing a zero float with the
#v fmt verb outputs "0" - e.g. missing the trailing decimal. This means
that the output would be interpreted as an int rather than a float when
parsed as Go source. After this change the the output is "0.0".

Fixes #26363 