### PR TITLE
cmd/go: refer to testflag help in go test -help output

### DIFF
--- a/src/cmd/go/internal/base/base.go
+++ b/src/cmd/go/internal/base/base.go
@@ -30,7 +30,7 @@ type Command struct {
 	Run func(cmd *Command, args []string)
 
 	// UsageLine is the one-line usage message.
-	// The first word in the line is taken to be the command name.
+	// The words between "go" and the first flag or argument in the line are taken to be the command name.
 	UsageLine string
 
 	// Short is the short description shown in the 'go help' output.

--- a/src/cmd/go/internal/test/test.go
+++ b/src/cmd/go/internal/test/test.go
@@ -514,10 +514,16 @@ var testVetFlags = []string{
 	// "-unusedresult",
 }
 
+func testCmdUsage() {
+	fmt.Fprintf(os.Stderr, "usage: %s\n", CmdTest.UsageLine)
+	fmt.Fprintf(os.Stderr, "Run 'go help %s' and 'go help %s' for details.\n", CmdTest.LongName(), HelpTestflag.LongName())
+	os.Exit(2)
+}
+
 func runTest(cmd *base.Command, args []string) {
 	modload.LoadTests = true
 
-	pkgArgs, testArgs = testFlags(cmd.Usage, args)
+	pkgArgs, testArgs = testFlags(testCmdUsage, args)
 
 	work.FindExecCmd() // initialize cached result
 

--- a/src/cmd/go/testdata/script/help.txt
+++ b/src/cmd/go/testdata/script/help.txt
@@ -42,7 +42,7 @@ stderr 'Run ''go tool vet -help'' for the vet tool''s flags'
 # lines.
 ! go test -h
 stderr 'usage: go test'
-stderr 'Run ''go help test'' for details'
+stderr 'Run ''go help test'' and ''go help testflag'' for details.'
 
 # go help get shows usage for get
 go help get


### PR DESCRIPTION
The change makes it easier for a user to get to the page where
she can check supported test flags, by adding 'go test testflag'
reference to the 'go test -help' output.

Fix #30365 