### PR TITLE
encoding/asn1: add ability to marshal to general string

### DIFF
--- a/src/encoding/asn1/asn1.go
+++ b/src/encoding/asn1/asn1.go
@@ -677,6 +677,8 @@ func parseField(v reflect.Value, bytes []byte, initOffset int, params fieldParam
 				result, err = parseIA5String(innerBytes)
 			case TagT61String:
 				result, err = parseT61String(innerBytes)
+			case TagGeneralString:
+				result, err = parseT61String(innerBytes)
 			case TagUTF8String:
 				result, err = parseUTF8String(innerBytes)
 			case TagInteger:
@@ -1018,7 +1020,7 @@ func setDefaultValue(v reflect.Value, params fieldParameters) (ok bool) {
 //
 // An ASN.1 UTCTIME or GENERALIZEDTIME can be written to a time.Time.
 //
-// An ASN.1 PrintableString, IA5String, or NumericString can be written to a string.
+// An ASN.1 PrintableString, IA5String, GeneralString or NumericString can be written to a string.
 //
 // Any of the above ASN.1 values can be written to an interface{}.
 // The value stored in the interface has the corresponding Go type.

--- a/src/encoding/asn1/common.go
+++ b/src/encoding/asn1/common.go
@@ -106,6 +106,8 @@ func parseFieldParameters(str string) (ret fieldParameters) {
 			ret.timeType = TagUTCTime
 		case part == "ia5":
 			ret.stringType = TagIA5String
+		case part == "generalstring":
+			ret.stringType = TagGeneralString
 		case part == "printable":
 			ret.stringType = TagPrintableString
 		case part == "numeric":

--- a/src/encoding/asn1/marshal.go
+++ b/src/encoding/asn1/marshal.go
@@ -668,12 +668,13 @@ func makeField(v reflect.Value, params fieldParameters) (e encoder, err error) {
 // In addition to the struct tags recognised by Unmarshal, the following can be
 // used:
 //
-//	ia5:         causes strings to be marshaled as ASN.1, IA5String values
-//	omitempty:   causes empty slices to be skipped
-//	printable:   causes strings to be marshaled as ASN.1, PrintableString values
-//	utf8:        causes strings to be marshaled as ASN.1, UTF8String values
-//	utc:         causes time.Time to be marshaled as ASN.1, UTCTime values
-//	generalized: causes time.Time to be marshaled as ASN.1, GeneralizedTime values
+//	omitempty:     causes empty slices to be skipped
+//	ia5:           causes strings to be marshaled as ASN.1, IA5String values
+//	printable:     causes strings to be marshaled as ASN.1, PrintableString values
+//	utf8:          causes strings to be marshaled as ASN.1, UTF8String values
+//  generalstring: causes strings to be marshaled as ASN.1, GeneralString values
+//	utc:           causes time.Time to be marshaled as ASN.1, UTCTime values
+//	generalized:   causes time.Time to be marshaled as ASN.1, GeneralizedTime values
 func Marshal(val interface{}) ([]byte, error) {
 	return MarshalWithParams(val, "")
 }

--- a/src/encoding/asn1/marshal.go
+++ b/src/encoding/asn1/marshal.go
@@ -672,7 +672,7 @@ func makeField(v reflect.Value, params fieldParameters) (e encoder, err error) {
 //	ia5:           causes strings to be marshaled as ASN.1, IA5String values
 //	printable:     causes strings to be marshaled as ASN.1, PrintableString values
 //	utf8:          causes strings to be marshaled as ASN.1, UTF8String values
-//  generalstring: causes strings to be marshaled as ASN.1, GeneralString values
+//	generalstring: causes strings to be marshaled as ASN.1, GeneralString values
 //	utc:           causes time.Time to be marshaled as ASN.1, UTCTime values
 //	generalized:   causes time.Time to be marshaled as ASN.1, GeneralizedTime values
 func Marshal(val interface{}) ([]byte, error) {

--- a/src/encoding/asn1/marshal_test.go
+++ b/src/encoding/asn1/marshal_test.go
@@ -64,6 +64,10 @@ type genericStringTest struct {
 	A string
 }
 
+type generalStringTest struct {
+	A string `asn1:"generalstring"`
+}
+
 type optionalRawValueTest struct {
 	A RawValue `asn1:"optional"`
 }
@@ -166,6 +170,7 @@ var marshalTests = []marshalTest{
 	{genericStringTest{"test"}, "3006130474657374"},
 	{genericStringTest{"test*"}, "30070c05746573742a"},
 	{genericStringTest{"test&"}, "30070c057465737426"},
+	{generalStringTest{"test"}, "30061b0474657374"},
 	{rawContentsStruct{nil, 64}, "3003020140"},
 	{rawContentsStruct{[]byte{0x30, 3, 1, 2, 3}, 64}, "3003010203"},
 	{RawValue{Tag: 1, Class: 2, IsCompound: false, Bytes: []byte{1, 2, 3}}, "8103010203"},


### PR DESCRIPTION
The current implementation cannot marshal a string into asn1 general
string encoded bytes. This capability has been added.

Fixes #18832