### PR TITLE
syscall/js: add Wrapper interface to support external Value wrapper types

### DIFF
--- a/src/syscall/js/callback.go
+++ b/src/syscall/js/callback.go
@@ -20,6 +20,8 @@ var (
 	nextCallbackID uint32 = 1
 )
 
+var _ Wrapper = Callback{} // Callback must implement Wrapper
+
 // Callback is a Go function that got wrapped for use as a JavaScript callback.
 type Callback struct {
 	Value // the JavaScript function that queues the callback for execution

--- a/src/syscall/js/typedarray.go
+++ b/src/syscall/js/typedarray.go
@@ -22,6 +22,8 @@ var (
 	float64Array = Global().Get("Float64Array")
 )
 
+var _ Wrapper = TypedArray{} // TypedArray must implement Wrapper
+
 // TypedArray represents a JavaScript typed array.
 type TypedArray struct {
 	Value


### PR DESCRIPTION
The Callback and TypedArray are the only JavaScript types supported by
the library, thus they are special-cased in a type switch of ValueOf.

Instead, a Ref interface is defined to allow external wrapper types
to be handled properly by ValueOf.
