### PR TITLE
container/list: change Len(), Front(), and Back() methods to allow nil receiver

### DIFF
--- a/src/container/list/list.go
+++ b/src/container/list/list.go
@@ -63,11 +63,16 @@ func New() *List { return new(List).Init() }
 
 // Len returns the number of elements of list l.
 // The complexity is O(1).
-func (l *List) Len() int { return l.len }
+func (l *List) Len() int {
+	if l == nil {
+		return 0
+	}
+	return l.len
+}
 
 // Front returns the first element of list l or nil if the list is empty.
 func (l *List) Front() *Element {
-	if l.len == 0 {
+	if l == nil || l.len == 0 {
 		return nil
 	}
 	return l.root.next
@@ -75,7 +80,7 @@ func (l *List) Front() *Element {
 
 // Back returns the last element of list l or nil if the list is empty.
 func (l *List) Back() *Element {
-	if l.len == 0 {
+	if l == nil || l.len == 0 {
 		return nil
 	}
 	return l.root.prev


### PR DESCRIPTION
At the moment List.Len() panics when called with an empty receiver:
https://play.golang.org/p/60wWutjR-mt

This is not consistent with the built-in `len` implementation that allows `nil` parameters: https://golang.org/pkg/builtin/#len

