### PR TITLE
cmd/compile: fix mips64 instruction UNPREDICTABLE bug

### DIFF
--- a/src/cmd/internal/obj/mips/asm0.go
+++ b/src/cmd/internal/obj/mips/asm0.go
@@ -1120,11 +1120,11 @@ func (c *ctxt0) asmout(p *obj.Prog, o *Optab, out []uint32) {
 	case 1: /* mov r1,r2 ==> OR r1,r0,r2 */
 		a := AOR
 		if p.As == AMOVW && c.ctxt.Arch.Family == sys.MIPS64 {
+			// On MIPS64, most of the 32-bit instructions have unpredictable behavior,
+			// but SLL is special that the result is always sign-extended to 64-bit.
 			a = ASLL // sign-extended to high 32 bits
-			o1 = OP_RRR(c.oprrr(a), uint32(p.From.Reg), uint32(REGZERO), uint32(p.To.Reg))
-		} else {
-			o1 = OP_RRR(c.oprrr(a), uint32(REGZERO), uint32(p.From.Reg), uint32(p.To.Reg))
- 		}
+		}
+		o1 = OP_RRR(c.oprrr(a), uint32(p.From.Reg), uint32(REGZERO), uint32(p.To.Reg))
 
 	case 2: /* add/sub r1,[r2],r3 */
 		r := int(p.Reg)

--- a/src/cmd/internal/obj/mips/asm0.go
+++ b/src/cmd/internal/obj/mips/asm0.go
@@ -1120,9 +1120,11 @@ func (c *ctxt0) asmout(p *obj.Prog, o *Optab, out []uint32) {
 	case 1: /* mov r1,r2 ==> OR r1,r0,r2 */
 		a := AOR
 		if p.As == AMOVW && c.ctxt.Arch.Family == sys.MIPS64 {
-			a = AADDU // sign-extended to high 32 bits
-		}
-		o1 = OP_RRR(c.oprrr(a), uint32(REGZERO), uint32(p.From.Reg), uint32(p.To.Reg))
+			a = ASLL // sign-extended to high 32 bits
+			o1 = OP_RRR(c.oprrr(a), uint32(p.From.Reg), uint32(REGZERO), uint32(p.To.Reg))
+		} else {
+			o1 = OP_RRR(c.oprrr(a), uint32(REGZERO), uint32(p.From.Reg), uint32(p.To.Reg))
+ 		}
 
 	case 2: /* add/sub r1,[r2],r3 */
 		r := int(p.Reg)

--- a/src/cmd/internal/obj/mips/asm0.go
+++ b/src/cmd/internal/obj/mips/asm0.go
@@ -1120,7 +1120,7 @@ func (c *ctxt0) asmout(p *obj.Prog, o *Optab, out []uint32) {
 	case 1: /* mov r1,r2 ==> OR r1,r0,r2 */
 		a := AOR
 		if p.As == AMOVW && c.ctxt.Arch.Family == sys.MIPS64 {
-			// On MIPS64, most of the 32-bit instructions have unpredictable behavior,
+			// on MIPS64, most of the 32-bit instructions have unpredictable behavior,
 			// but SLL is special that the result is always sign-extended to 64-bit.
 			a = ASLL // sign-extended to high 32 bits
 		}

--- a/src/cmd/internal/obj/mips/asm0.go
+++ b/src/cmd/internal/obj/mips/asm0.go
@@ -1122,7 +1122,7 @@ func (c *ctxt0) asmout(p *obj.Prog, o *Optab, out []uint32) {
 		if p.As == AMOVW && c.ctxt.Arch.Family == sys.MIPS64 {
 			// on MIPS64, most of the 32-bit instructions have unpredictable behavior,
 			// but SLL is special that the result is always sign-extended to 64-bit.
-			a = ASLL // sign-extended to high 32 bits
+			a = ASLL
 		}
 		o1 = OP_RRR(c.oprrr(a), uint32(p.From.Reg), uint32(REGZERO), uint32(p.To.Reg))
 


### PR DESCRIPTION
Replace addu with a sll instruction with a definite behavior (sll will discard the upper 32 bits of the 64 bits, then do sign extensions, with certain behavior). It won't have any UNPREDICTABLE expectation.

Fixes #30459