### PR TITLE
doc: add Go 1.11 to release history page

### DIFF
--- a/doc/devel/release.html
+++ b/doc/devel/release.html
@@ -23,6 +23,13 @@ in supported releases as needed by issuing minor revisions
 (for example, Go 1.6.1, Go 1.6.2, and so on).
 </p>
 
+<h2 id="go1.11">go1.11 (released 2018/08/24)</h2>
+
+<p>
+Go 1.11 is a major release of Go.
+Read the <a href="/doc/go1.11">Go 1.11 Release Notes</a> for more information.
+</p>
+
 <h2 id="go1.10">go1.10 (released 2018/02/16)</h2>
 
 <p>


### PR DESCRIPTION
Fixes issue #27359 

