### PR TITLE
time: improve implementation of 3 methods for the type Duration

### DIFF
--- a/src/time/time.go
+++ b/src/time/time.go
@@ -794,23 +794,17 @@ func (d Duration) Nanoseconds() int64 { return int64(d) }
 
 // Seconds returns the duration as a floating point number of seconds.
 func (d Duration) Seconds() float64 {
-	sec := d / Second
-	nsec := d % Second
-	return float64(sec) + float64(nsec)/1e9
+	return float64(d) / 1e9
 }
 
 // Minutes returns the duration as a floating point number of minutes.
 func (d Duration) Minutes() float64 {
-	min := d / Minute
-	nsec := d % Minute
-	return float64(min) + float64(nsec)/(60*1e9)
+	return float64(d) / 60e9
 }
 
 // Hours returns the duration as a floating point number of hours.
 func (d Duration) Hours() float64 {
-	hour := d / Hour
-	nsec := d % Hour
-	return float64(hour) + float64(nsec)/(60*60*1e9)
+	return float64(d) / 3600e9
 }
 
 // Truncate returns the result of rounding d toward zero to a multiple of m.


### PR DESCRIPTION
Improved the implementation of 3 methods below:
func (d Duration) Seconds() float64
func (d Duration) Minutes() float64
func (d Duration) Hours() float64