### PR TITLE
cmd/go: avoid panic on 'go mod' without arguments

### DIFF
--- a/src/cmd/go/main.go
+++ b/src/cmd/go/main.go
@@ -193,7 +193,8 @@ BigCmdLoop:
 				args = args[1:]
 				if len(args) == 0 {
 					help.PrintUsage(os.Stderr, bigCmd)
-					return
+					base.SetExitStatus(2)
+					base.Exit()
 				}
 				if args[0] == "help" {
 					// Accept 'go mod help' and 'go mod help foo' for 'go help mod' and 'go help mod foo'.

--- a/src/cmd/go/main.go
+++ b/src/cmd/go/main.go
@@ -193,6 +193,7 @@ BigCmdLoop:
 				args = args[1:]
 				if len(args) == 0 {
 					help.PrintUsage(os.Stderr, bigCmd)
+					return
 				}
 				if args[0] == "help" {
 					// Accept 'go mod help' and 'go mod help foo' for 'go help mod' and 'go help mod foo'.


### PR DESCRIPTION
Fixes #26738
