### PR TITLE
cmd/go: prevent infinite loop in QueryPackage()

### DIFF
--- a/src/cmd/go/internal/modload/query.go
+++ b/src/cmd/go/internal/modload/query.go
@@ -221,7 +221,7 @@ func QueryPackage(path, query string, allowed func(module.Version) bool) (module
 	}
 
 	finalErr := errMissing
-	for p := path; p != "."; p = pathpkg.Dir(p) {
+	for p := path; p != "." && p != "/"; p = pathpkg.Dir(p) {
 		info, err := Query(p, query, allowed)
 		if err != nil {
 			if _, ok := err.(*codehost.VCSError); ok {


### PR DESCRIPTION
p = path.Dir(p) converges to either "." or "/". The current
implementation of modload.QueryPackage() has a loop that
terminates only on ".", not "/". This leads to the go command
hanging in an infinite loop if the user manages to supply
a file path starting with "/" as package path.

An example of the issue is if the user (incorrectly) attempts
to use an absolute directory path in an import statement within
a module (import "/home/bob/myproj") and then runs go list.

Fixes #27558
