### PR TITLE
math: Pow(x,y) optimization for cases: constant integer `y`. 

### DIFF
--- a/src/math/all_test.go
+++ b/src/math/all_test.go
@@ -1602,6 +1602,26 @@ var nextafter64SC = []float64{
 	NaN(),
 }
 
+// Issue #29457
+// value `y` is integer
+var powInteger = []struct {
+	x, y   float64
+	result float64
+}{
+	{Pi, 125, 1.392304051057404453E+62},
+	{-Pi, 125, -1.392304051057404453E+62},
+	{Pi, -125, 7.182339225692378308E-63},
+	{-Pi, -125, -7.182339225692378308E-63},
+	{200, 125, 4.25352958651173248E+287},
+	{-200, 125, -4.25352958651173248E+287},
+	{200, -125, 2.35098870164457404E-288},
+	{-200, -125, -2.35098870164457404E-288},
+	{0.003, 125, 4.36673503164046280E-316},
+	{-0.003, 125, -4.36673503164046280E-316},
+	{0.006, 124, 3.0956727735707076e-276},
+	{-0.006, -124, 3.230315582892015e+275},
+}
+
 var vfpowSC = [][2]float64{
 	{Inf(-1), -Pi},
 	{Inf(-1), -3},
@@ -2766,6 +2786,11 @@ func TestPow(t *testing.T) {
 	for i := 0; i < len(vfpowSC); i++ {
 		if f := Pow(vfpowSC[i][0], vfpowSC[i][1]); !alike(powSC[i], f) {
 			t.Errorf("Pow(%g, %g) = %g, want %g", vfpowSC[i][0], vfpowSC[i][1], f, powSC[i])
+		}
+	}
+	for i := range powInteger {
+		if f := Pow(powInteger[i].x, powInteger[i].y); !alike(powInteger[i].result, f) {
+			t.Errorf("Pow(%g, %g) = %g, want %g", powInteger[i].x, powInteger[i].y, f, powInteger[i].result)
 		}
 	}
 }

--- a/src/math/pow.go
+++ b/src/math/pow.go
@@ -41,8 +41,6 @@ func pow(x, y float64) float64 {
 	switch {
 	case y == 0 || x == 1:
 		return 1
-	case y == 1:
-		return x
 	case IsNaN(x) || IsNaN(y):
 		return NaN()
 	case x == 0:
@@ -81,6 +79,19 @@ func pow(x, y float64) float64 {
 		return Sqrt(x)
 	case y == -0.5:
 		return 1 / Sqrt(x)
+	case float64(int8(y)) == y:
+		if y < 0 {
+			return 1.0 / pow(x, -y)
+		}
+		var (
+			i uint8   = 0
+			n uint8   = uint8(y)
+			r float64 = 1.0
+		)
+		for i = 0; i < n; i++ {
+			r *= x
+		}
+		return r
 	}
 
 	yi, yf := Modf(Abs(y))

--- a/src/math/pow.go
+++ b/src/math/pow.go
@@ -84,10 +84,26 @@ func pow(x, y float64) float64 {
 			return 1.0 / pow(x, -y)
 		}
 		var (
-			i uint8   = 0
+			i uint8
 			n uint8   = uint8(y)
 			r float64 = 1.0
+
+			// variables for iterations
+			tmp float64
+			c   uint8
 		)
+
+		for n > 1 {
+			tmp = x
+			c = 1
+			for 2*c <= n {
+				tmp *= tmp
+				c *= 2
+			}
+			n = n - c
+			r *= tmp
+		}
+
 		for i = 0; i < n; i++ {
 			r *= x
 		}

--- a/src/math/pow.go
+++ b/src/math/pow.go
@@ -80,8 +80,10 @@ func pow(x, y float64) float64 {
 	case y == -0.5:
 		return 1 / Sqrt(x)
 	case float64(int8(y)) == y:
+		isNegative := false
 		if y < 0 {
-			return 1.0 / pow(x, -y)
+			isNegative = true
+			y = -y
 		}
 		var (
 			i uint8
@@ -96,7 +98,7 @@ func pow(x, y float64) float64 {
 		for n > 1 {
 			tmp = x
 			c = 1
-			for 2*c <= n {
+			for c <= n/2 {
 				tmp *= tmp
 				c *= 2
 			}
@@ -106,6 +108,9 @@ func pow(x, y float64) float64 {
 
 		for i = 0; i < n; i++ {
 			r *= x
+		}
+		if isNegative {
+			return 1 / r
 		}
 		return r
 	}


### PR DESCRIPTION
Fixes #29456 