### PR TITLE
net/http: close connection if `Connection: close` is set

### DIFF
--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -1141,6 +1141,10 @@ func (w *response) WriteHeader(code int) {
 			w.handlerHeader.Del("Content-Length")
 		}
 	}
+
+	if w.handlerHeader.get("Connection") == "close" {
+		w.closeAfterReply = true
+	}
 }
 
 // extraHeader is the set of headers sometimes added by chunkWriter.writeHeader.
@@ -1540,6 +1544,10 @@ func (w *response) bodyAllowed() bool {
 // bufferBeforeChunkingSize smaller and having bufio's fast-paths deal
 // with this instead.
 func (w *response) Write(data []byte) (n int, err error) {
+	if w.closeAfterReply {
+		defer w.conn.Close()
+	}
+
 	return w.write(len(data), data, "")
 }
 

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -1141,10 +1141,6 @@ func (w *response) WriteHeader(code int) {
 			w.handlerHeader.Del("Content-Length")
 		}
 	}
-
-	if w.handlerHeader.get("Connection") == "close" {
-		w.closeAfterReply = true
-	}
 }
 
 // extraHeader is the set of headers sometimes added by chunkWriter.writeHeader.


### PR DESCRIPTION
As https://tools.ietf.org/html/rfc2616#page-117 says: 

HTTP/1.1 defines the "close" connection option for the sender to signal that the connection will be closed after completion of the response.

But it does not specify the connection should be closed by client or server, for safety, if `Connection: close`
is set in response header, server should close the connection after write data. Recently we have been
affect by this issue: we write a lots of data to client, but the client does not close the connection(
keep-alive is set by default in HTTP/1.1), so memory is still hold by `response`, and memory is used up.