### PR TITLE
net: ensure WriteTo on Windows sends even zero-byte payloads

### DIFF
--- a/src/internal/poll/fd_windows.go
+++ b/src/internal/poll/fd_windows.go
@@ -761,9 +761,6 @@ func (fd *FD) Writev(buf *[][]byte) (int64, error) {
 
 // WriteTo wraps the sendto network call.
 func (fd *FD) WriteTo(buf []byte, sa syscall.Sockaddr) (int, error) {
-	if len(buf) == 0 {
-		return 0, nil
-	}
 	if err := fd.writeLock(); err != nil {
 		return 0, err
 	}

--- a/src/net/udpsock_test.go
+++ b/src/net/udpsock_test.go
@@ -357,13 +357,15 @@ func TestUDPZeroBytePayload(t *testing.T) {
 		var b [1]byte
 		if genericRead {
 			_, err = c.(Conn).Read(b[:])
+			// Read may timeout, it depends on the platform.
+			if err != nil {
+				if nerr, ok := err.(Error); !ok || !nerr.Timeout() {
+					t.Fatal(err)
+				}
+			}
 		} else {
 			_, _, err = c.ReadFrom(b[:])
-		}
-		switch err {
-		case nil: // ReadFrom succeeds
-		default: // Read may timeout, it depends on the platform
-			if nerr, ok := err.(Error); !ok || !nerr.Timeout() {
+			if err != nil {
 				t.Fatal(err)
 			}
 		}


### PR DESCRIPTION
This builds on:
https://github.com/golang/go/pull/27445

"...And then send change to fix windows internal/poll.FD.WriteTo - together with making TestUDPZeroBytePayload run again."
- alexbrainman - https://github.com/golang/go/issues/26668#issuecomment-408657503

Fixes #26668