### PR TITLE
net/http: useless string replace operation in Cookie.String. Fixes #29135

### DIFF
--- a/src/net/http/cookie.go
+++ b/src/net/http/cookie.go
@@ -169,7 +169,7 @@ func (c *Cookie) String() string {
 		return ""
 	}
 	var b strings.Builder
-	b.WriteString(sanitizeCookieName(c.Name))
+	b.WriteString(c.Name)
 	b.WriteRune('=')
 	b.WriteString(sanitizeCookieValue(c.Value))
 

--- a/src/net/http/cookie_test.go
+++ b/src/net/http/cookie_test.go
@@ -127,6 +127,14 @@ var writeSetCookiesTests = []struct {
 		&Cookie{Name: "\t"},
 		``,
 	},
+	{
+		&Cookie{Name: "\r"},
+		``,
+	},
+	{
+		&Cookie{Name: "\n"},
+		``,
+	},
 }
 
 func TestWriteSetCookies(t *testing.T) {


### PR DESCRIPTION
net/http: useless string replace operation in Cookie.String. Fixes #29135