### PR TITLE
encoding/json: eliminate superfluous space in Decoder.Token error messages

### DIFF
--- a/src/encoding/json/stream.go
+++ b/src/encoding/json/stream.go
@@ -459,17 +459,17 @@ func (dec *Decoder) tokenError(c byte) (Token, error) {
 	var context string
 	switch dec.tokenState {
 	case tokenTopValue:
-		context = " looking for beginning of value"
+		context = "looking for beginning of value"
 	case tokenArrayStart, tokenArrayValue, tokenObjectValue:
-		context = " looking for beginning of value"
+		context = "looking for beginning of value"
 	case tokenArrayComma:
-		context = " after array element"
+		context = "after array element"
 	case tokenObjectKey:
-		context = " looking for beginning of object key string"
+		context = "looking for beginning of object key string"
 	case tokenObjectColon:
-		context = " after object key"
+		context = "after object key"
 	case tokenObjectComma:
-		context = " after object key:value pair"
+		context = "after object key:value pair"
 	}
 	return nil, &SyntaxError{"invalid character " + quoteChar(c) + " " + context, dec.offset()}
 }

--- a/src/encoding/json/stream.go
+++ b/src/encoding/json/stream.go
@@ -459,19 +459,19 @@ func (dec *Decoder) tokenError(c byte) (Token, error) {
 	var context string
 	switch dec.tokenState {
 	case tokenTopValue:
-		context = "looking for beginning of value"
+		context = " looking for beginning of value"
 	case tokenArrayStart, tokenArrayValue, tokenObjectValue:
-		context = "looking for beginning of value"
+		context = " looking for beginning of value"
 	case tokenArrayComma:
-		context = "after array element"
+		context = " after array element"
 	case tokenObjectKey:
-		context = "looking for beginning of object key string"
+		context = " looking for beginning of object key string"
 	case tokenObjectColon:
-		context = "after object key"
+		context = " after object key"
 	case tokenObjectComma:
-		context = "after object key:value pair"
+		context = " after object key:value pair"
 	}
-	return nil, &SyntaxError{"invalid character " + quoteChar(c) + " " + context, dec.offset()}
+	return nil, &SyntaxError{"invalid character " + quoteChar(c) + context, dec.offset()}
 }
 
 // More reports whether there is another element in the


### PR DESCRIPTION
The existing Decoder.tokenError implementation creates its error messages by
concatenating "invalid character " + quoteChar(c) + " " + context. All context
values however already start with a space leading to error messages containing
two spaces.

This change removes " " from the concatenation expression.

Fixes #26587