### PR TITLE
cmd/go: remove note about GOCACHE=off in docs

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -1397,7 +1397,6 @@
 // in the standard user cache directory for the current operating system.
 // Setting the GOCACHE environment variable overrides this default,
 // and running 'go env GOCACHE' prints the current cache directory.
-// You can set the variable to 'off' to disable the cache.
 //
 // The go command periodically deletes cached data that has not been
 // used recently. Running 'go clean -cache' deletes all cached data.

--- a/src/cmd/go/internal/help/helpdoc.go
+++ b/src/cmd/go/internal/help/helpdoc.go
@@ -705,7 +705,6 @@ The default location for cache data is a subdirectory named go-build
 in the standard user cache directory for the current operating system.
 Setting the GOCACHE environment variable overrides this default,
 and running 'go env GOCACHE' prints the current cache directory.
-You can set the variable to 'off' to disable the cache.
 
 The go command periodically deletes cached data that has not been
 used recently. Running 'go clean -cache' deletes all cached data.


### PR DESCRIPTION
This patch removes mention of GOCACHE=off from the help/docs.
It is no longer supported in Go 1.12, per the release notes.

Fixes #29680

