### PR TITLE
reflect: factor out special channel assignability rule from haveIdenticalUnderlyingType

### DIFF
--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -3378,6 +3378,9 @@ type MyBytes []byte
 type MyRunes []int32
 type MyFunc func()
 type MyByte byte
+type MyFuncChan chan MyFunc
+type MyFuncChanRcv <-chan MyFunc
+type MyFuncChanSend chan<- MyFunc
 
 var convertTests = []struct {
 	in  Value
@@ -3726,6 +3729,10 @@ var convertTests = []struct {
 	{V((**MyByte)(nil)), V((**MyByte)(nil))},
 	{V((chan byte)(nil)), V((chan byte)(nil))},
 	{V((chan MyByte)(nil)), V((chan MyByte)(nil))},
+	{V((chan MyByte)(nil)), V((chan MyByte)(nil))},
+	{V(MyFuncChan(nil)), V(MyFuncChan(nil))},
+	{V(MyFuncChanRcv(nil)), V(MyFuncChanRcv(nil))},
+	{V(MyFuncChanSend(nil)), V(MyFuncChanSend(nil))},
 	{V(([]byte)(nil)), V(([]byte)(nil))},
 	{V(([]MyByte)(nil)), V(([]MyByte)(nil))},
 	{V((map[int]byte)(nil)), V((map[int]byte)(nil))},
@@ -3744,8 +3751,6 @@ var convertTests = []struct {
 	{V((chan int)(nil)), V((chan<- int)(nil))},
 	{V((chan string)(nil)), V((<-chan string)(nil))},
 	{V((chan string)(nil)), V((chan<- string)(nil))},
-	{V((chan byte)(nil)), V((chan byte)(nil))},
-	{V((chan MyByte)(nil)), V((chan MyByte)(nil))},
 	{V((map[int]bool)(nil)), V((map[int]bool)(nil))},
 	{V((map[int]byte)(nil)), V((map[int]byte)(nil))},
 	{V((map[uint]bool)(nil)), V((map[uint]bool)(nil))},

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -3379,10 +3379,9 @@ type MyRunes []int32
 type MyFunc func()
 type MyByte byte
 
-type NoDup *NoDup
-type NoDupChan chan NoDup
-type NoDupChanRecv <-chan NoDup
-type NoDupChanSend chan<- NoDup
+type BytesChan chan []byte
+type BytesChanRecv <-chan []byte
+type BytesChanSend chan<- []byte
 
 var convertTests = []struct {
 	in  Value
@@ -3731,9 +3730,9 @@ var convertTests = []struct {
 	{V((**MyByte)(nil)), V((**MyByte)(nil))},
 	{V((chan byte)(nil)), V((chan byte)(nil))},
 	{V((chan MyByte)(nil)), V((chan MyByte)(nil))},
-	{V(NoDupChan(nil)), V(NoDupChan(nil))},
-	{V(NoDupChanRecv(nil)), V(NoDupChanRecv(nil))},
-	{V(NoDupChanSend(nil)), V(NoDupChanSend(nil))},
+	{V(BytesChan(nil)), V(BytesChan(nil))},
+	{V(BytesChanRecv(nil)), V(BytesChanRecv(nil))},
+	{V(BytesChanSend(nil)), V(BytesChanSend(nil))},
 	{V(([]byte)(nil)), V(([]byte)(nil))},
 	{V(([]MyByte)(nil)), V(([]MyByte)(nil))},
 	{V((map[int]byte)(nil)), V((map[int]byte)(nil))},
@@ -3760,18 +3759,18 @@ var convertTests = []struct {
 	{V(new(io.Writer)), V(new(io.Writer))},
 
 	// channel
-	{V(NoDupChan(nil)), V((chan<- NoDup)(nil))},
-	{V(NoDupChan(nil)), V((<-chan NoDup)(nil))},
-	{V((chan NoDup)(nil)), V(NoDupChanRecv(nil))},
-	{V((chan NoDup)(nil)), V(NoDupChanSend(nil))},
-	{V(NoDupChanRecv(nil)), V((<-chan NoDup)(nil))},
-	{V((<-chan NoDup)(nil)), V(NoDupChanRecv(nil))},
-	{V(NoDupChanSend(nil)), V((chan<- NoDup)(nil))},
-	{V((chan<- NoDup)(nil)), V(NoDupChanSend(nil))},
-	{V(NoDupChan(nil)), V((chan NoDup)(nil))},
-	{V((chan NoDup)(nil)), V(NoDupChan(nil))},
-	{V((chan NoDup)(nil)), V((<-chan NoDup)(nil))},
-	{V((chan NoDup)(nil)), V((chan<- NoDup)(nil))},
+	{V(BytesChan(nil)), V((chan<- []byte)(nil))},
+	{V(BytesChan(nil)), V((<-chan []byte)(nil))},
+	{V((chan []byte)(nil)), V(BytesChanRecv(nil))},
+	{V((chan []byte)(nil)), V(BytesChanSend(nil))},
+	{V(BytesChanRecv(nil)), V((<-chan []byte)(nil))},
+	{V((<-chan []byte)(nil)), V(BytesChanRecv(nil))},
+	{V(BytesChanSend(nil)), V((chan<- []byte)(nil))},
+	{V((chan<- []byte)(nil)), V(BytesChanSend(nil))},
+	{V(BytesChan(nil)), V((chan []byte)(nil))},
+	{V((chan []byte)(nil)), V(BytesChan(nil))},
+	{V((chan []byte)(nil)), V((<-chan []byte)(nil))},
+	{V((chan []byte)(nil)), V((chan<- []byte)(nil))},
 
 	// interfaces
 	{V(int(1)), EmptyInterfaceV(int(1))},

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -3378,6 +3378,10 @@ type MyBytes []byte
 type MyRunes []int32
 type MyFunc func()
 type MyByte byte
+
+type IntChan chan int
+type IntChanRev <-chan int
+type IntChanSnd chan<- int
 type NoDup *NoDup
 type NoDupChan chan NoDup
 type NoDupChanRcv <-chan NoDup
@@ -3745,15 +3749,27 @@ var convertTests = []struct {
 	{V([2]byte{}), V([2]byte{})},
 	{V([2]MyByte{}), V([2]MyByte{})},
 
+	// channel
+	{V(IntChan(nil)), V((chan<- int)(nil))},
+	{V(IntChan(nil)), V((<-chan int)(nil))},
+	{V((chan int)(nil)), V(IntChanRev(nil))},
+	{V((chan int)(nil)), V(IntChanSnd(nil))},
+	{V(IntChanRev(nil)), V((<-chan int)(nil))},
+	{V((<-chan int)(nil)), V(IntChanRev(nil))},
+	{V(IntChanSnd(nil)), V((chan<- int)(nil))},
+	{V((chan<- int)(nil)), V(IntChanSnd(nil))},
+	{V(IntChan(nil)), V((chan int)(nil))},
+	{V((chan int)(nil)), V(IntChan(nil))},
+	{V((chan int)(nil)), V((<-chan int)(nil))},
+	{V((chan int)(nil)), V((chan<- int)(nil))},
+	{V((chan string)(nil)), V((<-chan string)(nil))},
+	{V((chan string)(nil)), V((chan<- string)(nil))},
+
 	// other
 	{V((***int)(nil)), V((***int)(nil))},
 	{V((***byte)(nil)), V((***byte)(nil))},
 	{V((***int32)(nil)), V((***int32)(nil))},
 	{V((***int64)(nil)), V((***int64)(nil))},
-	{V((chan int)(nil)), V((<-chan int)(nil))},
-	{V((chan int)(nil)), V((chan<- int)(nil))},
-	{V((chan string)(nil)), V((<-chan string)(nil))},
-	{V((chan string)(nil)), V((chan<- string)(nil))},
 	{V((map[int]bool)(nil)), V((map[int]bool)(nil))},
 	{V((map[int]byte)(nil)), V((map[int]byte)(nil))},
 	{V((map[uint]bool)(nil)), V((map[uint]bool)(nil))},

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -3380,7 +3380,7 @@ type MyFunc func()
 type MyByte byte
 
 type IntChan chan int
-type IntChanRev <-chan int
+type IntChanRcv <-chan int
 type IntChanSnd chan<- int
 type NoDup *NoDup
 type NoDupChan chan NoDup
@@ -3752,18 +3752,16 @@ var convertTests = []struct {
 	// channel
 	{V(IntChan(nil)), V((chan<- int)(nil))},
 	{V(IntChan(nil)), V((<-chan int)(nil))},
-	{V((chan int)(nil)), V(IntChanRev(nil))},
+	{V((chan int)(nil)), V(IntChanRcv(nil))},
 	{V((chan int)(nil)), V(IntChanSnd(nil))},
-	{V(IntChanRev(nil)), V((<-chan int)(nil))},
-	{V((<-chan int)(nil)), V(IntChanRev(nil))},
+	{V(IntChanRcv(nil)), V((<-chan int)(nil))},
+	{V((<-chan int)(nil)), V(IntChanRcv(nil))},
 	{V(IntChanSnd(nil)), V((chan<- int)(nil))},
 	{V((chan<- int)(nil)), V(IntChanSnd(nil))},
 	{V(IntChan(nil)), V((chan int)(nil))},
 	{V((chan int)(nil)), V(IntChan(nil))},
 	{V((chan int)(nil)), V((<-chan int)(nil))},
 	{V((chan int)(nil)), V((chan<- int)(nil))},
-	{V((chan string)(nil)), V((<-chan string)(nil))},
-	{V((chan string)(nil)), V((chan<- string)(nil))},
 
 	// other
 	{V((***int)(nil)), V((***int)(nil))},

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -3379,6 +3379,9 @@ type MyRunes []int32
 type MyFunc func()
 type MyByte byte
 
+type IntChan chan int
+type IntChanRecv <-chan int
+type IntChanSend chan<- int
 type BytesChan chan []byte
 type BytesChanRecv <-chan []byte
 type BytesChanSend chan<- []byte
@@ -3730,9 +3733,6 @@ var convertTests = []struct {
 	{V((**MyByte)(nil)), V((**MyByte)(nil))},
 	{V((chan byte)(nil)), V((chan byte)(nil))},
 	{V((chan MyByte)(nil)), V((chan MyByte)(nil))},
-	{V(BytesChan(nil)), V(BytesChan(nil))},
-	{V(BytesChanRecv(nil)), V(BytesChanRecv(nil))},
-	{V(BytesChanSend(nil)), V(BytesChanSend(nil))},
 	{V(([]byte)(nil)), V(([]byte)(nil))},
 	{V(([]MyByte)(nil)), V(([]MyByte)(nil))},
 	{V((map[int]byte)(nil)), V((map[int]byte)(nil))},
@@ -3758,7 +3758,19 @@ var convertTests = []struct {
 	{V(new(io.Reader)), V(new(io.Reader))},
 	{V(new(io.Writer)), V(new(io.Writer))},
 
-	// channel
+	// channels
+	{V(IntChan(nil)), V((chan<- int)(nil))},
+	{V(IntChan(nil)), V((<-chan int)(nil))},
+	{V((chan int)(nil)), V(IntChanRecv(nil))},
+	{V((chan int)(nil)), V(IntChanSend(nil))},
+	{V(IntChanRecv(nil)), V((<-chan int)(nil))},
+	{V((<-chan int)(nil)), V(IntChanRecv(nil))},
+	{V(IntChanSend(nil)), V((chan<- int)(nil))},
+	{V((chan<- int)(nil)), V(IntChanSend(nil))},
+	{V(IntChan(nil)), V((chan int)(nil))},
+	{V((chan int)(nil)), V(IntChan(nil))},
+	{V((chan int)(nil)), V((<-chan int)(nil))},
+	{V((chan int)(nil)), V((chan<- int)(nil))},
 	{V(BytesChan(nil)), V((chan<- []byte)(nil))},
 	{V(BytesChan(nil)), V((<-chan []byte)(nil))},
 	{V((chan []byte)(nil)), V(BytesChanRecv(nil))},
@@ -3771,6 +3783,14 @@ var convertTests = []struct {
 	{V((chan []byte)(nil)), V(BytesChan(nil))},
 	{V((chan []byte)(nil)), V((<-chan []byte)(nil))},
 	{V((chan []byte)(nil)), V((chan<- []byte)(nil))},
+
+	// cannot convert other instances (channels)
+	{V(IntChan(nil)), V(IntChan(nil))},
+	{V(IntChanRecv(nil)), V(IntChanRecv(nil))},
+	{V(IntChanSend(nil)), V(IntChanSend(nil))},
+	{V(BytesChan(nil)), V(BytesChan(nil))},
+	{V(BytesChanRecv(nil)), V(BytesChanRecv(nil))},
+	{V(BytesChanSend(nil)), V(BytesChanSend(nil))},
 
 	// interfaces
 	{V(int(1)), EmptyInterfaceV(int(1))},

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -3380,12 +3380,12 @@ type MyFunc func()
 type MyByte byte
 
 type IntChan chan int
-type IntChanRcv <-chan int
-type IntChanSnd chan<- int
+type IntChanRecv <-chan int
+type IntChanSend chan<- int
 type NoDup *NoDup
 type NoDupChan chan NoDup
-type NoDupChanRcv <-chan NoDup
-type NoDupChanSnd chan<- NoDup
+type NoDupChanRecv <-chan NoDup
+type NoDupChanSend chan<- NoDup
 
 var convertTests = []struct {
 	in  Value
@@ -3735,11 +3735,11 @@ var convertTests = []struct {
 	{V((chan byte)(nil)), V((chan byte)(nil))},
 	{V((chan MyByte)(nil)), V((chan MyByte)(nil))},
 	{V(NoDupChan(nil)), V(NoDupChan(nil))},
-	{V(NoDupChanRcv(nil)), V(NoDupChanRcv(nil))},
-	{V(NoDupChanSnd(nil)), V(NoDupChanSnd(nil))},
+	{V(NoDupChanRecv(nil)), V(NoDupChanRecv(nil))},
+	{V(NoDupChanSend(nil)), V(NoDupChanSend(nil))},
 	{V((*NoDupChan)(nil)), V((*NoDupChan)(nil))},
-	{V((*NoDupChanRcv)(nil)), V((*NoDupChanRcv)(nil))},
-	{V((*NoDupChanSnd)(nil)), V((*NoDupChanSnd)(nil))},
+	{V((*NoDupChanRecv)(nil)), V((*NoDupChanRecv)(nil))},
+	{V((*NoDupChanSend)(nil)), V((*NoDupChanSend)(nil))},
 	{V(([]byte)(nil)), V(([]byte)(nil))},
 	{V(([]MyByte)(nil)), V(([]MyByte)(nil))},
 	{V((map[int]byte)(nil)), V((map[int]byte)(nil))},
@@ -3752,12 +3752,12 @@ var convertTests = []struct {
 	// channel
 	{V(IntChan(nil)), V((chan<- int)(nil))},
 	{V(IntChan(nil)), V((<-chan int)(nil))},
-	{V((chan int)(nil)), V(IntChanRcv(nil))},
-	{V((chan int)(nil)), V(IntChanSnd(nil))},
-	{V(IntChanRcv(nil)), V((<-chan int)(nil))},
-	{V((<-chan int)(nil)), V(IntChanRcv(nil))},
-	{V(IntChanSnd(nil)), V((chan<- int)(nil))},
-	{V((chan<- int)(nil)), V(IntChanSnd(nil))},
+	{V((chan int)(nil)), V(IntChanRecv(nil))},
+	{V((chan int)(nil)), V(IntChanSend(nil))},
+	{V(IntChanRecv(nil)), V((<-chan int)(nil))},
+	{V((<-chan int)(nil)), V(IntChanRecv(nil))},
+	{V(IntChanSend(nil)), V((chan<- int)(nil))},
+	{V((chan<- int)(nil)), V(IntChanSend(nil))},
 	{V(IntChan(nil)), V((chan int)(nil))},
 	{V((chan int)(nil)), V(IntChan(nil))},
 	{V((chan int)(nil)), V((<-chan int)(nil))},

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -3379,9 +3379,6 @@ type MyRunes []int32
 type MyFunc func()
 type MyByte byte
 
-type IntChan chan int
-type IntChanRecv <-chan int
-type IntChanSend chan<- int
 type NoDup *NoDup
 type NoDupChan chan NoDup
 type NoDupChanRecv <-chan NoDup
@@ -3737,9 +3734,6 @@ var convertTests = []struct {
 	{V(NoDupChan(nil)), V(NoDupChan(nil))},
 	{V(NoDupChanRecv(nil)), V(NoDupChanRecv(nil))},
 	{V(NoDupChanSend(nil)), V(NoDupChanSend(nil))},
-	{V((*NoDupChan)(nil)), V((*NoDupChan)(nil))},
-	{V((*NoDupChanRecv)(nil)), V((*NoDupChanRecv)(nil))},
-	{V((*NoDupChanSend)(nil)), V((*NoDupChanSend)(nil))},
 	{V(([]byte)(nil)), V(([]byte)(nil))},
 	{V(([]MyByte)(nil)), V(([]MyByte)(nil))},
 	{V((map[int]byte)(nil)), V((map[int]byte)(nil))},
@@ -3749,25 +3743,13 @@ var convertTests = []struct {
 	{V([2]byte{}), V([2]byte{})},
 	{V([2]MyByte{}), V([2]MyByte{})},
 
-	// channel
-	{V(IntChan(nil)), V((chan<- int)(nil))},
-	{V(IntChan(nil)), V((<-chan int)(nil))},
-	{V((chan int)(nil)), V(IntChanRecv(nil))},
-	{V((chan int)(nil)), V(IntChanSend(nil))},
-	{V(IntChanRecv(nil)), V((<-chan int)(nil))},
-	{V((<-chan int)(nil)), V(IntChanRecv(nil))},
-	{V(IntChanSend(nil)), V((chan<- int)(nil))},
-	{V((chan<- int)(nil)), V(IntChanSend(nil))},
-	{V(IntChan(nil)), V((chan int)(nil))},
-	{V((chan int)(nil)), V(IntChan(nil))},
-	{V((chan int)(nil)), V((<-chan int)(nil))},
-	{V((chan int)(nil)), V((chan<- int)(nil))},
-
 	// other
 	{V((***int)(nil)), V((***int)(nil))},
 	{V((***byte)(nil)), V((***byte)(nil))},
 	{V((***int32)(nil)), V((***int32)(nil))},
 	{V((***int64)(nil)), V((***int64)(nil))},
+	{V((chan byte)(nil)), V((chan byte)(nil))},
+	{V((chan MyByte)(nil)), V((chan MyByte)(nil))},
 	{V((map[int]bool)(nil)), V((map[int]bool)(nil))},
 	{V((map[int]byte)(nil)), V((map[int]byte)(nil))},
 	{V((map[uint]bool)(nil)), V((map[uint]bool)(nil))},
@@ -3776,6 +3758,20 @@ var convertTests = []struct {
 	{V(new(interface{})), V(new(interface{}))},
 	{V(new(io.Reader)), V(new(io.Reader))},
 	{V(new(io.Writer)), V(new(io.Writer))},
+
+	// channel
+	{V(NoDupChan(nil)), V((chan<- NoDup)(nil))},
+	{V(NoDupChan(nil)), V((<-chan NoDup)(nil))},
+	{V((chan NoDup)(nil)), V(NoDupChanRecv(nil))},
+	{V((chan NoDup)(nil)), V(NoDupChanSend(nil))},
+	{V(NoDupChanRecv(nil)), V((<-chan NoDup)(nil))},
+	{V((<-chan NoDup)(nil)), V(NoDupChanRecv(nil))},
+	{V(NoDupChanSend(nil)), V((chan<- NoDup)(nil))},
+	{V((chan<- NoDup)(nil)), V(NoDupChanSend(nil))},
+	{V(NoDupChan(nil)), V((chan NoDup)(nil))},
+	{V((chan NoDup)(nil)), V(NoDupChan(nil))},
+	{V((chan NoDup)(nil)), V((<-chan NoDup)(nil))},
+	{V((chan NoDup)(nil)), V((chan<- NoDup)(nil))},
 
 	// interfaces
 	{V(int(1)), EmptyInterfaceV(int(1))},

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -3378,9 +3378,10 @@ type MyBytes []byte
 type MyRunes []int32
 type MyFunc func()
 type MyByte byte
-type MyFuncChan chan MyFunc
-type MyFuncChanRcv <-chan MyFunc
-type MyFuncChanSend chan<- MyFunc
+type NoDup *NoDup
+type NoDupChan chan NoDup
+type NoDupChanRcv <-chan NoDup
+type NoDupChanSnd chan<- NoDup
 
 var convertTests = []struct {
 	in  Value
@@ -3729,9 +3730,12 @@ var convertTests = []struct {
 	{V((**MyByte)(nil)), V((**MyByte)(nil))},
 	{V((chan byte)(nil)), V((chan byte)(nil))},
 	{V((chan MyByte)(nil)), V((chan MyByte)(nil))},
-	{V(MyFuncChan(nil)), V(MyFuncChan(nil))},
-	{V(MyFuncChanRcv(nil)), V(MyFuncChanRcv(nil))},
-	{V(MyFuncChanSend(nil)), V(MyFuncChanSend(nil))},
+	{V(NoDupChan(nil)), V(NoDupChan(nil))},
+	{V(NoDupChanRcv(nil)), V(NoDupChanRcv(nil))},
+	{V(NoDupChanSnd(nil)), V(NoDupChanSnd(nil))},
+	{V((*NoDupChan)(nil)), V((*NoDupChan)(nil))},
+	{V((*NoDupChanRcv)(nil)), V((*NoDupChanRcv)(nil))},
+	{V((*NoDupChanSnd)(nil)), V((*NoDupChanSnd)(nil))},
 	{V(([]byte)(nil)), V(([]byte)(nil))},
 	{V(([]MyByte)(nil)), V(([]MyByte)(nil))},
 	{V((map[int]byte)(nil)), V((map[int]byte)(nil))},

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -3729,7 +3729,6 @@ var convertTests = []struct {
 	{V((**MyByte)(nil)), V((**MyByte)(nil))},
 	{V((chan byte)(nil)), V((chan byte)(nil))},
 	{V((chan MyByte)(nil)), V((chan MyByte)(nil))},
-	{V((chan MyByte)(nil)), V((chan MyByte)(nil))},
 	{V(MyFuncChan(nil)), V(MyFuncChan(nil))},
 	{V(MyFuncChanRcv(nil)), V(MyFuncChanRcv(nil))},
 	{V(MyFuncChanSend(nil)), V(MyFuncChanSend(nil))},

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -1609,7 +1609,7 @@ func haveIdenticalUnderlyingType(T, V *rtype, cmpTags bool) bool {
 		// Special case:
 		// x is a bidirectional channel value, T is a channel type,
 		// and x's type V and T have identical element types.
-		if V.ChanDir() == BothDir && haveIdenticalType(T.Elem(), V.Elem(), cmpTags) {
+		if V.ChanDir() == BothDir && (T.Name() == "" || V.Name() == "") && haveIdenticalType(T.Elem(), V.Elem(), cmpTags) {
 			return true
 		}
 

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -1554,7 +1554,7 @@ func implements(T, V *rtype) bool {
 // specialChannelAssignability reports whether a value x of channel type V
 // can be directly assigned (using memmove) to another channel type T.
 // https://golang.org/doc/go_spec.html#Assignability
-// T and V must be both Chan kind.
+// T and V must be both of Chan kind.
 func specialChannelAssignability(T, V *rtype) bool {
 	// Special case:
 	// x is a bidirectional channel value, T is a channel type,

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -1608,7 +1608,8 @@ func haveIdenticalUnderlyingType(T, V *rtype, cmpTags bool) bool {
 	case Chan:
 		// Special case:
 		// x is a bidirectional channel value, T is a channel type,
-		// and x's type V and T have identical element types.
+		// x's type V and T have identical element types,
+		// and at least one of V or T is not a defined type.
 		if V.ChanDir() == BothDir && (T.Name() == "" || V.Name() == "") && haveIdenticalType(T.Elem(), V.Elem(), cmpTags) {
 			return true
 		}

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -1551,6 +1551,18 @@ func implements(T, V *rtype) bool {
 	return false
 }
 
+// specialChannelAssignability reports whether a value x of channel type V
+// can be directly assigned (using memmove) to another channel type T.
+// https://golang.org/doc/go_spec.html#Assignability
+// T and V must be both Chan kind.
+func specialChannelAssignability(T, V *rtype) bool {
+	// Special case:
+	// x is a bidirectional channel value, T is a channel type,
+	// x's type V and T have identical element types,
+	// and at least one of V or T is not a defined type.
+	return V.ChanDir() == BothDir && (T.Name() == "" || V.Name() == "") && haveIdenticalType(T.Elem(), V.Elem(), true)
+}
+
 // directlyAssignable reports whether a value x of type V can be directly
 // assigned (using memmove) to a value of type T.
 // https://golang.org/doc/go_spec.html#Assignability
@@ -1568,7 +1580,11 @@ func directlyAssignable(T, V *rtype) bool {
 		return false
 	}
 
-	// x's type T and V must  have identical underlying types.
+	if T.Kind() == Chan && specialChannelAssignability(T, V) {
+		return true
+	}
+
+	// x's type T and V must have identical underlying types.
 	return haveIdenticalUnderlyingType(T, V, true)
 }
 
@@ -1606,15 +1622,6 @@ func haveIdenticalUnderlyingType(T, V *rtype, cmpTags bool) bool {
 		return T.Len() == V.Len() && haveIdenticalType(T.Elem(), V.Elem(), cmpTags)
 
 	case Chan:
-		// Special case:
-		// x is a bidirectional channel value, T is a channel type,
-		// x's type V and T have identical element types,
-		// and at least one of V or T is not a defined type.
-		if V.ChanDir() == BothDir && (T.Name() == "" || V.Name() == "") && haveIdenticalType(T.Elem(), V.Elem(), cmpTags) {
-			return true
-		}
-
-		// Otherwise continue test for identical underlying type.
 		return V.ChanDir() == T.ChanDir() && haveIdenticalType(T.Elem(), V.Elem(), cmpTags)
 
 	case Func:

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -2411,6 +2411,11 @@ func convertOp(dst, src *rtype) func(Value, Type) Value {
 				return cvtRunesString
 			}
 		}
+
+	case Chan:
+		if dst.Kind() == Chan && specialChannelAssignability(dst, src) {
+			return cvtDirect
+		}
 	}
 
 	// dst and src have same underlying type.


### PR DESCRIPTION
Go specification says: A value x is assignable to a variable of type T if x
is a bidirectional channel value, T is a channel type, x's type V and T have 
identical element types, and at least one of V or T is not a defined type. 
However, the current reflection implementation is incorrect which makes
"x is assignable to T" even if type V and T are both defined type.

The current reflection implementation also mistakes the base types of two
non-defined pointer types share the same underlying type when the two
base types satisfy the above mentioned special channel assignability rule.

Fixes #29469
