### PR TITLE
crypto/x509: revert change of article in SystemCertPool docs

### DIFF
--- a/src/crypto/x509/cert_pool.go
+++ b/src/crypto/x509/cert_pool.go
@@ -47,7 +47,7 @@ func (s *CertPool) copy() *CertPool {
 
 // SystemCertPool returns a copy of the system cert pool.
 //
-// Any mutations to a returned pool are not written to disk and do
+// Any mutations to the returned pool are not written to disk and do
 // not affect any other pool returned by SystemCertPool.
 //
 // New changes in the the system cert pool might not be reflected


### PR DESCRIPTION
The words 'the returned' were changed to 'a returned' in
8201b92aae7ba51ed2e2645c1f7815bfe845db72 when referring to the value
returned by SystemCertPool. Brad Fitz pointed out after that commit was
merged that it makes the wording of this function doc inconsistent with
rest of the stdlib since 'a returned' is not used anywhere, but 'the
returned' is frequently used.

Fixes #27385 