### PR TITLE
net/http/httputil: fix unannounced trailers when body is empty

### DIFF
--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -282,14 +282,7 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	rw.WriteHeader(res.StatusCode)
-	if len(res.Trailer) > 0 {
-		// Force chunking if we saw a response trailer.
-		// This prevents net/http from calculating the length for short
-		// bodies and adding a Content-Length.
-		if fl, ok := rw.(http.Flusher); ok {
-			fl.Flush()
-		}
-	}
+
 	err = p.copyResponse(rw, res.Body, p.flushInterval(req, res))
 	if err != nil {
 		defer res.Body.Close()
@@ -307,6 +300,15 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if len(res.Trailer) == announcedTrailers {
 		copyHeader(rw.Header(), res.Trailer)
 		return
+	}
+
+	if len(res.Trailer) > 0 {
+		// Force chunking if we saw a response trailer.
+		// This prevents net/http from calculating the length for short
+		// bodies and adding a Content-Length.
+		if fl, ok := rw.(http.Flusher); ok {
+			fl.Flush()
+		}
 	}
 
 	for k, vv := range res.Trailer {

--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -297,11 +297,6 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 	res.Body.Close() // close now, instead of defer, to populate res.Trailer
 
-	if len(res.Trailer) == announcedTrailers {
-		copyHeader(rw.Header(), res.Trailer)
-		return
-	}
-
 	if len(res.Trailer) > 0 {
 		// Force chunking if we saw a response trailer.
 		// This prevents net/http from calculating the length for short
@@ -309,6 +304,11 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		if fl, ok := rw.(http.Flusher); ok {
 			fl.Flush()
 		}
+	}
+
+	if len(res.Trailer) == announcedTrailers {
+		copyHeader(rw.Header(), res.Trailer)
+		return
 	}
 
 	for k, vv := range res.Trailer {

--- a/src/net/http/httputil/reverseproxy_test.go
+++ b/src/net/http/httputil/reverseproxy_test.go
@@ -7,23 +7,23 @@
 package httputil
 
 import (
-	"bufio"
-	"bytes"
-	"errors"
-	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
-	"reflect"
-	"strconv"
-	"strings"
-	"sync"
 	"testing"
 	"time"
+	"reflect"
+	"io"
+	"strings"
+	"bufio"
+	"sync"
+	"strconv"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
 )
 
 const fakeHopHeader = "X-Fake-Hop-Header-For-Test"
@@ -1047,4 +1047,34 @@ func TestReverseProxyWebSocket(t *testing.T) {
 	if got != want {
 		t.Errorf("got %#q, want %#q", got, want)
 	}
+}
+
+func TestUnannoncedTrailer(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		w.Header().Set(http.TrailerPrefix+"X-Unannounced-Trailer", "unannounced_trailer_value")
+	}))
+	defer backend.Close()
+	backendURL, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxyHandler := NewSingleHostReverseProxy(backendURL)
+	proxyHandler.ErrorLog = log.New(ioutil.Discard, "", 0) // quiet for tests
+	frontend := httptest.NewServer(proxyHandler)
+	defer frontend.Close()
+	frontendClient := frontend.Client()
+
+	res, err := frontendClient.Get(frontend.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	ioutil.ReadAll(res.Body)
+
+	if g, e := res.Trailer.Get("X-Unannounced-Trailer"), "unannounced_trailer_value"; g != e {
+		t.Errorf("Trailer(X-Unannounced-Trailer) = %q ; want %q", g, e)
+	}
+
 }

--- a/src/net/http/httputil/reverseproxy_test.go
+++ b/src/net/http/httputil/reverseproxy_test.go
@@ -1049,7 +1049,7 @@ func TestReverseProxyWebSocket(t *testing.T) {
 	}
 }
 
-func TestUnannoncedTrailer(t *testing.T) {
+func TestUnannouncedTrailer(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.(http.Flusher).Flush()
@@ -1073,8 +1073,8 @@ func TestUnannoncedTrailer(t *testing.T) {
 
 	ioutil.ReadAll(res.Body)
 
-	if g, e := res.Trailer.Get("X-Unannounced-Trailer"), "unannounced_trailer_value"; g != e {
-		t.Errorf("Trailer(X-Unannounced-Trailer) = %q ; want %q", g, e)
+	if g, w := res.Trailer.Get("X-Unannounced-Trailer"), "unannounced_trailer_value"; g != w {
+		t.Errorf("Trailer(X-Unannounced-Trailer) = %q; want %q", g, w)
 	}
 
 }


### PR DESCRIPTION
Fix unannounced trailers when body is empty and without announced trailers.

Fixes #29031