### PR TITLE
clean: clean cache with -n should only print remove commands.

### DIFF
--- a/src/cmd/go/internal/clean/clean.go
+++ b/src/cmd/go/internal/clean/clean.go
@@ -126,13 +126,15 @@ func runClean(cmd *base.Command, args []string) {
 				if cfg.BuildN || cfg.BuildX {
 					b.Showcmd("", "rm -r %s", strings.Join(subdirs, " "))
 				}
-				printedErrors := false
-				for _, d := range subdirs {
-					// Only print the first error - there may be many.
-					// This also mimics what os.RemoveAll(dir) would do.
-					if err := os.RemoveAll(d); err != nil && !printedErrors {
-						printedErrors = true
-						base.Errorf("go clean -cache: %v", err)
+				if !cfg.BuildN {
+					printedErrors := false
+					for _, d := range subdirs {
+						// Only print the first error - there may be many.
+						// This also mimics what os.RemoveAll(dir) would do.
+						if err := os.RemoveAll(d); err != nil && !printedErrors {
+							printedErrors = true
+							base.Errorf("go clean -cache: %v", err)
+						}
 					}
 				}
 			}

--- a/src/cmd/go/testdata/script/clean_cache.txt
+++ b/src/cmd/go/testdata/script/clean_cache.txt
@@ -1,0 +1,17 @@
+# Set up fresh GOCACHE.
+env GOCACHE=$WORK/gocache
+mkdir $GOCACHE
+
+go build lib.go
+
+# Would only print the remove commands
+go clean -cache -n 
+stdout 'gocache/[0-9a-z][0-9a-z]'
+exists $WORK/gocache/01
+
+# Would run the remove commands
+go clean -cache 
+! exists $WORK/gocache/01
+
+-- lib.go --
+package lib

--- a/src/cmd/go/testdata/script/clean_cache.txt
+++ b/src/cmd/go/testdata/script/clean_cache.txt
@@ -9,7 +9,7 @@ go clean -cache -n
 stdout 'gocache/[0-9a-z][0-9a-z]'
 exists $WORK/gocache/01
 
-# Would run the remove commands
+# Would actually run the remove commands
 go clean -cache 
 ! exists $WORK/gocache/01
 


### PR DESCRIPTION
runClean when cleanCache should not execute remove commands when cfg.BuildN = true, but only print them.
Fixes #27469.
