### PR TITLE
cmd/go: allow the user to specify ar via an environment variable

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -1500,6 +1500,8 @@
 // 		The command to use to compile C++ code.
 // 	PKG_CONFIG
 // 		Path to pkg-config tool.
+// 	AR
+// 		The command to use to create, modify, and extract from library archives.
 //
 // Architecture-specific environment variables:
 //

--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -1502,6 +1502,7 @@
 // 		Path to pkg-config tool.
 // 	AR
 // 		The command to use to create, modify, and extract from library archives.
+// 		Only used when the compiler is gccgo ('-compiler=gccgo').
 //
 // Architecture-specific environment variables:
 //

--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -1501,7 +1501,7 @@
 // 	PKG_CONFIG
 // 		Path to pkg-config tool.
 // 	AR
-// 		The command to use to manipualte library archives when
+// 		The command to use to manipulate library archives when
 // 		building with the gccgo compiler.
 // 		The default is 'ar'.
 //

--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -1501,8 +1501,9 @@
 // 	PKG_CONFIG
 // 		Path to pkg-config tool.
 // 	AR
-// 		The command to use to create, modify, and extract from library archives.
-// 		Only used when the compiler is gccgo ('-compiler=gccgo').
+// 		The command to use to manipualte library archives when
+// 		building with the gccgo compiler.
+// 		The default is 'ar'.
 //
 // Architecture-specific environment variables:
 //

--- a/src/cmd/go/internal/help/helpdoc.go
+++ b/src/cmd/go/internal/help/helpdoc.go
@@ -546,6 +546,8 @@ Environment variables for use with cgo:
 		The command to use to compile C++ code.
 	PKG_CONFIG
 		Path to pkg-config tool.
+	AR
+		The command to use to create, modify, and extract from library archives.
 
 Architecture-specific environment variables:
 

--- a/src/cmd/go/internal/help/helpdoc.go
+++ b/src/cmd/go/internal/help/helpdoc.go
@@ -548,6 +548,7 @@ Environment variables for use with cgo:
 		Path to pkg-config tool.
 	AR
 		The command to use to create, modify, and extract from library archives.
+		Only used when the compiler is gccgo ('-compiler=gccgo').
 
 Architecture-specific environment variables:
 

--- a/src/cmd/go/internal/help/helpdoc.go
+++ b/src/cmd/go/internal/help/helpdoc.go
@@ -547,8 +547,9 @@ Environment variables for use with cgo:
 	PKG_CONFIG
 		Path to pkg-config tool.
 	AR
-		The command to use to create, modify, and extract from library archives.
-		Only used when the compiler is gccgo ('-compiler=gccgo').
+		The command to use to manipulate library archives when
+		building with the gccgo compiler.
+		The default is 'ar'.
 
 Architecture-specific environment variables:
 

--- a/src/cmd/go/internal/work/gccgo.go
+++ b/src/cmd/go/internal/work/gccgo.go
@@ -184,12 +184,22 @@ func gccgoArchive(basedir, imp string) string {
 }
 
 func (gccgoToolchain) pack(b *Builder, a *Action, afile string, ofiles []string) error {
+	var ok bool
 	p := a.Package
 	objdir := a.Objdir
 	var absOfiles []string
 	for _, f := range ofiles {
 		absOfiles = append(absOfiles, mkAbs(objdir, f))
 	}
+
+	var AR, RC string
+	if AR, ok = os.LookupEnv("AR"); !ok {
+		AR = "ar"
+	}
+	if RC, ok = os.LookupEnv("RC"); !ok {
+		RC = "rc"
+	}
+
 	var arArgs []string
 	if cfg.Goos == "aix" && cfg.Goarch == "ppc64" {
 		// AIX puts both 32-bit and 64-bit objects in the same archive.
@@ -198,10 +208,12 @@ func (gccgoToolchain) pack(b *Builder, a *Action, afile string, ofiles []string)
 		arArgs = []string{"-X64"}
 	}
 
-	return b.run(a, p.Dir, p.ImportPath, nil, "ar", arArgs, "rc", mkAbs(objdir, afile), absOfiles)
+	return b.run(a, p.Dir, p.ImportPath, nil, AR, arArgs, RC, mkAbs(objdir, afile), absOfiles)
 }
 
 func (tools gccgoToolchain) link(b *Builder, root *Action, out, importcfg string, allactions []*Action, buildmode, desc string) error {
+	var ok bool
+
 	// gccgo needs explicit linking with all package dependencies,
 	// and all LDFLAGS from cgo dependencies.
 	afiles := []string{}
@@ -216,6 +228,14 @@ func (tools gccgoToolchain) link(b *Builder, root *Action, out, importcfg string
 		cxx = len(root.Package.CXXFiles) > 0 || len(root.Package.SwigCXXFiles) > 0
 		objc = len(root.Package.MFiles) > 0
 		fortran = len(root.Package.FFiles) > 0
+	}
+
+	var AR, RC string
+	if AR, ok = os.LookupEnv("AR"); !ok {
+		AR = "ar"
+	}
+	if RC, ok = os.LookupEnv("RC"); !ok {
+		RC = "rc"
 	}
 
 	readCgoFlags := func(flagsFile string) error {
@@ -257,11 +277,11 @@ func (tools gccgoToolchain) link(b *Builder, root *Action, out, importcfg string
 				return "", nil
 			}
 		}
-		err := b.run(root, root.Objdir, desc, nil, "ar", "x", newArchive, "_cgo_flags")
+		err := b.run(root, root.Objdir, desc, nil, AR, "x", newArchive, "_cgo_flags")
 		if err != nil {
 			return "", err
 		}
-		err = b.run(root, ".", desc, nil, "ar", "d", newArchive, "_cgo_flags")
+		err = b.run(root, ".", desc, nil, AR, "d", newArchive, "_cgo_flags")
 		if err != nil {
 			return "", err
 		}
@@ -473,7 +493,7 @@ func (tools gccgoToolchain) link(b *Builder, root *Action, out, importcfg string
 
 	switch buildmode {
 	case "c-archive":
-		if err := b.run(root, ".", desc, nil, "ar", "rc", realOut, out); err != nil {
+		if err := b.run(root, ".", desc, nil, AR, RC, realOut, out); err != nil {
 			return err
 		}
 	}

--- a/src/cmd/go/internal/work/gccgo.go
+++ b/src/cmd/go/internal/work/gccgo.go
@@ -185,6 +185,7 @@ func gccgoArchive(basedir, imp string) string {
 
 func (gccgoToolchain) pack(b *Builder, a *Action, afile string, ofiles []string) error {
 	var ok bool
+
 	p := a.Package
 	objdir := a.Objdir
 	var absOfiles []string
@@ -192,12 +193,9 @@ func (gccgoToolchain) pack(b *Builder, a *Action, afile string, ofiles []string)
 		absOfiles = append(absOfiles, mkAbs(objdir, f))
 	}
 
-	var AR, RC string
+	var AR string
 	if AR, ok = os.LookupEnv("AR"); !ok {
 		AR = "ar"
-	}
-	if RC, ok = os.LookupEnv("RC"); !ok {
-		RC = "rc"
 	}
 
 	var arArgs []string
@@ -208,7 +206,7 @@ func (gccgoToolchain) pack(b *Builder, a *Action, afile string, ofiles []string)
 		arArgs = []string{"-X64"}
 	}
 
-	return b.run(a, p.Dir, p.ImportPath, nil, AR, arArgs, RC, mkAbs(objdir, afile), absOfiles)
+	return b.run(a, p.Dir, p.ImportPath, nil, AR, arArgs, "rc", mkAbs(objdir, afile), absOfiles)
 }
 
 func (tools gccgoToolchain) link(b *Builder, root *Action, out, importcfg string, allactions []*Action, buildmode, desc string) error {
@@ -230,12 +228,9 @@ func (tools gccgoToolchain) link(b *Builder, root *Action, out, importcfg string
 		fortran = len(root.Package.FFiles) > 0
 	}
 
-	var AR, RC string
+	var AR string
 	if AR, ok = os.LookupEnv("AR"); !ok {
 		AR = "ar"
-	}
-	if RC, ok = os.LookupEnv("RC"); !ok {
-		RC = "rc"
 	}
 
 	readCgoFlags := func(flagsFile string) error {
@@ -493,7 +488,7 @@ func (tools gccgoToolchain) link(b *Builder, root *Action, out, importcfg string
 
 	switch buildmode {
 	case "c-archive":
-		if err := b.run(root, ".", desc, nil, AR, RC, realOut, out); err != nil {
+		if err := b.run(root, ".", desc, nil, AR, "rc", realOut, out); err != nil {
 			return err
 		}
 	}

--- a/src/cmd/go/internal/work/gccgo.go
+++ b/src/cmd/go/internal/work/gccgo.go
@@ -198,7 +198,6 @@ func (tools gccgoToolchain) pack(b *Builder, a *Action, afile string, ofiles []s
 	for _, f := range ofiles {
 		absOfiles = append(absOfiles, mkAbs(objdir, f))
 	}
-
 	var arArgs []string
 	if cfg.Goos == "aix" && cfg.Goarch == "ppc64" {
 		// AIX puts both 32-bit and 64-bit objects in the same archive.
@@ -211,7 +210,6 @@ func (tools gccgoToolchain) pack(b *Builder, a *Action, afile string, ofiles []s
 }
 
 func (tools gccgoToolchain) link(b *Builder, root *Action, out, importcfg string, allactions []*Action, buildmode, desc string) error {
-
 	// gccgo needs explicit linking with all package dependencies,
 	// and all LDFLAGS from cgo dependencies.
 	afiles := []string{}


### PR DESCRIPTION
This allows one to customize which ar to use by fetching its path
from the environment. This way one can swap it out for a
different implementation.