### PR TITLE
crypto/x509: clarify docs for SystemCertPool

### DIFF
--- a/src/crypto/x509/cert_pool.go
+++ b/src/crypto/x509/cert_pool.go
@@ -47,8 +47,8 @@ func (s *CertPool) copy() *CertPool {
 
 // SystemCertPool returns a copy of the system cert pool.
 //
-// Any mutations to the returned pool are not written to disk and do
-// not affect any other pool.
+// Any mutations to a returned pool are not written to disk and do
+// not affect any other pool returned by SystemCertPool.
 //
 // New changes in the the system cert pool might not be reflected
 // in subsequent calls.


### PR DESCRIPTION
The sentence in the docs for SystemCertPool that states that mutations
to a returned pool do not affect any other pool is ambiguous as to who
the any other pools are, because pools can be created in multiple ways
that have nothing to do with the system certificate pool. Also the use
of the word 'the' instead of 'a' early in the sentence implies there is
only one shared pool ever returned.

Fixes #27385
