### PR TITLE
io/ioutil: add AppendFile

### DIFF
--- a/src/io/ioutil/ioutil.go
+++ b/src/io/ioutil/ioutil.go
@@ -91,6 +91,23 @@ func WriteFile(filename string, data []byte, perm os.FileMode) error {
 	return err
 }
 
+// AppendFile appends data to a file named by filename.
+// If the file does not exist, AppendFile creates it with permissions perm.
+func AppendFile(filename string, data []byte, perm os.FileMode) error {
+	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_APPEND, perm)
+	if err != nil {
+		return err
+	}
+	n, err := f.Write(data)
+	if err == nil && n < len(data) {
+		err = io.ErrShortWrite
+	}
+	if err1 := f.Close(); err == nil {
+		err = err1
+	}
+	return err
+}
+
 // ReadDir reads the directory named by dirname and returns
 // a list of directory entries sorted by filename.
 func ReadDir(dirname string) ([]os.FileInfo, error) {

--- a/src/io/ioutil/ioutil_test.go
+++ b/src/io/ioutil/ioutil_test.go
@@ -63,6 +63,39 @@ func TestWriteFile(t *testing.T) {
 	os.Remove(filename) // ignore error
 }
 
+func TestAppendFile(t *testing.T) {
+	f, err := TempFile("", "ioutil-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	filename := f.Name()
+	data1 := "Programming today is a race between software engineers striving to "
+	data2 := "build bigger and better idiot-proof programs, and the Universe trying " +
+		"to produce bigger and better idiots. So far, the Universe is winning."
+	data := data1 + data2
+
+	if err := AppendFile(filename, []byte(data1), 0644); err != nil {
+		t.Fatalf("AppendFile %s: %v", filename, err)
+	}
+
+	if err := AppendFile(filename, []byte(data2), 0644); err != nil {
+		t.Fatalf("AppendFile %s: %v", filename, err)
+	}
+
+	contents, err := ReadFile(filename)
+	if err != nil {
+		t.Fatalf("ReadFile %s: %v", filename, err)
+	}
+
+	if string(contents) != data {
+		t.Fatalf("contents = %q\nexpected = %q", string(contents), data)
+	}
+
+	// cleanup
+	f.Close()
+	os.Remove(filename) // ignore error
+}
+
 func TestReadDir(t *testing.T) {
 	dirname := "rumpelstilzchen"
 	_, err := ReadDir(dirname)


### PR DESCRIPTION
This commit adds AppendFile function to io/ioutil.
It has the same behaviour as WriteFile, except that it doesn't truncate the file if it already exists.
