### PR TITLE
net: allow TCP only DNS requests in the pure Go resolver on unix

### DIFF
--- a/src/net/dnsclient_unix.go
+++ b/src/net/dnsclient_unix.go
@@ -137,7 +137,13 @@ func (r *Resolver) exchange(ctx context.Context, server string, q dnsmessage.Que
 	if err != nil {
 		return dnsmessage.Parser{}, dnsmessage.Header{}, errCannotMarshalDNSMessage
 	}
-	for _, network := range []string{"udp", "tcp"} {
+	var networks []string
+	if r.PreferTCP || systemConf().preferTCP {
+		networks = []string{"tcp"}
+	} else {
+		networks = []string{"udp", "tcp"}
+	}
+	for _, network := range networks {
 		ctx, cancel := context.WithDeadline(ctx, time.Now().Add(timeout))
 		defer cancel()
 

--- a/src/net/lookup.go
+++ b/src/net/lookup.go
@@ -123,6 +123,11 @@ type Resolver struct {
 	// GODEBUG=netdns=go, but scoped to just this resolver.
 	PreferGo bool
 
+	// PreferTCP controls whether Go's built-in DNS resolver will use
+	// TCP instead of UDP with a fallback to TCP. It is equivalent to setting
+	// GODEBUG=netdns=go+tcp, but scoped to just this resolver.
+	PreferTCP bool
+
 	// StrictErrors controls the behavior of temporary errors
 	// (including timeout, socket errors, and SERVFAIL) when using
 	// Go's built-in resolver. For a query composed of multiple

--- a/src/net/net.go
+++ b/src/net/net.go
@@ -66,6 +66,9 @@ GODEBUG environment variable (see package runtime) to go or cgo, as in:
 The decision can also be forced while building the Go source tree
 by setting the netgo or netcgo build tag.
 
+The pure Go resolver can be configured to use only TCP to communicate
+by using the tcp option, as in GODEBUG=netdns=go,tcp.
+
 A numeric netdns setting, as in GODEBUG=netdns=1, causes the resolver
 to print debugging information about its decisions.
 To force a particular resolver while also printing debugging information,


### PR DESCRIPTION
There is a DNS resolution bug in Kubernetes (UDP response packets get dropped by conntrack, causing timeouts in DNS queries).

This enables configuration of the pure Go resolver to use TCP, either using the GODEBUG env var (GODEBUG=netdns=go+tcp) or using the Resolver.PreferTCP flag.
 
Fixes #29358