### PR TITLE
path/filepath: implement IsPatternValid(pattern)

### DIFF
--- a/src/path/filepath/match.go
+++ b/src/path/filepath/match.go
@@ -223,6 +223,65 @@ func getEsc(chunk string) (r rune, nchunk string, err error) {
 	return
 }
 
+type charClassItem int // produced by the lexer lexing character classes (like [a-z]) in a pattern
+
+const (
+	charItem  charClassItem = iota // regular character, including escaped special characters
+	minusItem                      // minus symbol in a character range, like in 'a-z'
+)
+
+// If IsPatternValid(pattern) is true, Match(pattern, name) will not return an error.
+func IsPatternValid(pattern string) bool {
+	p := []rune(pattern)
+	charClassItems := make([]charClassItem, 0) // captures content of '[...]'
+	insideCharClass := false                   // we saw a '[' but no ']' yet
+	escaped := false                           // p[i] is escaped by '\\'
+	for i := 0; i < len(p); i++ {
+		switch {
+		case p[i] == '\\' && !escaped && runtime.GOOS != "windows":
+			escaped = true
+			continue
+		case !insideCharClass && p[i] == '[' && !escaped:
+			insideCharClass = true
+			if i+1 < len(p) && p[i+1] == '^' {
+				i++ // It doesn't matter if the char class starts with '[' or '[^'.
+			}
+		case insideCharClass && !escaped && p[i] == '-':
+			charClassItems = append(charClassItems, minusItem)
+		case insideCharClass && !escaped && p[i] == ']':
+			if !isCharClassValid(charClassItems) {
+				return false
+			}
+			charClassItems = charClassItems[:0]
+			insideCharClass = false
+		case insideCharClass:
+			charClassItems = append(charClassItems, charItem)
+		}
+		escaped = false
+	}
+	return !escaped && !insideCharClass
+}
+
+func isCharClassValid(charClassItems []charClassItem) bool {
+	if len(charClassItems) == 0 {
+		return false
+	}
+	for i := 0; i < len(charClassItems); i++ {
+		if charClassItems[i] == minusItem {
+			return false
+		}
+		if i+1 < len(charClassItems) {
+			if charClassItems[i+1] == minusItem {
+				i += 2
+				if i >= len(charClassItems) || charClassItems[i] == minusItem {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
 // Glob returns the names of all files matching pattern or nil
 // if there is no matching file. The syntax of patterns is the same
 // as in Match. The pattern may describe hierarchical names such as

--- a/src/path/filepath/match_test.go
+++ b/src/path/filepath/match_test.go
@@ -20,64 +20,65 @@ import (
 type MatchTest struct {
 	pattern, s string
 	match      bool
+	valid      bool
 	err        error
 }
 
 var matchTests = []MatchTest{
-	{"abc", "abc", true, nil},
-	{"*", "abc", true, nil},
-	{"*c", "abc", true, nil},
-	{"a*", "a", true, nil},
-	{"a*", "abc", true, nil},
-	{"a*", "ab/c", false, nil},
-	{"a*/b", "abc/b", true, nil},
-	{"a*/b", "a/c/b", false, nil},
-	{"a*b*c*d*e*/f", "axbxcxdxe/f", true, nil},
-	{"a*b*c*d*e*/f", "axbxcxdxexxx/f", true, nil},
-	{"a*b*c*d*e*/f", "axbxcxdxe/xxx/f", false, nil},
-	{"a*b*c*d*e*/f", "axbxcxdxexxx/fff", false, nil},
-	{"a*b?c*x", "abxbbxdbxebxczzx", true, nil},
-	{"a*b?c*x", "abxbbxdbxebxczzy", false, nil},
-	{"ab[c]", "abc", true, nil},
-	{"ab[b-d]", "abc", true, nil},
-	{"ab[e-g]", "abc", false, nil},
-	{"ab[^c]", "abc", false, nil},
-	{"ab[^b-d]", "abc", false, nil},
-	{"ab[^e-g]", "abc", true, nil},
-	{"a\\*b", "a*b", true, nil},
-	{"a\\*b", "ab", false, nil},
-	{"a?b", "a☺b", true, nil},
-	{"a[^a]b", "a☺b", true, nil},
-	{"a???b", "a☺b", false, nil},
-	{"a[^a][^a][^a]b", "a☺b", false, nil},
-	{"[a-ζ]*", "α", true, nil},
-	{"*[a-ζ]", "A", false, nil},
-	{"a?b", "a/b", false, nil},
-	{"a*b", "a/b", false, nil},
-	{"[\\]a]", "]", true, nil},
-	{"[\\-]", "-", true, nil},
-	{"[x\\-]", "x", true, nil},
-	{"[x\\-]", "-", true, nil},
-	{"[x\\-]", "z", false, nil},
-	{"[\\-x]", "x", true, nil},
-	{"[\\-x]", "-", true, nil},
-	{"[\\-x]", "a", false, nil},
-	{"[]a]", "]", false, ErrBadPattern},
-	{"[-]", "-", false, ErrBadPattern},
-	{"[x-]", "x", false, ErrBadPattern},
-	{"[x-]", "-", false, ErrBadPattern},
-	{"[x-]", "z", false, ErrBadPattern},
-	{"[-x]", "x", false, ErrBadPattern},
-	{"[-x]", "-", false, ErrBadPattern},
-	{"[-x]", "a", false, ErrBadPattern},
-	{"\\", "a", false, ErrBadPattern},
-	{"[a-b-c]", "a", false, ErrBadPattern},
-	{"[", "a", false, ErrBadPattern},
-	{"[^", "a", false, ErrBadPattern},
-	{"[^bc", "a", false, ErrBadPattern},
-	{"a[", "a", false, nil},
-	{"a[", "ab", false, ErrBadPattern},
-	{"*x", "xxx", true, nil},
+	{"abc", "abc", true, true, nil},
+	{"*", "abc", true, true, nil},
+	{"*c", "abc", true, true, nil},
+	{"a*", "a", true, true, nil},
+	{"a*", "abc", true, true, nil},
+	{"a*", "ab/c", false, true, nil},
+	{"a*/b", "abc/b", true, true, nil},
+	{"a*/b", "a/c/b", false, true, nil},
+	{"a*b*c*d*e*/f", "axbxcxdxe/f", true, true, nil},
+	{"a*b*c*d*e*/f", "axbxcxdxexxx/f", true, true, nil},
+	{"a*b*c*d*e*/f", "axbxcxdxe/xxx/f", false, true, nil},
+	{"a*b*c*d*e*/f", "axbxcxdxexxx/fff", false, true, nil},
+	{"a*b?c*x", "abxbbxdbxebxczzx", true, true, nil},
+	{"a*b?c*x", "abxbbxdbxebxczzy", false, true, nil},
+	{"ab[c]", "abc", true, true, nil},
+	{"ab[b-d]", "abc", true, true, nil},
+	{"ab[e-g]", "abc", false, true, nil},
+	{"ab[^c]", "abc", false, true, nil},
+	{"ab[^b-d]", "abc", false, true, nil},
+	{"ab[^e-g]", "abc", true, true, nil},
+	{"a\\*b", "a*b", true, true, nil},
+	{"a\\*b", "ab", false, true, nil},
+	{"a?b", "a☺b", true, true, nil},
+	{"a[^a]b", "a☺b", true, true, nil},
+	{"a???b", "a☺b", false, true, nil},
+	{"a[^a][^a][^a]b", "a☺b", false, true, nil},
+	{"[a-ζ]*", "α", true, true, nil},
+	{"*[a-ζ]", "A", false, true, nil},
+	{"a?b", "a/b", false, true, nil},
+	{"a*b", "a/b", false, true, nil},
+	{"[\\]a]", "]", true, true, nil},
+	{"[\\-]", "-", true, true, nil},
+	{"[x\\-]", "x", true, true, nil},
+	{"[x\\-]", "-", true, true, nil},
+	{"[x\\-]", "z", false, true, nil},
+	{"[\\-x]", "x", true, true, nil},
+	{"[\\-x]", "-", true, true, nil},
+	{"[\\-x]", "a", false, true, nil},
+	{"[]a]", "]", false, false, ErrBadPattern},
+	{"[-]", "-", false, false, ErrBadPattern},
+	{"[x-]", "x", false, false, ErrBadPattern},
+	{"[x-]", "-", false, false, ErrBadPattern},
+	{"[x-]", "z", false, false, ErrBadPattern},
+	{"[-x]", "x", false, false, ErrBadPattern},
+	{"[-x]", "-", false, false, ErrBadPattern},
+	{"[-x]", "a", false, false, ErrBadPattern},
+	{"\\", "a", false, false, ErrBadPattern},
+	{"[a-b-c]", "a", false, false, ErrBadPattern},
+	{"[", "a", false, false, ErrBadPattern},
+	{"[^", "a", false, false, ErrBadPattern},
+	{"[^bc", "a", false, false, ErrBadPattern},
+	{"a[", "a", false, false, nil},
+	{"a[", "ab", false, false, ErrBadPattern},
+	{"*x", "xxx", true, true, nil},
 }
 
 func errp(e error) string {
@@ -114,6 +115,15 @@ func contains(vector []string, s string) bool {
 		}
 	}
 	return false
+}
+
+func TestIsPatternValid(t *testing.T) {
+	for _, tt := range matchTests {
+		valid := IsPatternValid(tt.pattern)
+		if valid && !tt.valid || !valid && tt.valid {
+			t.Errorf("IsPatternValid(%#q) returned %t", tt.pattern, tt.valid)
+		}
+	}
 }
 
 var globTests = []struct {

--- a/src/path/match_test.go
+++ b/src/path/match_test.go
@@ -9,64 +9,65 @@ import "testing"
 type MatchTest struct {
 	pattern, s string
 	match      bool
+	valid      bool
 	err        error
 }
 
 var matchTests = []MatchTest{
-	{"abc", "abc", true, nil},
-	{"*", "abc", true, nil},
-	{"*c", "abc", true, nil},
-	{"a*", "a", true, nil},
-	{"a*", "abc", true, nil},
-	{"a*", "ab/c", false, nil},
-	{"a*/b", "abc/b", true, nil},
-	{"a*/b", "a/c/b", false, nil},
-	{"a*b*c*d*e*/f", "axbxcxdxe/f", true, nil},
-	{"a*b*c*d*e*/f", "axbxcxdxexxx/f", true, nil},
-	{"a*b*c*d*e*/f", "axbxcxdxe/xxx/f", false, nil},
-	{"a*b*c*d*e*/f", "axbxcxdxexxx/fff", false, nil},
-	{"a*b?c*x", "abxbbxdbxebxczzx", true, nil},
-	{"a*b?c*x", "abxbbxdbxebxczzy", false, nil},
-	{"ab[c]", "abc", true, nil},
-	{"ab[b-d]", "abc", true, nil},
-	{"ab[e-g]", "abc", false, nil},
-	{"ab[^c]", "abc", false, nil},
-	{"ab[^b-d]", "abc", false, nil},
-	{"ab[^e-g]", "abc", true, nil},
-	{"a\\*b", "a*b", true, nil},
-	{"a\\*b", "ab", false, nil},
-	{"a?b", "a☺b", true, nil},
-	{"a[^a]b", "a☺b", true, nil},
-	{"a???b", "a☺b", false, nil},
-	{"a[^a][^a][^a]b", "a☺b", false, nil},
-	{"[a-ζ]*", "α", true, nil},
-	{"*[a-ζ]", "A", false, nil},
-	{"a?b", "a/b", false, nil},
-	{"a*b", "a/b", false, nil},
-	{"[\\]a]", "]", true, nil},
-	{"[\\-]", "-", true, nil},
-	{"[x\\-]", "x", true, nil},
-	{"[x\\-]", "-", true, nil},
-	{"[x\\-]", "z", false, nil},
-	{"[\\-x]", "x", true, nil},
-	{"[\\-x]", "-", true, nil},
-	{"[\\-x]", "a", false, nil},
-	{"[]a]", "]", false, ErrBadPattern},
-	{"[-]", "-", false, ErrBadPattern},
-	{"[x-]", "x", false, ErrBadPattern},
-	{"[x-]", "-", false, ErrBadPattern},
-	{"[x-]", "z", false, ErrBadPattern},
-	{"[-x]", "x", false, ErrBadPattern},
-	{"[-x]", "-", false, ErrBadPattern},
-	{"[-x]", "a", false, ErrBadPattern},
-	{"\\", "a", false, ErrBadPattern},
-	{"[a-b-c]", "a", false, ErrBadPattern},
-	{"[", "a", false, ErrBadPattern},
-	{"[^", "a", false, ErrBadPattern},
-	{"[^bc", "a", false, ErrBadPattern},
-	{"a[", "a", false, nil},
-	{"a[", "ab", false, ErrBadPattern},
-	{"*x", "xxx", true, nil},
+	{"abc", "abc", true, true, nil},
+	{"*", "abc", true, true, nil},
+	{"*c", "abc", true, true, nil},
+	{"a*", "a", true, true, nil},
+	{"a*", "abc", true, true, nil},
+	{"a*", "ab/c", false, true, nil},
+	{"a*/b", "abc/b", true, true, nil},
+	{"a*/b", "a/c/b", false, true, nil},
+	{"a*b*c*d*e*/f", "axbxcxdxe/f", true, true, nil},
+	{"a*b*c*d*e*/f", "axbxcxdxexxx/f", true, true, nil},
+	{"a*b*c*d*e*/f", "axbxcxdxe/xxx/f", false, true, nil},
+	{"a*b*c*d*e*/f", "axbxcxdxexxx/fff", false, true, nil},
+	{"a*b?c*x", "abxbbxdbxebxczzx", true, true, nil},
+	{"a*b?c*x", "abxbbxdbxebxczzy", false, true, nil},
+	{"ab[c]", "abc", true, true, nil},
+	{"ab[b-d]", "abc", true, true, nil},
+	{"ab[e-g]", "abc", false, true, nil},
+	{"ab[^c]", "abc", false, true, nil},
+	{"ab[^b-d]", "abc", false, true, nil},
+	{"ab[^e-g]", "abc", true, true, nil},
+	{"a\\*b", "a*b", true, true, nil},
+	{"a\\*b", "ab", false, true, nil},
+	{"a?b", "a☺b", true, true, nil},
+	{"a[^a]b", "a☺b", true, true, nil},
+	{"a???b", "a☺b", false, true, nil},
+	{"a[^a][^a][^a]b", "a☺b", false, true, nil},
+	{"[a-ζ]*", "α", true, true, nil},
+	{"*[a-ζ]", "A", false, true, nil},
+	{"a?b", "a/b", false, true, nil},
+	{"a*b", "a/b", false, true, nil},
+	{"[\\]a]", "]", true, true, nil},
+	{"[\\-]", "-", true, true, nil},
+	{"[x\\-]", "x", true, true, nil},
+	{"[x\\-]", "-", true, true, nil},
+	{"[x\\-]", "z", false, true, nil},
+	{"[\\-x]", "x", true, true, nil},
+	{"[\\-x]", "-", true, true, nil},
+	{"[\\-x]", "a", false, true, nil},
+	{"[]a]", "]", false, false, ErrBadPattern},
+	{"[-]", "-", false, false, ErrBadPattern},
+	{"[x-]", "x", false, false, ErrBadPattern},
+	{"[x-]", "-", false, false, ErrBadPattern},
+	{"[x-]", "z", false, false, ErrBadPattern},
+	{"[-x]", "x", false, false, ErrBadPattern},
+	{"[-x]", "-", false, false, ErrBadPattern},
+	{"[-x]", "a", false, false, ErrBadPattern},
+	{"\\", "a", false, false, ErrBadPattern},
+	{"[a-b-c]", "a", false, false, ErrBadPattern},
+	{"[", "a", false, false, ErrBadPattern},
+	{"[^", "a", false, false, ErrBadPattern},
+	{"[^bc", "a", false, false, ErrBadPattern},
+	{"a[", "a", false, false, nil},
+	{"a[", "ab", false, false, ErrBadPattern},
+	{"*x", "xxx", true, true, nil},
 }
 
 func TestMatch(t *testing.T) {
@@ -74,6 +75,15 @@ func TestMatch(t *testing.T) {
 		ok, err := Match(tt.pattern, tt.s)
 		if ok != tt.match || err != tt.err {
 			t.Errorf("Match(%#q, %#q) = %v, %v want %v, %v", tt.pattern, tt.s, ok, err, tt.match, tt.err)
+		}
+	}
+}
+
+func TestIsPatternValid(t *testing.T) {
+	for _, tt := range matchTests {
+		valid := IsPatternValid(tt.pattern)
+		if valid && !tt.valid || !valid && tt.valid {
+			t.Errorf("IsPatternValid(%#q) returned %t", tt.pattern, tt.valid)
 		}
 	}
 }


### PR DESCRIPTION
The current glob pattern implementation in `match.go` does not provide any way to learn if pattern is valid.

It does not help to call `Match(pattern, s)` to test if you get an error, because depending on `s` this might not return an error even though the pattern is invalid (like `Match("a[", "a")`).

As patterns are often provided by the user, it would be great to have a way to validate the pattern when reading the user input.

This PR implements `IsPatternValid(pattern)` to validate glob patterns. If `IsPatternValid(pattern)` returns `true`, you can be sure that `Match(pattern, s)` will never return an error.