### PR TITLE
doc: fix error prone ebnf grammar about unary_expr production

### DIFF
--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -3413,7 +3413,7 @@ Operators combine operands into expressions.
 
 <pre class="ebnf">
 Expression = UnaryExpr | Expression binary_op Expression .
-UnaryExpr  = PrimaryExpr | unary_op UnaryExpr .
+UnaryExpr  = unary_op UnaryExpr | PrimaryExpr .
 
 binary_op  = "||" | "&amp;&amp;" | rel_op | add_op | mul_op .
 rel_op     = "==" | "!=" | "&lt;" | "&lt;=" | ">" | ">=" .


### PR DESCRIPTION
consider the following expr:
```go
const (
	EOF = -(iota + 1)
        ....
)
```
if we write recursive-descent parser according to official language specification, we would get recursive calling.
In fact, official implementation is also not conformed to those grammar:
```go
// UnaryExpr = PrimaryExpr | unary_op UnaryExpr .
func (p *parser) unaryExpr() Expr {
	if trace {
		defer p.trace("unaryExpr")()
	}
        //unary_op first
	switch p.tok {
	case _Operator, _Star:...
	case _Arrow:...
	}
       // primaryExpr second
	return p.pexpr(true)
}
```
