### PR TITLE
math/big: fix incorrect comment variable reference

### DIFF
--- a/src/math/big/prime.go
+++ b/src/math/big/prime.go
@@ -51,7 +51,7 @@ func (x *Int) ProbablyPrime(n int) bool {
 	}
 
 	if w&1 == 0 {
-		return false // n is even
+		return false // x is even
 	}
 
 	const primesA = 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 37


### PR DESCRIPTION
Fix comment as w&1 is the parity of 'x', not of 'n'.