### PR TITLE
cmd/go: correctly suggest tidy instead of nonexistent fix for -fix

### DIFF
--- a/src/cmd/go/main.go
+++ b/src/cmd/go/main.go
@@ -151,10 +151,10 @@ func main() {
 				flag = flag[:i]
 			}
 			switch flag {
-			case "-sync":
-				fmt.Fprintf(os.Stderr, "go: go mod -sync is now go mod tidy\n")
+			case "-sync", "-fix":
+				fmt.Fprintf(os.Stderr, "go: go mod %s is now go mod tidy\n", flag)
 				os.Exit(2)
-			case "-init", "-fix", "-graph", "-vendor", "-verify":
+			case "-init", "-graph", "-vendor", "-verify":
 				fmt.Fprintf(os.Stderr, "go: go mod %s is now go mod %s\n", flag, flag[1:])
 				os.Exit(2)
 			case "-fmt", "-json", "-module", "-require", "-droprequire", "-replace", "-dropreplace", "-exclude", "-dropexclude":


### PR DESCRIPTION
CL 129682 removed go mod fix but unfortunately
we hadn't updated the source code hence running
   go mod -fix
would suggest
   go mod fix
which is a nonexistent command.

This change fixes that to instead suggest
   go mod tidy