### PR TITLE
encoding/base32: increase performance and code reuse

### DIFF
--- a/src/encoding/base32/base32.go
+++ b/src/encoding/base32/base32.go
@@ -365,7 +365,7 @@ func (enc *Encoding) decode(dst, src []byte) (n int, end bool, err error) {
 func (enc *Encoding) Decode(dst, src []byte) (n int, err error) {
 	buf := make([]byte, len(src))
 	copy(buf, src)
-	l := stripNewlines(buf, len(buf))
+	l := stripNewlines(buf)
 	n, _, err = enc.decode(dst, buf[:l])
 	return
 }
@@ -375,7 +375,7 @@ func (enc *Encoding) DecodeString(s string) ([]byte, error) {
 	dbuf := make([]byte, enc.DecodedLen(len(s)))
 	src := make([]byte, len(s))
 	copy(src, s)
-	l := stripNewlines(src, len(src))
+	l := stripNewlines(src)
 	n, _, err := enc.decode(dbuf, src[:l])
 	return dbuf[:n], err
 }
@@ -492,9 +492,11 @@ type newlineFilteringReader struct {
 	wrapped io.Reader
 }
 
-func stripNewlines(p []byte, n int) int {
+// stripNewlines removes newline characters and returns the number
+// of non-newline characters moved to the beginning of p.
+func stripNewlines(p []byte) int {
 	offset := 0
-	for i, b := range p[0:n] {
+	for i, b := range p[0:len(p)] {
 		if b != '\r' && b != '\n' {
 			if i != offset {
 				p[offset] = b
@@ -508,7 +510,7 @@ func stripNewlines(p []byte, n int) int {
 func (r *newlineFilteringReader) Read(p []byte) (int, error) {
 	n, err := r.wrapped.Read(p)
 	for n > 0 {
-		offset := stripNewlines(p, n)
+		offset := stripNewlines(p[:n])
 		if err != nil || offset > 0 {
 			return offset, err
 		}

--- a/src/encoding/base32/base32.go
+++ b/src/encoding/base32/base32.go
@@ -373,8 +373,7 @@ func (enc *Encoding) Decode(dst, src []byte) (n int, err error) {
 // DecodeString returns the bytes represented by the base32 string s.
 func (enc *Encoding) DecodeString(s string) ([]byte, error) {
 	dbuf := make([]byte, enc.DecodedLen(len(s)))
-	src := make([]byte, len(s))
-	copy(src, s)
+	src := []byte(s)
 	l := stripNewlines(src)
 	n, _, err := enc.decode(dbuf, src[:l])
 	return dbuf[:n], err
@@ -496,9 +495,9 @@ type newlineFilteringReader struct {
 // of non-newline characters moved to the beginning of p.
 func stripNewlines(p []byte) int {
 	offset := 0
-	for i, b := range p[0:len(p)] {
+	for i, b := range p {
 		if b != '\r' && b != '\n' {
-			if i != offset {
+			if i > offset {
 				p[offset] = b
 			}
 			offset++

--- a/src/encoding/base32/base32_test.go
+++ b/src/encoding/base32/base32_test.go
@@ -445,6 +445,15 @@ LNEBUWIIDFON2CA3DBMJXXE5LNFY==
 	}
 }
 
+func BenchmarkEncode(b *testing.B) {
+	data := make([]byte, 8192)
+	buf := make([]byte, StdEncoding.EncodedLen(len(data)))
+	b.SetBytes(int64(len(data)))
+	for i := 0; i < b.N; i++ {
+		StdEncoding.Encode(buf, data)
+	}
+}
+
 func BenchmarkEncodeToString(b *testing.B) {
 	data := make([]byte, 8192)
 	b.SetBytes(int64(len(data)))
@@ -453,6 +462,15 @@ func BenchmarkEncodeToString(b *testing.B) {
 	}
 }
 
+func BenchmarkDecode(b *testing.B) {
+	data := make([]byte, StdEncoding.EncodedLen(8192))
+	StdEncoding.Encode(data, make([]byte, 8192))
+	buf := make([]byte, 8192)
+	b.SetBytes(int64(len(data)))
+	for i := 0; i < b.N; i++ {
+		StdEncoding.Decode(buf, data)
+	}
+}
 func BenchmarkDecodeString(b *testing.B) {
 	data := StdEncoding.EncodeToString(make([]byte, 8192))
 	b.SetBytes(int64(len(data)))


### PR DESCRIPTION
Add benchmarks for the Encode/Decode functions operating on []byte and increase decoding performance by removing the calls to strings.Map/bytes.Map and reusing the newline filtering code that is used by NewDecoder.
Cut allocations in half for DecodeString.

Comparison using the new benchmarks:
name            old time/op    new time/op     delta
Encode            16.7µs ± 1%     17.0µs ± 2%    +2.25%  (p=0.000 n=9+9)
EncodeToString    21.1µs ± 1%     20.9µs ± 1%    -0.96%  (p=0.000 n=10+10)
Decode             141µs ± 1%       54µs ± 1%   -61.51%  (p=0.000 n=10+10)
DecodeString      81.4µs ± 0%     54.7µs ± 1%   -32.79%  (p=0.000 n=9+10)

name            old speed      new speed       delta
Encode           492MB/s ± 1%    481MB/s ± 2%    -2.19%  (p=0.000 n=9+9)
EncodeToString   389MB/s ± 1%    392MB/s ± 1%    +0.97%  (p=0.000 n=10+10)
Decode          93.0MB/s ± 1%  241.6MB/s ± 1%  +159.82%  (p=0.000 n=10+10)
DecodeString     161MB/s ± 0%    240MB/s ± 1%   +48.78%  (p=0.000 n=9+10)
