### PR TITLE
expvar: optimize Map.String() and expvar HTTP handler

### DIFF
--- a/src/expvar/expvar_test.go
+++ b/src/expvar/expvar_test.go
@@ -272,6 +272,19 @@ func BenchmarkMapSet(b *testing.B) {
 	})
 }
 
+var sink string
+
+func BenchmarkMapString(b *testing.B) {
+	m := new(Map).Init()
+	m.Add("red", 1)
+	m.Add("green", 2)
+	m.Add("blue", 3)
+
+	for i := 0; i < b.N; i++ {
+		sink = m.String()
+	}
+}
+
 func BenchmarkMapSetDifferent(b *testing.B) {
 	procKeys := make([][]string, runtime.GOMAXPROCS(0))
 	for i := range procKeys {


### PR DESCRIPTION
name         old time/op    new time/op    delta
MapString-4    2.69µs ± 2%    1.07µs ± 2%  -60.26%  (p=0.000 n=10+8)

name         old alloc/op   new alloc/op   delta
MapString-4      200B ± 0%      184B ± 0%   -8.00%  (p=0.000 n=10+10)

name         old allocs/op  new allocs/op  delta
MapString-4      8.00 ± 0%      5.00 ± 0%  -37.50%  (p=0.000 n=10+10)
