### PR TITLE
encoding/gob: mention that Encoder and Decoder are safe for concurrent use

### DIFF
--- a/src/encoding/gob/decoder.go
+++ b/src/encoding/gob/decoder.go
@@ -18,7 +18,8 @@ import (
 const tooBig = (1 << 30) << (^uint(0) >> 62)
 
 // A Decoder manages the receipt of type and data information read from the
-// remote side of a connection.
+// remote side of a connection.  It is safe for concurrent use by multiple
+// goroutines.
 //
 // The Decoder does only basic sanity checking on decoded input sizes,
 // and its limits are not configurable. Take caution when decoding gob data

--- a/src/encoding/gob/encoder.go
+++ b/src/encoding/gob/encoder.go
@@ -12,7 +12,8 @@ import (
 )
 
 // An Encoder manages the transmission of type and data information to the
-// other side of a connection.
+// other side of a connection.  It is safe for concurrent use by multiple
+// goroutines.
 type Encoder struct {
 	mutex      sync.Mutex              // each item must be sent atomically
 	w          []io.Writer             // where to send the data


### PR DESCRIPTION
Fixes #29416

Change-Id: I24364bfee77aceace53f85f1046ef4d73f8feebb