### PR TITLE
runtime/pprof: document labels bug

### DIFF
--- a/src/runtime/pprof/label.go
+++ b/src/runtime/pprof/label.go
@@ -54,6 +54,8 @@ func WithLabels(ctx context.Context, labels LabelSet) context.Context {
 // Labels takes an even number of strings representing key-value pairs
 // and makes a LabelSet containing them.
 // A label overwrites a prior label with the same key.
+// BUG(hyangah): Currently only CPU profile utilizes labels information..
+// See https://github.com/golang/go/issues/23458 for details.
 func Labels(args ...string) LabelSet {
 	if len(args)%2 != 0 {
 		panic("uneven number of arguments to pprof.Labels")

--- a/src/runtime/pprof/label.go
+++ b/src/runtime/pprof/label.go
@@ -54,8 +54,8 @@ func WithLabels(ctx context.Context, labels LabelSet) context.Context {
 // Labels takes an even number of strings representing key-value pairs
 // and makes a LabelSet containing them.
 // A label overwrites a prior label with the same key.
-// BUG(hyangah): Currently only CPU profile utilizes labels information..
-// See https://github.com/golang/go/issues/23458 for details.
+// BUG(hyangah): Currently only CPU profile utilizes labels information.
+// See https://golang.org/issue/23458 for details.
 func Labels(args ...string) LabelSet {
 	if len(args)%2 != 0 {
 		panic("uneven number of arguments to pprof.Labels")

--- a/src/runtime/pprof/label.go
+++ b/src/runtime/pprof/label.go
@@ -54,7 +54,7 @@ func WithLabels(ctx context.Context, labels LabelSet) context.Context {
 // Labels takes an even number of strings representing key-value pairs
 // and makes a LabelSet containing them.
 // A label overwrites a prior label with the same key.
-// BUG(hyangah): Currently only CPU profile utilizes labels information.
+// Currently only CPU profile utilizes labels information.
 // See https://golang.org/issue/23458 for details.
 func Labels(args ...string) LabelSet {
 	if len(args)%2 != 0 {


### PR DESCRIPTION
Currently only CPU profile utilizes tag information.
This change documents that fact

Updates #23458