### PR TITLE
time: reuse the result of Time.sec in Time.Before

### DIFF
--- a/src/time/time.go
+++ b/src/time/time.go
@@ -252,7 +252,9 @@ func (t Time) Before(u Time) bool {
 	if t.wall&u.wall&hasMonotonic != 0 {
 		return t.ext < u.ext
 	}
-	return t.sec() < u.sec() || t.sec() == u.sec() && t.nsec() < u.nsec()
+	ts := t.sec()
+	us := u.sec()
+	return ts < us || ts == us && t.nsec() < u.nsec()
 }
 
 // Equal reports whether t and u represent the same time instant.


### PR DESCRIPTION
The current implementation calls sec() for both the receiver t and
the parameter u twice, if the seconds of t are greater or equal than u's seconds.
The same optimization is already present in Time.After.