### PR TITLE
json: Add InputOffset for stream byte offset access

### DIFF
--- a/src/encoding/json/stream.go
+++ b/src/encoding/json/stream.go
@@ -56,7 +56,7 @@ func (dec *Decoder) Decode(v interface{}) error {
 	}
 
 	if !dec.tokenValueAllowed() {
-		return &SyntaxError{msg: "not at beginning of value", Offset: dec.offset()}
+		return &SyntaxError{msg: "not at beginning of value", Offset: dec.InputOffset()}
 	}
 
 	// Read whole value into buffer.
@@ -308,7 +308,7 @@ func (dec *Decoder) tokenPrepareForDecode() error {
 			return err
 		}
 		if c != ',' {
-			return &SyntaxError{"expected comma after array element", dec.offset()}
+			return &SyntaxError{"expected comma after array element", dec.InputOffset()}
 		}
 		dec.scanp++
 		dec.tokenState = tokenArrayValue
@@ -318,7 +318,7 @@ func (dec *Decoder) tokenPrepareForDecode() error {
 			return err
 		}
 		if c != ':' {
-			return &SyntaxError{"expected colon after object key", dec.offset()}
+			return &SyntaxError{"expected colon after object key", dec.InputOffset()}
 		}
 		dec.scanp++
 		dec.tokenState = tokenObjectValue
@@ -471,7 +471,7 @@ func (dec *Decoder) tokenError(c byte) (Token, error) {
 	case tokenObjectComma:
 		context = " after object key:value pair"
 	}
-	return nil, &SyntaxError{"invalid character " + quoteChar(c) + context, dec.offset()}
+	return nil, &SyntaxError{"invalid character " + quoteChar(c) + context, dec.InputOffset()}
 }
 
 // More reports whether there is another element in the
@@ -500,6 +500,9 @@ func (dec *Decoder) peek() (byte, error) {
 	}
 }
 
-func (dec *Decoder) offset() int64 {
+// InputOffset returns the input stream byte offset of the current decoder position.
+// The offset gives the location of the end of the most recently returned token
+// and the beginning of the next token.
+func (dec *Decoder) InputOffset() int64 {
 	return dec.scanned + int64(dec.scanp)
 }


### PR DESCRIPTION
I'm sending proposal along with pull request, please don't feel I'm trying to force anything.

Use case: I'm trying to index entries in JSON file by their byte offset position for random access

This pull request makes `offset` method public and changes its name to `InputOffset` to match XML's decoder API: https://golang.org/pkg/encoding/xml/#Decoder.InputOffset

Reference to proposal: https://github.com/golang/go/issues/29688