### PR TITLE
crypto/tls: clarify documentation on tls.Config.NextProtos

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -424,7 +424,7 @@ type Config struct {
 	// If RootCAs is nil, TLS uses the host's root CA set.
 	RootCAs *x509.CertPool
 
-	// NextProtos is a list of supported, application level protocols.
+	// NextProtos is a list of supported application level protocols, in order of preference.
 	NextProtos []string
 
 	// ServerName is used to verify the hostname on the returned

--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -424,7 +424,8 @@ type Config struct {
 	// If RootCAs is nil, TLS uses the host's root CA set.
 	RootCAs *x509.CertPool
 
-	// NextProtos is a list of supported application level protocols, in order of preference.
+	// NextProtos is a list of supported application level protocols, in
+	// order of preference.
 	NextProtos []string
 
 	// ServerName is used to verify the hostname on the returned


### PR DESCRIPTION
This change will aid users to make less mistakes where you, for example, define both HTTP/1.1 and H2, but in the wrong order.

    package main

    import (
        "crypto/tls"
        "net"
    )

    func main() {
        srv := &http.Server{
            TLSConfig: &tls.Config{
                NextProtos: []string{"http/1.1", "h2"},
            },
        }
        srv.ListenAndServeTLS("server.crt", "server.key")
    }

When using major browsers or curl, they will never be served H2 since they also support HTTP/1.0 and the list is processed in order.