### PR TITLE
cmd/go: remove init() to fix precedence issue when setting debug mod info

### DIFF
--- a/src/cmd/go/internal/modload/build.go
+++ b/src/cmd/go/internal/modload/build.go
@@ -252,13 +252,10 @@ func findModule(target, path string) module.Version {
 func ModInfoProg(info string) []byte {
 	// Inject a variable with the debug information as runtime/debug.modinfo,
 	// but compile it in package main so that it is specific to the binary.
-	// Populate it in an init func so that it will work with go:linkname,
-	// but use a string constant instead of the name 'string' in case
-	// package main shadows the built-in 'string' with some local declaration.
+	// No need to populate in an init func, it will still work with go:linkname,
 	return []byte(fmt.Sprintf(`package main
 import _ "unsafe"
 //go:linkname __debug_modinfo__ runtime/debug.modinfo
-var __debug_modinfo__ = ""
-func init() { __debug_modinfo__ = %q }
+var __debug_modinfo__ = %q
 	`, string(infoStart)+info+string(infoEnd)))
 }


### PR DESCRIPTION
Fixes #29628