### PR TITLE
cmd/cgo: perform explicit conversion in _GoStringLen

### DIFF
--- a/src/cmd/cgo/out.go
+++ b/src/cmd/cgo/out.go
@@ -1432,7 +1432,7 @@ void *CBytes(_GoBytes_);
 void *_CMalloc(size_t);
 
 __attribute__ ((unused))
-static size_t _GoStringLen(_GoString_ s) { return s.n; }
+static size_t _GoStringLen(_GoString_ s) { return (size_t)s.n; }
 
 __attribute__ ((unused))
 static const char *_GoStringPtr(_GoString_ s) { return s.p; }


### PR DESCRIPTION
_GoStringLen performs an implicit conversion from intgo to size_t.
Explicitly cast to size_t.

This change avoids warnings when using cgo with CFLAGS:
-Wconversion.