### PR TITLE
cmd/go/internal/modfetch: update proxy usage

### DIFF
--- a/src/cmd/go/internal/modfetch/proxy.go
+++ b/src/cmd/go/internal/modfetch/proxy.go
@@ -53,6 +53,9 @@ for that version of the given module.
 GET $GOPROXY/<module>/@v/<version>.zip returns the zip archive
 for that version of the given module.
 
+GET $GOPROXY/<module>/@latest returns JSON-formatted metadata
+about the latest commit in the default branch of the given module.
+
 To avoid problems when serving from case-sensitive file systems,
 the <module> and <version> elements are case-encoded, replacing every
 uppercase letter with an exclamation mark followed by the correponding
@@ -62,8 +65,10 @@ The JSON-formatted metadata about a given module corresponds to
 this Go data structure, which may be expanded in the future:
 
     type Info struct {
-        Version string    // version string
-        Time    time.Time // commit time
+		Version string    // version string
+		Name    string    // complete ID in underlying repository
+		Short   string    // shortened ID, for use in pseudo-version
+		Time    time.Time // commit time
     }
 
 The zip archive for a specific version of a given module is a

--- a/src/cmd/go/internal/modfetch/proxy.go
+++ b/src/cmd/go/internal/modfetch/proxy.go
@@ -65,10 +65,10 @@ The JSON-formatted metadata about a given module corresponds to
 this Go data structure, which may be expanded in the future:
 
     type Info struct {
-		Version string    // version string
-		Name    string    // complete ID in underlying repository
-		Short   string    // shortened ID, for use in pseudo-version
-		Time    time.Time // commit time
+        Version string    // version string
+        Name    string    // complete ID in underlying repository
+        Short   string    // shortened ID, for use in pseudo-version
+        Time    time.Time // commit time
     }
 
 The zip archive for a specific version of a given module is a


### PR DESCRIPTION
Updated the cmd/go CLI docs for `go help goproxy` to include the `/@latest` endpoint as well as the remaining fields of version metadata.