### PR TITLE
net/http: add MethodSearch as http request method SEARCH (RFC7230/7231)

### DIFF
--- a/src/net/http/method.go
+++ b/src/net/http/method.go
@@ -17,4 +17,5 @@ const (
 	MethodConnect = "CONNECT"
 	MethodOptions = "OPTIONS"
 	MethodTrace   = "TRACE"
+	MethodSearch  = "SEARCH"
 )


### PR DESCRIPTION
As stated in RFC7230/7231, SEARCH http method may be helpful in some sort of web-dev routines.
For further reading see - https://tools.ietf.org/id/draft-snell-search-method-00.html#search
