### PR TITLE
net/http: track the state of HTTP/2 connections

### DIFF
--- a/src/net/http/h2_bundle.go
+++ b/src/net/http/h2_bundle.go
@@ -4158,10 +4158,9 @@ func (sc *http2serverConn) state(streamID uint32) (http2streamState, *http2strea
 // setConnState calls the net/http ConnState hook for this connection, if configured.
 // Note that the net/http package does StateNew and StateClosed for us.
 // There is currently no plan for StateHijacked or hijacking HTTP/2 connections.
+// TODO update this comment because it's a lie
 func (sc *http2serverConn) setConnState(state ConnState) {
-	if sc.hs.ConnState != nil {
-		sc.hs.ConnState(sc.conn, state)
-	}
+	sc.hs.SetConnState(sc.conn, state)
 }
 
 func (sc *http2serverConn) vlogf(format string, args ...interface{}) {

--- a/src/net/http/serve_test.go
+++ b/src/net/http/serve_test.go
@@ -5538,11 +5538,10 @@ func testServerShutdown(t *testing.T, h2 bool) {
 	var gotOnShutdown = make(chan struct{}, 1)
 	handler := HandlerFunc(func(w ResponseWriter, r *Request) {
 		go doShutdown()
-		// Shutdown is graceful, so it should not interrupt
-		// this in-flight response. Add a tiny sleep here to
-		// increase the odds of a failure if shutdown has
-		// bugs.
-		time.Sleep(20 * time.Millisecond)
+		// Shutdown is graceful, so it should not interrupt this in-flight
+		// response. Add a nice big sleep here to increase the odds of a
+		// failure if shutdown has bugs.
+		time.Sleep(6 * time.Second)
 		io.WriteString(w, r.RemoteAddr)
 	})
 	cst := newClientServerTest(t, h2, handler, func(srv *httptest.Server) {

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -2556,6 +2556,16 @@ type Server struct {
 	onShutdown []func()
 }
 
+func (s *Server) SetConnState(nc net.Conn, state ConnState) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for c := range s.activeConn {
+		if c.rwc == nc {
+			c.setState(nc, state)
+		}
+	}
+}
+
 func (s *Server) getDoneChan() <-chan struct{} {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
The state of HTTP/2 connections is currently never set to StateActive,
causing them to be closed immediately on server.Shutdown if they are at
least 5 seconds old. This change modifies the Shutdown tests so that the
h2 version fails with the existing implementation, and introduces a
method on the http Server to set the state from within the http2
bundle/package.

This is a proof of concept and illustration of the issue. The new
exported method on the Server type is probably a Very Bad Idea and a
naive implementation to boot. I'd love suggestions for a better
solution.

Fixes #29764
