### PR TITLE
net: support single-request resolv.conf option in pure Go resolver

### DIFF
--- a/src/net/dnsconfig_unix_test.go
+++ b/src/net/dnsconfig_unix_test.go
@@ -102,6 +102,28 @@ var dnsReadConfigTests = []struct {
 			search:   []string{"c.symbolic-datum-552.internal."},
 		},
 	},
+	{
+		name: "testdata/single-request-resolv.conf",
+		want: &dnsConfig{
+			servers:       defaultNS,
+			ndots:         1,
+			singleRequest: true,
+			timeout:       5 * time.Second,
+			attempts:      2,
+			search:        []string{"domain.local."},
+		},
+	},
+	{
+		name: "testdata/single-request-reopen-resolv.conf",
+		want: &dnsConfig{
+			servers:       defaultNS,
+			ndots:         1,
+			singleRequest: true,
+			timeout:       5 * time.Second,
+			attempts:      2,
+			search:        []string{"domain.local."},
+		},
+	},
 }
 
 func TestDNSReadConfig(t *testing.T) {

--- a/src/net/testdata/single-request-reopen-resolv.conf
+++ b/src/net/testdata/single-request-reopen-resolv.conf
@@ -1,0 +1,1 @@
+options single-request-reopen

--- a/src/net/testdata/single-request-resolv.conf
+++ b/src/net/testdata/single-request-resolv.conf
@@ -1,0 +1,1 @@
+options single-request


### PR DESCRIPTION
There is a DNS resolution issue in Kubernetes (UDP response packets get dropped due to a race in conntrack between the parallel A and AAAA queries, causing timeouts in DNS queries).

A workaround is to enable single-request / single-request-reopen in resolv.conf in order to use sequential A and AAAA queries instead of parallel queries.

With this PR, the pure Go resolver searches for "single-request" and "single-request-reopen" in resolv.conf and send A and AAAA queries sequentially when found.

Fixes #29644
