### PR TITLE
net/http: add StatusTooEarly (425)

### DIFF
--- a/src/net/http/status.go
+++ b/src/net/http/status.go
@@ -55,6 +55,7 @@ const (
 	StatusUnprocessableEntity          = 422 // RFC 4918, 11.2
 	StatusLocked                       = 423 // RFC 4918, 11.3
 	StatusFailedDependency             = 424 // RFC 4918, 11.4
+	StatusTooEarly                     = 425 // RFC 8470, 5.2.
 	StatusUpgradeRequired              = 426 // RFC 7231, 6.5.15
 	StatusPreconditionRequired         = 428 // RFC 6585, 3
 	StatusTooManyRequests              = 429 // RFC 6585, 4
@@ -122,6 +123,7 @@ var statusText = map[int]string{
 	StatusUnprocessableEntity:          "Unprocessable Entity",
 	StatusLocked:                       "Locked",
 	StatusFailedDependency:             "Failed Dependency",
+	StatusTooEarly:                     "Too Early",
 	StatusUpgradeRequired:              "Upgrade Required",
 	StatusPreconditionRequired:         "Precondition Required",
 	StatusTooManyRequests:              "Too Many Requests",


### PR DESCRIPTION
StatusTooEarly can be returned to indicate that a server is unwilling
to accept early data as introduced in TLS 1.3.
The status code was specified in RFC 8470, section 5.2.

Major supported browsers are:
- Firefox as of version 58
  https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/425#Browser_compatibility
- Chromium as of version 73.0.3628.1
  https://chromium.googlesource.com/chromium/src/+/58097ec3823e0f340ab5abfcaec1306e1d954c5a