### PR TITLE
go/printer: print parenthesized declarations if len(d.Specs) > 1

### DIFF
--- a/src/go/printer/nodes.go
+++ b/src/go/printer/nodes.go
@@ -1537,7 +1537,7 @@ func (p *printer) genDecl(d *ast.GenDecl) {
 	p.setComment(d.Doc)
 	p.print(d.Pos(), d.Tok, blank)
 
-	if d.Lparen.IsValid() {
+	if d.Lparen.IsValid() || len(d.Specs) > 1 {
 		// group of parenthesized declarations
 		p.print(d.Lparen, token.LPAREN)
 		if n := len(d.Specs); n > 0 {

--- a/src/go/printer/printer_test.go
+++ b/src/go/printer/printer_test.go
@@ -745,18 +745,15 @@ func TestParenthesizedDecl(t *testing.T) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, "", src, 0)
 
-	// reset the file set to get uniform formatting
-	fset = token.NewFileSet()
-
+	// print the original package
 	var buf bytes.Buffer
-	// Print the original package
 	err = Fprint(&buf, fset, f)
 	if err != nil {
 		t.Fatal(err)
 	}
 	original := buf.String()
 
-	// Now remove parentheses from the declaration
+	// now remove parentheses from the declaration
 	for i := 0; i != len(f.Decls); i++ {
 		f.Decls[i].(*ast.GenDecl).Lparen = token.NoPos
 	}

--- a/src/go/printer/printer_test.go
+++ b/src/go/printer/printer_test.go
@@ -736,3 +736,38 @@ func TestIssue11151(t *testing.T) {
 		t.Errorf("%v\norig: %q\ngot : %q", err, src, got)
 	}
 }
+
+// If a declaration has multiple specifications, a parenthesized
+// declaration must be printed even if Lparen is token.NoPos.
+func TestParenthesizedDecl(t *testing.T) {
+	// a package with multiple specs in a single declaration
+	const src = "package p; var ( a float64; b int )"
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "", src, 0)
+
+	// reset the file set to get uniform formatting
+	fset = token.NewFileSet()
+
+	var buf bytes.Buffer
+	// Print the original package
+	err = Fprint(&buf, fset, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := buf.String()
+
+	// Now remove parentheses from the declaration
+	for i := 0; i != len(f.Decls); i++ {
+		f.Decls[i].(*ast.GenDecl).Lparen = token.NoPos
+	}
+	buf.Reset()
+	err = Fprint(&buf, fset, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	noparen := buf.String()
+
+	if noparen != original {
+		t.Errorf("got %q, want %q", noparen, original)
+	}
+}


### PR DESCRIPTION
Parenthesized declaration must be printed if len(d.Specs) > 1 even if d.Lparen==token.NoPos. This happens if the node tree is created programmatically. Otherwise, all but the first specifications just silently disappear from the output.