### PR TITLE
runtime: fix unconditional plural in goroutineheader

### DIFF
--- a/src/runtime/traceback.go
+++ b/src/runtime/traceback.go
@@ -913,7 +913,9 @@ func goroutineheader(gp *g) {
 	if isScan {
 		print(" (scan)")
 	}
-	if waitfor >= 1 {
+	if waitfor == 1 {
+		print(", ", waitfor, " minute")
+	} else if waitfor > 1 {
 		print(", ", waitfor, " minutes")
 	}
 	if gp.lockedm != 0 {


### PR DESCRIPTION
Tracebacks currently print "1 minutes". Make them print "1 minute"
instead.

This change breaks at least one know tool (panicparse). If this PR
is merged, I will open a PR on that tool to fix it immediately.
Still, I acknowledge that breaking existing tools is not something
to be done lightly.