### PR TITLE
cmd/go: fix typo in output of go help importpath

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -2054,7 +2054,7 @@
 // (See 'go help gopath-get' and 'go help gopath'.)
 //
 // When using modules, downloaded packages are stored in the module cache.
-// (See 'go help modules-get' and 'go help goproxy'.)
+// (See 'go help module-get' and 'go help goproxy'.)
 //
 // When using modules, an additional variant of the go-import meta tag is
 // recognized and is preferred over those listing version control systems.

--- a/src/cmd/go/internal/help/helpdoc.go
+++ b/src/cmd/go/internal/help/helpdoc.go
@@ -266,7 +266,7 @@ listed in the GOPATH environment variable.
 (See 'go help gopath-get' and 'go help gopath'.)
 
 When using modules, downloaded packages are stored in the module cache.
-(See 'go help modules-get' and 'go help goproxy'.)
+(See 'go help module-get' and 'go help goproxy'.)
 
 When using modules, an additional variant of the go-import meta tag is
 recognized and is preferred over those listing version control systems.


### PR DESCRIPTION
The output refers to 'go help modules-get' but the actual command is 'go
help module-get', singular.