### PR TITLE
encoding/json: document the unmarshalling of missing json fields

### DIFF
--- a/src/encoding/json/decode.go
+++ b/src/encoding/json/decode.go
@@ -21,7 +21,8 @@ import (
 
 // Unmarshal parses the JSON-encoded data and stores the result
 // in the value pointed to by v. If v is nil or not a pointer,
-// Unmarshal returns an InvalidUnmarshalError.
+// Unmarshal returns an InvalidUnmarshalError. Fields that are not present
+// in the JSON encoded data will retain their original values.
 //
 // Unmarshal uses the inverse of the encodings that
 // Marshal uses, allocating maps, slices, and pointers as necessary,

--- a/src/encoding/json/decode.go
+++ b/src/encoding/json/decode.go
@@ -22,7 +22,7 @@ import (
 // Unmarshal parses the JSON-encoded data and stores the result
 // in the value pointed to by v. If v is nil or not a pointer,
 // Unmarshal returns an InvalidUnmarshalError. Fields that are not present
-// in the JSON encoded data will retain their original values.
+// in the JSON-encoded data will retain their original values.
 //
 // Unmarshal uses the inverse of the encodings that
 // Marshal uses, allocating maps, slices, and pointers as necessary,


### PR DESCRIPTION
The existing documentation misses covering what will happen if JSON
data with missing fields is unmarshalled, so a line is added to the
documentation of json.Unmarshall() mentioning the consequences of
unmarshalling JSON fields.

Fixes #27172
