### PR TITLE
syscall/js: improve speed of wasm callback loop by making helper functions

### DIFF
--- a/src/syscall/js/callback.go
+++ b/src/syscall/js/callback.go
@@ -89,15 +89,15 @@ func (c Callback) Release() {
 }
 
 var callbackLoopOnce sync.Once
-var (
-	fun                      = Global().Get("Function")
-	funcShift                = fun.New("t", "return t.shift()")
-	funcPropID               = fun.New("t", "return t.id")
-	funcPropArgs             = fun.New("t", "return t.args")
-	funcPropCallbackShutdown = fun.New("t", "return t._callbackShutdown")
-)
 
 func callbackLoop() {
+	var (
+		fun                      = Global().Get("Function")
+		funcShift                = fun.New("t", "return t.shift()")
+		funcPropID               = fun.New("t", "return t.id")
+		funcPropArgs             = fun.New("t", "return t.args")
+		funcPropCallbackShutdown = fun.New("t", "return t._callbackShutdown")
+	)
 
 	for !funcPropCallbackShutdown.Invoke(jsGo).Bool() {
 		sleepUntilCallback()


### PR DESCRIPTION
As reported previously in https://github.com/golang/go/issues/26277#issuecomment-403320938 moving strings from wasm to js is a hotspot in the current implementation. Method calls and property lookups are strings. For especially hot code like callback loop you can get a performance boost by creating little helper functions and relying instead on invoke.

In my benchmarks this reduced request time by about ~11%
Benchmark -- https://github.com/trashhalo/go_wasm_node_http/tree/speed
To try the benchmark yourself:

GOOS=js GOARCH=wasm go build .
node go.js go_wasm_node_http

ab -n 20000 -c 1000 http://localhost:3000/

I have to run ab a couple times for the response times to stabilize around a number.

Small note - my go.js(wasm_exec) is slightly modified to remove the setTimeout around callback execution. As @neelance noted here https://github.com/golang/go/issues/26277#issuecomment-403312049