### PR TITLE
container/heap: avoid memory leak in example

### DIFF
--- a/src/container/heap/example_pq_test.go
+++ b/src/container/heap/example_pq_test.go
@@ -45,6 +45,7 @@ func (pq *PriorityQueue) Pop() interface{} {
 	old := *pq
 	n := len(old)
 	item := old[n-1]
+	old[n-1] = nil  // avoid memory leak
 	item.index = -1 // for safety
 	*pq = old[0 : n-1]
 	return item


### PR DESCRIPTION
Set element in slice to nil avoiding memory leak.
