### PR TITLE
cmd/dist: fix compilation on windows

### DIFF
--- a/src/make.bat
+++ b/src/make.bat
@@ -79,7 +79,7 @@ set GOBIN=
 "%GOROOT_BOOTSTRAP%\bin\go" build -o cmd\dist\dist.exe .\cmd\dist
 endlocal
 if errorlevel 1 goto fail
-.\cmd\dist\dist env -w -p >env.bat
+.\cmd\dist\dist.exe env -w -p >env.bat
 if errorlevel 1 goto fail
 call env.bat
 del env.bat
@@ -103,7 +103,7 @@ if x%4==x--no-banner set buildall=%buildall% --no-banner
 :: Run dist bootstrap to complete make.bash.
 :: Bootstrap installs a proper cmd/dist, built with the new toolchain.
 :: Throw ours, built with Go 1.4, away after bootstrap.
-.\cmd\dist\dist bootstrap %vflag% %buildall% 
+.\cmd\dist\dist.exe bootstrap %vflag% %buildall%
 if errorlevel 1 goto fail
 del .\cmd\dist\dist.exe
 goto end

--- a/src/race.bat
+++ b/src/race.bat
@@ -18,7 +18,7 @@ goto end
 set GOROOT=%CD%\..
 call make.bat --dist-tool >NUL
 if errorlevel 1 goto fail
-.\cmd\dist\dist env -w -p >env.bat
+.\cmd\dist\dist.exe env -w -p >env.bat
 if errorlevel 1 goto fail
 call env.bat
 del env.bat


### PR DESCRIPTION
Add missing extensions to binary files in order to allow execution.

Change-Id: Idfe4c72c80c26b7b938023bc7bbe1ef85e1aa7b0