### PR TITLE
cmd/go,cmd/link: Adds shared linking support for FreeBSD/amd64

### DIFF
--- a/src/cmd/go/internal/work/init.go
+++ b/src/cmd/go/internal/work/init.go
@@ -170,7 +170,8 @@ func buildModeInit() {
 			codegenArg = "-fPIC"
 		} else {
 			switch platform {
-			case "linux/386", "linux/amd64", "linux/arm", "linux/arm64", "linux/ppc64le", "linux/s390x":
+			case "linux/386", "linux/amd64", "linux/arm", "linux/arm64", "linux/ppc64le", "linux/s390x",
+				"freebsd/amd64":
 			default:
 				base.Fatalf("-buildmode=shared not supported on %s\n", platform)
 			}
@@ -206,7 +207,8 @@ func buildModeInit() {
 			codegenArg = "-fPIC"
 		} else {
 			switch platform {
-			case "linux/386", "linux/amd64", "linux/arm", "linux/arm64", "linux/ppc64le", "linux/s390x":
+			case "linux/386", "linux/amd64", "linux/arm", "linux/arm64", "linux/ppc64le", "linux/s390x",
+				"freebsd/amd64":
 				forcedAsmflags = append(forcedAsmflags, "-D=GOBUILDMODE_shared=1")
 			default:
 				base.Fatalf("-linkshared not supported on %s\n", platform)

--- a/src/cmd/link/internal/ld/config.go
+++ b/src/cmd/link/internal/ld/config.go
@@ -83,6 +83,12 @@ func (mode *BuildMode) Set(s string) error {
 			default:
 				return badmode()
 			}
+		case "freebsd":
+			switch objabi.GOARCH {
+			case "amd64":
+			default:
+				return badmode()
+			}
 		default:
 			return badmode()
 		}


### PR DESCRIPTION
Fixes #29715 