### PR TITLE
html/template: document that comments are stripped from html templates

### DIFF
--- a/src/html/template/doc.go
+++ b/src/html/template/doc.go
@@ -73,6 +73,10 @@ functions.
 For these internal escaping functions, if an action pipeline evaluates to
 a nil interface value, it is treated as though it were an empty string.
 
+HTML/CSS/JS comments make the injection context ambiguous, and so correct
+escaping can't be guaranteed. A possible workaround is using a template.HTML variable.
+For more information you can refer to this https://github.com/golang/go/issues/28628
+
 Errors
 
 See the documentation of ErrorCode for details.

--- a/src/html/template/template.go
+++ b/src/html/template/template.go
@@ -173,7 +173,10 @@ func (t *Template) DefinedTemplates() string {
 // Parse parses text as a template body for t.
 // Named template definitions ({{define ...}} or {{block ...}} statements) in text
 // define additional templates associated with t and are removed from the
-// definition of t itself.
+// definition of t itself. Comments in the html format i.e <!-- comment -->
+// are stripped while parsing, this is because they make the injection context
+// ambiguous, and so correct escaping can't be guaranteed. A possible workaround
+// is using a template.HTML variable.
 //
 // Templates can be redefined in successive calls to Parse,
 // before the first use of Execute on t or any associated template.

--- a/src/html/template/template.go
+++ b/src/html/template/template.go
@@ -174,9 +174,7 @@ func (t *Template) DefinedTemplates() string {
 // Named template definitions ({{define ...}} or {{block ...}} statements) in text
 // define additional templates associated with t and are removed from the
 // definition of t itself. Comments in the html format i.e <!-- comment -->
-// are stripped while parsing, this is because they make the injection context
-// ambiguous, and so correct escaping can't be guaranteed. A possible workaround
-// is using a template.HTML variable.
+// are stripped while parsing.
 //
 // Templates can be redefined in successive calls to Parse,
 // before the first use of Execute on t or any associated template.


### PR DESCRIPTION
The existing documentation doesn't document that the comments are
stripped from HTML templates after they are parsed. This patch tries
to document the behavior and provide a rationale along with a workaround
for that.

Fixes #28628 