### PR TITLE
httptest: guarantee ResponseRecorder.Result returns a non-nil body

### DIFF
--- a/src/net/http/httptest/recorder.go
+++ b/src/net/http/httptest/recorder.go
@@ -184,6 +184,8 @@ func (rw *ResponseRecorder) Result() *http.Response {
 	res.Status = fmt.Sprintf("%03d %s", res.StatusCode, http.StatusText(res.StatusCode))
 	if rw.Body != nil {
 		res.Body = ioutil.NopCloser(bytes.NewReader(rw.Body.Bytes()))
+	} else {
+		res.Body = http.NoBody
 	}
 	res.ContentLength = parseContentLength(res.Header.Get("Content-Length"))
 


### PR DESCRIPTION
The doc for ResponseRecorder.Result guarantees that the body of the returned
http.Response will be non-nil, but this only holds true if the caller's body is
non-nil. With this change, if the caller's body is nil then the returned
response's body will be an empty io.ReadCloser.

Fixes #26442