### PR TITLE
sync/once: remove unnecessary atomic operation

### DIFF
--- a/src/sync/once.go
+++ b/src/sync/once.go
@@ -40,7 +40,7 @@ func (o *Once) Do(f func()) {
 	o.m.Lock()
 	defer o.m.Unlock()
 	if o.done == 0 {
-		defer atomic.StoreUint32(&o.done, 1)
 		f()
+		o.done = 1
 	}
 }


### PR DESCRIPTION
The Lock() of a Mutex is a memory barrier,
so the subsequent lock owners guarantee to see
the new value, the heavyweight atomic operation
is not needed

Signed-off-by: Li Wang <laurence.liwang@gmail.com>