### PR TITLE
cmd/vendor/golang.org/x/sys/unix: chase FreeBSD header rename

### DIFF
--- a/src/cmd/vendor/golang.org/x/sys/unix/mkerrors.sh
+++ b/src/cmd/vendor/golang.org/x/sys/unix/mkerrors.sh
@@ -80,7 +80,7 @@ includes_DragonFly='
 '
 
 includes_FreeBSD='
-#include <sys/capability.h>
+#include <sys/capsicum.h>
 #include <sys/param.h>
 #include <sys/types.h>
 #include <sys/event.h>


### PR DESCRIPTION
When Capsicum (FreeBSD's capability-based sandboxing framework) was
first developed it used sys/capability.h as its header, but that
conflicted with the draft POSIX.1e capability header used on other
systems (Linux).  As a result FreeBSD's header was renamed to
sys/capsicum.h, with capability.h remaining as a backwards-compatibility
shim.

Today all supported (and most unsupported) versions of FreeBSD have
sys/capsicum.h so unconditionally switch to using the updated header.
