### PR TITLE
go/cmd: remove redundant check for nil

### DIFF
--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -103,9 +103,7 @@ func (b *Builder) Do(root *Action) {
 		var err error
 
 		if a.Func != nil && (!a.Failed || a.IgnoreFail) {
-			if err == nil {
-				err = a.Func(b, a)
-			}
+			err = a.Func(b, a)
 		}
 
 		// The actions run in parallel but all the updates to the


### PR DESCRIPTION
Local variable err is defined with nil value and almost immediately
compared with nil. This comparison is redundant as always evaluates
to true.

Updates #30208