### PR TITLE
Not-exists check for non-existent file should return true on Windows

### DIFF
--- a/src/os/error_windows.go
+++ b/src/os/error_windows.go
@@ -14,12 +14,14 @@ func isExist(err error) bool {
 }
 
 const _ERROR_BAD_NETPATH = syscall.Errno(53)
+const _ERROR_INVALID_PARAMETER =  syscall.Errno(87)
 
 func isNotExist(err error) bool {
 	err = underlyingError(err)
 	return err == syscall.ERROR_FILE_NOT_FOUND ||
 		err == _ERROR_BAD_NETPATH ||
-		err == syscall.ERROR_PATH_NOT_FOUND || err == ErrNotExist
+		err == syscall.ERROR_PATH_NOT_FOUND ||
+		err == _ERROR_INVALID_PARAMETER || err == ErrNotExist
 }
 
 func isPermission(err error) bool {

--- a/src/os/os_windows_test.go
+++ b/src/os/os_windows_test.go
@@ -1010,3 +1010,15 @@ func TestStatOfInvalidName(t *testing.T) {
 		t.Fatal(`os.Stat("*.go") unexpectedly succeeded`)
 	}
 }
+
+func TestStatOfInvalidNameWithTrailingSlash(t *testing.T) {
+	const ERROR_INVALID_PARAMETER = syscall.Errno(87)
+	_, err := os.Stat("doesnotexist/")
+	if err == nil {
+		t.Fatal(`os.Stat("doesnotexist/") unexpectedly succeeded`)
+	}
+	if perr, ok := err.(*os.PathError); !ok {
+		t.Errorf("got %v, want %v", perr.Err, ERROR_INVALID_PARAMETER)
+	}
+}
+

--- a/src/os/os_windows_test.go
+++ b/src/os/os_windows_test.go
@@ -1017,8 +1017,12 @@ func TestStatOfInvalidNameWithTrailingSlash(t *testing.T) {
 	if err == nil {
 		t.Fatal(`os.Stat("doesnotexist/") unexpectedly succeeded`)
 	}
-	if perr, ok := err.(*os.PathError); !ok {
-		t.Errorf("got %v, want %v", perr.Err, ERROR_INVALID_PARAMETER)
+	perr, ok := err.(*os.PathError)
+	if !ok {
+		t.Fatalf("got %v, want %v", perr, err)
+	}
+	if ok && perr.Err != ERROR_INVALID_PARAMETER {
+		t.Fatalf("got %v, want %v", perr.Err, ERROR_INVALID_PARAMETER)
 	}
 }
 

--- a/src/os/os_windows_test.go
+++ b/src/os/os_windows_test.go
@@ -563,6 +563,13 @@ func TestBadNetPathError(t *testing.T) {
 	}
 }
 
+func TestInvalidParameterError(t *testing.T) {
+	const ERROR_INVALID_PARAMETER = syscall.Errno(87)
+	if !os.IsNotExist(ERROR_INVALID_PARAMETER) {
+		t.Fatal("os.IsNotExist(syscall.Errno(87)) is false, but want true")
+	}
+}
+
 func TestStatDir(t *testing.T) {
 	defer chtmpdir(t)()
 


### PR DESCRIPTION
This fixes https://github.com/golang/go/issues/29119

