### PR TITLE
cmd/asm/internal/arch: add package definition

### DIFF
--- a/src/cmd/asm/internal/arch/arch.go
+++ b/src/cmd/asm/internal/arch/arch.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Package arch provides basic constants and deals with machine architecture information.
+// It contains the Arch object with architecture information
 package arch
 
 import (

--- a/src/cmd/asm/internal/arch/arch.go
+++ b/src/cmd/asm/internal/arch/arch.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package arch provides basic constants and deals with machine architecture information.
-// It contains the Arch object with architecture information
+// Package arch provides basic constants and deals with machine architecture 
+// information wrapped in Arch.
 package arch
 
 import (

--- a/src/cmd/asm/internal/arch/arch.go
+++ b/src/cmd/asm/internal/arch/arch.go
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package arch provides basic constants and deals with machine architecture 
-// information wrapped in Arch.
+// Package arch defines architecture-specific information and support functions.
 package arch
 
 import (


### PR DESCRIPTION
The package arch didn't have a definition as you can see in https://tip.golang.org/pkg/cmd/asm/internal/arch/