### PR TITLE
compress/gzip: allow multi-stream io.Reader reuse

### DIFF
--- a/src/compress/gzip/gunzip.go
+++ b/src/compress/gzip/gunzip.go
@@ -100,7 +100,11 @@ func NewReader(r io.Reader) (*Reader, error) {
 // Reset discards the Reader z's state and makes it equivalent to the
 // result of its original state from NewReader, but reading from r instead.
 // This permits reusing a Reader rather than allocating a new one.
+// If r is nil, Reader will reuse the existing io.Reader.
 func (z *Reader) Reset(r io.Reader) error {
+	if r == nil {
+		r = z.r
+	}
 	*z = Reader{
 		decompressor: z.decompressor,
 		multistream:  true,


### PR DESCRIPTION
Fixes #30230 