### PR TITLE
net/http/httputil: remove all fields in Connection header

### DIFF
--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -357,12 +357,10 @@ func shouldPanicOnCopyError(req *http.Request) bool {
 // removeConnectionHeaders removes hop-by-hop headers listed in the "Connection" header of h.
 // See RFC 7230, section 6.1
 func removeConnectionHeaders(h http.Header) {
-	if c := h["Connection"]; len(c) > 0 {
-		for _, f := range c {
-			for _, sf := range strings.Split(f, ",") {
-				if sf = strings.TrimSpace(sf); sf != "" {
-					h.Del(sf)
-				}
+	for _, f := range h["Connection"] {
+		for _, sf := range strings.Split(f, ",") {
+			if sf = strings.TrimSpace(sf); sf != "" {
+				h.Del(sf)
 			}
 		}
 	}

--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -359,8 +359,10 @@ func shouldPanicOnCopyError(req *http.Request) bool {
 func removeConnectionHeaders(h http.Header) {
 	if c := h["Connection"]; len(c) > 0 {
 		for _, f := range c {
-			if f = strings.TrimSpace(f); f != "" {
-				h.Del(f)
+			for _, sf := range strings.Split(f, ",") {
+				if sf = strings.TrimSpace(sf); sf != "" {
+					h.Del(sf)
+				}
 			}
 		}
 	}

--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -357,8 +357,8 @@ func shouldPanicOnCopyError(req *http.Request) bool {
 // removeConnectionHeaders removes hop-by-hop headers listed in the "Connection" header of h.
 // See RFC 7230, section 6.1
 func removeConnectionHeaders(h http.Header) {
-	if c := h.Get("Connection"); c != "" {
-		for _, f := range strings.Split(c, ",") {
+	if c := h["Connection"]; len(c) > 0 {
+		for _, f := range c {
 			if f = strings.TrimSpace(f); f != "" {
 				h.Del(f)
 			}


### PR DESCRIPTION
In the reverseproxy, replace use (Header).Get, which returns only one value
of a multiple value header, with using the Header map directly. Also fixes
corresponding tests which hid the bug, and adds more tests.

Fixes #30303