### PR TITLE
internal/poll: make FD.isFile mean whether it isn't socket on Windows

### DIFF
--- a/src/os/os_test.go
+++ b/src/os/os_test.go
@@ -2279,8 +2279,7 @@ func TestPipeThreads(t *testing.T) {
 	}
 }
 
-func TestDoubleCloseError(t *testing.T) {
-	path := sfdir + "/" + sfname
+func testDoubleCloseError(t *testing.T, path string) {
 	file, err := Open(path)
 	if err != nil {
 		t.Fatal(err)
@@ -2297,6 +2296,11 @@ func TestDoubleCloseError(t *testing.T) {
 	} else {
 		t.Logf("second close returned expected error %q", err)
 	}
+}
+
+func TestDoubleCloseError(t *testing.T) {
+	testDoubleCloseError(t, filepath.Join(sfdir, sfname))
+	testDoubleCloseError(t, sfdir)
 }
 
 func TestUserHomeDir(t *testing.T) {


### PR DESCRIPTION
Before this change, if a directory was closed twice on Windows,
the returning error would be "use of closed network connection".

Some code assumes FD.isFile means whether the fd isn't a network
socket, which is true on Unix. But isFile reports whether
the fd is a normal file rather than directory or console on Windows.

With this change, isFile will have the same meaning on different
platforms. And the change adds a new field kind to replace isConsole
and isDir.