### PR TITLE
testing: add Write method to T and B

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -155,6 +155,7 @@ Andrew Jackura <ajackura@google.com>
 Andrew Lutomirski <andy@luto.us>
 Andrew Pilloud <andrewpilloud@igneoussystems.com>
 Andrew Pogrebnoy <absourd.noise@gmail.com>
+Andrew Poydence <apoydence@gmail.com>
 Andrew Pritchard <awpritchard@gmail.com>
 Andrew Radev <andrey.radev@gmail.com>
 Andrew Skiba <skibaa@gmail.com>

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -532,6 +532,27 @@ func (c *common) Name() string {
 	return c.name
 }
 
+// Write implements io.Writer for test logging. It is suited for creating a
+// logger type.
+func (c *common) Write(data []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !c.done {
+		println("non parent")
+		c.output = append(c.output, data...)
+		return len(data), nil
+	}
+
+	if c.parent != nil {
+		println("parent")
+		c.parent.output = append(c.parent.output, data...)
+		return len(data), nil
+	}
+
+	panic("Log in goroutine after " + c.name + " has completed")
+}
+
 func (c *common) setRan() {
 	if c.parent != nil {
 		c.parent.setRan()


### PR DESCRIPTION
T and B implement io.Writer so that each can be used to create a logger.

Fixes #22513

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
