### PR TITLE
net/textproto: prevent test from failing with nil pointer dereference

### DIFF
--- a/src/net/textproto/reader_test.go
+++ b/src/net/textproto/reader_test.go
@@ -332,7 +332,7 @@ func TestReadMultiLineError(t *testing.T) {
 	if msg != wantMsg {
 		t.Errorf("ReadResponse: msg=%q, want %q", msg, wantMsg)
 	}
-	if err.Error() != "550 "+wantMsg {
+	if err != nil && err.Error() != "550 "+wantMsg {
 		t.Errorf("ReadResponse: error=%q, want %q", err.Error(), "550 "+wantMsg)
 	}
 }


### PR DESCRIPTION
The variable err could have nil value when we call err.Error(),
because after we check it for nil above we continue the test
(t.Errorf doesn't stop the test execution).

Updates #30208