### PR TITLE
go/cmd, crypto/x509, net/textproto, html/template: fix minor issues with nil values

### DIFF
--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -103,9 +103,7 @@ func (b *Builder) Do(root *Action) {
 		var err error
 
 		if a.Func != nil && (!a.Failed || a.IgnoreFail) {
-			if err == nil {
-				err = a.Func(b, a)
-			}
+			err = a.Func(b, a)
 		}
 
 		// The actions run in parallel but all the updates to the

--- a/src/crypto/x509/name_constraints_test.go
+++ b/src/crypto/x509/name_constraints_test.go
@@ -2220,10 +2220,8 @@ func TestBadNamesInSANs(t *testing.T) {
 			continue
 		}
 
-		if err != nil {
-			if str := err.Error(); !strings.Contains(str, "cannot parse ") {
-				t.Errorf("bad name %q triggered unrecognised error: %s", badName, str)
-			}
+		if str := err.Error(); !strings.Contains(str, "cannot parse ") {
+			t.Errorf("bad name %q triggered unrecognised error: %s", badName, str)
 		}
 	}
 }

--- a/src/html/template/escape_test.go
+++ b/src/html/template/escape_test.go
@@ -1869,8 +1869,7 @@ func TestErrorOnUndefined(t *testing.T) {
 	err := tmpl.Execute(nil, nil)
 	if err == nil {
 		t.Error("expected error")
-	}
-	if !strings.Contains(err.Error(), "incomplete") {
+	} else if !strings.Contains(err.Error(), "incomplete") {
 		t.Errorf("expected error about incomplete template; got %s", err)
 	}
 }

--- a/src/net/textproto/reader_test.go
+++ b/src/net/textproto/reader_test.go
@@ -332,7 +332,7 @@ func TestReadMultiLineError(t *testing.T) {
 	if msg != wantMsg {
 		t.Errorf("ReadResponse: msg=%q, want %q", msg, wantMsg)
 	}
-	if err.Error() != "550 "+wantMsg {
+	if err != nil && err.Error() != "550 "+wantMsg {
 		t.Errorf("ReadResponse: error=%q, want %q", err.Error(), "550 "+wantMsg)
 	}
 }


### PR DESCRIPTION
Remove redundant checks for nil value, add missing nil checks to prevent tests from failing with 'nil pointer dereference'.

Fixes #30208.