### PR TITLE
html/template: prevent test from failing with nil pointer dereference

### DIFF
--- a/src/html/template/escape_test.go
+++ b/src/html/template/escape_test.go
@@ -1869,8 +1869,7 @@ func TestErrorOnUndefined(t *testing.T) {
 	err := tmpl.Execute(nil, nil)
 	if err == nil {
 		t.Error("expected error")
-	}
-	if !strings.Contains(err.Error(), "incomplete") {
+	} else if !strings.Contains(err.Error(), "incomplete") {
 		t.Errorf("expected error about incomplete template; got %s", err)
 	}
 }


### PR DESCRIPTION
The variable err could have nil value when we call err.Error(),
because after we check it for nil above we continue the test
(t.Errorf doesn't stop the test execution).

Updates #30208