### PR TITLE
archive/zip: use Modified in FileHeader.FileInfo

### DIFF
--- a/src/archive/zip/struct.go
+++ b/src/archive/zip/struct.go
@@ -178,6 +178,7 @@ func FileInfoHeader(fi os.FileInfo) (*FileHeader, error) {
 		UncompressedSize64: uint64(size),
 	}
 	fh.SetModTime(fi.ModTime())
+	fh.Modified = fi.ModTime()
 	fh.SetMode(fi.Mode())
 	if fh.UncompressedSize64 > uint32max {
 		fh.UncompressedSize = uint32max

--- a/src/archive/zip/struct.go
+++ b/src/archive/zip/struct.go
@@ -155,7 +155,7 @@ func (fi headerFileInfo) Size() int64 {
 	return int64(fi.fh.UncompressedSize)
 }
 func (fi headerFileInfo) IsDir() bool        { return fi.Mode().IsDir() }
-func (fi headerFileInfo) ModTime() time.Time { return fi.fh.ModTime() }
+func (fi headerFileInfo) ModTime() time.Time { return fi.fh.Modified }
 func (fi headerFileInfo) Mode() os.FileMode  { return fi.fh.Mode() }
 func (fi headerFileInfo) Sys() interface{}   { return fi.fh }
 

--- a/src/archive/zip/struct.go
+++ b/src/archive/zip/struct.go
@@ -159,7 +159,7 @@ func (fi headerFileInfo) ModTime() time.Time {
 	if fi.fh.Modified.IsZero() {
 		return fi.fh.ModTime()
 	}
-	return fi.fh.Modified
+	return fi.fh.Modified.UTC()
 }
 func (fi headerFileInfo) Mode() os.FileMode { return fi.fh.Mode() }
 func (fi headerFileInfo) Sys() interface{}  { return fi.fh }
@@ -178,7 +178,6 @@ func FileInfoHeader(fi os.FileInfo) (*FileHeader, error) {
 		UncompressedSize64: uint64(size),
 	}
 	fh.SetModTime(fi.ModTime())
-	fh.Modified = fi.ModTime()
 	fh.SetMode(fi.Mode())
 	if fh.UncompressedSize64 > uint32max {
 		fh.UncompressedSize = uint32max

--- a/src/archive/zip/struct.go
+++ b/src/archive/zip/struct.go
@@ -154,10 +154,15 @@ func (fi headerFileInfo) Size() int64 {
 	}
 	return int64(fi.fh.UncompressedSize)
 }
-func (fi headerFileInfo) IsDir() bool        { return fi.Mode().IsDir() }
-func (fi headerFileInfo) ModTime() time.Time { return fi.fh.Modified }
-func (fi headerFileInfo) Mode() os.FileMode  { return fi.fh.Mode() }
-func (fi headerFileInfo) Sys() interface{}   { return fi.fh }
+func (fi headerFileInfo) IsDir() bool { return fi.Mode().IsDir() }
+func (fi headerFileInfo) ModTime() time.Time {
+	if fi.fh.Modified.IsZero() {
+		return fi.fh.ModTime()
+	}
+	return fi.fh.Modified
+}
+func (fi headerFileInfo) Mode() os.FileMode { return fi.fh.Mode() }
+func (fi headerFileInfo) Sys() interface{}  { return fi.fh }
 
 // FileInfoHeader creates a partially-populated FileHeader from an
 // os.FileInfo.

--- a/src/archive/zip/zip_test.go
+++ b/src/archive/zip/zip_test.go
@@ -114,6 +114,25 @@ func TestFileHeaderRoundTrip64(t *testing.T) {
 	testHeaderRoundTrip(fh, uint32max, fh.UncompressedSize64, t)
 }
 
+func TestFileHeaderRoundTripModified(t *testing.T) {
+	fh := &FileHeader{
+		Name:             "foo.txt",
+		UncompressedSize: 987654321,
+		Modified:         time.Now().Local(),
+	}
+	fi := fh.FileInfo()
+	fh2, err := FileInfoHeader(fi)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := fh2.Modified, fh.Modified; got != want {
+		t.Errorf("Modified: got %s, want %s\n", got, want)
+	}
+	if got, want := fi.ModTime(), fh.Modified; got != want {
+		t.Errorf("Modified: got %s, want %s\n", got, want)
+	}
+}
+
 type repeatedByte struct {
 	off int64
 	b   byte

--- a/src/archive/zip/zip_test.go
+++ b/src/archive/zip/zip_test.go
@@ -119,6 +119,8 @@ func TestFileHeaderRoundTripModified(t *testing.T) {
 		Name:             "foo.txt",
 		UncompressedSize: 987654321,
 		Modified:         time.Now().Local(),
+		ModifiedTime:     1234,
+		ModifiedDate:     5678,
 	}
 	fi := fh.FileInfo()
 	fh2, err := FileInfoHeader(fi)
@@ -129,6 +131,26 @@ func TestFileHeaderRoundTripModified(t *testing.T) {
 		t.Errorf("Modified: got %s, want %s\n", got, want)
 	}
 	if got, want := fi.ModTime(), fh.Modified; got != want {
+		t.Errorf("Modified: got %s, want %s\n", got, want)
+	}
+}
+
+func TestFileHeaderRoundTripWithoutModified(t *testing.T) {
+	fh := &FileHeader{
+		Name:             "foo.txt",
+		UncompressedSize: 987654321,
+		ModifiedTime:     1234,
+		ModifiedDate:     5678,
+	}
+	fi := fh.FileInfo()
+	fh2, err := FileInfoHeader(fi)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := fh2.ModTime(), fh.ModTime(); got != want {
+		t.Errorf("Modified: got %s, want %s\n", got, want)
+	}
+	if got, want := fi.ModTime(), fh.ModTime(); got != want {
 		t.Errorf("Modified: got %s, want %s\n", got, want)
 	}
 }

--- a/src/archive/zip/zip_test.go
+++ b/src/archive/zip/zip_test.go
@@ -127,10 +127,10 @@ func TestFileHeaderRoundTripModified(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := fh2.Modified, fh.Modified; got != want {
+	if got, want := fh2.Modified, fh.Modified.UTC(); got != want {
 		t.Errorf("Modified: got %s, want %s\n", got, want)
 	}
-	if got, want := fi.ModTime(), fh.Modified; got != want {
+	if got, want := fi.ModTime(), fh.Modified.UTC(); got != want {
 		t.Errorf("Modified: got %s, want %s\n", got, want)
 	}
 }


### PR DESCRIPTION
The Modified field allows representation of extended timestamps, which provide more accuracy than the legacy MS-DOS timestamps.
The FileInfo method provides an implementation of the os.FileInfo interface for files inside archives.

With this change, we make FileInfo use the Modified field, if present, to return more detailed timestamps from its ModTime method.

Fixes #28350 