### PR TITLE
cmd/go/internal/test: pass default timeout to test programs if not given from command line

### DIFF
--- a/src/cmd/go/testdata/script/test_timeout.txt
+++ b/src/cmd/go/testdata/script/test_timeout.txt
@@ -1,0 +1,21 @@
+env GO111MODULE=off
+cd a
+
+# No timeout is passed via 'go test' command.
+go test -v
+stdout '10m0s'
+
+# Timeout is passed via 'go test' command.
+go test -v -timeout 30m
+stdout '30m0s'
+
+-- a/timeout_test.go --
+package t
+import (
+	"flag"
+	"fmt"
+	"testing"
+)
+func TestTimeout(t *testing.T) {
+	fmt.Println(flag.Lookup("test.timeout").Value.String())
+}


### PR DESCRIPTION
Make 'go test' command to pass the default timeout (10m) to test programs if the value is not given from command line.

Fixes #28147