### PR TITLE
cmd/go/internal/modfetch: stop cutting the last character of versions

### DIFF
--- a/src/cmd/go/internal/modfetch/fetch.go
+++ b/src/cmd/go/internal/modfetch/fetch.go
@@ -123,7 +123,7 @@ func downloadZip(mod module.Version, target string) error {
 	for _, f := range z.File {
 		if !strings.HasPrefix(f.Name, prefix) {
 			z.Close()
-			return fmt.Errorf("zip for %s has unexpected file %s", prefix[:len(prefix)-1], f.Name)
+			return fmt.Errorf("zip for %s has unexpected file %s", prefix, f.Name)
 		}
 	}
 	z.Close()


### PR DESCRIPTION
When a zip archive for a module contains an unexpected file, the error
message removes the last character in the version number, e.g. an invalid
archive for "somemod@v1.2.3" would generate the following error:
"zip for somemod@1.2. has unexpected file..."