### PR TITLE
crypto/tls: expose implemented cipher suites

### DIFF
--- a/src/crypto/tls/cipher_suites.go
+++ b/src/crypto/tls/cipher_suites.go
@@ -14,8 +14,8 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/x509"
-	"github.com/test/go-fork/fmt"
 	"hash"
+	"errors"
 	"internal/x/crypto/chacha20poly1305"
 )
 
@@ -121,7 +121,7 @@ func CipherSuiteById(id uint16) (CipherSuite, error) {
 			return CipherSuite(*cs), nil
 		}
 	}
-	return CipherSuite{}, fmt.Errorf("cipher id not existing")
+	return CipherSuite{}, errors.New("cipher id not existing")
 }
 
 // CipherSuite returns a copy of the CipherSuite struct given the name of the cipher suite.
@@ -131,7 +131,7 @@ func CipherSuiteByName(name string) (CipherSuite, error) {
 			return CipherSuite(*cs), nil
 		}
 	}
-	return CipherSuite{}, fmt.Errorf("cipher name not existing")
+	return CipherSuite{}, errors.New("cipher name not existing")
 }
 
 // A CipherSuiteTLS13 defines only the pair of the AEAD algorithm and hash
@@ -166,7 +166,7 @@ func CipherSuiteTLS13ById(id uint16) (CipherSuiteTLS13, error) {
 			return CipherSuiteTLS13(*cs), nil
 		}
 	}
-	return CipherSuiteTLS13{}, fmt.Errorf("cipher id not existing")
+	return CipherSuiteTLS13{}, errors.New("cipher id not existing")
 }
 
 // CipherSuite returns a copy of the CipherSuite struct given the name of the cipher suite.
@@ -176,7 +176,7 @@ func CipherSuiteTLS13ByName(name string) (CipherSuiteTLS13, error) {
 			return CipherSuiteTLS13(*cs), nil
 		}
 	}
-	return CipherSuiteTLS13{}, fmt.Errorf("cipher name not existing")
+	return CipherSuiteTLS13{}, errors.New("cipher name not existing")
 }
 
 func cipherRC4(key, iv []byte, isRead bool) interface{} {

--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -1097,7 +1097,7 @@ func defaultCipherSuitesTLS13() []uint16 {
 func initDefaultCipherSuites() {
 	var topCipherSuites []uint16
 
-	// Check the cpu flags for each platform that has optimized GCM implementations.
+	// Check the cpu Flags for each platform that has optimized GCM implementations.
 	// Worst case, these variables will just all be false.
 	var (
 		hasGCMAsmAMD64 = cpu.X86.HasAES && cpu.X86.HasPCLMULQDQ
@@ -1147,15 +1147,15 @@ func initDefaultCipherSuites() {
 
 NextCipherSuite:
 	for _, suite := range cipherSuites {
-		if suite.flags&suiteDefaultOff != 0 {
+		if suite.Flags&SuiteDefaultOff != 0 {
 			continue
 		}
 		for _, existing := range varDefaultCipherSuites {
-			if existing == suite.id {
+			if existing == suite.Id {
 				continue NextCipherSuite
 			}
 		}
-		varDefaultCipherSuites = append(varDefaultCipherSuites, suite.id)
+		varDefaultCipherSuites = append(varDefaultCipherSuites, suite.Id)
 	}
 }
 

--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -191,7 +191,7 @@ func (hc *halfConn) changeCipherSpec() error {
 	return nil
 }
 
-func (hc *halfConn) setTrafficSecret(suite *cipherSuiteTLS13, secret []byte) {
+func (hc *halfConn) setTrafficSecret(suite *CipherSuiteTLS13, secret []byte) {
 	hc.trafficSecret = secret
 	key, iv := suite.trafficKey(secret)
 	hc.cipher = suite.aead(key, iv)

--- a/src/crypto/tls/handshake_client.go
+++ b/src/crypto/tls/handshake_client.go
@@ -25,7 +25,7 @@ type clientHandshakeState struct {
 	c            *Conn
 	serverHello  *serverHelloMsg
 	hello        *clientHelloMsg
-	suite        *cipherSuite
+	suite        *CipherSuite
 	finishedHash finishedHash
 	masterSecret []byte
 	session      *ClientSessionState
@@ -87,12 +87,12 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, ecdheParameters, error) {
 
 	for _, suiteId := range possibleCipherSuites {
 		for _, suite := range cipherSuites {
-			if suite.id != suiteId {
+			if suite.Id != suiteId {
 				continue
 			}
 			// Don't advertise TLS 1.2-only cipher suites unless
 			// we're attempting TLS 1.2.
-			if hello.vers < VersionTLS12 && suite.flags&suiteTLS12 != 0 {
+			if hello.vers < VersionTLS12 && suite.Flags&SuiteTLS12 != 0 {
 				break
 			}
 			hello.cipherSuites = append(hello.cipherSuites, suiteId)
@@ -429,7 +429,7 @@ func (hs *clientHandshakeState) pickCipherSuite() error {
 		return errors.New("tls: server chose an unconfigured cipher suite")
 	}
 
-	hs.c.cipherSuite = hs.suite.id
+	hs.c.cipherSuite = hs.suite.Id
 	return nil
 }
 
@@ -617,7 +617,7 @@ func (hs *clientHandshakeState) establishKeys() error {
 	c := hs.c
 
 	clientMAC, serverMAC, clientKey, serverKey, clientIV, serverIV :=
-		keysFromMasterSecret(c.vers, hs.suite, hs.masterSecret, hs.hello.random, hs.serverHello.random, hs.suite.macLen, hs.suite.keyLen, hs.suite.ivLen)
+		keysFromMasterSecret(c.vers, hs.suite, hs.masterSecret, hs.hello.random, hs.serverHello.random, hs.suite.MacLen, hs.suite.KeyLen, hs.suite.IvLen)
 	var clientCipher, serverCipher interface{}
 	var clientHash, serverHash macFunction
 	if hs.suite.cipher != nil {
@@ -707,7 +707,7 @@ func (hs *clientHandshakeState) processServerHello() (bool, error) {
 		return false, errors.New("tls: server resumed a session with a different version")
 	}
 
-	if hs.session.cipherSuite != hs.suite.id {
+	if hs.session.cipherSuite != hs.suite.Id {
 		c.sendAlert(alertHandshakeFailure)
 		return false, errors.New("tls: server resumed a session with a different cipher suite")
 	}
@@ -767,7 +767,7 @@ func (hs *clientHandshakeState) readSessionTicket() error {
 	hs.session = &ClientSessionState{
 		sessionTicket:      sessionTicketMsg.ticket,
 		vers:               c.vers,
-		cipherSuite:        hs.suite.id,
+		cipherSuite:        hs.suite.Id,
 		masterSecret:       hs.masterSecret,
 		serverCertificates: c.peerCertificates,
 		verifiedChains:     c.verifiedChains,

--- a/src/crypto/tls/handshake_client_tls13.go
+++ b/src/crypto/tls/handshake_client_tls13.go
@@ -28,7 +28,7 @@ type clientHandshakeStateTLS13 struct {
 	certReq       *certificateRequestMsgTLS13
 	usingPSK      bool
 	sentDummyCCS  bool
-	suite         *cipherSuiteTLS13
+	suite         *CipherSuiteTLS13
 	transcript    hash.Hash
 	masterSecret  []byte
 	trafficSecret []byte // client_application_traffic_secret_0
@@ -155,7 +155,7 @@ func (hs *clientHandshakeStateTLS13) checkServerHelloOrHRR() error {
 		return errors.New("tls: server chose an unconfigured cipher suite")
 	}
 	hs.suite = selectedSuite
-	c.cipherSuite = hs.suite.id
+	c.cipherSuite = hs.suite.Id
 
 	return nil
 }

--- a/src/crypto/tls/handshake_server_test.go
+++ b/src/crypto/tls/handshake_server_test.go
@@ -43,7 +43,7 @@ var testConfig *Config
 func allCipherSuites() []uint16 {
 	ids := make([]uint16, len(cipherSuites))
 	for i, suite := range cipherSuites {
-		ids[i] = suite.id
+		ids[i] = suite.Id
 	}
 
 	return ids

--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -27,7 +27,7 @@ type serverHandshakeStateTLS13 struct {
 	hello           *serverHelloMsg
 	sentDummyCCS    bool
 	usingPSK        bool
-	suite           *cipherSuiteTLS13
+	suite           *CipherSuiteTLS13
 	cert            *Certificate
 	sigAlg          SignatureScheme
 	earlySecret     []byte
@@ -165,8 +165,8 @@ func (hs *serverHandshakeStateTLS13) processClientHello() error {
 		c.sendAlert(alertHandshakeFailure)
 		return errors.New("tls: no cipher suite supported by both client and server")
 	}
-	c.cipherSuite = hs.suite.id
-	hs.hello.cipherSuite = hs.suite.id
+	c.cipherSuite = hs.suite.Id
+	hs.hello.cipherSuite = hs.suite.Id
 	hs.transcript = hs.suite.hash.New()
 
 	// Pick the ECDHE group in server preference order, but give priority to
@@ -739,7 +739,7 @@ func (hs *serverHandshakeStateTLS13) sendSessionTickets() error {
 		certsFromClient = append(certsFromClient, cert.Raw)
 	}
 	state := sessionStateTLS13{
-		cipherSuite:      hs.suite.id,
+		cipherSuite:      hs.suite.Id,
 		createdAt:        uint64(c.config.time().Unix()),
 		resumptionSecret: resumptionSecret,
 		certificate: Certificate{

--- a/src/crypto/tls/key_schedule.go
+++ b/src/crypto/tls/key_schedule.go
@@ -31,7 +31,7 @@ const (
 )
 
 // expandLabel implements HKDF-Expand-Label from RFC 8446, Section 7.1.
-func (c *cipherSuiteTLS13) expandLabel(secret []byte, label string, context []byte, length int) []byte {
+func (c *CipherSuiteTLS13) expandLabel(secret []byte, label string, context []byte, length int) []byte {
 	var hkdfLabel cryptobyte.Builder
 	hkdfLabel.AddUint16(uint16(length))
 	hkdfLabel.AddUint8LengthPrefixed(func(b *cryptobyte.Builder) {
@@ -50,7 +50,7 @@ func (c *cipherSuiteTLS13) expandLabel(secret []byte, label string, context []by
 }
 
 // deriveSecret implements Derive-Secret from RFC 8446, Section 7.1.
-func (c *cipherSuiteTLS13) deriveSecret(secret []byte, label string, transcript hash.Hash) []byte {
+func (c *CipherSuiteTLS13) deriveSecret(secret []byte, label string, transcript hash.Hash) []byte {
 	if transcript == nil {
 		transcript = c.hash.New()
 	}
@@ -58,7 +58,7 @@ func (c *cipherSuiteTLS13) deriveSecret(secret []byte, label string, transcript 
 }
 
 // extract implements HKDF-Extract with the cipher suite hash.
-func (c *cipherSuiteTLS13) extract(newSecret, currentSecret []byte) []byte {
+func (c *CipherSuiteTLS13) extract(newSecret, currentSecret []byte) []byte {
 	if newSecret == nil {
 		newSecret = make([]byte, c.hash.Size())
 	}
@@ -67,13 +67,13 @@ func (c *cipherSuiteTLS13) extract(newSecret, currentSecret []byte) []byte {
 
 // nextTrafficSecret generates the next traffic secret, given the current one,
 // according to RFC 8446, Section 7.2.
-func (c *cipherSuiteTLS13) nextTrafficSecret(trafficSecret []byte) []byte {
+func (c *CipherSuiteTLS13) nextTrafficSecret(trafficSecret []byte) []byte {
 	return c.expandLabel(trafficSecret, trafficUpdateLabel, nil, c.hash.Size())
 }
 
 // trafficKey generates traffic keys according to RFC 8446, Section 7.3.
-func (c *cipherSuiteTLS13) trafficKey(trafficSecret []byte) (key, iv []byte) {
-	key = c.expandLabel(trafficSecret, "key", nil, c.keyLen)
+func (c *CipherSuiteTLS13) trafficKey(trafficSecret []byte) (key, iv []byte) {
+	key = c.expandLabel(trafficSecret, "key", nil, c.KeyLen)
 	iv = c.expandLabel(trafficSecret, "iv", nil, aeadNonceLength)
 	return
 }
@@ -81,7 +81,7 @@ func (c *cipherSuiteTLS13) trafficKey(trafficSecret []byte) (key, iv []byte) {
 // finishedHash generates the Finished verify_data or PskBinderEntry according
 // to RFC 8446, Section 4.4.4. See sections 4.4 and 4.2.11.2 for the baseKey
 // selection.
-func (c *cipherSuiteTLS13) finishedHash(baseKey []byte, transcript hash.Hash) []byte {
+func (c *CipherSuiteTLS13) finishedHash(baseKey []byte, transcript hash.Hash) []byte {
 	finishedKey := c.expandLabel(baseKey, "finished", nil, c.hash.Size())
 	verifyData := hmac.New(c.hash.New, finishedKey)
 	verifyData.Write(transcript.Sum(nil))
@@ -90,7 +90,7 @@ func (c *cipherSuiteTLS13) finishedHash(baseKey []byte, transcript hash.Hash) []
 
 // exportKeyingMaterial implements RFC5705 exporters for TLS 1.3 according to
 // RFC 8446, Section 7.5.
-func (c *cipherSuiteTLS13) exportKeyingMaterial(masterSecret []byte, transcript hash.Hash) func(string, []byte, int) ([]byte, error) {
+func (c *CipherSuiteTLS13) exportKeyingMaterial(masterSecret []byte, transcript hash.Hash) func(string, []byte, int) ([]byte, error) {
 	expMasterSecret := c.deriveSecret(masterSecret, exporterLabel, transcript)
 	return func(label string, context []byte, length int) ([]byte, error) {
 		secret := c.deriveSecret(expMasterSecret, label, nil)

--- a/src/crypto/tls/key_schedule_test.go
+++ b/src/crypto/tls/key_schedule_test.go
@@ -97,7 +97,7 @@ func TestDeriveSecret(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := cipherSuitesTLS13[0]
 			if got := c.deriveSecret(tt.args.secret, tt.args.label, tt.args.transcript); !bytes.Equal(got, tt.want) {
-				t.Errorf("cipherSuiteTLS13.deriveSecret() = % x, want % x", got, tt.want)
+				t.Errorf("CipherSuiteTLS13.deriveSecret() = % x, want % x", got, tt.want)
 			}
 		})
 	}
@@ -116,10 +116,10 @@ func TestTrafficKey(t *testing.T) {
 	c := cipherSuitesTLS13[0]
 	gotKey, gotIV := c.trafficKey(trafficSecret)
 	if !bytes.Equal(gotKey, wantKey) {
-		t.Errorf("cipherSuiteTLS13.trafficKey() gotKey = % x, want % x", gotKey, wantKey)
+		t.Errorf("CipherSuiteTLS13.trafficKey() gotKey = % x, want % x", gotKey, wantKey)
 	}
 	if !bytes.Equal(gotIV, wantIV) {
-		t.Errorf("cipherSuiteTLS13.trafficKey() gotIV = % x, want % x", gotIV, wantIV)
+		t.Errorf("CipherSuiteTLS13.trafficKey() gotIV = % x, want % x", gotIV, wantIV)
 	}
 }
 
@@ -168,7 +168,7 @@ func TestExtract(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := cipherSuitesTLS13[0]
 			if got := c.extract(tt.args.newSecret, tt.args.currentSecret); !bytes.Equal(got, tt.want) {
-				t.Errorf("cipherSuiteTLS13.extract() = % x, want % x", got, tt.want)
+				t.Errorf("CipherSuiteTLS13.extract() = % x, want % x", got, tt.want)
 			}
 		})
 	}

--- a/src/crypto/tls/prf.go
+++ b/src/crypto/tls/prf.go
@@ -117,14 +117,14 @@ var keyExpansionLabel = []byte("key expansion")
 var clientFinishedLabel = []byte("client finished")
 var serverFinishedLabel = []byte("server finished")
 
-func prfAndHashForVersion(version uint16, suite *cipherSuite) (func(result, secret, label, seed []byte), crypto.Hash) {
+func prfAndHashForVersion(version uint16, suite *CipherSuite) (func(result, secret, label, seed []byte), crypto.Hash) {
 	switch version {
 	case VersionSSL30:
 		return prf30, crypto.Hash(0)
 	case VersionTLS10, VersionTLS11:
 		return prf10, crypto.Hash(0)
 	case VersionTLS12:
-		if suite.flags&suiteSHA384 != 0 {
+		if suite.Flags&SuiteSHA384 != 0 {
 			return prf12(sha512.New384), crypto.SHA384
 		}
 		return prf12(sha256.New), crypto.SHA256
@@ -133,14 +133,14 @@ func prfAndHashForVersion(version uint16, suite *cipherSuite) (func(result, secr
 	}
 }
 
-func prfForVersion(version uint16, suite *cipherSuite) func(result, secret, label, seed []byte) {
+func prfForVersion(version uint16, suite *CipherSuite) func(result, secret, label, seed []byte) {
 	prf, _ := prfAndHashForVersion(version, suite)
 	return prf
 }
 
 // masterFromPreMasterSecret generates the master secret from the pre-master
 // secret. See RFC 5246, Section 8.1.
-func masterFromPreMasterSecret(version uint16, suite *cipherSuite, preMasterSecret, clientRandom, serverRandom []byte) []byte {
+func masterFromPreMasterSecret(version uint16, suite *CipherSuite, preMasterSecret, clientRandom, serverRandom []byte) []byte {
 	seed := make([]byte, 0, len(clientRandom)+len(serverRandom))
 	seed = append(seed, clientRandom...)
 	seed = append(seed, serverRandom...)
@@ -153,7 +153,7 @@ func masterFromPreMasterSecret(version uint16, suite *cipherSuite, preMasterSecr
 // keysFromMasterSecret generates the connection keys from the master
 // secret, given the lengths of the MAC key, cipher key and IV, as defined in
 // RFC 2246, Section 6.3.
-func keysFromMasterSecret(version uint16, suite *cipherSuite, masterSecret, clientRandom, serverRandom []byte, macLen, keyLen, ivLen int) (clientMAC, serverMAC, clientKey, serverKey, clientIV, serverIV []byte) {
+func keysFromMasterSecret(version uint16, suite *CipherSuite, masterSecret, clientRandom, serverRandom []byte, macLen, keyLen, ivLen int) (clientMAC, serverMAC, clientKey, serverKey, clientIV, serverIV []byte) {
 	seed := make([]byte, 0, len(serverRandom)+len(clientRandom))
 	seed = append(seed, serverRandom...)
 	seed = append(seed, clientRandom...)
@@ -192,7 +192,7 @@ func hashFromSignatureScheme(signatureAlgorithm SignatureScheme) (crypto.Hash, e
 	}
 }
 
-func newFinishedHash(version uint16, cipherSuite *cipherSuite) finishedHash {
+func newFinishedHash(version uint16, cipherSuite *CipherSuite) finishedHash {
 	var buffer []byte
 	if version == VersionSSL30 || version >= VersionTLS12 {
 		buffer = []byte{}
@@ -353,7 +353,7 @@ func noExportedKeyingMaterial(label string, context []byte, length int) ([]byte,
 }
 
 // ekmFromMasterSecret generates exported keying material as defined in RFC 5705.
-func ekmFromMasterSecret(version uint16, suite *cipherSuite, masterSecret, clientRandom, serverRandom []byte) func(string, []byte, int) ([]byte, error) {
+func ekmFromMasterSecret(version uint16, suite *CipherSuite, masterSecret, clientRandom, serverRandom []byte) func(string, []byte, int) ([]byte, error) {
 	return func(label string, context []byte, length int) ([]byte, error) {
 		switch label {
 		case "client finished", "server finished", "master secret", "key expansion":

--- a/src/crypto/tls/prf_test.go
+++ b/src/crypto/tls/prf_test.go
@@ -35,7 +35,7 @@ func TestSplitPreMasterSecret(t *testing.T) {
 
 type testKeysFromTest struct {
 	version                                        uint16
-	suite                                          *cipherSuite
+	suite                                          *CipherSuite
 	preMasterSecret                                string
 	clientRandom, serverRandom                     string
 	masterSecret                                   string


### PR DESCRIPTION
Allows to dynamically retrieve a list of available cipher suites. This change allows a variety of applicatoins:
- Enable all available ciphers programmatically, without hardcoding, and always refering to the latest set of implemented ciphers
- Filter ciphers by desired flags and use them dynamically, without hardcoding, and always refering to the latest set of implemented ciphers
- Build application configs for user-decided selection of ciphers to allow

Ciphers are returned as copies, in order to avoid messing up internal stuff.

In contrast to the already discussed solutions, this one reduced the amount of necessary changes. Maintainability will be equal to before. This should not contain any breaking changes, as it only makes former private variables public, respectively, adds functions.

Fixes #30325 and #21167