### PR TITLE
net/http: support body as a concrete nil type in NewRequest

### DIFF
--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -819,48 +819,57 @@ func NewRequest(method, url string, body io.Reader) (*Request, error) {
 		Body:       rc,
 		Host:       u.Host,
 	}
-	if body != nil {
-		switch v := body.(type) {
-		case *bytes.Buffer:
-			req.ContentLength = int64(v.Len())
-			buf := v.Bytes()
-			req.GetBody = func() (io.ReadCloser, error) {
-				r := bytes.NewReader(buf)
-				return ioutil.NopCloser(r), nil
-			}
-		case *bytes.Reader:
-			req.ContentLength = int64(v.Len())
-			snapshot := *v
-			req.GetBody = func() (io.ReadCloser, error) {
-				r := snapshot
-				return ioutil.NopCloser(&r), nil
-			}
-		case *strings.Reader:
-			req.ContentLength = int64(v.Len())
-			snapshot := *v
-			req.GetBody = func() (io.ReadCloser, error) {
-				r := snapshot
-				return ioutil.NopCloser(&r), nil
-			}
-		default:
-			// This is where we'd set it to -1 (at least
-			// if body != NoBody) to mean unknown, but
-			// that broke people during the Go 1.8 testing
-			// period. People depend on it being 0 I
-			// guess. Maybe retry later. See Issue 18117.
+	switch v := body.(type) {
+	case *bytes.Buffer:
+		if v == nil {
+			return req, nil
 		}
-		// For client requests, Request.ContentLength of 0
-		// means either actually 0, or unknown. The only way
-		// to explicitly say that the ContentLength is zero is
-		// to set the Body to nil. But turns out too much code
-		// depends on NewRequest returning a non-nil Body,
-		// so we use a well-known ReadCloser variable instead
-		// and have the http package also treat that sentinel
-		// variable to mean explicitly zero.
-		if req.GetBody != nil && req.ContentLength == 0 {
-			req.Body = NoBody
-			req.GetBody = func() (io.ReadCloser, error) { return NoBody, nil }
+		req.ContentLength = int64(v.Len())
+		buf := v.Bytes()
+		req.GetBody = func() (io.ReadCloser, error) {
+			r := bytes.NewReader(buf)
+			return ioutil.NopCloser(r), nil
 		}
+	case *bytes.Reader:
+		if v == nil {
+			return req, nil
+		}
+		req.ContentLength = int64(v.Len())
+		snapshot := *v
+		req.GetBody = func() (io.ReadCloser, error) {
+			r := snapshot
+			return ioutil.NopCloser(&r), nil
+		}
+	case *strings.Reader:
+		if v == nil {
+			return req, nil
+		}
+		req.ContentLength = int64(v.Len())
+		snapshot := *v
+		req.GetBody = func() (io.ReadCloser, error) {
+			r := snapshot
+			return ioutil.NopCloser(&r), nil
+		}
+	case nil:
+		return req, nil
+	default:
+		// This is where we'd set it to -1 (at least
+		// if body != NoBody) to mean unknown, but
+		// that broke people during the Go 1.8 testing
+		// period. People depend on it being 0 I
+		// guess. Maybe retry later. See Issue 18117.
+	}
+	// For client requests, Request.ContentLength of 0
+	// means either actually 0, or unknown. The only way
+	// to explicitly say that the ContentLength is zero is
+	// to set the Body to nil. But turns out too much code
+	// depends on NewRequest returning a non-nil Body,
+	// so we use a well-known ReadCloser variable instead
+	// and have the http package also treat that sentinel
+	// variable to mean explicitly zero.
+	if req.GetBody != nil && req.ContentLength == 0 {
+		req.Body = NoBody
+		req.GetBody = func() (io.ReadCloser, error) { return NoBody, nil }
 	}
 
 	return req, nil


### PR DESCRIPTION
When passing a nil value for a concrete type like *strings.Reader as an
io.Reader NewRequest would panic.

Ref: https://golang.org/doc/faq#nil_error