### PR TITLE
crypto/tls: add SkipSNI option

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -502,6 +502,9 @@ type Config struct {
 	// an IP address.
 	ServerName string
 
+	// SkipSNI is used to disable client send the SNI extension.
+	SkipSNI bool
+
 	// ClientAuth determines the server's policy for
 	// TLS Client Authentication. The default is NoClientCert.
 	ClientAuth ClientAuthType
@@ -644,6 +647,7 @@ func (c *Config) Clone() *Config {
 		RootCAs:                     c.RootCAs,
 		NextProtos:                  c.NextProtos,
 		ServerName:                  c.ServerName,
+		SkipSNI:                     c.SkipSNI,
 		ClientAuth:                  c.ClientAuth,
 		ClientCAs:                   c.ClientCAs,
 		InsecureSkipVerify:          c.InsecureSkipVerify,

--- a/src/crypto/tls/handshake_client.go
+++ b/src/crypto/tls/handshake_client.go
@@ -69,13 +69,16 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, ecdheParameters, error) {
 		sessionId:                    make([]byte, 32),
 		ocspStapling:                 true,
 		scts:                         true,
-		serverName:                   hostnameInSNI(config.ServerName),
 		supportedCurves:              config.curvePreferences(),
 		supportedPoints:              []uint8{pointFormatUncompressed},
 		nextProtoNeg:                 len(config.NextProtos) > 0,
 		secureRenegotiationSupported: true,
 		alpnProtocols:                config.NextProtos,
 		supportedVersions:            supportedVersions,
+	}
+
+	if !config.SkipSNI {
+		hello.serverName = hostnameInSNI(config.ServerName)
 	}
 
 	if c.handshakes > 0 {

--- a/src/crypto/tls/tls_test.go
+++ b/src/crypto/tls/tls_test.go
@@ -715,6 +715,8 @@ func TestCloneNonFuncFields(t *testing.T) {
 			f.Set(reflect.ValueOf([]string{"a", "b"}))
 		case "ServerName":
 			f.Set(reflect.ValueOf("b"))
+		case "SkipSNI":
+			f.Set(reflect.ValueOf(true))
 		case "ClientAuth":
 			f.Set(reflect.ValueOf(VerifyClientCertIfGiven))
 		case "InsecureSkipVerify", "SessionTicketsDisabled", "DynamicRecordSizingDisabled", "PreferServerCipherSuites":


### PR DESCRIPTION
This change modifies Go to has the ability not to send the SNI extension information.

Fixes #28754 