### PR TITLE
syscall/js: add the Value.Truthy method

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1022,6 +1022,7 @@ Lai Jiangshan <eag0628@gmail.com>
 Lakshay Garg <lakshay.garg.1996@gmail.com>
 Lann Martin <lannm@google.com>
 Lanre Adelowo <yo@lanre.wtf>
+Larry Clapp <larry@theclapp.org> <lmclapp68@gmail.com>
 Larry Hosken <lahosken@golang.org>
 Lars Jeppesen <jeppesen.lars@gmail.com>
 Lars Lehtonen <lars.lehtonen@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1022,7 +1022,6 @@ Lai Jiangshan <eag0628@gmail.com>
 Lakshay Garg <lakshay.garg.1996@gmail.com>
 Lann Martin <lannm@google.com>
 Lanre Adelowo <yo@lanre.wtf>
-Larry Clapp <larry@theclapp.org> <lmclapp68@gmail.com>
 Larry Hosken <lahosken@golang.org>
 Lars Jeppesen <jeppesen.lars@gmail.com>
 Lars Lehtonen <lars.lehtonen@gmail.com>

--- a/src/syscall/js/js.go
+++ b/src/syscall/js/js.go
@@ -361,9 +361,9 @@ func (v Value) Bool() bool {
 	}
 }
 
-// Truthy returns the JavaScript "truthiness" of the value v.  In JavaScript,
+// Truthy returns the JavaScript "truthiness" of the value v. In JavaScript,
 // false, 0, "", null, undefined, and NaN are "falsy", and everything else is
-// "truthy".  See https://developer.mozilla.org/en-US/docs/Glossary/Truthy.
+// "truthy". See https://developer.mozilla.org/en-US/docs/Glossary/Truthy.
 func (v Value) Truthy() bool {
 	switch v.Type() {
 	case TypeUndefined, TypeNull:
@@ -371,10 +371,7 @@ func (v Value) Truthy() bool {
 	case TypeBoolean:
 		return v.Bool()
 	case TypeNumber:
-		if v.ref == valueNaN.ref {
-			return false
-		}
-		return v.ref != valueZero.ref
+		return v.ref != valueNaN.ref && v.ref != valueZero.ref
 	case TypeString:
 		return v.String() != ""
 	case TypeSymbol, TypeFunction, TypeObject:

--- a/src/syscall/js/js.go
+++ b/src/syscall/js/js.go
@@ -363,7 +363,7 @@ func (v Value) Bool() bool {
 
 // Truthy returns the JavaScript "truthiness" of the value v.  In JavaScript,
 // false, 0, "", null, undefined, and NaN are "falsy", and everything else is
-// "truthy".
+// "truthy".  See https://developer.mozilla.org/en-US/docs/Glossary/Truthy.
 func (v Value) Truthy() bool {
 	switch v.Type() {
 	case TypeUndefined, TypeNull:
@@ -374,13 +374,14 @@ func (v Value) Truthy() bool {
 		if v.ref == valueNaN.ref {
 			return false
 		}
-		return v.Float() != 0
+		return v.ref != valueZero.ref
 	case TypeString:
 		return v.String() != ""
 	case TypeSymbol, TypeFunction, TypeObject:
 		return true
+	default:
+		panic("bad type")
 	}
-	panic("Unknown type")
 }
 
 // String returns the value v converted to string according to JavaScript type conversions.

--- a/src/syscall/js/js.go
+++ b/src/syscall/js/js.go
@@ -361,6 +361,28 @@ func (v Value) Bool() bool {
 	}
 }
 
+// Truthy returns the JavaScript "truthiness" of the value v.  In JavaScript,
+// false, 0, "", null, undefined, and NaN are "falsy", and everything else is
+// "truthy".
+func (v Value) Truthy() bool {
+	switch v.Type() {
+	case TypeUndefined, TypeNull:
+		return false
+	case TypeBoolean:
+		return v.Bool()
+	case TypeNumber:
+		if v.ref == valueNaN.ref {
+			return false
+		}
+		return v.Float() != 0
+	case TypeString:
+		return v.String() != ""
+	case TypeSymbol, TypeFunction, TypeObject:
+		return true
+	}
+	panic("Unknown type")
+}
+
 // String returns the value v converted to string according to JavaScript type conversions.
 func (v Value) String() string {
 	str, length := valuePrepareString(v.ref)

--- a/src/syscall/js/js_test.go
+++ b/src/syscall/js/js_test.go
@@ -33,11 +33,14 @@ var dummys = js.Global().Call("eval", `({
 		return a + b;
 	},
 	zero: 0,
+	stringZero: "0",
 	NaN: NaN,
 	emptyObj: {},
 	emptyArray: [],
 	Infinity: Infinity,
 	NegInfinity: -Infinity,
+	objNumber0: new Number(0),
+	objBooleanFalse: new Boolean(false),
 })`)
 
 func TestBool(t *testing.T) {
@@ -346,12 +349,20 @@ func ExampleNewCallback() {
 	js.Global().Get("document").Call("getElementById", "myButton").Call("addEventListener", "click", cb)
 }
 
+// See
+// - https://developer.mozilla.org/en-US/docs/Glossary/Truthy
+// - https://stackoverflow.com/questions/19839952/all-falsey-values-in-javascript/19839953#19839953
+// - http://www.ecma-international.org/ecma-262/5.1/#sec-9.2
 func TestTruthy(t *testing.T) {
 	want := true
 	for _, key := range []string{
 		"someBool", "someString", "someInt", "someFloat", "someArray", "someDate",
-		"add", // functions are truthy
-		"emptyObj", "emptyArray", "Infinity", "NegInfinity"} {
+		"stringZero", // "0" is truthy
+		"add",        // functions are truthy
+		"emptyObj", "emptyArray", "Infinity", "NegInfinity",
+		// All objects are truthy, even if they're Number(0) or Boolean(false).
+		"objNumber0", "objBooleanFalse",
+	} {
 		if got := dummys.Get(key).Truthy(); got != want {
 			t.Errorf("%s: got %#v, want %#v", key, got, want)
 		}


### PR DESCRIPTION
Truthy returns the JavaScript "truthiness" of the given value.  In
JavaScript, false, 0, "", null, undefined, and NaN are "falsy", and
everything else is "truthy".

Fixes #28264
