### PR TITLE
runtime/cgo: fix stack size for the test on FreeBSD.

### DIFF
--- a/src/runtime/testdata/testprogcgo/callback.go
+++ b/src/runtime/testdata/testprogcgo/callback.go
@@ -20,7 +20,7 @@ static void foo() {
     pthread_t th;
     pthread_attr_t attr;
     pthread_attr_init(&attr);
-    pthread_attr_setstacksize(&attr, 256 << 10);
+    pthread_attr_setstacksize(&attr, 512 << 10);
     pthread_create(&th, &attr, thr, 0);
     pthread_join(th, 0);
 }


### PR DESCRIPTION
The test triggers a SIGQUIT signal, thus doubling the
stack size makes the test pass on FreeBSD.