### PR TITLE
syscall/js: move callback helper code to misc/wasm to avoid using eval()

### DIFF
--- a/misc/wasm/wasm_exec.js
+++ b/misc/wasm/wasm_exec.js
@@ -387,6 +387,28 @@
 				await callbackPromise;
 			}
 		}
+
+		static _makeCallbackHelper(id, pendingCallbacks, go) {
+			return function() {
+				pendingCallbacks.push({ id: id, args: arguments });
+				go._resolveCallbackPromise();
+			};
+		}
+
+		static _makeEventCallbackHelper(preventDefault, stopPropagation, stopImmediatePropagation, fn) {
+			return function(event) {
+				if (preventDefault) {
+					event.preventDefault();
+				}
+				if (stopPropagation) {
+					event.stopPropagation();
+				}
+				if (stopImmediatePropagation) {
+					event.stopImmediatePropagation();
+				}
+				fn(event);
+			};
+		}
 	}
 
 	if (isNodeJS) {

--- a/src/syscall/js/callback.go
+++ b/src/syscall/js/callback.go
@@ -8,33 +8,11 @@ package js
 
 import "sync"
 
-var pendingCallbacks = Global().Get("Array").New()
-
-var makeCallbackHelper = Global().Call("eval", `
-	(function(id, pendingCallbacks, go) {
-		return function() {
-			pendingCallbacks.push({ id: id, args: arguments });
-			go._resolveCallbackPromise();
-		};
-	})
-`)
-
-var makeEventCallbackHelper = Global().Call("eval", `
-	(function(preventDefault, stopPropagation, stopImmediatePropagation, fn) {
-		return function(event) {
-			if (preventDefault) {
-				event.preventDefault();
-			}
-			if (stopPropagation) {
-				event.stopPropagation();
-			}
-			if (stopImmediatePropagation) {
-				event.stopImmediatePropagation();
-			}
-			fn(event);
-		};
-	})
-`)
+var (
+	pendingCallbacks        = Global().Get("Array").New()
+	makeCallbackHelper      = Global().Get("Go").Get("_makeCallbackHelper")
+	makeEventCallbackHelper = Global().Get("Go").Get("_makeEventCallbackHelper")
+)
 
 var (
 	callbacksMu    sync.Mutex


### PR DESCRIPTION
When using the compiled .wasm with misc/wasm/wasm_exec.js, we get an error message if the site prohibits eval() via the Content-Security-Policy header. This can be resolved by moving the callback helper code from src/syscall/js/callback.go to misc/wasm/wasm_exec.js.

Fixes #26748 