### PR TITLE
net: replace `' with `` to avoid breaking doc presentation

### DIFF
--- a/src/net/ip.go
+++ b/src/net/ip.go
@@ -65,8 +65,8 @@ func IPv4Mask(a, b, c, d byte) IPMask {
 	return p
 }
 
-// CIDRMask returns an IPMask consisting of `ones' 1 bits
-// followed by 0s up to a total length of `bits' bits.
+// CIDRMask returns an IPMask consisting of `ones` 1 bits
+// followed by 0s up to a total length of `bits` bits.
 // For a mask of this form, CIDRMask is the inverse of IPMask.Size.
 func CIDRMask(ones, bits int) IPMask {
 	if bits != 8*IPv4len && bits != 8*IPv6len {


### PR DESCRIPTION
Although common in early Unix docs, this breaks certain formats of doc presentation, such as in vscode, which interprets text between two backticks as code and generates confusing doc presentation