### PR TITLE
cmd/go/internal/get: fix go get for Azure DevOps Git repos

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -1950,6 +1950,11 @@
 // 		import "hub.jazz.net/git/user/project"
 // 		import "hub.jazz.net/git/user/project/sub/directory"
 //
+// 	Azure DevOps (Git)
+//
+// 		import "dev.azure.com/organization/project/package"
+// 		import "dev.azure.com/organization/project/package.git/sub/directory"
+//
 // For code hosted on other servers, import paths may either be qualified
 // with the version control type, or the go tool can dynamically fetch
 // the import path over https/http and discover where the code resides

--- a/src/cmd/go/internal/get/vcs.go
+++ b/src/cmd/go/internal/get/vcs.go
@@ -1030,7 +1030,7 @@ var vcsPaths = []*vcsPath{
 	// Azure DevOps
 	{
 		prefix: "dev.azure.com/",
-		re:     `^(?P<path>dev\.azure\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)(?P<package>/[A-Za-z0-9_.\-]+)(/[\p{L}0-9_.\-]+)*$`,
+		re:     `^(?P<path>dev\.azure\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+(/_git)?)(?P<package>/[A-Za-z0-9_.\-]+)(/[\p{L}0-9_.\-]+)*$`,
 		vcs:    "git",
 		repo:   "https://{path}/_git{package}",
 		check:  azureVCS,
@@ -1148,5 +1148,10 @@ func launchpadVCS(match map[string]string) error {
 // azureVCS sets the root since it composed of 2 parts.
 func azureVCS(match map[string]string) error {
 	match["root"] = expand(match, "{path}{package}")
+	if strings.HasSuffix(match["path"], "/_git") {
+		// Handle legacy Azure DevOps import paths with _git and .git.
+		match["package"] = strings.TrimSuffix(match["package"], ".git")
+		match["repo"] = expand(match, "https://{path}{package}")
+	}
 	return nil
 }

--- a/src/cmd/go/internal/get/vcs.go
+++ b/src/cmd/go/internal/get/vcs.go
@@ -1024,6 +1024,15 @@ var vcsPaths = []*vcsPath{
 		repo:   "https://{root}",
 	},
 
+	// Azure DevOps
+	{
+		prefix: "dev.azure.com/",
+		re:     `^(?P<path>dev\.azure\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)(?P<package>/[A-Za-z0-9_.\-]+)(/[\p{L}0-9_.\-]+)*$`,
+		vcs: 	"git",
+		repo:   "https://{path}/_git{package}",
+		check:  azureVCS,
+	},
+
 	// General syntax for any server.
 	// Must be last.
 	{
@@ -1130,5 +1139,10 @@ func launchpadVCS(match map[string]string) error {
 		match["root"] = expand(match, "launchpad.net/{project}")
 		match["repo"] = expand(match, "https://{root}")
 	}
+	return nil
+}
+
+func azureVCS(match map[string]string) error {
+	match["root"] = expand(match, "{path}{package}")
 	return nil
 }

--- a/src/cmd/go/internal/get/vcs.go
+++ b/src/cmd/go/internal/get/vcs.go
@@ -638,7 +638,10 @@ var httpPrefixRE = regexp.MustCompile(`^https?:`)
 type ModuleMode int
 
 const (
+	// IgnoreMod - ignore modules mode
 	IgnoreMod ModuleMode = iota
+
+	// PreferMod - prefer modules mode
 	PreferMod
 )
 
@@ -1028,7 +1031,7 @@ var vcsPaths = []*vcsPath{
 	{
 		prefix: "dev.azure.com/",
 		re:     `^(?P<path>dev\.azure\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)(?P<package>/[A-Za-z0-9_.\-]+)(/[\p{L}0-9_.\-]+)*$`,
-		vcs: 	"git",
+		vcs:    "git",
 		repo:   "https://{path}/_git{package}",
 		check:  azureVCS,
 	},
@@ -1142,6 +1145,7 @@ func launchpadVCS(match map[string]string) error {
 	return nil
 }
 
+// azureVCS sets the root since it composed of 2 parts.
 func azureVCS(match map[string]string) error {
 	match["root"] = expand(match, "{path}{package}")
 	return nil

--- a/src/cmd/go/internal/get/vcs_test.go
+++ b/src/cmd/go/internal/get/vcs_test.go
@@ -178,6 +178,35 @@ func TestRepoRootForImportPath(t *testing.T) {
 			"chiselapp.com/user/kyle/fossilgg",
 			nil,
 		},
+		{
+			// Azure DevOps
+			path: "dev.azure.com/user/project/package",
+			want: &RepoRoot{
+				vcs:  vcsGit,
+				Repo: "https://dev.azure.com/user/project/_git/package",
+			},
+		},
+		{
+			// with subpackages
+			path: "dev.azure.com/user/project/package/sub-package",
+			want: &RepoRoot{
+				vcs:  vcsGit,
+				Repo: "https://dev.azure.com/user/project/_git/package",
+			},
+		},
+		{
+			// with .git extension
+			path: "dev.azure.com/user-name/project_name/package.git/sub-package",
+			want: &RepoRoot{
+				vcs:  vcsGit,
+				Repo: "https://dev.azure.com/user-name/project_name/_git/package.git",
+			},
+		},
+		{
+			// Azure DevOps supports user/projects/repos with spaces but these are not valid go paths
+			path: "dev.azure.com/user name/project name/package/sub-package",
+			want: nil,
+		},
 	}
 
 	for _, test := range tests {

--- a/src/cmd/go/internal/get/vcs_test.go
+++ b/src/cmd/go/internal/get/vcs_test.go
@@ -195,7 +195,7 @@ func TestRepoRootForImportPath(t *testing.T) {
 			},
 		},
 		{
-			// with .git extension
+			// with .git extension which is optional when creating a repo
 			path: "dev.azure.com/user-name/project_name/package.git/sub-package",
 			want: &RepoRoot{
 				vcs:  vcsGit,

--- a/src/cmd/go/internal/get/vcs_test.go
+++ b/src/cmd/go/internal/get/vcs_test.go
@@ -203,6 +203,14 @@ func TestRepoRootForImportPath(t *testing.T) {
 			},
 		},
 		{
+			// with _git and .git at the end should use default behavior
+			path: "dev.azure.com/user-name/project_name/_git/package.git/sub-package",
+			want: &RepoRoot{
+				vcs:  vcsGit,
+				Repo: "https://dev.azure.com/user-name/project_name/_git/package",
+			},
+		},
+		{
 			// Azure DevOps supports user/projects/repos with spaces but these are not valid go paths
 			path: "dev.azure.com/user name/project name/package/sub-package",
 			want: nil,

--- a/src/cmd/go/internal/help/helpdoc.go
+++ b/src/cmd/go/internal/help/helpdoc.go
@@ -183,8 +183,8 @@ A few common code hosting sites have special syntax:
 
 	Azure DevOps (Git)
 		
-		import "dev.azure.com/user/project/package"
-		import "dev.azure.com/user/project/package/sub/directory"
+		import "dev.azure.com/organization/project/package"
+		import "dev.azure.com/organization/project/package.git/sub/directory"
 
 For code hosted on other servers, import paths may either be qualified
 with the version control type, or the go tool can dynamically fetch

--- a/src/cmd/go/internal/help/helpdoc.go
+++ b/src/cmd/go/internal/help/helpdoc.go
@@ -182,7 +182,7 @@ A few common code hosting sites have special syntax:
 		import "hub.jazz.net/git/user/project/sub/directory"
 
 	Azure DevOps (Git)
-		
+
 		import "dev.azure.com/organization/project/package"
 		import "dev.azure.com/organization/project/package.git/sub/directory"
 

--- a/src/cmd/go/internal/help/helpdoc.go
+++ b/src/cmd/go/internal/help/helpdoc.go
@@ -181,6 +181,11 @@ A few common code hosting sites have special syntax:
 		import "hub.jazz.net/git/user/project"
 		import "hub.jazz.net/git/user/project/sub/directory"
 
+	Azure DevOps (Git)
+		
+		import "dev.azure.com/user/project/package"
+		import "dev.azure.com/user/project/package/sub/directory"
+
 For code hosted on other servers, import paths may either be qualified
 with the version control type, or the go tool can dynamically fetch
 the import path over https/http and discover where the code resides


### PR DESCRIPTION
The existing URL parsing logic is incompatible with the format of Azure 
DevOps Git repos. This revision enables the go get command to work with
Azure DevOps repos under the following assumptions:
* Only Git repos are supported, not TFVC. TFVC is not available for 
  public repos anyway.
* If the Git repo name has a .git extension in Azure DevOps then the
  extension needs to be added in the import path, 
  e.g. import "dev.azure.com/organization/project/package.git"
* The _git part of the Azure DevOps URL is removed when the package is
  cloned to the GOPATH

Fixes #28236