### PR TITLE
net/http: use Header.clone rather then duplicating functionality

### DIFF
--- a/src/net/http/client.go
+++ b/src/net/http/client.go
@@ -238,7 +238,7 @@ func send(ireq *Request, rt RoundTripper, deadline time.Time) (resp *Response, d
 		username := u.Username()
 		password, _ := u.Password()
 		forkReq()
-		req.Header = cloneHeader(ireq.Header)
+		req.Header = ireq.Header.clone()
 		req.Header.Set("Authorization", "Basic "+basicAuth(username, password))
 	}
 

--- a/src/net/http/header.go
+++ b/src/net/http/header.go
@@ -229,13 +229,3 @@ func hasToken(v, token string) bool {
 func isTokenBoundary(b byte) bool {
 	return b == ' ' || b == ',' || b == '\t'
 }
-
-func cloneHeader(h Header) Header {
-	h2 := make(Header, len(h))
-	for k, vv := range h {
-		vv2 := make([]string, len(vv))
-		copy(vv2, vv)
-		h2[k] = vv2
-	}
-	return h2
-}


### PR DESCRIPTION
cloneHeader duplicates what Header.clone() method is doing. It's
used in a single place, which can be replaced with the use of the
method.
