### PR TITLE
doc.Example should not worry about unresolved blank identifiers

### DIFF
--- a/src/go/doc/example.go
+++ b/src/go/doc/example.go
@@ -188,7 +188,7 @@ func playExample(file *ast.File, f *ast.FuncDecl) *ast.File {
 	inspectFunc = func(n ast.Node) bool {
 		switch e := n.(type) {
 		case *ast.Ident:
-			if e.Obj == nil {
+			if e.Obj == nil && e.Name != "_" {
 				unresolved[e.Name] = true
 			} else if d := topDecls[e.Obj]; d != nil {
 				if !hasDepDecls[d] {


### PR DESCRIPTION
https://golang.org/pkg/bufio/#example_Scanner_custom is not directly
runnable in the playground via godoc, but if I copy+paste the code into
https://play.golang.org/ then it runs just fine.

This seems to be due to the blank identifier being considered unresolved
in the following line in the example:

_, err = strconv.ParseInt(string(token), 10, 32)

But that's the whole point of blank identifiers- they're not supposed
to be resolved.  So let's skip adding the blank identifier to
doc.playExample's unresolved map.

Fixes #26447