### PR TITLE
cmd/go: accept @hash/branch in mod download

### DIFF
--- a/src/cmd/go/internal/modfetch/cache.go
+++ b/src/cmd/go/internal/modfetch/cache.go
@@ -129,15 +129,17 @@ func (r *cachingRepo) Stat(rev string) (*RevInfo, error) {
 		}
 		info, err = r.r.Stat(rev)
 		if err == nil {
-			if err := writeDiskStat(file, info); err != nil {
-				fmt.Fprintf(os.Stderr, "go: writing stat cache: %v\n", err)
-			}
 			// If we resolved, say, 1234abcde to v0.0.0-20180604122334-1234abcdef78,
 			// then save the information under the proper version, for future use.
 			if info.Version != rev {
+				file, _ = CachePath(module.Version{Path: r.path, Version: info.Version}, "info")
 				r.cache.Do("stat:"+info.Version, func() interface{} {
 					return cachedInfo{info, err}
 				})
+			}
+
+			if err := writeDiskStat(file, info); err != nil {
+				fmt.Fprintf(os.Stderr, "go: writing stat cache: %v\n", err)
 			}
 		}
 		return cachedInfo{info, err}

--- a/src/cmd/go/testdata/script/mod_download_hash.txt
+++ b/src/cmd/go/testdata/script/mod_download_hash.txt
@@ -1,0 +1,23 @@
+env GO111MODULE=on
+
+# Testing mod download with non semantic versions; turn off proxy.
+[!net] skip
+[!exec:git] skip
+env GOPROXY=
+
+go mod download rsc.io/quote@a91498bed0a73d4bb9c1fb2597925f7883bc40a7
+exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v0.0.0-20180709162918-a91498bed0a7.info
+exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v0.0.0-20180709162918-a91498bed0a7.mod
+exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v0.0.0-20180709162918-a91498bed0a7.zip
+
+go mod download rsc.io/quote@master
+exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v0.0.0-20180710144737-5d9f230bcfba.info
+exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v0.0.0-20180710144737-5d9f230bcfba.mod
+exists $GOPATH/pkg/mod/cache/download/rsc.io/quote/@v/v0.0.0-20180710144737-5d9f230bcfba.zip
+
+
+-- go.mod --
+module m
+
+-- m.go --
+package m


### PR DESCRIPTION
Go get in mod-enabled packages lets you do go get "pkg@<hash>" or "pkg@<branch>".
Go internally will switch the hash or branch into a pseudo version.
Go mod download should do the same. The bug lay in the fact that the disk cache
was not being written when Go converted the hash/branch into a pseudo version.

Fixes #27947