### PR TITLE
bufio: make Reader.Peek invalidate Unreads

### DIFF
--- a/src/bufio/bufio.go
+++ b/src/bufio/bufio.go
@@ -128,6 +128,9 @@ func (b *Reader) Peek(n int) ([]byte, error) {
 		return nil, ErrNegativeCount
 	}
 
+	b.lastByte = -1
+	b.lastRuneSize = -1
+
 	for b.w-b.r < n && b.w-b.r < len(b.buf) && b.err == nil {
 		b.fill() // b.w-b.r < len(b.buf) => buffer is not full
 	}

--- a/src/bufio/bufio_test.go
+++ b/src/bufio/bufio_test.go
@@ -285,6 +285,24 @@ func TestUnreadRune(t *testing.T) {
 	}
 }
 
+func TestNoUnreadRuneAfterPeek(t *testing.T) {
+	br := NewReader(strings.NewReader("example"))
+	br.ReadRune()
+	br.Peek(1)
+	if err := br.UnreadRune(); err == nil {
+		t.Error("UnreadRune didn't fail after Peek")
+	}
+}
+
+func TestNoUnreadByteAfterPeek(t *testing.T) {
+	br := NewReader(strings.NewReader("example"))
+	br.ReadByte()
+	br.Peek(1)
+	if err := br.UnreadByte(); err == nil {
+		t.Error("UnreadByte didn't fail after Peek")
+	}
+}
+
 func TestUnreadByte(t *testing.T) {
 	segments := []string{"Hello, ", "world"}
 	r := NewReader(&StringReader{data: segments})


### PR DESCRIPTION
Since Reader.Peek potentially reads from the underlying io.Reader,
discarding previous buffers, UnreadRune and UnreadByte cannot
necessarily work.  Change Peek to invalidate the unread buffers in all
cases (as allowed according to the documentation) and thus prevent
hiding bugs in the caller.

(This change was previoiusly merged and then reverted due concern about
being too close to a release)

Fixes #18556
