### PR TITLE
runtime: fix syscall error returns on mips/mips64/ppc64

### DIFF
--- a/src/runtime/sys_linux_mips64x.s
+++ b/src/runtime/sys_linux_mips64x.s
@@ -218,6 +218,8 @@ TEXT runtime·rt_sigaction(SB),NOSPLIT|NOFRAME,$0-36
 	MOVV	size+24(FP), R7
 	MOVV	$SYS_rt_sigaction, R2
 	SYSCALL
+	BEQ	R7, 2(PC)
+	SUBVU	R2, R0, R2	// caller expects negative errno
 	MOVW	R2, ret+32(FP)
 	RET
 
@@ -299,6 +301,8 @@ TEXT runtime·futex(SB),NOSPLIT|NOFRAME,$0
 	MOVW	val3+32(FP), R9
 	MOVV	$SYS_futex, R2
 	SYSCALL
+	BEQ	R7, 2(PC)
+	SUBVU	R2, R0, R2	// caller expects negative errno
 	MOVW	R2, ret+40(FP)
 	RET
 
@@ -321,6 +325,8 @@ TEXT runtime·clone(SB),NOSPLIT|NOFRAME,$0
 
 	MOVV	$SYS_clone, R2
 	SYSCALL
+	BEQ	R7, 2(PC)
+	SUBVU	R2, R0, R2	// caller expects negative errno
 
 	// In parent, return.
 	BEQ	R2, 3(PC)
@@ -383,6 +389,8 @@ TEXT runtime·sched_getaffinity(SB),NOSPLIT|NOFRAME,$0
 	MOVV	buf+16(FP), R6
 	MOVV	$SYS_sched_getaffinity, R2
 	SYSCALL
+	BEQ	R7, 2(PC)
+	SUBVU	R2, R0, R2	// caller expects negative errno
 	MOVW	R2, ret+24(FP)
 	RET
 
@@ -391,6 +399,8 @@ TEXT runtime·epollcreate(SB),NOSPLIT|NOFRAME,$0
 	MOVW    size+0(FP), R4
 	MOVV	$SYS_epoll_create, R2
 	SYSCALL
+	BEQ	R7, 2(PC)
+	SUBVU	R2, R0, R2	// caller expects negative errno
 	MOVW	R2, ret+8(FP)
 	RET
 
@@ -399,6 +409,8 @@ TEXT runtime·epollcreate1(SB),NOSPLIT|NOFRAME,$0
 	MOVW	flags+0(FP), R4
 	MOVV	$SYS_epoll_create1, R2
 	SYSCALL
+	BEQ	R7, 2(PC)
+	SUBVU	R2, R0, R2	// caller expects negative errno
 	MOVW	R2, ret+8(FP)
 	RET
 
@@ -424,6 +436,8 @@ TEXT runtime·epollwait(SB),NOSPLIT|NOFRAME,$0
 	MOVV	$0, R8
 	MOVV	$SYS_epoll_pwait, R2
 	SYSCALL
+	BEQ	R7, 2(PC)
+	SUBVU	R2, R0, R2	// caller expects negative errno
 	MOVW	R2, ret+24(FP)
 	RET
 

--- a/src/runtime/sys_linux_mipsx.s
+++ b/src/runtime/sys_linux_mipsx.s
@@ -234,6 +234,8 @@ TEXT runtime·rt_sigaction(SB),NOSPLIT,$0-20
 	MOVW	size+12(FP), R7
 	MOVW	$SYS_rt_sigaction, R2
 	SYSCALL
+	BEQ	R7, 2(PC)
+	SUBU	R2, R0, R2	// caller expects negative errno
 	MOVW	R2, ret+16(FP)
 	RET
 
@@ -320,6 +322,8 @@ TEXT runtime·futex(SB),NOSPLIT,$20-28
 
 	MOVW	$SYS_futex, R2
 	SYSCALL
+	BEQ	R7, 2(PC)
+	SUBU	R2, R0, R2	// caller expects negative errno
 	MOVW	R2, ret+24(FP)
 	RET
 
@@ -351,11 +355,11 @@ TEXT runtime·clone(SB),NOSPLIT|NOFRAME,$0-24
 
 	MOVW	$SYS_clone, R2
 	SYSCALL
+	BEQ	R7, 2(PC)
+	SUBU	R2, R0, R2	// caller expects negative errno
 
 	// In parent, return.
-	BEQ	R2, 5(PC)
-	SUBU	R2, R0, R3
-	CMOVN	R7, R3, R2
+	BEQ	R2, 3(PC)
 	MOVW	R2, ret+20(FP)
 	RET
 
@@ -417,6 +421,8 @@ TEXT runtime·sched_getaffinity(SB),NOSPLIT,$0-16
 	MOVW	buf+8(FP), R6
 	MOVW	$SYS_sched_getaffinity, R2
 	SYSCALL
+	BEQ	R7, 2(PC)
+	SUBU	R2, R0, R2	// caller expects negative errno
 	MOVW	R2, ret+12(FP)
 	RET
 
@@ -425,6 +431,8 @@ TEXT runtime·epollcreate(SB),NOSPLIT,$0-8
 	MOVW	size+0(FP), R4
 	MOVW	$SYS_epoll_create, R2
 	SYSCALL
+	BEQ	R7, 2(PC)
+	SUBU	R2, R0, R2	// caller expects negative errno
 	MOVW	R2, ret+4(FP)
 	RET
 
@@ -433,6 +441,8 @@ TEXT runtime·epollcreate1(SB),NOSPLIT,$0-8
 	MOVW	flags+0(FP), R4
 	MOVW	$SYS_epoll_create1, R2
 	SYSCALL
+	BEQ	R7, 2(PC)
+	SUBU	R2, R0, R2	// caller expects negative errno
 	MOVW	R2, ret+4(FP)
 	RET
 
@@ -456,6 +466,8 @@ TEXT runtime·epollwait(SB),NOSPLIT,$0-20
 	MOVW	timeout+12(FP), R7
 	MOVW	$SYS_epoll_wait, R2
 	SYSCALL
+	BEQ	R7, 2(PC)
+	SUBU	R2, R0, R2	// caller expects negative errno
 	MOVW	R2, ret+16(FP)
 	RET
 

--- a/src/runtime/sys_linux_ppc64x.s
+++ b/src/runtime/sys_linux_ppc64x.s
@@ -193,6 +193,8 @@ TEXT runtime·rt_sigaction(SB),NOSPLIT|NOFRAME,$0-36
 	MOVD	old+16(FP), R5
 	MOVD	size+24(FP), R6
 	SYSCALL	$SYS_rt_sigaction
+	BVC	2(PC)
+	NEG	R3	// caller expects negative errno
 	MOVW	R3, ret+32(FP)
 	RET
 
@@ -388,6 +390,8 @@ TEXT runtime·futex(SB),NOSPLIT|NOFRAME,$0
 	MOVD	addr2+24(FP), R7
 	MOVW	val3+32(FP), R8
 	SYSCALL	$SYS_futex
+	BVC	2(PC)
+	NEG	R3	// caller expects negative errno
 	MOVW	R3, ret+40(FP)
 	RET
 
@@ -409,6 +413,8 @@ TEXT runtime·clone(SB),NOSPLIT|NOFRAME,$0
 	MOVD	R7, -32(R4)
 
 	SYSCALL $SYS_clone
+	BVC	2(PC)
+	NEG	R3	// caller expects negative errno
 
 	// In parent, return.
 	CMP	R3, $0
@@ -472,6 +478,8 @@ TEXT runtime·sched_getaffinity(SB),NOSPLIT|NOFRAME,$0
 	MOVD	len+8(FP), R4
 	MOVD	buf+16(FP), R5
 	SYSCALL	$SYS_sched_getaffinity
+	BVC	2(PC)
+	NEG	R3	// caller expects negative errno
 	MOVW	R3, ret+24(FP)
 	RET
 
@@ -479,6 +487,8 @@ TEXT runtime·sched_getaffinity(SB),NOSPLIT|NOFRAME,$0
 TEXT runtime·epollcreate(SB),NOSPLIT|NOFRAME,$0
 	MOVW    size+0(FP), R3
 	SYSCALL	$SYS_epoll_create
+	BVC	2(PC)
+	NEG	R3	// caller expects negative errno
 	MOVW	R3, ret+8(FP)
 	RET
 
@@ -486,6 +496,8 @@ TEXT runtime·epollcreate(SB),NOSPLIT|NOFRAME,$0
 TEXT runtime·epollcreate1(SB),NOSPLIT|NOFRAME,$0
 	MOVW	flags+0(FP), R3
 	SYSCALL	$SYS_epoll_create1
+	BVC	2(PC)
+	NEG	R3	// caller expects negative errno
 	MOVW	R3, ret+8(FP)
 	RET
 
@@ -507,6 +519,8 @@ TEXT runtime·epollwait(SB),NOSPLIT|NOFRAME,$0
 	MOVW	nev+16(FP), R5
 	MOVW	timeout+20(FP), R6
 	SYSCALL	$SYS_epoll_wait
+	BVC	2(PC)
+	NEG	R3	// caller expects negative errno
 	MOVW	R3, ret+24(FP)
 	RET
 


### PR DESCRIPTION
The linux syscall functions used in runtime are designed around the calling
convention of returning errors as negative numbers. On some other systems
(like mips and ppc) the actual syscalls signal errors in other ways. This
means that the assembly implementations of the syscall functions on these
platforms need to transform the return values in the error cases to match
the expected negative errno values. This was addressed for certain syscalls
in https://golang.org/cl/19455 and https://golang.org/cl/89235. This patch
handles the rest of the syscall functions in sys_linux_*.s that return any
value for mips/mips64/ppc64.

Fixes #23446