### PR TITLE
syscall/js: run callback function in goroutine

### DIFF
--- a/src/syscall/js/callback.go
+++ b/src/syscall/js/callback.go
@@ -113,7 +113,7 @@ func callbackLoop() {
 			for i := range args {
 				args[i] = argsObj.Index(i)
 			}
-			f(args)
+			go f(args)
 		}
 	}
 }


### PR DESCRIPTION
When one callback function depends on the result of another callback function,
the result is an "all goroutines asleep and no JavaScript callback pending"
error. This can occur when making an HTTP request inside a callback function.

Fixes #26382