### PR TITLE
cmd/link: clear up the Shlib record when building a pkg

### DIFF
--- a/src/cmd/go/internal/work/buildid.go
+++ b/src/cmd/go/internal/work/buildid.go
@@ -530,6 +530,7 @@ func (b *Builder) useCache(a *Action, p *load.Package, actionHash cache.ActionID
 							}
 						}
 						a.built = file
+						a.Package.Shlib = ""
 						a.Target = "DO NOT USE - using cache"
 						a.buildID = buildID
 						if p := a.Package; p != nil {

--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -714,6 +714,7 @@ func (b *Builder) build(a *Action) (err error) {
 	}
 
 	a.built = objpkg
+	a.Package.Shlib = ""
 	return nil
 }
 

--- a/src/cmd/internal/obj/mips/asm0.go
+++ b/src/cmd/internal/obj/mips/asm0.go
@@ -1120,9 +1120,11 @@ func (c *ctxt0) asmout(p *obj.Prog, o *Optab, out []uint32) {
 	case 1: /* mov r1,r2 ==> OR r1,r0,r2 */
 		a := AOR
 		if p.As == AMOVW && c.ctxt.Arch.Family == sys.MIPS64 {
-			a = AADDU // sign-extended to high 32 bits
-		}
-		o1 = OP_RRR(c.oprrr(a), uint32(REGZERO), uint32(p.From.Reg), uint32(p.To.Reg))
+			a = ASLL // sign-extended to high 32 bits
+			o1 = OP_RRR(c.oprrr(a), uint32(p.From.Reg), uint32(REGZERO), uint32(p.To.Reg))
+		} else {
+			o1 = OP_RRR(c.oprrr(a), uint32(REGZERO), uint32(p.From.Reg), uint32(p.To.Reg))
+ 		}
 
 	case 2: /* add/sub r1,[r2],r3 */
 		r := int(p.Reg)


### PR DESCRIPTION
The Shlib record of a pkg should be cleaned once the pkg is being built and packed to _pkg_.a（or using cached file _pkg_.a）. 
Otherwise, the "packageshlib" key word in importcfg.link file will render the "packagefile" ineffective, in which the "packagefile" indicate the path of _pkg_.a( or cached _pkg_.a) and the "packageshlib" indicate the path of it's shlib( pkg's antiquated libXXX.so path ).

Fixes #26582