### PR TITLE
cmd/go: fix command name in error messages

### DIFF
--- a/src/cmd/go/internal/modcmd/vendor.go
+++ b/src/cmd/go/internal/modcmd/vendor.go
@@ -45,7 +45,7 @@ func runVendor(cmd *base.Command, args []string) {
 
 	vdir := filepath.Join(modload.ModRoot, "vendor")
 	if err := os.RemoveAll(vdir); err != nil {
-		base.Fatalf("go vendor: %v", err)
+		base.Fatalf("go mod vendor: %v", err)
 	}
 
 	modpkgs := make(map[module.Version][]string)
@@ -85,7 +85,7 @@ func runVendor(cmd *base.Command, args []string) {
 		return
 	}
 	if err := ioutil.WriteFile(filepath.Join(vdir, "modules.txt"), buf.Bytes(), 0666); err != nil {
-		base.Fatalf("go vendor: %v", err)
+		base.Fatalf("go mod vendor: %v", err)
 	}
 }
 
@@ -172,10 +172,10 @@ func matchNonTest(info os.FileInfo) bool {
 func copyDir(dst, src string, match func(os.FileInfo) bool) {
 	files, err := ioutil.ReadDir(src)
 	if err != nil {
-		base.Fatalf("go vendor: %v", err)
+		base.Fatalf("go mod vendor: %v", err)
 	}
 	if err := os.MkdirAll(dst, 0777); err != nil {
-		base.Fatalf("go vendor: %v", err)
+		base.Fatalf("go mod vendor: %v", err)
 	}
 	for _, file := range files {
 		if file.IsDir() || !file.Mode().IsRegular() || !match(file) {
@@ -183,18 +183,18 @@ func copyDir(dst, src string, match func(os.FileInfo) bool) {
 		}
 		r, err := os.Open(filepath.Join(src, file.Name()))
 		if err != nil {
-			base.Fatalf("go vendor: %v", err)
+			base.Fatalf("go mod vendor: %v", err)
 		}
 		w, err := os.Create(filepath.Join(dst, file.Name()))
 		if err != nil {
-			base.Fatalf("go vendor: %v", err)
+			base.Fatalf("go mod vendor: %v", err)
 		}
 		if _, err := io.Copy(w, r); err != nil {
-			base.Fatalf("go vendor: %v", err)
+			base.Fatalf("go mod vendor: %v", err)
 		}
 		r.Close()
 		if err := w.Close(); err != nil {
-			base.Fatalf("go vendor: %v", err)
+			base.Fatalf("go mod vendor: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
`go vendor` is now `go mod vendor`. So it should be unified to use `go mod vendor` in error messages.
