### PR TITLE
crypto/tls: Expose CipherSuite structure and add names

### DIFF
--- a/src/crypto/tls/cipher_suites.go
+++ b/src/crypto/tls/cipher_suites.go
@@ -108,6 +108,40 @@ func CipherSuites() []*CipherSuite {
 	return append(cipherSuites[:0:0], cipherSuites...)
 }
 
+// IsSuiteECDH indicates that the cipher suite involves elliptic curve
+// Diffie-Hellman. This means that it should only be selected when the
+// client indicates that it supports ECC with a curve and point format
+// that we're happy with.
+func (cs *CipherSuite) IsSuiteECDHE() bool {
+	return cs.flags&suiteECDHE != 0
+}
+
+// IsSuiteECDSA indicates that the cipher suite involves an ECDSA
+// signature and therefore may only be selected when the server's
+// certificate is ECDSA. If this is not set then the cipher suite is
+// RSA based.
+func (cs *CipherSuite) IsSuiteECDSA() bool {
+	return cs.flags&suiteECDSA != 0
+}
+
+// IsSuiteTLS12 indicates that the cipher suite should only be advertised
+// and accepted when using TLS 1.2.
+func (cs *CipherSuite) IsSuiteTLS12() bool {
+	return cs.flags&suiteTLS12 != 0
+}
+
+// IsSuiteSHA384 indicates that the cipher suite uses SHA384 as the
+// handshake hash.
+func (cs *CipherSuite) IsSuiteSHA384() bool {
+	return cs.flags&suiteSHA384 != 0
+}
+
+// IsSuiteDefaultOff indicates that this cipher suite is not included by
+// default.
+func (cs *CipherSuite) IsSuiteDefaultOff() bool {
+	return cs.flags&suiteDefaultOff != 0
+}
+
 // A CipherSuiteTLS13 defines only the pair of the AEAD algorithm and hash
 // algorithm to be used with HKDF. See RFC 8446, Appendix B.4.
 type CipherSuiteTLS13 struct {

--- a/src/crypto/tls/cipher_suites.go
+++ b/src/crypto/tls/cipher_suites.go
@@ -59,9 +59,10 @@ const (
 	suiteDefaultOff
 )
 
-// A cipherSuite is a specific combination of key agreement, cipher and MAC function.
-type cipherSuite struct {
-	id uint16
+// A CipherSuite is a specific combination of key agreement, cipher and MAC function.
+type CipherSuite struct {
+	ID   uint16
+	Name string
 	// the lengths, in bytes, of the key material needed for each component.
 	keyLen int
 	macLen int
@@ -74,48 +75,57 @@ type cipherSuite struct {
 	aead   func(key, fixedNonce []byte) aead
 }
 
-var cipherSuites = []*cipherSuite{
+var cipherSuites = []*CipherSuite{
 	// Ciphersuite order is chosen so that ECDHE comes before plain RSA and
 	// AEADs are the top preference.
-	{TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, 32, 0, 12, ecdheRSAKA, suiteECDHE | suiteTLS12, nil, nil, aeadChaCha20Poly1305},
-	{TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305, 32, 0, 12, ecdheECDSAKA, suiteECDHE | suiteECDSA | suiteTLS12, nil, nil, aeadChaCha20Poly1305},
-	{TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, 16, 0, 4, ecdheRSAKA, suiteECDHE | suiteTLS12, nil, nil, aeadAESGCM},
-	{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, 16, 0, 4, ecdheECDSAKA, suiteECDHE | suiteECDSA | suiteTLS12, nil, nil, aeadAESGCM},
-	{TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, 32, 0, 4, ecdheRSAKA, suiteECDHE | suiteTLS12 | suiteSHA384, nil, nil, aeadAESGCM},
-	{TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, 32, 0, 4, ecdheECDSAKA, suiteECDHE | suiteECDSA | suiteTLS12 | suiteSHA384, nil, nil, aeadAESGCM},
-	{TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, 16, 32, 16, ecdheRSAKA, suiteECDHE | suiteTLS12 | suiteDefaultOff, cipherAES, macSHA256, nil},
-	{TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, 16, 20, 16, ecdheRSAKA, suiteECDHE, cipherAES, macSHA1, nil},
-	{TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, 16, 32, 16, ecdheECDSAKA, suiteECDHE | suiteECDSA | suiteTLS12 | suiteDefaultOff, cipherAES, macSHA256, nil},
-	{TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, 16, 20, 16, ecdheECDSAKA, suiteECDHE | suiteECDSA, cipherAES, macSHA1, nil},
-	{TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, 32, 20, 16, ecdheRSAKA, suiteECDHE, cipherAES, macSHA1, nil},
-	{TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, 32, 20, 16, ecdheECDSAKA, suiteECDHE | suiteECDSA, cipherAES, macSHA1, nil},
-	{TLS_RSA_WITH_AES_128_GCM_SHA256, 16, 0, 4, rsaKA, suiteTLS12, nil, nil, aeadAESGCM},
-	{TLS_RSA_WITH_AES_256_GCM_SHA384, 32, 0, 4, rsaKA, suiteTLS12 | suiteSHA384, nil, nil, aeadAESGCM},
-	{TLS_RSA_WITH_AES_128_CBC_SHA256, 16, 32, 16, rsaKA, suiteTLS12 | suiteDefaultOff, cipherAES, macSHA256, nil},
-	{TLS_RSA_WITH_AES_128_CBC_SHA, 16, 20, 16, rsaKA, 0, cipherAES, macSHA1, nil},
-	{TLS_RSA_WITH_AES_256_CBC_SHA, 32, 20, 16, rsaKA, 0, cipherAES, macSHA1, nil},
-	{TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, 24, 20, 8, ecdheRSAKA, suiteECDHE, cipher3DES, macSHA1, nil},
-	{TLS_RSA_WITH_3DES_EDE_CBC_SHA, 24, 20, 8, rsaKA, 0, cipher3DES, macSHA1, nil},
+	{TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305", 32, 0, 12, ecdheRSAKA, suiteECDHE | suiteTLS12, nil, nil, aeadChaCha20Poly1305},
+	{TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305, "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305", 32, 0, 12, ecdheECDSAKA, suiteECDHE | suiteECDSA | suiteTLS12, nil, nil, aeadChaCha20Poly1305},
+	{TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", 16, 0, 4, ecdheRSAKA, suiteECDHE | suiteTLS12, nil, nil, aeadAESGCM},
+	{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", 16, 0, 4, ecdheECDSAKA, suiteECDHE | suiteECDSA | suiteTLS12, nil, nil, aeadAESGCM},
+	{TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", 32, 0, 4, ecdheRSAKA, suiteECDHE | suiteTLS12 | suiteSHA384, nil, nil, aeadAESGCM},
+	{TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", 32, 0, 4, ecdheECDSAKA, suiteECDHE | suiteECDSA | suiteTLS12 | suiteSHA384, nil, nil, aeadAESGCM},
+	{TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", 16, 32, 16, ecdheRSAKA, suiteECDHE | suiteTLS12 | suiteDefaultOff, cipherAES, macSHA256, nil},
+	{TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", 16, 20, 16, ecdheRSAKA, suiteECDHE, cipherAES, macSHA1, nil},
+	{TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", 16, 32, 16, ecdheECDSAKA, suiteECDHE | suiteECDSA | suiteTLS12 | suiteDefaultOff, cipherAES, macSHA256, nil},
+	{TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA", 16, 20, 16, ecdheECDSAKA, suiteECDHE | suiteECDSA, cipherAES, macSHA1, nil},
+	{TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", 32, 20, 16, ecdheRSAKA, suiteECDHE, cipherAES, macSHA1, nil},
+	{TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", 32, 20, 16, ecdheECDSAKA, suiteECDHE | suiteECDSA, cipherAES, macSHA1, nil},
+	{TLS_RSA_WITH_AES_128_GCM_SHA256, "TLS_RSA_WITH_AES_128_GCM_SHA256", 16, 0, 4, rsaKA, suiteTLS12, nil, nil, aeadAESGCM},
+	{TLS_RSA_WITH_AES_256_GCM_SHA384, "TLS_RSA_WITH_AES_256_GCM_SHA384", 32, 0, 4, rsaKA, suiteTLS12 | suiteSHA384, nil, nil, aeadAESGCM},
+	{TLS_RSA_WITH_AES_128_CBC_SHA256, "TLS_RSA_WITH_AES_128_CBC_SHA256", 16, 32, 16, rsaKA, suiteTLS12 | suiteDefaultOff, cipherAES, macSHA256, nil},
+	{TLS_RSA_WITH_AES_128_CBC_SHA, "TLS_RSA_WITH_AES_128_CBC_SHA", 16, 20, 16, rsaKA, 0, cipherAES, macSHA1, nil},
+	{TLS_RSA_WITH_AES_256_CBC_SHA, "TLS_RSA_WITH_AES_256_CBC_SHA", 32, 20, 16, rsaKA, 0, cipherAES, macSHA1, nil},
+	{TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA", 24, 20, 8, ecdheRSAKA, suiteECDHE, cipher3DES, macSHA1, nil},
+	{TLS_RSA_WITH_3DES_EDE_CBC_SHA, "TLS_RSA_WITH_3DES_EDE_CBC_SHA", 24, 20, 8, rsaKA, 0, cipher3DES, macSHA1, nil},
 
 	// RC4-based cipher suites are disabled by default.
-	{TLS_RSA_WITH_RC4_128_SHA, 16, 20, 0, rsaKA, suiteDefaultOff, cipherRC4, macSHA1, nil},
-	{TLS_ECDHE_RSA_WITH_RC4_128_SHA, 16, 20, 0, ecdheRSAKA, suiteECDHE | suiteDefaultOff, cipherRC4, macSHA1, nil},
-	{TLS_ECDHE_ECDSA_WITH_RC4_128_SHA, 16, 20, 0, ecdheECDSAKA, suiteECDHE | suiteECDSA | suiteDefaultOff, cipherRC4, macSHA1, nil},
+	{TLS_RSA_WITH_RC4_128_SHA, "TLS_RSA_WITH_RC4_128_SHA", 16, 20, 0, rsaKA, suiteDefaultOff, cipherRC4, macSHA1, nil},
+	{TLS_ECDHE_RSA_WITH_RC4_128_SHA, "TLS_ECDHE_RSA_WITH_RC4_128_SHA", 16, 20, 0, ecdheRSAKA, suiteECDHE | suiteDefaultOff, cipherRC4, macSHA1, nil},
+	{TLS_ECDHE_ECDSA_WITH_RC4_128_SHA, "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA", 16, 20, 0, ecdheECDSAKA, suiteECDHE | suiteECDSA | suiteDefaultOff, cipherRC4, macSHA1, nil},
 }
 
-// A cipherSuiteTLS13 defines only the pair of the AEAD algorithm and hash
+func CipherSuites() []*CipherSuite {
+	return append(cipherSuites[:0:0], cipherSuites...)
+}
+
+// A CipherSuiteTLS13 defines only the pair of the AEAD algorithm and hash
 // algorithm to be used with HKDF. See RFC 8446, Appendix B.4.
-type cipherSuiteTLS13 struct {
-	id     uint16
+type CipherSuiteTLS13 struct {
+	ID     uint16
+	Name   string
 	keyLen int
 	aead   func(key, fixedNonce []byte) aead
 	hash   crypto.Hash
 }
 
-var cipherSuitesTLS13 = []*cipherSuiteTLS13{
-	{TLS_AES_128_GCM_SHA256, 16, aeadAESGCMTLS13, crypto.SHA256},
-	{TLS_CHACHA20_POLY1305_SHA256, 32, aeadChaCha20Poly1305, crypto.SHA256},
-	{TLS_AES_256_GCM_SHA384, 32, aeadAESGCMTLS13, crypto.SHA384},
+var cipherSuitesTLS13 = []*CipherSuiteTLS13{
+	{TLS_AES_128_GCM_SHA256, "TLS_AES_128_GCM_SHA256", 16, aeadAESGCMTLS13, crypto.SHA256},
+	{TLS_CHACHA20_POLY1305_SHA256, "TLS_CHACHA20_POLY1305_SHA256", 32, aeadChaCha20Poly1305, crypto.SHA256},
+	{TLS_AES_256_GCM_SHA384, "TLS_AES_256_GCM_SHA384", 32, aeadAESGCMTLS13, crypto.SHA384},
+}
+
+func CipherSuitesTLS13() []*CipherSuiteTLS13 {
+	return append(cipherSuitesTLS13[:0:0], cipherSuitesTLS13...)
 }
 
 func cipherRC4(key, iv []byte, isRead bool) interface{} {
@@ -396,36 +406,58 @@ func ecdheRSAKA(version uint16) keyAgreement {
 
 // mutualCipherSuite returns a cipherSuite given a list of supported
 // ciphersuites and the id requested by the peer.
-func mutualCipherSuite(have []uint16, want uint16) *cipherSuite {
+func mutualCipherSuite(have []uint16, want uint16) *CipherSuite {
 	for _, id := range have {
 		if id == want {
-			return cipherSuiteByID(id)
+			return CipherSuiteByID(id)
 		}
 	}
 	return nil
 }
 
-func cipherSuiteByID(id uint16) *cipherSuite {
+// Returns a CipherSuite struct given the ID
+func CipherSuiteByID(id uint16) *CipherSuite {
 	for _, cipherSuite := range cipherSuites {
-		if cipherSuite.id == id {
+		if cipherSuite.ID == id {
 			return cipherSuite
 		}
 	}
 	return nil
 }
 
-func mutualCipherSuiteTLS13(have []uint16, want uint16) *cipherSuiteTLS13 {
-	for _, id := range have {
-		if id == want {
-			return cipherSuiteTLS13ByID(id)
+// Returns a CipherSuite struct given the name of the cipher suite.
+func CipherSuiteByName(name string) *CipherSuite {
+	for _, cipherSuite := range cipherSuites {
+		if cipherSuite.Name == name {
+			return cipherSuite
 		}
 	}
 	return nil
 }
 
-func cipherSuiteTLS13ByID(id uint16) *cipherSuiteTLS13 {
+func mutualCipherSuiteTLS13(have []uint16, want uint16) *CipherSuiteTLS13 {
+	for _, id := range have {
+		if id == want {
+			return CipherSuiteTLS13ByID(id)
+		}
+	}
+	return nil
+}
+
+// Returns a CipherSuiteTLS13 struct given the ID
+func CipherSuiteTLS13ByID(id uint16) *CipherSuiteTLS13 {
 	for _, cipherSuite := range cipherSuitesTLS13 {
-		if cipherSuite.id == id {
+		if cipherSuite.ID == id {
+			return cipherSuite
+		}
+	}
+	return nil
+}
+
+// Returns a CipherSuiteTLS13 struct given the name of the cipher suite.
+func CipherSuiteTLS13ByName(name string) *CipherSuiteTLS13 {
+	for _, cipherSuite := range cipherSuitesTLS13 {
+		if cipherSuite.Name == name {
 			return cipherSuite
 		}
 	}

--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -1151,11 +1151,11 @@ NextCipherSuite:
 			continue
 		}
 		for _, existing := range varDefaultCipherSuites {
-			if existing == suite.id {
+			if existing == suite.ID {
 				continue NextCipherSuite
 			}
 		}
-		varDefaultCipherSuites = append(varDefaultCipherSuites, suite.id)
+		varDefaultCipherSuites = append(varDefaultCipherSuites, suite.ID)
 	}
 }
 

--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -191,7 +191,7 @@ func (hc *halfConn) changeCipherSpec() error {
 	return nil
 }
 
-func (hc *halfConn) setTrafficSecret(suite *cipherSuiteTLS13, secret []byte) {
+func (hc *halfConn) setTrafficSecret(suite *CipherSuiteTLS13, secret []byte) {
 	hc.trafficSecret = secret
 	key, iv := suite.trafficKey(secret)
 	hc.cipher = suite.aead(key, iv)
@@ -1190,7 +1190,7 @@ func (c *Conn) handlePostHandshakeMessage() error {
 }
 
 func (c *Conn) handleKeyUpdate(keyUpdate *keyUpdateMsg) error {
-	cipherSuite := cipherSuiteTLS13ByID(c.cipherSuite)
+	cipherSuite := CipherSuiteTLS13ByID(c.cipherSuite)
 	if cipherSuite == nil {
 		return c.in.setErrorLocked(c.sendAlert(alertInternalError))
 	}

--- a/src/crypto/tls/handshake_client.go
+++ b/src/crypto/tls/handshake_client.go
@@ -25,7 +25,7 @@ type clientHandshakeState struct {
 	c            *Conn
 	serverHello  *serverHelloMsg
 	hello        *clientHelloMsg
-	suite        *cipherSuite
+	suite        *CipherSuite
 	finishedHash finishedHash
 	masterSecret []byte
 	session      *ClientSessionState
@@ -87,7 +87,7 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, ecdheParameters, error) {
 
 	for _, suiteId := range possibleCipherSuites {
 		for _, suite := range cipherSuites {
-			if suite.id != suiteId {
+			if suite.ID != suiteId {
 				continue
 			}
 			// Don't advertise TLS 1.2-only cipher suites unless
@@ -295,13 +295,13 @@ func (c *Conn) loadSession(hello *clientHelloMsg) (cacheKey string,
 
 	// In TLS 1.3 the KDF hash must match the resumed session. Ensure we
 	// offer at least one cipher suite with that hash.
-	cipherSuite := cipherSuiteTLS13ByID(session.cipherSuite)
+	cipherSuite := CipherSuiteTLS13ByID(session.cipherSuite)
 	if cipherSuite == nil {
 		return cacheKey, nil, nil, nil
 	}
 	cipherSuiteOk := false
 	for _, offeredID := range hello.cipherSuites {
-		offeredSuite := cipherSuiteTLS13ByID(offeredID)
+		offeredSuite := CipherSuiteTLS13ByID(offeredID)
 		if offeredSuite != nil && offeredSuite.hash == cipherSuite.hash {
 			cipherSuiteOk = true
 			break
@@ -429,7 +429,7 @@ func (hs *clientHandshakeState) pickCipherSuite() error {
 		return errors.New("tls: server chose an unconfigured cipher suite")
 	}
 
-	hs.c.cipherSuite = hs.suite.id
+	hs.c.cipherSuite = hs.suite.ID
 	return nil
 }
 
@@ -707,7 +707,7 @@ func (hs *clientHandshakeState) processServerHello() (bool, error) {
 		return false, errors.New("tls: server resumed a session with a different version")
 	}
 
-	if hs.session.cipherSuite != hs.suite.id {
+	if hs.session.cipherSuite != hs.suite.ID {
 		c.sendAlert(alertHandshakeFailure)
 		return false, errors.New("tls: server resumed a session with a different cipher suite")
 	}
@@ -767,7 +767,7 @@ func (hs *clientHandshakeState) readSessionTicket() error {
 	hs.session = &ClientSessionState{
 		sessionTicket:      sessionTicketMsg.ticket,
 		vers:               c.vers,
-		cipherSuite:        hs.suite.id,
+		cipherSuite:        hs.suite.ID,
 		masterSecret:       hs.masterSecret,
 		serverCertificates: c.peerCertificates,
 		verifiedChains:     c.verifiedChains,

--- a/src/crypto/tls/handshake_client_tls13.go
+++ b/src/crypto/tls/handshake_client_tls13.go
@@ -28,7 +28,7 @@ type clientHandshakeStateTLS13 struct {
 	certReq       *certificateRequestMsgTLS13
 	usingPSK      bool
 	sentDummyCCS  bool
-	suite         *cipherSuiteTLS13
+	suite         *CipherSuiteTLS13
 	transcript    hash.Hash
 	masterSecret  []byte
 	trafficSecret []byte // client_application_traffic_secret_0
@@ -155,7 +155,7 @@ func (hs *clientHandshakeStateTLS13) checkServerHelloOrHRR() error {
 		return errors.New("tls: server chose an unconfigured cipher suite")
 	}
 	hs.suite = selectedSuite
-	c.cipherSuite = hs.suite.id
+	c.cipherSuite = hs.suite.ID
 
 	return nil
 }
@@ -226,7 +226,7 @@ func (hs *clientHandshakeStateTLS13) processHelloRetryRequest() error {
 
 	hs.hello.raw = nil
 	if len(hs.hello.pskIdentities) > 0 {
-		pskSuite := cipherSuiteTLS13ByID(hs.session.cipherSuite)
+		pskSuite := CipherSuiteTLS13ByID(hs.session.cipherSuite)
 		if pskSuite == nil {
 			return c.sendAlert(alertInternalError)
 		}
@@ -312,7 +312,7 @@ func (hs *clientHandshakeStateTLS13) processServerHello() error {
 	if len(hs.hello.pskIdentities) != 1 || hs.session == nil {
 		return c.sendAlert(alertInternalError)
 	}
-	pskSuite := cipherSuiteTLS13ByID(hs.session.cipherSuite)
+	pskSuite := CipherSuiteTLS13ByID(hs.session.cipherSuite)
 	if pskSuite == nil {
 		return c.sendAlert(alertInternalError)
 	}
@@ -644,7 +644,7 @@ func (c *Conn) handleNewSessionTicket(msg *newSessionTicketMsgTLS13) error {
 		return errors.New("tls: received a session ticket with invalid lifetime")
 	}
 
-	cipherSuite := cipherSuiteTLS13ByID(c.cipherSuite)
+	cipherSuite := CipherSuiteTLS13ByID(c.cipherSuite)
 	if cipherSuite == nil || c.resumptionSecret == nil {
 		return c.sendAlert(alertInternalError)
 	}

--- a/src/crypto/tls/handshake_server.go
+++ b/src/crypto/tls/handshake_server.go
@@ -22,7 +22,7 @@ type serverHandshakeState struct {
 	c            *Conn
 	clientHello  *clientHelloMsg
 	hello        *serverHelloMsg
-	suite        *cipherSuite
+	suite        *CipherSuite
 	ellipticOk   bool
 	ecdsaOk      bool
 	rsaDecryptOk bool
@@ -379,7 +379,7 @@ func (hs *serverHandshakeState) checkForResumption() bool {
 func (hs *serverHandshakeState) doResumeHandshake() error {
 	c := hs.c
 
-	hs.hello.cipherSuite = hs.suite.id
+	hs.hello.cipherSuite = hs.suite.ID
 	// We echo the client's session ID in the ServerHello to let it know
 	// that we're doing a resumption.
 	hs.hello.sessionId = hs.clientHello.sessionId
@@ -411,7 +411,7 @@ func (hs *serverHandshakeState) doFullHandshake() error {
 	}
 
 	hs.hello.ticketSupported = hs.clientHello.ticketSupported && !c.config.SessionTicketsDisabled
-	hs.hello.cipherSuite = hs.suite.id
+	hs.hello.cipherSuite = hs.suite.ID
 
 	hs.finishedHash = newFinishedHash(hs.c.vers, hs.suite)
 	if c.config.ClientAuth == NoClientCert {
@@ -664,7 +664,7 @@ func (hs *serverHandshakeState) sendSessionTicket() error {
 	}
 	state := sessionState{
 		vers:         c.vers,
-		cipherSuite:  hs.suite.id,
+		cipherSuite:  hs.suite.ID,
 		masterSecret: hs.masterSecret,
 		certificates: certsFromClient,
 	}
@@ -696,7 +696,7 @@ func (hs *serverHandshakeState) sendFinished(out []byte) error {
 		return err
 	}
 
-	c.cipherSuite = hs.suite.id
+	c.cipherSuite = hs.suite.ID
 	copy(out, finished.verifyData)
 
 	return nil
@@ -772,7 +772,7 @@ func (c *Conn) processCertsFromClient(certificate Certificate) error {
 func (hs *serverHandshakeState) setCipherSuite(id uint16, supportedCipherSuites []uint16, version uint16) bool {
 	for _, supported := range supportedCipherSuites {
 		if id == supported {
-			candidate := cipherSuiteByID(id)
+			candidate := CipherSuiteByID(id)
 			if candidate == nil {
 				continue
 			}

--- a/src/crypto/tls/handshake_server_test.go
+++ b/src/crypto/tls/handshake_server_test.go
@@ -43,7 +43,7 @@ var testConfig *Config
 func allCipherSuites() []uint16 {
 	ids := make([]uint16, len(cipherSuites))
 	for i, suite := range cipherSuites {
-		ids[i] = suite.id
+		ids[i] = suite.ID
 	}
 
 	return ids

--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -27,7 +27,7 @@ type serverHandshakeStateTLS13 struct {
 	hello           *serverHelloMsg
 	sentDummyCCS    bool
 	usingPSK        bool
-	suite           *cipherSuiteTLS13
+	suite           *CipherSuiteTLS13
 	cert            *Certificate
 	sigAlg          SignatureScheme
 	earlySecret     []byte
@@ -165,8 +165,8 @@ func (hs *serverHandshakeStateTLS13) processClientHello() error {
 		c.sendAlert(alertHandshakeFailure)
 		return errors.New("tls: no cipher suite supported by both client and server")
 	}
-	c.cipherSuite = hs.suite.id
-	hs.hello.cipherSuite = hs.suite.id
+	c.cipherSuite = hs.suite.ID
+	hs.hello.cipherSuite = hs.suite.ID
 	hs.transcript = hs.suite.hash.New()
 
 	// Pick the ECDHE group in server preference order, but give priority to
@@ -272,7 +272,7 @@ func (hs *serverHandshakeStateTLS13) checkForResumption() error {
 		// clock skew and it's only a freshness signal useful for shrinking the
 		// window for replay attacks, which don't affect us as we don't do 0-RTT.
 
-		pskSuite := cipherSuiteTLS13ByID(sessionState.cipherSuite)
+		pskSuite := CipherSuiteTLS13ByID(sessionState.cipherSuite)
 		if pskSuite == nil || pskSuite.hash != hs.suite.hash {
 			continue
 		}
@@ -739,7 +739,7 @@ func (hs *serverHandshakeStateTLS13) sendSessionTickets() error {
 		certsFromClient = append(certsFromClient, cert.Raw)
 	}
 	state := sessionStateTLS13{
-		cipherSuite:      hs.suite.id,
+		cipherSuite:      hs.suite.ID,
 		createdAt:        uint64(c.config.time().Unix()),
 		resumptionSecret: resumptionSecret,
 		certificate: Certificate{

--- a/src/crypto/tls/key_schedule.go
+++ b/src/crypto/tls/key_schedule.go
@@ -31,7 +31,7 @@ const (
 )
 
 // expandLabel implements HKDF-Expand-Label from RFC 8446, Section 7.1.
-func (c *cipherSuiteTLS13) expandLabel(secret []byte, label string, context []byte, length int) []byte {
+func (c *CipherSuiteTLS13) expandLabel(secret []byte, label string, context []byte, length int) []byte {
 	var hkdfLabel cryptobyte.Builder
 	hkdfLabel.AddUint16(uint16(length))
 	hkdfLabel.AddUint8LengthPrefixed(func(b *cryptobyte.Builder) {
@@ -50,7 +50,7 @@ func (c *cipherSuiteTLS13) expandLabel(secret []byte, label string, context []by
 }
 
 // deriveSecret implements Derive-Secret from RFC 8446, Section 7.1.
-func (c *cipherSuiteTLS13) deriveSecret(secret []byte, label string, transcript hash.Hash) []byte {
+func (c *CipherSuiteTLS13) deriveSecret(secret []byte, label string, transcript hash.Hash) []byte {
 	if transcript == nil {
 		transcript = c.hash.New()
 	}
@@ -58,7 +58,7 @@ func (c *cipherSuiteTLS13) deriveSecret(secret []byte, label string, transcript 
 }
 
 // extract implements HKDF-Extract with the cipher suite hash.
-func (c *cipherSuiteTLS13) extract(newSecret, currentSecret []byte) []byte {
+func (c *CipherSuiteTLS13) extract(newSecret, currentSecret []byte) []byte {
 	if newSecret == nil {
 		newSecret = make([]byte, c.hash.Size())
 	}
@@ -67,12 +67,12 @@ func (c *cipherSuiteTLS13) extract(newSecret, currentSecret []byte) []byte {
 
 // nextTrafficSecret generates the next traffic secret, given the current one,
 // according to RFC 8446, Section 7.2.
-func (c *cipherSuiteTLS13) nextTrafficSecret(trafficSecret []byte) []byte {
+func (c *CipherSuiteTLS13) nextTrafficSecret(trafficSecret []byte) []byte {
 	return c.expandLabel(trafficSecret, trafficUpdateLabel, nil, c.hash.Size())
 }
 
 // trafficKey generates traffic keys according to RFC 8446, Section 7.3.
-func (c *cipherSuiteTLS13) trafficKey(trafficSecret []byte) (key, iv []byte) {
+func (c *CipherSuiteTLS13) trafficKey(trafficSecret []byte) (key, iv []byte) {
 	key = c.expandLabel(trafficSecret, "key", nil, c.keyLen)
 	iv = c.expandLabel(trafficSecret, "iv", nil, aeadNonceLength)
 	return
@@ -81,7 +81,7 @@ func (c *cipherSuiteTLS13) trafficKey(trafficSecret []byte) (key, iv []byte) {
 // finishedHash generates the Finished verify_data or PskBinderEntry according
 // to RFC 8446, Section 4.4.4. See sections 4.4 and 4.2.11.2 for the baseKey
 // selection.
-func (c *cipherSuiteTLS13) finishedHash(baseKey []byte, transcript hash.Hash) []byte {
+func (c *CipherSuiteTLS13) finishedHash(baseKey []byte, transcript hash.Hash) []byte {
 	finishedKey := c.expandLabel(baseKey, "finished", nil, c.hash.Size())
 	verifyData := hmac.New(c.hash.New, finishedKey)
 	verifyData.Write(transcript.Sum(nil))
@@ -90,7 +90,7 @@ func (c *cipherSuiteTLS13) finishedHash(baseKey []byte, transcript hash.Hash) []
 
 // exportKeyingMaterial implements RFC5705 exporters for TLS 1.3 according to
 // RFC 8446, Section 7.5.
-func (c *cipherSuiteTLS13) exportKeyingMaterial(masterSecret []byte, transcript hash.Hash) func(string, []byte, int) ([]byte, error) {
+func (c *CipherSuiteTLS13) exportKeyingMaterial(masterSecret []byte, transcript hash.Hash) func(string, []byte, int) ([]byte, error) {
 	expMasterSecret := c.deriveSecret(masterSecret, exporterLabel, transcript)
 	return func(label string, context []byte, length int) ([]byte, error) {
 		secret := c.deriveSecret(expMasterSecret, label, nil)

--- a/src/crypto/tls/key_schedule_test.go
+++ b/src/crypto/tls/key_schedule_test.go
@@ -97,7 +97,7 @@ func TestDeriveSecret(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := cipherSuitesTLS13[0]
 			if got := c.deriveSecret(tt.args.secret, tt.args.label, tt.args.transcript); !bytes.Equal(got, tt.want) {
-				t.Errorf("cipherSuiteTLS13.deriveSecret() = % x, want % x", got, tt.want)
+				t.Errorf("CipherSuiteTLS13.deriveSecret() = % x, want % x", got, tt.want)
 			}
 		})
 	}
@@ -116,10 +116,10 @@ func TestTrafficKey(t *testing.T) {
 	c := cipherSuitesTLS13[0]
 	gotKey, gotIV := c.trafficKey(trafficSecret)
 	if !bytes.Equal(gotKey, wantKey) {
-		t.Errorf("cipherSuiteTLS13.trafficKey() gotKey = % x, want % x", gotKey, wantKey)
+		t.Errorf("CipherSuiteTLS13.trafficKey() gotKey = % x, want % x", gotKey, wantKey)
 	}
 	if !bytes.Equal(gotIV, wantIV) {
-		t.Errorf("cipherSuiteTLS13.trafficKey() gotIV = % x, want % x", gotIV, wantIV)
+		t.Errorf("CipherSuiteTLS13.trafficKey() gotIV = % x, want % x", gotIV, wantIV)
 	}
 }
 
@@ -168,7 +168,7 @@ func TestExtract(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := cipherSuitesTLS13[0]
 			if got := c.extract(tt.args.newSecret, tt.args.currentSecret); !bytes.Equal(got, tt.want) {
-				t.Errorf("cipherSuiteTLS13.extract() = % x, want % x", got, tt.want)
+				t.Errorf("CipherSuiteTLS13.extract() = % x, want % x", got, tt.want)
 			}
 		})
 	}

--- a/src/crypto/tls/prf.go
+++ b/src/crypto/tls/prf.go
@@ -117,7 +117,7 @@ var keyExpansionLabel = []byte("key expansion")
 var clientFinishedLabel = []byte("client finished")
 var serverFinishedLabel = []byte("server finished")
 
-func prfAndHashForVersion(version uint16, suite *cipherSuite) (func(result, secret, label, seed []byte), crypto.Hash) {
+func prfAndHashForVersion(version uint16, suite *CipherSuite) (func(result, secret, label, seed []byte), crypto.Hash) {
 	switch version {
 	case VersionSSL30:
 		return prf30, crypto.Hash(0)
@@ -133,14 +133,14 @@ func prfAndHashForVersion(version uint16, suite *cipherSuite) (func(result, secr
 	}
 }
 
-func prfForVersion(version uint16, suite *cipherSuite) func(result, secret, label, seed []byte) {
+func prfForVersion(version uint16, suite *CipherSuite) func(result, secret, label, seed []byte) {
 	prf, _ := prfAndHashForVersion(version, suite)
 	return prf
 }
 
 // masterFromPreMasterSecret generates the master secret from the pre-master
 // secret. See RFC 5246, Section 8.1.
-func masterFromPreMasterSecret(version uint16, suite *cipherSuite, preMasterSecret, clientRandom, serverRandom []byte) []byte {
+func masterFromPreMasterSecret(version uint16, suite *CipherSuite, preMasterSecret, clientRandom, serverRandom []byte) []byte {
 	seed := make([]byte, 0, len(clientRandom)+len(serverRandom))
 	seed = append(seed, clientRandom...)
 	seed = append(seed, serverRandom...)
@@ -153,7 +153,7 @@ func masterFromPreMasterSecret(version uint16, suite *cipherSuite, preMasterSecr
 // keysFromMasterSecret generates the connection keys from the master
 // secret, given the lengths of the MAC key, cipher key and IV, as defined in
 // RFC 2246, Section 6.3.
-func keysFromMasterSecret(version uint16, suite *cipherSuite, masterSecret, clientRandom, serverRandom []byte, macLen, keyLen, ivLen int) (clientMAC, serverMAC, clientKey, serverKey, clientIV, serverIV []byte) {
+func keysFromMasterSecret(version uint16, suite *CipherSuite, masterSecret, clientRandom, serverRandom []byte, macLen, keyLen, ivLen int) (clientMAC, serverMAC, clientKey, serverKey, clientIV, serverIV []byte) {
 	seed := make([]byte, 0, len(serverRandom)+len(clientRandom))
 	seed = append(seed, serverRandom...)
 	seed = append(seed, clientRandom...)
@@ -192,7 +192,7 @@ func hashFromSignatureScheme(signatureAlgorithm SignatureScheme) (crypto.Hash, e
 	}
 }
 
-func newFinishedHash(version uint16, cipherSuite *cipherSuite) finishedHash {
+func newFinishedHash(version uint16, cipherSuite *CipherSuite) finishedHash {
 	var buffer []byte
 	if version == VersionSSL30 || version >= VersionTLS12 {
 		buffer = []byte{}
@@ -353,7 +353,7 @@ func noExportedKeyingMaterial(label string, context []byte, length int) ([]byte,
 }
 
 // ekmFromMasterSecret generates exported keying material as defined in RFC 5705.
-func ekmFromMasterSecret(version uint16, suite *cipherSuite, masterSecret, clientRandom, serverRandom []byte) func(string, []byte, int) ([]byte, error) {
+func ekmFromMasterSecret(version uint16, suite *CipherSuite, masterSecret, clientRandom, serverRandom []byte) func(string, []byte, int) ([]byte, error) {
 	return func(label string, context []byte, length int) ([]byte, error) {
 		switch label {
 		case "client finished", "server finished", "master secret", "key expansion":

--- a/src/crypto/tls/prf_test.go
+++ b/src/crypto/tls/prf_test.go
@@ -35,7 +35,7 @@ func TestSplitPreMasterSecret(t *testing.T) {
 
 type testKeysFromTest struct {
 	version                                        uint16
-	suite                                          *cipherSuite
+	suite                                          *CipherSuite
 	preMasterSecret                                string
 	clientRandom, serverRandom                     string
 	masterSecret                                   string
@@ -91,7 +91,7 @@ func TestKeysFromPreMasterSecret(t *testing.T) {
 var testKeysFromTests = []testKeysFromTest{
 	{
 		VersionTLS10,
-		cipherSuiteByID(TLS_RSA_WITH_RC4_128_SHA),
+		CipherSuiteByID(TLS_RSA_WITH_RC4_128_SHA),
 		"0302cac83ad4b1db3b9ab49ad05957de2a504a634a386fc600889321e1a971f57479466830ac3e6f468e87f5385fa0c5",
 		"4ae66303755184a3917fcb44880605fcc53baa01912b22ed94473fc69cebd558",
 		"4ae663020ec16e6bb5130be918cfcafd4d765979a3136a5d50c593446e4e44db",
@@ -107,7 +107,7 @@ var testKeysFromTests = []testKeysFromTest{
 	},
 	{
 		VersionTLS10,
-		cipherSuiteByID(TLS_RSA_WITH_RC4_128_SHA),
+		CipherSuiteByID(TLS_RSA_WITH_RC4_128_SHA),
 		"03023f7527316bc12cbcd69e4b9e8275d62c028f27e65c745cfcddc7ce01bd3570a111378b63848127f1c36e5f9e4890",
 		"4ae66364b5ea56b20ce4e25555aed2d7e67f42788dd03f3fee4adae0459ab106",
 		"4ae66363ab815cbf6a248b87d6b556184e945e9b97fbdf247858b0bdafacfa1c",
@@ -123,7 +123,7 @@ var testKeysFromTests = []testKeysFromTest{
 	},
 	{
 		VersionTLS10,
-		cipherSuiteByID(TLS_RSA_WITH_RC4_128_SHA),
+		CipherSuiteByID(TLS_RSA_WITH_RC4_128_SHA),
 		"832d515f1d61eebb2be56ba0ef79879efb9b527504abb386fb4310ed5d0e3b1f220d3bb6b455033a2773e6d8bdf951d278a187482b400d45deb88a5d5a6bb7d6a7a1decc04eb9ef0642876cd4a82d374d3b6ff35f0351dc5d411104de431375355addc39bfb1f6329fb163b0bc298d658338930d07d313cd980a7e3d9196cac1",
 		"4ae663b2ee389c0de147c509d8f18f5052afc4aaf9699efe8cb05ece883d3a5e",
 		"4ae664d503fd4cff50cfc1fb8fc606580f87b0fcdac9554ba0e01d785bdf278e",
@@ -139,7 +139,7 @@ var testKeysFromTests = []testKeysFromTest{
 	},
 	{
 		VersionSSL30,
-		cipherSuiteByID(TLS_RSA_WITH_RC4_128_SHA),
+		CipherSuiteByID(TLS_RSA_WITH_RC4_128_SHA),
 		"832d515f1d61eebb2be56ba0ef79879efb9b527504abb386fb4310ed5d0e3b1f220d3bb6b455033a2773e6d8bdf951d278a187482b400d45deb88a5d5a6bb7d6a7a1decc04eb9ef0642876cd4a82d374d3b6ff35f0351dc5d411104de431375355addc39bfb1f6329fb163b0bc298d658338930d07d313cd980a7e3d9196cac1",
 		"4ae663b2ee389c0de147c509d8f18f5052afc4aaf9699efe8cb05ece883d3a5e",
 		"4ae664d503fd4cff50cfc1fb8fc606580f87b0fcdac9554ba0e01d785bdf278e",


### PR DESCRIPTION
This change exposes the CipherSuite structure, so folks can actually use
it in their code-bases. It also exposes the needed functions to get the
cipher suite both by name and by ID.

The "name" of the cipher suite was added to the struct.

Fixes: #30325