### PR TITLE
clean: clean mod cache should respect "-n" option.

### DIFF
--- a/src/cmd/go/internal/clean/clean.go
+++ b/src/cmd/go/internal/clean/clean.go
@@ -112,9 +112,10 @@ func runClean(cmd *base.Command, args []string) {
 		}
 	}
 
+	var b work.Builder
+	b.Print = fmt.Print
+
 	if cleanCache {
-		var b work.Builder
-		b.Print = fmt.Print
 		dir := cache.DefaultDir()
 		if dir != "off" {
 			// Remove the cache subdirectories but not the top cache directory.
@@ -156,8 +157,13 @@ func runClean(cmd *base.Command, args []string) {
 		if modfetch.PkgMod == "" {
 			base.Fatalf("go clean -modcache: no module cache")
 		}
-		if err := removeAll(modfetch.PkgMod); err != nil {
-			base.Errorf("go clean -modcache: %v", err)
+		if cfg.BuildN || cfg.BuildX {
+			b.Showcmd("", "rm -r %s", modfetch.PkgMod)
+		}
+		if !cfg.BuildN {
+			if err := removeAll(modfetch.PkgMod); err != nil {
+				base.Errorf("go clean -modcache: %v", err)
+			}
 		}
 	}
 }

--- a/src/cmd/go/internal/clean/clean.go
+++ b/src/cmd/go/internal/clean/clean.go
@@ -158,7 +158,7 @@ func runClean(cmd *base.Command, args []string) {
 			base.Fatalf("go clean -modcache: no module cache")
 		}
 		if cfg.BuildN || cfg.BuildX {
-			b.Showcmd("", "rm -r %s", modfetch.PkgMod)
+			b.Showcmd("", "rm -rf %s", modfetch.PkgMod)
 		}
 		if !cfg.BuildN {
 			if err := removeAll(modfetch.PkgMod); err != nil {

--- a/src/cmd/go/script_test.go
+++ b/src/cmd/go/script_test.go
@@ -53,32 +53,6 @@ func TestScript(t *testing.T) {
 	}
 }
 
-// TestScript runs the tests in testdata/script/*.txt.
-func TestCleanModeCache(t *testing.T) {
-	testenv.MustHaveGoBuild(t)
-	if skipExternal {
-		t.Skipf("skipping external tests on %s/%s", runtime.GOOS, runtime.GOARCH)
-	}
-
-	files, err := filepath.Glob("testdata/script/mod_clean_cache.txt")
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, file := range files {
-		file := file
-		name := strings.TrimSuffix(filepath.Base(file), ".txt")
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			ts := &testScript{t: t, name: name, file: file}
-			ts.setup()
-			if !*testWork {
-				defer removeAll(ts.workdir)
-			}
-			ts.run()
-		})
-	}
-}
-
 // A testScript holds execution state for a single test script.
 type testScript struct {
 	t       *testing.T

--- a/src/cmd/go/script_test.go
+++ b/src/cmd/go/script_test.go
@@ -53,6 +53,32 @@ func TestScript(t *testing.T) {
 	}
 }
 
+// TestScript runs the tests in testdata/script/*.txt.
+func TestCleanModeCache(t *testing.T) {
+	testenv.MustHaveGoBuild(t)
+	if skipExternal {
+		t.Skipf("skipping external tests on %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+
+	files, err := filepath.Glob("testdata/script/mod_clean_cache.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range files {
+		file := file
+		name := strings.TrimSuffix(filepath.Base(file), ".txt")
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ts := &testScript{t: t, name: name, file: file}
+			ts.setup()
+			if !*testWork {
+				defer removeAll(ts.workdir)
+			}
+			ts.run()
+		})
+	}
+}
+
 // A testScript holds execution state for a single test script.
 type testScript struct {
 	t       *testing.T

--- a/src/cmd/go/testdata/script/mod_clean_cache.txt
+++ b/src/cmd/go/testdata/script/mod_clean_cache.txt
@@ -1,0 +1,23 @@
+env GO111MODULE=on
+
+go mod download rsc.io/quote@v1.5.0
+exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v1.5.0.info
+exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v1.5.0.mod
+exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v1.5.0.zip
+
+go clean -modcache -n
+stdout '^rm -rf .*/pkg/mod$'
+exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v1.5.0.info
+exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v1.5.0.mod
+exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v1.5.0.zip
+
+go clean -modcache
+! exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v1.5.0.info
+! exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v1.5.0.mod
+! exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v1.5.0.zip
+
+-- go.mod --
+module m
+
+-- m.go --
+package m

--- a/src/cmd/go/testdata/script/mod_clean_cache.txt
+++ b/src/cmd/go/testdata/script/mod_clean_cache.txt
@@ -6,7 +6,7 @@ exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v1.5.0.mod
 exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v1.5.0.zip
 
 go clean -modcache -n
-stdout '^rm -rf .*/pkg/mod$'
+stdout '^rm -rf .*pkg.mod$'
 exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v1.5.0.info
 exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v1.5.0.mod
 exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v1.5.0.zip


### PR DESCRIPTION
Clean mod cache should print remove commands and not run them when with set "-n" option.
Fixes #27458.