### PR TITLE
strings: use Builder in ToUpper and ToLower

### DIFF
--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -561,15 +561,16 @@ func ToUpper(s string) string {
 		if !hasLower {
 			return s
 		}
-		b := make([]byte, len(s))
+		var b Builder
+		b.Grow(len(s))
 		for i := 0; i < len(s); i++ {
 			c := s[i]
 			if c >= 'a' && c <= 'z' {
 				c -= 'a' - 'A'
 			}
-			b[i] = c
+			b.WriteByte(c)
 		}
-		return string(b)
+		return b.String()
 	}
 	return Map(unicode.ToUpper, s)
 }
@@ -590,15 +591,16 @@ func ToLower(s string) string {
 		if !hasUpper {
 			return s
 		}
-		b := make([]byte, len(s))
+		var b Builder
+		b.Grow(len(s))
 		for i := 0; i < len(s); i++ {
 			c := s[i]
 			if c >= 'A' && c <= 'Z' {
 				c += 'a' - 'A'
 			}
-			b[i] = c
+			b.WriteByte(c)
 		}
-		return string(b)
+		return b.String()
 	}
 	return Map(unicode.ToLower, s)
 }


### PR DESCRIPTION
Map was optimized to use Builder in 45c7d80832, which avoided the []byte
to string converstion. This left the ToUpper and ToLower ASCII fast path
with an extra allocation over Map.

name                                        old time/op    new time/op    delta
ToUpper/#00-12                                3.59ns ± 4%    3.71ns ± 1%     ~     (p=0.056 n=5+5)
ToUpper/ONLYUPPER-12                          11.8ns ± 2%    10.5ns ± 2%  -10.85%  (p=0.008 n=5+5)
ToUpper/abc-12                                31.8ns ± 1%    25.3ns ± 1%  -20.40%  (p=0.008 n=5+5)
ToUpper/AbC123-12                             46.2ns ± 7%    31.9ns ± 8%  -30.89%  (p=0.008 n=5+5)
ToUpper/azAZ09_-12                            47.1ns ± 8%    32.6ns ± 4%  -30.77%  (p=0.008 n=5+5)
ToUpper/longStrinGwitHmixofsmaLLandcAps-12     137ns ±15%     104ns ±11%  -24.11%  (p=0.008 n=5+5)
ToUpper/longɐstringɐwithɐnonasciiⱯchars-12     231ns ± 1%     228ns ± 1%     ~     (p=0.079 n=5+5)
ToUpper/ɐɐɐɐɐ-12                               207ns ± 3%     206ns ± 1%     ~     (p=0.913 n=5+5)
ToUpper/a\u0080\U0010ffff-12                  90.8ns ± 1%    89.6ns ± 1%   -1.30%  (p=0.024 n=5+5)
ToLower/#00-12                                3.59ns ± 1%    4.26ns ± 2%  +18.66%  (p=0.008 n=5+5)
ToLower/abc-12                                6.32ns ± 1%    6.62ns ± 1%   +4.72%  (p=0.008 n=5+5)
ToLower/AbC123-12                             45.0ns ±13%    31.5ns ± 4%  -29.89%  (p=0.008 n=5+5)
ToLower/azAZ09_-12                            48.8ns ± 6%    33.2ns ± 3%  -31.91%  (p=0.008 n=5+5)
ToLower/longStrinGwitHmixofsmaLLandcAps-12     149ns ±13%      98ns ± 8%  -34.30%  (p=0.008 n=5+5)
ToLower/LONGⱯSTRINGⱯWITHⱯNONASCIIⱯCHARS-12     237ns ± 4%     237ns ± 2%     ~     (p=0.635 n=5+5)
ToLower/ⱭⱭⱭⱭⱭ-12                               181ns ± 1%     181ns ± 1%     ~     (p=0.762 n=5+5)
ToLower/A\u0080\U0010ffff-12                  90.6ns ± 1%    92.5ns ± 1%   +2.05%  (p=0.016 n=5+5)

name                                        old alloc/op   new alloc/op   delta
ToUpper/#00-12                                 0.00B          0.00B          ~     (all equal)
ToUpper/ONLYUPPER-12                           0.00B          0.00B          ~     (all equal)
ToUpper/abc-12                                 6.00B ± 0%     3.00B ± 0%  -50.00%  (p=0.008 n=5+5)
ToUpper/AbC123-12                              16.0B ± 0%      8.0B ± 0%  -50.00%  (p=0.008 n=5+5)
ToUpper/azAZ09_-12                             16.0B ± 0%      8.0B ± 0%  -50.00%  (p=0.008 n=5+5)
ToUpper/longStrinGwitHmixofsmaLLandcAps-12     64.0B ± 0%     32.0B ± 0%  -50.00%  (p=0.008 n=5+5)
ToUpper/longɐstringɐwithɐnonasciiⱯchars-12     48.0B ± 0%     48.0B ± 0%     ~     (all equal)
ToUpper/ɐɐɐɐɐ-12                               48.0B ± 0%     48.0B ± 0%     ~     (all equal)
ToUpper/a\u0080\U0010ffff-12                   16.0B ± 0%     16.0B ± 0%     ~     (all equal)
ToLower/#00-12                                 0.00B          0.00B          ~     (all equal)
ToLower/abc-12                                 0.00B          0.00B          ~     (all equal)
ToLower/AbC123-12                              16.0B ± 0%      8.0B ± 0%  -50.00%  (p=0.008 n=5+5)
ToLower/azAZ09_-12                             16.0B ± 0%      8.0B ± 0%  -50.00%  (p=0.008 n=5+5)
ToLower/longStrinGwitHmixofsmaLLandcAps-12     64.0B ± 0%     32.0B ± 0%  -50.00%  (p=0.008 n=5+5)
ToLower/LONGⱯSTRINGⱯWITHⱯNONASCIIⱯCHARS-12     48.0B ± 0%     48.0B ± 0%     ~     (all equal)
ToLower/ⱭⱭⱭⱭⱭ-12                               32.0B ± 0%     32.0B ± 0%     ~     (all equal)
ToLower/A\u0080\U0010ffff-12                   16.0B ± 0%     16.0B ± 0%     ~     (all equal)

name                                        old allocs/op  new allocs/op  delta
ToUpper/#00-12                                  0.00           0.00          ~     (all equal)
ToUpper/ONLYUPPER-12                            0.00           0.00          ~     (all equal)
ToUpper/abc-12                                  2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.008 n=5+5)
ToUpper/AbC123-12                               2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.008 n=5+5)
ToUpper/azAZ09_-12                              2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.008 n=5+5)
ToUpper/longStrinGwitHmixofsmaLLandcAps-12      2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.008 n=5+5)
ToUpper/longɐstringɐwithɐnonasciiⱯchars-12      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
ToUpper/ɐɐɐɐɐ-12                                2.00 ± 0%      2.00 ± 0%     ~     (all equal)
ToUpper/a\u0080\U0010ffff-12                    1.00 ± 0%      1.00 ± 0%     ~     (all equal)
ToLower/#00-12                                  0.00           0.00          ~     (all equal)
ToLower/abc-12                                  0.00           0.00          ~     (all equal)
ToLower/AbC123-12                               2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.008 n=5+5)
ToLower/azAZ09_-12                              2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.008 n=5+5)
ToLower/longStrinGwitHmixofsmaLLandcAps-12      2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.008 n=5+5)
ToLower/LONGⱯSTRINGⱯWITHⱯNONASCIIⱯCHARS-12      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
ToLower/ⱭⱭⱭⱭⱭ-12                                1.00 ± 0%      1.00 ± 0%     ~     (all equal)
ToLower/A\u0080\U0010ffff-12                    1.00 ± 0%      1.00 ± 0%     ~     (all equal)

Updates #26304