### PR TITLE
fix root_cgo_darwin omits some trusty intermediate ca certificate

### DIFF
--- a/src/crypto/x509/root_cgo_darwin.go
+++ b/src/crypto/x509/root_cgo_darwin.go
@@ -34,12 +34,12 @@ static bool isSSLPolicy(SecPolicyRef policyRef) {
 }
 
 static bool verifyUnspecifiedCert(SecCertificateRef cert) {
-	SecTrustRef			trustRef = NULL;
-	CFMutableArrayRef	certs = NULL;
-	CFMutableArrayRef	policies = NULL;
-	SecPolicyRef		policyRef = NULL;
-	OSStatus			ortn;
-	bool				isOk		= true;
+	SecTrustRef trustRef = NULL;
+	CFMutableArrayRef certs = NULL;
+	CFMutableArrayRef policies = NULL;
+	SecPolicyRef policyRef = NULL;
+	OSStatus ortn;
+	bool isOk = true;
 
 	policyRef = SecPolicyCreateSSL(true, NULL);
 
@@ -142,7 +142,7 @@ static SInt32 sslTrustSettingsResult(SecCertificateRef cert) {
 				continue;
 			}
 		} else {
-			// empty policy also means trust
+			// empty policy also means trusty
 			// continue;
 		}
 


### PR DESCRIPTION
root_cgo_darwin omit intermediate ca certificate if the cert has empty policy settings or an unspecified trust type settings. 

 Verify the cert instead of ignore it simply. The verification is implemented by  calling the security framework interface.

Fixes [#30672](https://github.com/golang/go/issues/30672)