### PR TITLE
log: add Logger.Writer method

### DIFF
--- a/src/log/log.go
+++ b/src/log/log.go
@@ -254,6 +254,13 @@ func (l *Logger) SetPrefix(prefix string) {
 	l.prefix = prefix
 }
 
+// Writer returns the output destination for the logger.
+func (l *Logger) Writer() io.Writer {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.out
+}
+
 // SetOutput sets the output destination for the standard logger.
 func SetOutput(w io.Writer) {
 	std.mu.Lock()


### PR DESCRIPTION
Writer method returns the underlying io.Writer used by the given Logger
object.

Fixes #28327