### PR TITLE
html/template: don't escape '+' chars in HTML attributes

### DIFF
--- a/src/html/template/html.go
+++ b/src/html/template/html.go
@@ -60,7 +60,6 @@ var htmlReplacementTable = []string{
 	'"':  "&#34;",
 	'&':  "&amp;",
 	'\'': "&#39;",
-	'+':  "&#43;",
 	'<':  "&lt;",
 	'>':  "&gt;",
 }
@@ -71,7 +70,6 @@ var htmlNormReplacementTable = []string{
 	0:    "\uFFFD",
 	'"':  "&#34;",
 	'\'': "&#39;",
-	'+':  "&#43;",
 	'<':  "&lt;",
 	'>':  "&gt;",
 }


### PR DESCRIPTION
The "+" (plus) symbol is being escaped right now from HTML attributes 
via html/template even though it's a valid character.

This causes what would be a valid ISO8601 date such as 
2018-09-19T19:52:28+06:00 to be escaped in an HTML meta tag. Which is 
unnecessary and may prevent certain search bots and other tools from 
parsing the date correctly.

HTML 4.x and HTML 5 attribute values can have a plus (+) character unescaped without issue: https://www.w3.org/TR/2011/WD-html5-20110525/syntax.html#attributes-0

You can further verify that put validating the snipper below at the [W3C HTML Validator](https://validator.w3.org/#validate_by_input).

```
<!DOCTYPE html>
<html lang="en">
<head>
<meta name="generator" content="Hugo 0.49-DEV" />
	<meta charset="UTF-8" />
	<meta property="og:updated_time" content="2006-01-02T15:04:05+07:00" /> 
	<title>My Fake Website</title>
</head>
<body class="home ">
	<h1 class="site-title">Hello!</h1>
</body>
</html>
```

Notice how there's a datetime timestamp with the plus symbol for the timezone. That's perfectly valid and this PR will enable that to happen with `html/template`.