### PR TITLE
path: present the correct error message in TestMatch

### DIFF
--- a/src/path/match_test.go
+++ b/src/path/match_test.go
@@ -73,7 +73,7 @@ func TestMatch(t *testing.T) {
 	for _, tt := range matchTests {
 		ok, err := Match(tt.pattern, tt.s)
 		if ok != tt.match || err != tt.err {
-			t.Errorf("Match(%#q, %#q) = %v, %v want %v, nil", tt.pattern, tt.s, ok, err, tt.match)
+			t.Errorf("Match(%#q, %#q) = %v, %v want %v, %v", tt.pattern, tt.s, ok, err, tt.match, tt.err)
 		}
 	}
 }


### PR DESCRIPTION
The message was hardcoded to indicate that the test wanted a nil error, even
though in some cases a specific error was wanted. This patch fixes the
message to print the wanted error.