### PR TITLE
cmd/go: remove redundant variable lineno.

### DIFF
--- a/src/cmd/go/internal/modconv/glock.go
+++ b/src/cmd/go/internal/modconv/glock.go
@@ -13,8 +13,7 @@ import (
 
 func ParseGLOCKFILE(file string, data []byte) (*modfile.File, error) {
 	mf := new(modfile.File)
-	for lineno, line := range strings.Split(string(data), "\n") {
-		lineno++
+	for _, line := range strings.Split(string(data), "\n") {
 		f := strings.Fields(line)
 		if len(f) >= 2 && f[0] != "cmd" {
 			mf.Require = append(mf.Require, &modfile.Require{Mod: module.Version{Path: f[0], Version: f[1]}})


### PR DESCRIPTION
Remove redundant variable lineno.