### PR TITLE
database/sql: fix Rows.Columns() documentation

### DIFF
--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -2735,8 +2735,7 @@ func (rs *Rows) Err() error {
 }
 
 // Columns returns the column names.
-// Columns returns an error if the rows are closed, or if the rows
-// are from QueryRow and there was a deferred error.
+// Columns returns an error if the rows are closed.
 func (rs *Rows) Columns() ([]string, error) {
 	rs.closemu.RLock()
 	defer rs.closemu.RUnlock()


### PR DESCRIPTION
Fixes #27202
