### PR TITLE
crypto/x509: remove redundant check for nil in tests

### DIFF
--- a/src/crypto/x509/name_constraints_test.go
+++ b/src/crypto/x509/name_constraints_test.go
@@ -2220,10 +2220,8 @@ func TestBadNamesInSANs(t *testing.T) {
 			continue
 		}
 
-		if err != nil {
-			if str := err.Error(); !strings.Contains(str, "cannot parse ") {
-				t.Errorf("bad name %q triggered unrecognised error: %s", badName, str)
-			}
+		if str := err.Error(); !strings.Contains(str, "cannot parse ") {
+			t.Errorf("bad name %q triggered unrecognised error: %s", badName, str)
 		}
 	}
 }


### PR DESCRIPTION
Comparing err variable to be not nil is redundant in this case.
The code above ensures that it is always not nil.

Updates #30208