### PR TITLE
net/http: support configuring fetch options

### DIFF
--- a/src/net/http/roundtrip_js.go
+++ b/src/net/http/roundtrip_js.go
@@ -17,16 +17,26 @@ import (
 	"syscall/js"
 )
 
+// ModeHeader is a Request.Header map key that, if present,
+// signals that the map entry is actually an option to the Fetch API mode setting.
+// Valid values are: "cors", "no-cors", "same-origin", "navigate"
+// The default is "same-origin".
+//
+// Reference: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters
+const ModeHeader = "Fetch:Mode"
+
+// CredentialsHeader is a Request.Header map key that, if present,
+// signals that the map entry is actually an option to the Fetch API credentials setting.
+// Valid values are: "omit", "same-origin", "include"
+// The default is "same-origin".
+//
+// Reference: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters
+const CredentialsHeader = "Fetch:Credentials"
+
 // RoundTrip implements the RoundTripper interface using the WHATWG Fetch API.
 func (t *Transport) RoundTrip(req *Request) (*Response, error) {
 	if useFakeNetwork() {
 		return t.roundTrip(req)
-	}
-	headers := js.Global().Get("Headers").New()
-	for key, values := range req.Header {
-		for _, value := range values {
-			headers.Call("append", key, value)
-		}
 	}
 
 	ac := js.Global().Get("AbortController")
@@ -40,12 +50,26 @@ func (t *Transport) RoundTrip(req *Request) (*Response, error) {
 	opt := js.Global().Get("Object").New()
 	// See https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch
 	// for options available.
-	opt.Set("headers", headers)
 	opt.Set("method", req.Method)
 	opt.Set("credentials", "same-origin")
+	if h := req.Header.Get(CredentialsHeader); h != "" {
+		opt.Set("credentials", h)
+		req.Header.Del(CredentialsHeader)
+	}
+	if h := req.Header.Get(ModeHeader); h != "" {
+		opt.Set("credentials", h)
+		req.Header.Del(ModeHeader)
+	}
 	if ac != js.Undefined() {
 		opt.Set("signal", ac.Get("signal"))
 	}
+	headers := js.Global().Get("Headers").New()
+	for key, values := range req.Header {
+		for _, value := range values {
+			headers.Call("append", key, value)
+		}
+	}
+	opt.Set("headers", headers)
 
 	if req.Body != nil {
 		// TODO(johanbrandhorst): Stream request body when possible.


### PR DESCRIPTION
The default WASM RoundTripper is implemented using
the browser Fetch API. Some options don't readily map to
existing http.Request options, so we use the precedent
set by the TrailerPrefix constant to allow a user to configure
the "mode" and "credentials" options by supplying them
as headers in the http.Request.

Updates #26769
