### PR TITLE
src/make.bat: add missing go.exe and dist.exe extensions

### DIFF
--- a/src/make.bat
+++ b/src/make.bat
@@ -77,10 +77,10 @@ set GOROOT=%GOROOT_BOOTSTRAP%
 set GOOS=
 set GOARCH=
 set GOBIN=
-"%GOROOT_BOOTSTRAP%\bin\go" build -o cmd\dist\dist.exe .\cmd\dist
+"%GOROOT_BOOTSTRAP%\bin\go.exe" build -o cmd\dist\dist.exe .\cmd\dist
 endlocal
 if errorlevel 1 goto fail
-.\cmd\dist\dist env -w -p >env.bat
+.\cmd\dist\dist.exe env -w -p >env.bat
 if errorlevel 1 goto fail
 call env.bat
 del env.bat
@@ -104,7 +104,7 @@ if x%4==x--no-banner set buildall=%buildall% --no-banner
 :: Run dist bootstrap to complete make.bash.
 :: Bootstrap installs a proper cmd/dist, built with the new toolchain.
 :: Throw ours, built with Go 1.4, away after bootstrap.
-.\cmd\dist\dist bootstrap %vflag% %buildall% 
+.\cmd\dist\dist.exe bootstrap %vflag% %buildall% 
 if errorlevel 1 goto fail
 del .\cmd\dist\dist.exe
 goto end


### PR DESCRIPTION
'go' is not an internal or external command, nor is it a runnable program
'disk' is not an internal or external command, nor is it a runnable program
