### PR TITLE
os: fix backslash behavior in Expand

### DIFF
--- a/src/testdata/testenv.txt
+++ b/src/testdata/testenv.txt
@@ -1,0 +1,6 @@
+# test cases for Env Expend
+$foo=bar
+\$foo=\$foo
+\\$foo=\\bar
+\\\$foo=\\\$foo
+\\\\$foo=\\\\bar


### PR DESCRIPTION
os.Setenv("foo", "bar")
If we use os.ExpandEnv("\\$foo"), we will get \bar, not \$foo.
So, I think we need to fix this problem.

Please check, thanks.