### PR TITLE
cmd/go: don't panic when go run is passed ... under nonexistent dir

### DIFF
--- a/src/cmd/go/internal/run/run.go
+++ b/src/cmd/go/internal/run/run.go
@@ -78,6 +78,9 @@ func runRun(cmd *base.Command, args []string) {
 		p = load.GoFilesPackage(files)
 	} else if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
 		pkgs := load.PackagesAndErrors(args[:1])
+		if len(pkgs) == 0 {
+			base.Fatalf("go run: no packages loaded from %s", args[0])
+		}
 		if len(pkgs) > 1 {
 			var names []string
 			for _, p := range pkgs {

--- a/src/cmd/go/testdata/script/run_wildcard.txt
+++ b/src/cmd/go/testdata/script/run_wildcard.txt
@@ -1,0 +1,5 @@
+# Fix for https://github.com/golang/go/issues/28696:
+# go run x/... should not panic when directory x doesn't exist.
+
+! go run nonexistent/...
+stderr '^go run: no packages loaded from nonexistent/...$'


### PR DESCRIPTION
Given a nonexistent directory above a wildcard:

    go run ./nonexistent/...

Print this error instead of panicking:

    go run: no packages loaded from ./nonexistent/...

Fixes #28696.