### PR TITLE
context: allow cancelling a context with custom error

### DIFF
--- a/src/context/context.go
+++ b/src/context/context.go
@@ -232,6 +232,18 @@ func WithCancel(parent Context) (ctx Context, cancel CancelFunc) {
 	return &c, func() { c.cancel(true, Canceled) }
 }
 
+// A CustomCancelFunc behaves like CancelFunc, except for it accepts
+// particular error to be returned. The error is not allowed to be nil.
+type CustomCancelFunc func(error)
+
+// WithCustomCancel behaves like WithCancel, except for it allows cancelling
+// with user-provided error.
+func WithCustomCancel(parent Context) (ctx Context, cancel CustomCancelFunc) {
+	c := newCancelCtx(parent)
+	propagateCancel(parent, &c)
+	return &c, func(err error) { c.cancel(true, err) }
+}
+
 // newCancelCtx returns an initialized cancelCtx.
 func newCancelCtx(parent Context) cancelCtx {
 	return cancelCtx{Context: parent}


### PR DESCRIPTION
Sometimes it is useful to cancel a context with a more specific error, say,
"cancelled job X after timeout of Y expired" instead of default and not 
very informative "context cancelled". This can provide valuable 
information on what level of execution has actually timed out, if there are
multiple possibilities. Apparently, current implementation of cancellable
context in standard library already supports that, yet for some reason does
not expose this possibility, forcing developers to copy-parse `cancelCtx`
sources to achieve the described functionality. I added a simple function
to do that near the existing WithCancel function. I'm not sure what a 
perfect name would there be for it though.