### PR TITLE
cmd/go: honor vendor.conf fork repositories in modconv

### DIFF
--- a/src/cmd/go/internal/modconv/modconv_test.go
+++ b/src/cmd/go/internal/modconv/modconv_test.go
@@ -58,6 +58,9 @@ func Test(t *testing.T) {
 			for _, r := range out.Require {
 				fmt.Fprintf(&buf, "%s %s\n", r.Mod.Path, r.Mod.Version)
 			}
+			for _, r := range out.Replace {
+				fmt.Fprintf(&buf, "%s %s -> %s %s\n", r.Old.Path, r.Old.Version, r.New.Path, r.New.Version)
+			}
 			if !bytes.Equal(buf.Bytes(), want) {
 				t.Errorf("have:\n%s\nwant:\n%s", buf.Bytes(), want)
 			}

--- a/src/cmd/go/internal/modconv/testdata/moby.out
+++ b/src/cmd/go/internal/modconv/testdata/moby.out
@@ -3,7 +3,7 @@ github.com/Microsoft/hcsshim v0.6.5
 github.com/Microsoft/go-winio v0.4.5
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
-github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609
+github.com/go-check/check latest
 github.com/gorilla/context v1.1
 github.com/gorilla/mux v1.1
 github.com/Microsoft/opengcs v0.3.4
@@ -97,9 +97,12 @@ github.com/prometheus/procfs abf152e5f3e97f2fafac028d2cc06c1feb87ffa5
 github.com/matttproud/golang_protobuf_extensions v1.0.0
 github.com/pkg/errors 839d9e913e063e28dfd0e6c7b7512793e0a48be9
 github.com/grpc-ecosystem/go-grpc-prometheus 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
-github.com/spf13/cobra v1.5.1
+github.com/spf13/cobra latest
 github.com/spf13/pflag 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
-github.com/Nvveen/Gotty a8b993ba6abdb0e0c12b0125c603323a71c7790c
+github.com/Nvveen/Gotty latest
 github.com/docker/go-metrics d466d4f6fd960e01820085bd7e1a24426ee7ef18
 github.com/opencontainers/selinux v1.0.0-rc1
+github.com/go-check/check  -> github.com/cpuguy83/check 4ed411733c5785b40214c70bce814c3a3a689609
+github.com/spf13/cobra  -> github.com/dnephin/cobra v1.5.1
+github.com/Nvveen/Gotty  -> github.com/ijc25/Gotty a8b993ba6abdb0e0c12b0125c603323a71c7790c

--- a/src/cmd/go/internal/modconv/vconf.go
+++ b/src/cmd/go/internal/modconv/vconf.go
@@ -20,8 +20,27 @@ func ParseVendorConf(file string, data []byte) (*modfile.File, error) {
 		}
 		f := strings.Fields(line)
 		if len(f) >= 2 {
-			mf.Require = append(mf.Require, &modfile.Require{Mod: module.Version{Path: f[0], Version: f[1]}})
+			v := module.Version{Path: f[0]}
+			if len(f) >= 3 {
+				vNew := module.Version{Path: repoPathToImportPath(f[2]), Version: f[1]}
+				mf.Replace = append(mf.Replace, &modfile.Replace{Old: v, New: vNew})
+				v.Version = "latest"
+			} else {
+				v.Version = f[1]
+			}
+			mf.Require = append(mf.Require, &modfile.Require{Mod: v})
 		}
 	}
 	return mf, nil
+}
+
+func repoPathToImportPath(repo string) string {
+	path := repo
+	for _, prefix := range []string{"https://", "git://", "ssh://", "git+ssh://", "svn://", "svn+ssh://", "bzr://", "bzr+ssh://", "http://"} {
+		if strings.HasPrefix(path, prefix) {
+			path = strings.TrimPrefix(path, prefix)
+			break
+		}
+	}
+	return strings.TrimSuffix(path, ".git")
 }


### PR DESCRIPTION
With this patch, many projects using vendor.conf format should be able
to transition to go mod.

Example of a problematic line in cmd/go/internal/modconv/testdata/moby.out:

  github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git

In vendor.conf format, the third column represents the URL of a fork
repository which was being ignored before this patch.

Because of this, go mod was incorrectly assuming the revision (4ed...609)
exists in the upstream github.com/go-check/check when in fact it only does
in the github.com/cpuguy83/check fork.

One cannot simply expect a user to change github.com/go-check/check to
github.com/cpuguy83/check because the import path in both cases is
github.com/go-check/check.

For that example, this patch would do the equivalent of:
  go mod edit -require=github.com/go-check/check@latest
              -replace=github.com/go-check/check=github.com/cpuguy83/check@4ed411733c5785b40214c70bce814c3a3a689609