### PR TITLE
doc/articles/wiki: remove misleading code in tutorial

### DIFF
--- a/doc/articles/wiki/final-noclosure.go
+++ b/doc/articles/wiki/final-noclosure.go
@@ -80,7 +80,7 @@ func renderTemplate(w http.ResponseWriter, tmpl string, p *Page) {
 	}
 	err = t.Execute(w, p)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		log.Printf("error executing template %s.html: %v", tmpl, err)
 	}
 }
 

--- a/doc/articles/wiki/final-parsetemplate.go
+++ b/doc/articles/wiki/final-parsetemplate.go
@@ -67,7 +67,7 @@ func renderTemplate(w http.ResponseWriter, tmpl string, p *Page) {
 	}
 	err = t.Execute(w, p)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		log.Printf("error executing template %s.html: %v", tmpl, err)
 	}
 }
 

--- a/doc/articles/wiki/final.go
+++ b/doc/articles/wiki/final.go
@@ -64,7 +64,7 @@ var templates = template.Must(template.ParseFiles("edit.html", "view.html"))
 func renderTemplate(w http.ResponseWriter, tmpl string, p *Page) {
 	err := templates.ExecuteTemplate(w, tmpl+".html", p)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		log.Printf("error executing template %s.html: %v", tmpl, err)
 	}
 }
 

--- a/doc/articles/wiki/index.html
+++ b/doc/articles/wiki/index.html
@@ -508,9 +508,13 @@ First, let's handle the errors in <code>renderTemplate</code>:
 {{code "doc/articles/wiki/final-parsetemplate.go" `/^func renderTemplate/` `/^}/`}}
 
 <p>
-The <code>http.Error</code> function sends a specified HTTP response code
-(in this case "Internal Server Error") and error message.
-Already the decision to put this in a separate function is paying off.
+There are two places that we are handling errors. To handle the error from
+<code>ParseFiles</code>, we use the <code>http.Error</code> function which
+sends an HTTP response code (in this case "Internal Server Error") and error 
+message to the user. For the next error we can't use <code>http.Error</code>, 
+as we have already started writing the HTTP response by executing the template, 
+and so we use <code>log.Printf</code> to note that the error occurred. Already 
+the decision to put this in a separate function is paying off.
 </p>
 
 <p>


### PR DESCRIPTION
In the "Writing Web Applications" example, we attempt to write the
response header twice when handling errors from template.Execute.
Since this doesn't work in practice, it shouldn't be done in the
tutorial. Instead, simply log the error, and note the reason.

Fixes #27789