### PR TITLE
net/http/httputil: fix missing previous headers in response when switching protocol in ReverseProxy 

### DIFF
--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -497,6 +497,9 @@ func (p *ReverseProxy) handleUpgradeResponse(rw http.ResponseWriter, req *http.R
 		p.getErrorHandler()(rw, req, fmt.Errorf("backend tried to switch protocol %q when %q was requested", resUpType, reqUpType))
 		return
 	}
+
+	copyHeader(res.Header, rw.Header())
+
 	hj, ok := rw.(http.Hijacker)
 	if !ok {
 		p.getErrorHandler()(rw, req, fmt.Errorf("can't switch protocols using non-Hijacker ResponseWriter type %T", rw))


### PR DESCRIPTION
When using switching protocol, previous headers set before the reverse proxy are lost.

Fixes #29407 