### PR TITLE
crypto/hmac: rename CheckHMAC to ValidHMAC in package docs

### DIFF
--- a/src/crypto/hmac/hmac.go
+++ b/src/crypto/hmac/hmac.go
@@ -11,8 +11,8 @@ The receiver verifies the hash by recomputing it using the same key.
 Receivers should be careful to use Equal to compare MACs in order to avoid
 timing side-channels:
 
-	// CheckMAC reports whether messageMAC is a valid HMAC tag for message.
-	func CheckMAC(message, messageMAC, key []byte) bool {
+	// ValidMAC reports whether messageMAC is a valid HMAC tag for message.
+	func ValidMAC(message, messageMAC, key []byte) bool {
 		mac := hmac.New(sha256.New, key)
 		mac.Write(message)
 		expectedMAC := mac.Sum(nil)


### PR DESCRIPTION
Procedure names should reflect what they do; function names
should reflect what they return. Functions are used in
expressions, often in things like if's, so they need
to read appropriately.

        if CheckHMAC(a, b, key)

is unhelpful because we can't deduce whether CheckHMAC
returns true on error or non­-error; instead

        if ValidHMAC(a, b, key)

makes the point clear and makes a future mistake
in using the routine less likely.

https://www.lysator.liu.se/c/pikestyle.html