### PR TITLE
cmd/go: don't mention -mod=release

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -144,7 +144,7 @@
 // 		link against shared libraries previously created with
 // 		-buildmode=shared.
 // 	-mod mode
-// 		module download mode to use: readonly, release, or vendor.
+// 		module download mode to use: readonly or vendor.
 // 		See 'go help modules' for more.
 // 	-pkgdir dir
 // 		install and load all packages from dir instead of the usual locations.

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -99,7 +99,7 @@ and test commands:
 		link against shared libraries previously created with
 		-buildmode=shared.
 	-mod mode
-		module download mode to use: readonly, release, or vendor.
+		module download mode to use: readonly or vendor.
 		See 'go help modules' for more.
 	-pkgdir dir
 		install and load all packages from dir instead of the usual locations.


### PR DESCRIPTION
The -mod=release flag is not supported, so this appears to be a
documentation mistake.

Fixes #27354.