### PR TITLE
cmd/go: run git log with --no-show-signature

### DIFF
--- a/src/cmd/go/internal/modfetch/codehost/git.go
+++ b/src/cmd/go/internal/modfetch/codehost/git.go
@@ -362,7 +362,7 @@ func (r *gitRepo) stat(rev string) (*RevInfo, error) {
 // statLocal returns a RevInfo describing rev in the local git repository.
 // It uses version as info.Version.
 func (r *gitRepo) statLocal(version, rev string) (*RevInfo, error) {
-	out, err := Run(r.dir, "git", "log", "-n1", "--format=format:%H %ct %D", rev)
+	out, err := Run(r.dir, "git", "log", "-n1", "--format=format:%H %ct %D", "--no-show-signature", rev)
 	if err != nil {
 		return nil, fmt.Errorf("unknown revision %s", rev)
 	}


### PR DESCRIPTION
Git timestamp parsing is broken when fetching modules if the
local git configuration has 'log.showsignature=true'.

Fixes #26388