### PR TITLE
encoding/json: Add "nonil" struct tag for json encoding of nil slices/maps

### DIFF
--- a/src/encoding/json/encode.go
+++ b/src/encoding/json/encode.go
@@ -71,10 +71,10 @@ import (
 // false, 0, a nil pointer, a nil interface value, and any empty array,
 // slice, map, or string.
 //
-// The "heednull" option specifies that if the field is a slice or map
+// The "nonil" option specifies that if the field is a slice or map
 // of nil value, then the value encoded will be [] or {} respectively (instead
-// of "null"). If both "heednull" and "omitempty" are present, then "heednull" is
-// ignored. If the field is not a slice or map, "heednull" does nothing.
+// of "null"). If both "nonil" and "omitempty" are present, then "nonil" is
+// ignored. If the field is not a slice or map, "nonil" does nothing.
 //
 // As a special case, if the field tag is "-", the field is always omitted.
 // Note that a field with name "-" can still be generated using the tag "-,".
@@ -662,7 +662,7 @@ FieldLoop:
 		}
 		opts.quoted = f.quoted
 
-		if f.heedNull {
+		if f.noNil {
 			if f.typ.Kind() == reflect.Slice && fv.IsNil() {
 				e.WriteString("[]")
 			} else if f.typ.Kind() == reflect.Map && fv.IsNil() {
@@ -1055,7 +1055,7 @@ type field struct {
 	index     []int
 	typ       reflect.Type
 	omitEmpty bool
-	heedNull  bool
+	noNil     bool
 	quoted    bool
 
 	encoder encoderFunc
@@ -1173,7 +1173,7 @@ func typeFields(t reflect.Type) []field {
 						index:     index,
 						typ:       ft,
 						omitEmpty: opts.Contains("omitempty"),
-						heedNull:  !opts.Contains("omitempty") && opts.Contains("heednull"),
+						noNil:     !opts.Contains("omitempty") && opts.Contains("nonil"),
 						quoted:    quoted,
 					}
 					field.nameBytes = []byte(field.name)

--- a/src/encoding/json/encode_test.go
+++ b/src/encoding/json/encode_test.go
@@ -42,11 +42,11 @@ type Optionals struct {
 	Str struct{} `json:"str"`
 	Sto struct{} `json:"sto,omitempty"`
 
-	Slh []string `json:"slh,heednull"`
-	Slb []string `json:"slb,omitempty,heednull"`
+	Slh []string `json:"slh,nonil"`
+	Slb []string `json:"slb,omitempty,nonil"`
 
-	Mh map[string]interface{} `json:"mh,heednull"`
-	Mb map[string]interface{} `json:"mb,omitempty,heednull"`
+	Mh map[string]interface{} `json:"mh,nonil"`
+	Mb map[string]interface{} `json:"mb,omitempty,nonil"`
 }
 
 var optionalsExpected = `{

--- a/src/encoding/json/encode_test.go
+++ b/src/encoding/json/encode_test.go
@@ -41,6 +41,12 @@ type Optionals struct {
 
 	Str struct{} `json:"str"`
 	Sto struct{} `json:"sto,omitempty"`
+
+	Slh []string `json:"slh,heednull"`
+	Slb []string `json:"slb,omitempty,heednull"`
+
+	Mh map[string]interface{} `json:"mh,heednull"`
+	Mb map[string]interface{} `json:"mb,omitempty,heednull"`
 }
 
 var optionalsExpected = `{
@@ -52,7 +58,9 @@ var optionalsExpected = `{
  "br": false,
  "ur": 0,
  "str": {},
- "sto": {}
+ "sto": {},
+ "slh": [],
+ "mh": {}
 }`
 
 func TestOmitEmpty(t *testing.T) {


### PR DESCRIPTION
add "nonil" struct tag for json marshaling slices/maps so that nil slices/maps get encoded as []/{} respectively.

Fixes #27589