### PR TITLE
runtime: sample large heap allocations correctly

### DIFF
--- a/src/runtime/malloc.go
+++ b/src/runtime/malloc.go
@@ -1012,7 +1012,7 @@ func mallocgc(size uintptr, typ *_type, needzero bool) unsafe.Pointer {
 	}
 
 	if rate := MemProfileRate; rate > 0 {
-		if size < uintptr(rate) && int32(size) < c.next_sample {
+		if rate != 1 && int32(size) < c.next_sample {
 			c.next_sample -= int32(size)
 		} else {
 			mp := acquirem()

--- a/src/runtime/testdata/testprog/memprof.go
+++ b/src/runtime/testdata/testprog/memprof.go
@@ -14,6 +14,8 @@ import (
 )
 
 func init() {
+	// Force heap sampling for determinism.
+	runtime.MemProfileRate = 1
 	register("MemProf", MemProf)
 }
 

--- a/src/runtime/testdata/testprog/memprof.go
+++ b/src/runtime/testdata/testprog/memprof.go
@@ -14,8 +14,6 @@ import (
 )
 
 func init() {
-	// Force heap sampling for determinism.
-	runtime.MemProfileRate = 1
 	register("MemProf", MemProf)
 }
 
@@ -23,7 +21,10 @@ var memProfBuf bytes.Buffer
 var memProfStr string
 
 func MemProf() {
-	for i := 0; i < 1000; i++ {
+	// Force heap sampling for determinism.
+	runtime.MemProfileRate = 1
+
+	for i := 0; i < 10; i++ {
 		fmt.Fprintf(&memProfBuf, "%*d\n", i, i)
 	}
 	memProfStr = memProfBuf.String()


### PR DESCRIPTION
Remove an unnecessary check on the heap sampling code that forced sampling
of all heap allocations larger than the sampling rate. This need to follow
a poisson process so that they can be correctly unsampled. Maintain a check
for MemProfileRate==1 to provide a mechanism for full sampling, as
documented in https://golang.org/pkg/runtime/#pkg-variables.

Additional testing for this change is on cl/129117.

Fixes #26618
