### PR TITLE
cmd/go: make sure that the RelPaths always returns valid paths

### DIFF
--- a/src/cmd/go/internal/base/path.go
+++ b/src/cmd/go/internal/base/path.go
@@ -37,7 +37,12 @@ func RelPaths(paths []string) []string {
 	for _, p := range paths {
 		rel, err := filepath.Rel(pwd, p)
 		if err == nil && len(rel) < len(p) {
-			p = rel
+			// Verify that the shorter path is a valid path. This is not the
+			// case if pwd is in a symlink as p is set to the realpath, not the
+			// relative path seen from pwd.
+			if _, err := os.Stat(rel); err == nil {
+				p = rel
+			}
 		}
 		out = append(out, p)
 	}


### PR DESCRIPTION
When dealing with symlinks, filepath.Rel does not always return a valid path
as described in #30336

This change makes sure that the shorter path is not used if it isn't valid.

Fixes #30336
