### PR TITLE
html/template: add support for JavaScript modules.

### DIFF
--- a/src/html/template/js.go
+++ b/src/html/template/js.go
@@ -388,6 +388,7 @@ func isJSType(mimeType string) bool {
 	mimeType = strings.TrimSpace(mimeType)
 	switch mimeType {
 	case
+		"module",
 		"application/ecmascript",
 		"application/javascript",
 		"application/json",


### PR DESCRIPTION
html/template does not properly treat JavaScript code as JavaScript when using a <script>
tag with "module" set as the name attribute.

See also:
https://www.w3.org/TR/html5/semantics-scripting.html#element-attrdef-script-type and
https://html.spec.whatwg.org/multipage/scripting.html#the-script-element:module-script-2

Fixes #31327