### PR TITLE
Use 404 error Status Text instead of hardcoded value

### DIFF
--- a/src/net/http/serve_test.go
+++ b/src/net/http/serve_test.go
@@ -518,7 +518,7 @@ func TestServeWithSlashRedirectKeepsQueryString(t *testing.T) {
 
 		// canonicalization or not
 		8: {"/testOne/foo/..?foo", "GET", "foo", true},
-		9: {"/testOne/foo/..?foo", "CONNECT", "404 page not found\n", false},
+		9: {"/testOne/foo/..?foo", "CONNECT", StatusText(404) + "\n", false},
 	}
 
 	for i, tt := range tests {

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -1978,10 +1978,10 @@ func Error(w ResponseWriter, error string, code int) {
 }
 
 // NotFound replies to the request with an HTTP 404 not found error.
-func NotFound(w ResponseWriter, r *Request) { Error(w, "404 page not found", StatusNotFound) }
+func NotFound(w ResponseWriter, r *Request) { Error(w, StatusText(StatusNotFound), StatusNotFound) }
 
 // NotFoundHandler returns a simple request handler
-// that replies to each request with a ``404 page not found'' reply.
+// that replies to each request with a 404 Status Text as reply.
 func NotFoundHandler() Handler { return HandlerFunc(NotFound) }
 
 // StripPrefix returns a handler that serves HTTP requests


### PR DESCRIPTION
net/http: Use Status Text for 404 Error in the NotFound function instead of hardcoded string

At the moment NotFound function that is used as handler function for NotFoundHandler uses a hardcoded string as response. This commit uses appropriate Status Text from net/http/status.go for this purpose to avoid hardcoded values