### PR TITLE
crypto/tls: delete session tickets on TLS handshake failure

### DIFF
--- a/src/crypto/tls/handshake_client.go
+++ b/src/crypto/tls/handshake_client.go
@@ -128,7 +128,7 @@ func (c *Conn) clientHandshake() error {
 		// available.
 		cacheKey = clientSessionCacheKey(c.conn.RemoteAddr(), c.config)
 		candidateSession, ok := sessionCache.Get(cacheKey)
-		if ok {
+		if ok && candidateSession != nil {
 			// Check that the ciphersuite/version used for the
 			// previous session are still valid.
 			cipherSuiteOk := false
@@ -165,6 +165,11 @@ func (c *Conn) clientHandshake() error {
 	}
 
 	if err = hs.handshake(); err != nil {
+		// If we got a handshake failure when resuming a session, throw
+		// the ticket away
+		if session != nil {
+			sessionCache.Put(cacheKey, nil)
+		}
 		return err
 	}
 


### PR DESCRIPTION
When a server accepts a session ticket presented by a client, but
the TLS handshake fails, RFC 5077 recommends that the client delete
the ticket. Because adding a Delete method to the interface for
ClientSessionCache would break existing implementations, we have the
handshake implementation overwrite the ticket with a nil instead.

Fixes #24919
