### PR TITLE
fmt: rewrite if-else-if-else chain to switch statement

### DIFF
--- a/src/fmt/scan.go
+++ b/src/fmt/scan.go
@@ -612,25 +612,25 @@ func (s *ss) scanRune(bitSize int) int64 {
 // scanBasePrefix reports whether the integer begins with a bas prefix
 // and returns the base, digit string, and whether a zero was found.
 // It is called only if the verb is %v.
-func (s *ss) scanBasePrefix() (base int, digits string, found bool) {
+func (s *ss) scanBasePrefix() (int, string, bool) {
 	if !s.peek("0") {
 		return 0, decimalDigits + "_", false
 	}
 	s.accept("0")
-	found = true // We've put a digit into the token buffer.
 	// Special cases for 0, 0b, 0o, 0x.
-	base, digits = 0, octalDigits+"_"
-	if s.peek("bB") {
+	switch {
+	case s.peek("bB"):
 		s.consume("bB", true)
-		base, digits = 0, binaryDigits+"_"
-	} else if s.peek("oO") {
+		return 0, binaryDigits + "_", true
+	case s.peek("oO"):
 		s.consume("oO", true)
-		base, digits = 0, octalDigits+"_"
-	} else if s.peek("xX") {
+		return 0, octalDigits + "_", true
+	case s.peek("xX"):
 		s.consume("xX", true)
-		base, digits = 0, hexadecimalDigits+"_"
+		return 0, hexadecimalDigits + "_", true
+	default:
+		return 0, octalDigits + "_", true
 	}
-	return
 }
 
 // scanInt returns the value of the integer represented by the next


### PR DESCRIPTION
This commit rewrites if-else-if-else chain in scanBasePrefix function as a switch.

Based on Go style guide https://golang.org/doc/effective_go.html#switch
