### PR TITLE
database/sql: add description to String method of IsolationLevel struct.

### DIFF
--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -133,6 +133,7 @@ const (
 	LevelLinearizable
 )
 
+// String returns the name of the transaction isolation level.
 func (i IsolationLevel) String() string {
 	switch i {
 	case LevelDefault:


### PR DESCRIPTION
Add simple description to String method of IsolationLevel struct.