### PR TITLE
fmt: fix an error in documentation for fmt

### DIFF
--- a/src/fmt/doc.go
+++ b/src/fmt/doc.go
@@ -214,7 +214,7 @@
 	description of the problem, as in these examples:
 
 		Wrong type or unknown verb: %!verb(type=value)
-			Printf("%d", hi):          %!d(string=hi)
+			Printf("%d", "hi"):        %!d(string=hi)
 		Too many arguments: %!(EXTRA type=value)
 			Printf("hi", "guys"):      hi%!(EXTRA string=guys)
 		Too few arguments: %!verb(MISSING)


### PR DESCRIPTION
Original Printf("%d", hi) obviously doesn't produce
%!d(string=hi) unless somewhere before this code
block you have hi := "hi" somewhere, also this change
maintains consistency with the rest of it