### PR TITLE
crypto/x509: allow certificates to be exported from CertPool

### DIFF
--- a/src/crypto/x509/cert_pool.go
+++ b/src/crypto/x509/cert_pool.go
@@ -159,6 +159,11 @@ func (s *CertPool) AppendCertsFromPEM(pemCerts []byte) (ok bool) {
 	return
 }
 
+// Certificates returns all certificates from the pool.
+func (s *CertPool) Certificates() []*Certificate {
+	return append([]*Certificate(nil), s.certs...)
+}
+
 // Subjects returns a list of the DER-encoded subjects of
 // all of the certificates in the pool.
 func (s *CertPool) Subjects() [][]byte {

--- a/src/crypto/x509/cert_pool_test.go
+++ b/src/crypto/x509/cert_pool_test.go
@@ -1,0 +1,21 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package x509
+
+import "testing"
+
+func TestCertPoolCertificates(t *testing.T) {
+	pool, err := SystemCertPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if certs := pool.Certificates(); len(certs) > 0 {
+		if certs[0] = nil; pool.certs[0] == nil {
+			t.Error("returned slice shouldn't share storage with pool")
+		}
+	}
+
+}


### PR DESCRIPTION
Some users may find it helpful to be able to inspect the `Roots`/
`Intermediates` in a `VerifyOptions`.

The main issue with exposing this is that users could mess with the slice,
causing the two indices (`bySubjectKeyId` and `byName`) to be broken. To
avoid this, a `Certificates()` method is added, returning a copy of the
internal slice.