### PR TITLE
crypto/tls: Deprecate tls 1.0 and tls 1.1

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -35,7 +35,7 @@ const (
 	maxHandshake      = 65536        // maximum handshake we support (protocol max is 16 MB)
 	maxWarnAlertCount = 5            // maximum number of consecutive warning alerts
 
-	minVersion = VersionTLS10
+	minVersion = VersionTLS12
 	maxVersion = VersionTLS12
 )
 

--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -480,7 +480,7 @@ type Config struct {
 	ClientSessionCache ClientSessionCache
 
 	// MinVersion contains the minimum SSL/TLS version that is acceptable.
-	// If zero, then TLS 1.0 is taken as the minimum.
+	// If zero, then TLS 1.2 is taken as the minimum.
 	MinVersion uint16
 
 	// MaxVersion contains the maximum SSL/TLS version that is acceptable.


### PR DESCRIPTION
According to : https://tools.ietf.org/html/draft-ietf-tls-oldversions-deprecate-00
