### PR TITLE
cmd/compile: make duplicate anonymous interface output deterministic

### DIFF
--- a/src/cmd/compile/internal/gc/reproduciblebuilds_test.go
+++ b/src/cmd/compile/internal/gc/reproduciblebuilds_test.go
@@ -18,6 +18,7 @@ func TestReproducibleBuilds(t *testing.T) {
 	tests := []string{
 		"issue20272.go",
 		"issue27013.go",
+		"issue30202.go",
 	}
 
 	testenv.MustHaveGoBuild(t)
@@ -38,7 +39,7 @@ func TestReproducibleBuilds(t *testing.T) {
 			defer os.Remove(tmp.Name())
 			defer tmp.Close()
 			for i := 0; i < iters; i++ {
-				out, err := exec.Command(testenv.GoToolPath(t), "tool", "compile", "-o", tmp.Name(), filepath.Join("testdata", "reproducible", test)).CombinedOutput()
+				out, err := exec.Command(testenv.GoToolPath(t), "tool", "compile", "-c", "2" "-o", tmp.Name(), filepath.Join("testdata", "reproducible", test)).CombinedOutput()
 				if err != nil {
 					t.Fatalf("failed to compile: %v\n%s", err, out)
 				}

--- a/src/cmd/compile/internal/gc/testdata/reproducible/issue30202.go
+++ b/src/cmd/compile/internal/gc/testdata/reproducible/issue30202.go
@@ -1,0 +1,17 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package p
+
+func A(x interface {
+        X() int
+}) int {
+        return x.X()
+}
+
+func B(x interface {
+        X() int
+}) int {
+        return x.X()
+}


### PR DESCRIPTION
A concurrent build will make the ordering in signatslice non-deterministic.
Instead of relying on signatslice for ordering seemingly identical but
actually different interface types, order the types by their location in
source code.

Fixes #30202.