### PR TITLE
testing/quick: skip struct fields that cannot be set by Value function

### DIFF
--- a/src/testing/quick/quick.go
+++ b/src/testing/quick/quick.go
@@ -160,6 +160,9 @@ func sizedValue(t reflect.Type, rand *rand.Rand, size int) (value reflect.Value,
 			sizeLeft /= n
 		}
 		for i := 0; i < n; i++ {
+			if !v.Field(i).CanSet() {
+				continue
+			}
 			elem, ok := sizedValue(concrete.Field(i).Type, rand, sizeLeft)
 			if !ok {
 				return reflect.Value{}, false


### PR DESCRIPTION
Fixes https://github.com/golang/go/issues/27017