### PR TITLE
crypto/tls: expose implemented cipher suites

### DIFF
--- a/src/crypto/tls/cipher_suites.go
+++ b/src/crypto/tls/cipher_suites.go
@@ -15,6 +15,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"hash"
+	"errors"
 	"internal/x/crypto/chacha20poly1305"
 )
 
@@ -42,80 +43,140 @@ const (
 	// Diffie-Hellman. This means that it should only be selected when the
 	// client indicates that it supports ECC with a curve and point format
 	// that we're happy with.
-	suiteECDHE = 1 << iota
-	// suiteECDSA indicates that the cipher suite involves an ECDSA
+	SuiteECDHE = 1 << iota
+	// SuiteECDSA indicates that the cipher suite involves an ECDSA
 	// signature and therefore may only be selected when the server's
 	// certificate is ECDSA. If this is not set then the cipher suite is
 	// RSA based.
-	suiteECDSA
-	// suiteTLS12 indicates that the cipher suite should only be advertised
+	SuiteECDSA
+	// SuiteTLS12 indicates that the cipher suite should only be advertised
 	// and accepted when using TLS 1.2.
-	suiteTLS12
-	// suiteSHA384 indicates that the cipher suite uses SHA384 as the
+	SuiteTLS12
+	// SuiteSHA384 indicates that the cipher suite uses SHA384 as the
 	// handshake hash.
-	suiteSHA384
-	// suiteDefaultOff indicates that this cipher suite is not included by
+	SuiteSHA384
+	// SuiteDefaultOff indicates that this cipher suite is not included by
 	// default.
-	suiteDefaultOff
+	SuiteDefaultOff
 )
 
-// A cipherSuite is a specific combination of key agreement, cipher and MAC function.
-type cipherSuite struct {
-	id uint16
+// A CipherSuite is a specific combination of key agreement, cipher and MAC function.
+type CipherSuite struct {
+	Id uint16
+	Name string
 	// the lengths, in bytes, of the key material needed for each component.
-	keyLen int
-	macLen int
-	ivLen  int
+	KeyLen int
+	MacLen int
+	IvLen  int
 	ka     func(version uint16) keyAgreement
-	// flags is a bitmask of the suite* values, above.
-	flags  int
+	// Flags is a bitmask of the suite* values, above.
+	Flags  int
 	cipher func(key, iv []byte, isRead bool) interface{}
 	mac    func(version uint16, macKey []byte) macFunction
 	aead   func(key, fixedNonce []byte) aead
 }
 
-var cipherSuites = []*cipherSuite{
+var cipherSuites = []*CipherSuite{
 	// Ciphersuite order is chosen so that ECDHE comes before plain RSA and
 	// AEADs are the top preference.
-	{TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, 32, 0, 12, ecdheRSAKA, suiteECDHE | suiteTLS12, nil, nil, aeadChaCha20Poly1305},
-	{TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305, 32, 0, 12, ecdheECDSAKA, suiteECDHE | suiteECDSA | suiteTLS12, nil, nil, aeadChaCha20Poly1305},
-	{TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, 16, 0, 4, ecdheRSAKA, suiteECDHE | suiteTLS12, nil, nil, aeadAESGCM},
-	{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, 16, 0, 4, ecdheECDSAKA, suiteECDHE | suiteECDSA | suiteTLS12, nil, nil, aeadAESGCM},
-	{TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, 32, 0, 4, ecdheRSAKA, suiteECDHE | suiteTLS12 | suiteSHA384, nil, nil, aeadAESGCM},
-	{TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, 32, 0, 4, ecdheECDSAKA, suiteECDHE | suiteECDSA | suiteTLS12 | suiteSHA384, nil, nil, aeadAESGCM},
-	{TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, 16, 32, 16, ecdheRSAKA, suiteECDHE | suiteTLS12 | suiteDefaultOff, cipherAES, macSHA256, nil},
-	{TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, 16, 20, 16, ecdheRSAKA, suiteECDHE, cipherAES, macSHA1, nil},
-	{TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, 16, 32, 16, ecdheECDSAKA, suiteECDHE | suiteECDSA | suiteTLS12 | suiteDefaultOff, cipherAES, macSHA256, nil},
-	{TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, 16, 20, 16, ecdheECDSAKA, suiteECDHE | suiteECDSA, cipherAES, macSHA1, nil},
-	{TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, 32, 20, 16, ecdheRSAKA, suiteECDHE, cipherAES, macSHA1, nil},
-	{TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, 32, 20, 16, ecdheECDSAKA, suiteECDHE | suiteECDSA, cipherAES, macSHA1, nil},
-	{TLS_RSA_WITH_AES_128_GCM_SHA256, 16, 0, 4, rsaKA, suiteTLS12, nil, nil, aeadAESGCM},
-	{TLS_RSA_WITH_AES_256_GCM_SHA384, 32, 0, 4, rsaKA, suiteTLS12 | suiteSHA384, nil, nil, aeadAESGCM},
-	{TLS_RSA_WITH_AES_128_CBC_SHA256, 16, 32, 16, rsaKA, suiteTLS12 | suiteDefaultOff, cipherAES, macSHA256, nil},
-	{TLS_RSA_WITH_AES_128_CBC_SHA, 16, 20, 16, rsaKA, 0, cipherAES, macSHA1, nil},
-	{TLS_RSA_WITH_AES_256_CBC_SHA, 32, 20, 16, rsaKA, 0, cipherAES, macSHA1, nil},
-	{TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, 24, 20, 8, ecdheRSAKA, suiteECDHE, cipher3DES, macSHA1, nil},
-	{TLS_RSA_WITH_3DES_EDE_CBC_SHA, 24, 20, 8, rsaKA, 0, cipher3DES, macSHA1, nil},
+	{TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305", 32, 0, 12, ecdheRSAKA, SuiteECDHE | SuiteTLS12, nil, nil, aeadChaCha20Poly1305},
+	{TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305, "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305", 32, 0, 12, ecdheECDSAKA, SuiteECDHE | SuiteECDSA | SuiteTLS12, nil, nil, aeadChaCha20Poly1305},
+	{TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", 16, 0, 4, ecdheRSAKA, SuiteECDHE | SuiteTLS12, nil, nil, aeadAESGCM},
+	{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", 16, 0, 4, ecdheECDSAKA, SuiteECDHE | SuiteECDSA | SuiteTLS12, nil, nil, aeadAESGCM},
+	{TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", 32, 0, 4, ecdheRSAKA, SuiteECDHE | SuiteTLS12 | SuiteSHA384, nil, nil, aeadAESGCM},
+	{TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", 32, 0, 4, ecdheECDSAKA, SuiteECDHE | SuiteECDSA | SuiteTLS12 | SuiteSHA384, nil, nil, aeadAESGCM},
+	{TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", 16, 32, 16, ecdheRSAKA, SuiteECDHE | SuiteTLS12 | SuiteDefaultOff, cipherAES, macSHA256, nil},
+	{TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", 16, 20, 16, ecdheRSAKA, SuiteECDHE, cipherAES, macSHA1, nil},
+	{TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", 16, 32, 16, ecdheECDSAKA, SuiteECDHE | SuiteECDSA | SuiteTLS12 | SuiteDefaultOff, cipherAES, macSHA256, nil},
+	{TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA", 16, 20, 16, ecdheECDSAKA, SuiteECDHE | SuiteECDSA, cipherAES, macSHA1, nil},
+	{TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", 32, 20, 16, ecdheRSAKA, SuiteECDHE, cipherAES, macSHA1, nil},
+	{TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", 32, 20, 16, ecdheECDSAKA, SuiteECDHE | SuiteECDSA, cipherAES, macSHA1, nil},
+	{TLS_RSA_WITH_AES_128_GCM_SHA256, "TLS_RSA_WITH_AES_128_GCM_SHA256", 16, 0, 4, rsaKA, SuiteTLS12, nil, nil, aeadAESGCM},
+	{TLS_RSA_WITH_AES_256_GCM_SHA384, "TLS_RSA_WITH_AES_256_GCM_SHA384", 32, 0, 4, rsaKA, SuiteTLS12 | SuiteSHA384, nil, nil, aeadAESGCM},
+	{TLS_RSA_WITH_AES_128_CBC_SHA256, "TLS_RSA_WITH_AES_128_CBC_SHA256", 16, 32, 16, rsaKA, SuiteTLS12 | SuiteDefaultOff, cipherAES, macSHA256, nil},
+	{TLS_RSA_WITH_AES_128_CBC_SHA, "TLS_RSA_WITH_AES_128_CBC_SHA", 16, 20, 16, rsaKA, 0, cipherAES, macSHA1, nil},
+	{TLS_RSA_WITH_AES_256_CBC_SHA, "TLS_RSA_WITH_AES_256_CBC_SHA,", 32, 20, 16, rsaKA, 0, cipherAES, macSHA1, nil},
+	{TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA", 24, 20, 8, ecdheRSAKA, SuiteECDHE, cipher3DES, macSHA1, nil},
+	{TLS_RSA_WITH_3DES_EDE_CBC_SHA, "TLS_RSA_WITH_3DES_EDE_CBC_SHA", 24, 20, 8, rsaKA, 0, cipher3DES, macSHA1, nil},
 
 	// RC4-based cipher suites are disabled by default.
-	{TLS_RSA_WITH_RC4_128_SHA, 16, 20, 0, rsaKA, suiteDefaultOff, cipherRC4, macSHA1, nil},
-	{TLS_ECDHE_RSA_WITH_RC4_128_SHA, 16, 20, 0, ecdheRSAKA, suiteECDHE | suiteDefaultOff, cipherRC4, macSHA1, nil},
-	{TLS_ECDHE_ECDSA_WITH_RC4_128_SHA, 16, 20, 0, ecdheECDSAKA, suiteECDHE | suiteECDSA | suiteDefaultOff, cipherRC4, macSHA1, nil},
+	{TLS_RSA_WITH_RC4_128_SHA, "TLS_RSA_WITH_RC4_128_SHA", 16, 20, 0, rsaKA, SuiteDefaultOff, cipherRC4, macSHA1, nil},
+	{TLS_ECDHE_RSA_WITH_RC4_128_SHA, "TLS_ECDHE_RSA_WITH_RC4_128_SHA", 16, 20, 0, ecdheRSAKA, SuiteECDHE | SuiteDefaultOff, cipherRC4, macSHA1, nil},
+	{TLS_ECDHE_ECDSA_WITH_RC4_128_SHA, "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA", 16, 20, 0, ecdheECDSAKA, SuiteECDHE | SuiteECDSA | SuiteDefaultOff, cipherRC4, macSHA1, nil},
 }
 
-// A cipherSuiteTLS13 defines only the pair of the AEAD algorithm and hash
+// CipherSuites returns a copy of all available CipherSuites, including disabled by default ones
+func CipherSuites() []CipherSuite {
+	var suites []CipherSuite
+	for _, cs := range cipherSuites {
+		suites = append(suites, CipherSuite(*cs))
+	}
+	return suites
+}
+
+// CipherSuite returns a copy of the CipherSuite struct given the ID
+func CipherSuiteById(id uint16) (CipherSuite, error) {
+	for _, cs := range cipherSuites {
+		if cs.Id == id {
+			return CipherSuite(*cs), nil
+		}
+	}
+	return CipherSuite{}, errors.New("cipher id not existing")
+}
+
+// CipherSuite returns a copy of the CipherSuite struct given the name of the cipher suite.
+func CipherSuiteByName(name string) (CipherSuite, error) {
+	for _, cs := range cipherSuites {
+		if cs.Name == name {
+			return CipherSuite(*cs), nil
+		}
+	}
+	return CipherSuite{}, errors.New("cipher name not existing")
+}
+
+// A CipherSuiteTLS13 defines only the pair of the AEAD algorithm and hash
 // algorithm to be used with HKDF. See RFC 8446, Appendix B.4.
-type cipherSuiteTLS13 struct {
-	id     uint16
-	keyLen int
+type CipherSuiteTLS13 struct {
+	Id     uint16
+	Name string
+	KeyLen int
 	aead   func(key, fixedNonce []byte) aead
 	hash   crypto.Hash
 }
 
-var cipherSuitesTLS13 = []*cipherSuiteTLS13{
-	{TLS_AES_128_GCM_SHA256, 16, aeadAESGCMTLS13, crypto.SHA256},
-	{TLS_CHACHA20_POLY1305_SHA256, 32, aeadChaCha20Poly1305, crypto.SHA256},
-	{TLS_AES_256_GCM_SHA384, 32, aeadAESGCMTLS13, crypto.SHA384},
+var cipherSuitesTLS13 = []*CipherSuiteTLS13{
+	{TLS_AES_128_GCM_SHA256, "TLS_AES_128_GCM_SHA256", 16, aeadAESGCMTLS13, crypto.SHA256},
+	{TLS_CHACHA20_POLY1305_SHA256, "TLS_CHACHA20_POLY1305_SHA256", 32, aeadChaCha20Poly1305, crypto.SHA256},
+	{TLS_AES_256_GCM_SHA384, "TLS_AES_256_GCM_SHA384", 32, aeadAESGCMTLS13, crypto.SHA384},
+}
+
+// CipherSuitesTLS13 returns a copy of all available CipherSuiteTLS13, including disabled by default ones
+func CipherSuitesTLS13() []CipherSuiteTLS13 {
+	var suites []CipherSuiteTLS13
+	for _, cs := range cipherSuitesTLS13 {
+		suites = append(suites, CipherSuiteTLS13(*cs))
+	}
+	return suites
+}
+
+// CipherSuite returns a copy of the CipherSuite struct given the ID
+func CipherSuiteTLS13ById(id uint16) (CipherSuiteTLS13, error) {
+	for _, cs := range cipherSuitesTLS13 {
+		if cs.Id == id {
+			return CipherSuiteTLS13(*cs), nil
+		}
+	}
+	return CipherSuiteTLS13{}, errors.New("cipher id not existing")
+}
+
+// CipherSuite returns a copy of the CipherSuite struct given the name of the cipher suite.
+func CipherSuiteTLS13ByName(name string) (CipherSuiteTLS13, error) {
+	for _, cs := range cipherSuitesTLS13 {
+		if cs.Name == name {
+			return CipherSuiteTLS13(*cs), nil
+		}
+	}
+	return CipherSuiteTLS13{}, errors.New("cipher name not existing")
 }
 
 func cipherRC4(key, iv []byte, isRead bool) interface{} {
@@ -394,9 +455,9 @@ func ecdheRSAKA(version uint16) keyAgreement {
 	}
 }
 
-// mutualCipherSuite returns a cipherSuite given a list of supported
-// ciphersuites and the id requested by the peer.
-func mutualCipherSuite(have []uint16, want uint16) *cipherSuite {
+// mutualCipherSuite returns a CipherSuite given a list of supported
+// ciphersuites and the Id requested by the peer.
+func mutualCipherSuite(have []uint16, want uint16) *CipherSuite {
 	for _, id := range have {
 		if id == want {
 			return cipherSuiteByID(id)
@@ -405,16 +466,16 @@ func mutualCipherSuite(have []uint16, want uint16) *cipherSuite {
 	return nil
 }
 
-func cipherSuiteByID(id uint16) *cipherSuite {
+func cipherSuiteByID(id uint16) *CipherSuite {
 	for _, cipherSuite := range cipherSuites {
-		if cipherSuite.id == id {
+		if cipherSuite.Id == id {
 			return cipherSuite
 		}
 	}
 	return nil
 }
 
-func mutualCipherSuiteTLS13(have []uint16, want uint16) *cipherSuiteTLS13 {
+func mutualCipherSuiteTLS13(have []uint16, want uint16) *CipherSuiteTLS13 {
 	for _, id := range have {
 		if id == want {
 			return cipherSuiteTLS13ByID(id)
@@ -423,9 +484,9 @@ func mutualCipherSuiteTLS13(have []uint16, want uint16) *cipherSuiteTLS13 {
 	return nil
 }
 
-func cipherSuiteTLS13ByID(id uint16) *cipherSuiteTLS13 {
+func cipherSuiteTLS13ByID(id uint16) *CipherSuiteTLS13 {
 	for _, cipherSuite := range cipherSuitesTLS13 {
-		if cipherSuite.id == id {
+		if cipherSuite.Id == id {
 			return cipherSuite
 		}
 	}

--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -1097,7 +1097,7 @@ func defaultCipherSuitesTLS13() []uint16 {
 func initDefaultCipherSuites() {
 	var topCipherSuites []uint16
 
-	// Check the cpu flags for each platform that has optimized GCM implementations.
+	// Check the cpu Flags for each platform that has optimized GCM implementations.
 	// Worst case, these variables will just all be false.
 	var (
 		hasGCMAsmAMD64 = cpu.X86.HasAES && cpu.X86.HasPCLMULQDQ
@@ -1147,15 +1147,15 @@ func initDefaultCipherSuites() {
 
 NextCipherSuite:
 	for _, suite := range cipherSuites {
-		if suite.flags&suiteDefaultOff != 0 {
+		if suite.Flags&SuiteDefaultOff != 0 {
 			continue
 		}
 		for _, existing := range varDefaultCipherSuites {
-			if existing == suite.id {
+			if existing == suite.Id {
 				continue NextCipherSuite
 			}
 		}
-		varDefaultCipherSuites = append(varDefaultCipherSuites, suite.id)
+		varDefaultCipherSuites = append(varDefaultCipherSuites, suite.Id)
 	}
 }
 

--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -191,7 +191,7 @@ func (hc *halfConn) changeCipherSpec() error {
 	return nil
 }
 
-func (hc *halfConn) setTrafficSecret(suite *cipherSuiteTLS13, secret []byte) {
+func (hc *halfConn) setTrafficSecret(suite *CipherSuiteTLS13, secret []byte) {
 	hc.trafficSecret = secret
 	key, iv := suite.trafficKey(secret)
 	hc.cipher = suite.aead(key, iv)

--- a/src/crypto/tls/handshake_client.go
+++ b/src/crypto/tls/handshake_client.go
@@ -25,7 +25,7 @@ type clientHandshakeState struct {
 	c            *Conn
 	serverHello  *serverHelloMsg
 	hello        *clientHelloMsg
-	suite        *cipherSuite
+	suite        *CipherSuite
 	finishedHash finishedHash
 	masterSecret []byte
 	session      *ClientSessionState
@@ -87,12 +87,12 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, ecdheParameters, error) {
 
 	for _, suiteId := range possibleCipherSuites {
 		for _, suite := range cipherSuites {
-			if suite.id != suiteId {
+			if suite.Id != suiteId {
 				continue
 			}
 			// Don't advertise TLS 1.2-only cipher suites unless
 			// we're attempting TLS 1.2.
-			if hello.vers < VersionTLS12 && suite.flags&suiteTLS12 != 0 {
+			if hello.vers < VersionTLS12 && suite.Flags&SuiteTLS12 != 0 {
 				break
 			}
 			hello.cipherSuites = append(hello.cipherSuites, suiteId)
@@ -429,7 +429,7 @@ func (hs *clientHandshakeState) pickCipherSuite() error {
 		return errors.New("tls: server chose an unconfigured cipher suite")
 	}
 
-	hs.c.cipherSuite = hs.suite.id
+	hs.c.cipherSuite = hs.suite.Id
 	return nil
 }
 
@@ -617,7 +617,7 @@ func (hs *clientHandshakeState) establishKeys() error {
 	c := hs.c
 
 	clientMAC, serverMAC, clientKey, serverKey, clientIV, serverIV :=
-		keysFromMasterSecret(c.vers, hs.suite, hs.masterSecret, hs.hello.random, hs.serverHello.random, hs.suite.macLen, hs.suite.keyLen, hs.suite.ivLen)
+		keysFromMasterSecret(c.vers, hs.suite, hs.masterSecret, hs.hello.random, hs.serverHello.random, hs.suite.MacLen, hs.suite.KeyLen, hs.suite.IvLen)
 	var clientCipher, serverCipher interface{}
 	var clientHash, serverHash macFunction
 	if hs.suite.cipher != nil {
@@ -707,7 +707,7 @@ func (hs *clientHandshakeState) processServerHello() (bool, error) {
 		return false, errors.New("tls: server resumed a session with a different version")
 	}
 
-	if hs.session.cipherSuite != hs.suite.id {
+	if hs.session.cipherSuite != hs.suite.Id {
 		c.sendAlert(alertHandshakeFailure)
 		return false, errors.New("tls: server resumed a session with a different cipher suite")
 	}
@@ -767,7 +767,7 @@ func (hs *clientHandshakeState) readSessionTicket() error {
 	hs.session = &ClientSessionState{
 		sessionTicket:      sessionTicketMsg.ticket,
 		vers:               c.vers,
-		cipherSuite:        hs.suite.id,
+		cipherSuite:        hs.suite.Id,
 		masterSecret:       hs.masterSecret,
 		serverCertificates: c.peerCertificates,
 		verifiedChains:     c.verifiedChains,

--- a/src/crypto/tls/handshake_client_tls13.go
+++ b/src/crypto/tls/handshake_client_tls13.go
@@ -28,7 +28,7 @@ type clientHandshakeStateTLS13 struct {
 	certReq       *certificateRequestMsgTLS13
 	usingPSK      bool
 	sentDummyCCS  bool
-	suite         *cipherSuiteTLS13
+	suite         *CipherSuiteTLS13
 	transcript    hash.Hash
 	masterSecret  []byte
 	trafficSecret []byte // client_application_traffic_secret_0
@@ -155,7 +155,7 @@ func (hs *clientHandshakeStateTLS13) checkServerHelloOrHRR() error {
 		return errors.New("tls: server chose an unconfigured cipher suite")
 	}
 	hs.suite = selectedSuite
-	c.cipherSuite = hs.suite.id
+	c.cipherSuite = hs.suite.Id
 
 	return nil
 }

--- a/src/crypto/tls/handshake_server_test.go
+++ b/src/crypto/tls/handshake_server_test.go
@@ -43,7 +43,7 @@ var testConfig *Config
 func allCipherSuites() []uint16 {
 	ids := make([]uint16, len(cipherSuites))
 	for i, suite := range cipherSuites {
-		ids[i] = suite.id
+		ids[i] = suite.Id
 	}
 
 	return ids

--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -27,7 +27,7 @@ type serverHandshakeStateTLS13 struct {
 	hello           *serverHelloMsg
 	sentDummyCCS    bool
 	usingPSK        bool
-	suite           *cipherSuiteTLS13
+	suite           *CipherSuiteTLS13
 	cert            *Certificate
 	sigAlg          SignatureScheme
 	earlySecret     []byte
@@ -165,8 +165,8 @@ func (hs *serverHandshakeStateTLS13) processClientHello() error {
 		c.sendAlert(alertHandshakeFailure)
 		return errors.New("tls: no cipher suite supported by both client and server")
 	}
-	c.cipherSuite = hs.suite.id
-	hs.hello.cipherSuite = hs.suite.id
+	c.cipherSuite = hs.suite.Id
+	hs.hello.cipherSuite = hs.suite.Id
 	hs.transcript = hs.suite.hash.New()
 
 	// Pick the ECDHE group in server preference order, but give priority to
@@ -739,7 +739,7 @@ func (hs *serverHandshakeStateTLS13) sendSessionTickets() error {
 		certsFromClient = append(certsFromClient, cert.Raw)
 	}
 	state := sessionStateTLS13{
-		cipherSuite:      hs.suite.id,
+		cipherSuite:      hs.suite.Id,
 		createdAt:        uint64(c.config.time().Unix()),
 		resumptionSecret: resumptionSecret,
 		certificate: Certificate{

--- a/src/crypto/tls/key_schedule.go
+++ b/src/crypto/tls/key_schedule.go
@@ -31,7 +31,7 @@ const (
 )
 
 // expandLabel implements HKDF-Expand-Label from RFC 8446, Section 7.1.
-func (c *cipherSuiteTLS13) expandLabel(secret []byte, label string, context []byte, length int) []byte {
+func (c *CipherSuiteTLS13) expandLabel(secret []byte, label string, context []byte, length int) []byte {
 	var hkdfLabel cryptobyte.Builder
 	hkdfLabel.AddUint16(uint16(length))
 	hkdfLabel.AddUint8LengthPrefixed(func(b *cryptobyte.Builder) {
@@ -50,7 +50,7 @@ func (c *cipherSuiteTLS13) expandLabel(secret []byte, label string, context []by
 }
 
 // deriveSecret implements Derive-Secret from RFC 8446, Section 7.1.
-func (c *cipherSuiteTLS13) deriveSecret(secret []byte, label string, transcript hash.Hash) []byte {
+func (c *CipherSuiteTLS13) deriveSecret(secret []byte, label string, transcript hash.Hash) []byte {
 	if transcript == nil {
 		transcript = c.hash.New()
 	}
@@ -58,7 +58,7 @@ func (c *cipherSuiteTLS13) deriveSecret(secret []byte, label string, transcript 
 }
 
 // extract implements HKDF-Extract with the cipher suite hash.
-func (c *cipherSuiteTLS13) extract(newSecret, currentSecret []byte) []byte {
+func (c *CipherSuiteTLS13) extract(newSecret, currentSecret []byte) []byte {
 	if newSecret == nil {
 		newSecret = make([]byte, c.hash.Size())
 	}
@@ -67,13 +67,13 @@ func (c *cipherSuiteTLS13) extract(newSecret, currentSecret []byte) []byte {
 
 // nextTrafficSecret generates the next traffic secret, given the current one,
 // according to RFC 8446, Section 7.2.
-func (c *cipherSuiteTLS13) nextTrafficSecret(trafficSecret []byte) []byte {
+func (c *CipherSuiteTLS13) nextTrafficSecret(trafficSecret []byte) []byte {
 	return c.expandLabel(trafficSecret, trafficUpdateLabel, nil, c.hash.Size())
 }
 
 // trafficKey generates traffic keys according to RFC 8446, Section 7.3.
-func (c *cipherSuiteTLS13) trafficKey(trafficSecret []byte) (key, iv []byte) {
-	key = c.expandLabel(trafficSecret, "key", nil, c.keyLen)
+func (c *CipherSuiteTLS13) trafficKey(trafficSecret []byte) (key, iv []byte) {
+	key = c.expandLabel(trafficSecret, "key", nil, c.KeyLen)
 	iv = c.expandLabel(trafficSecret, "iv", nil, aeadNonceLength)
 	return
 }
@@ -81,7 +81,7 @@ func (c *cipherSuiteTLS13) trafficKey(trafficSecret []byte) (key, iv []byte) {
 // finishedHash generates the Finished verify_data or PskBinderEntry according
 // to RFC 8446, Section 4.4.4. See sections 4.4 and 4.2.11.2 for the baseKey
 // selection.
-func (c *cipherSuiteTLS13) finishedHash(baseKey []byte, transcript hash.Hash) []byte {
+func (c *CipherSuiteTLS13) finishedHash(baseKey []byte, transcript hash.Hash) []byte {
 	finishedKey := c.expandLabel(baseKey, "finished", nil, c.hash.Size())
 	verifyData := hmac.New(c.hash.New, finishedKey)
 	verifyData.Write(transcript.Sum(nil))
@@ -90,7 +90,7 @@ func (c *cipherSuiteTLS13) finishedHash(baseKey []byte, transcript hash.Hash) []
 
 // exportKeyingMaterial implements RFC5705 exporters for TLS 1.3 according to
 // RFC 8446, Section 7.5.
-func (c *cipherSuiteTLS13) exportKeyingMaterial(masterSecret []byte, transcript hash.Hash) func(string, []byte, int) ([]byte, error) {
+func (c *CipherSuiteTLS13) exportKeyingMaterial(masterSecret []byte, transcript hash.Hash) func(string, []byte, int) ([]byte, error) {
 	expMasterSecret := c.deriveSecret(masterSecret, exporterLabel, transcript)
 	return func(label string, context []byte, length int) ([]byte, error) {
 		secret := c.deriveSecret(expMasterSecret, label, nil)

--- a/src/crypto/tls/key_schedule_test.go
+++ b/src/crypto/tls/key_schedule_test.go
@@ -97,7 +97,7 @@ func TestDeriveSecret(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := cipherSuitesTLS13[0]
 			if got := c.deriveSecret(tt.args.secret, tt.args.label, tt.args.transcript); !bytes.Equal(got, tt.want) {
-				t.Errorf("cipherSuiteTLS13.deriveSecret() = % x, want % x", got, tt.want)
+				t.Errorf("CipherSuiteTLS13.deriveSecret() = % x, want % x", got, tt.want)
 			}
 		})
 	}
@@ -116,10 +116,10 @@ func TestTrafficKey(t *testing.T) {
 	c := cipherSuitesTLS13[0]
 	gotKey, gotIV := c.trafficKey(trafficSecret)
 	if !bytes.Equal(gotKey, wantKey) {
-		t.Errorf("cipherSuiteTLS13.trafficKey() gotKey = % x, want % x", gotKey, wantKey)
+		t.Errorf("CipherSuiteTLS13.trafficKey() gotKey = % x, want % x", gotKey, wantKey)
 	}
 	if !bytes.Equal(gotIV, wantIV) {
-		t.Errorf("cipherSuiteTLS13.trafficKey() gotIV = % x, want % x", gotIV, wantIV)
+		t.Errorf("CipherSuiteTLS13.trafficKey() gotIV = % x, want % x", gotIV, wantIV)
 	}
 }
 
@@ -168,7 +168,7 @@ func TestExtract(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := cipherSuitesTLS13[0]
 			if got := c.extract(tt.args.newSecret, tt.args.currentSecret); !bytes.Equal(got, tt.want) {
-				t.Errorf("cipherSuiteTLS13.extract() = % x, want % x", got, tt.want)
+				t.Errorf("CipherSuiteTLS13.extract() = % x, want % x", got, tt.want)
 			}
 		})
 	}

--- a/src/crypto/tls/prf.go
+++ b/src/crypto/tls/prf.go
@@ -117,14 +117,14 @@ var keyExpansionLabel = []byte("key expansion")
 var clientFinishedLabel = []byte("client finished")
 var serverFinishedLabel = []byte("server finished")
 
-func prfAndHashForVersion(version uint16, suite *cipherSuite) (func(result, secret, label, seed []byte), crypto.Hash) {
+func prfAndHashForVersion(version uint16, suite *CipherSuite) (func(result, secret, label, seed []byte), crypto.Hash) {
 	switch version {
 	case VersionSSL30:
 		return prf30, crypto.Hash(0)
 	case VersionTLS10, VersionTLS11:
 		return prf10, crypto.Hash(0)
 	case VersionTLS12:
-		if suite.flags&suiteSHA384 != 0 {
+		if suite.Flags&SuiteSHA384 != 0 {
 			return prf12(sha512.New384), crypto.SHA384
 		}
 		return prf12(sha256.New), crypto.SHA256
@@ -133,14 +133,14 @@ func prfAndHashForVersion(version uint16, suite *cipherSuite) (func(result, secr
 	}
 }
 
-func prfForVersion(version uint16, suite *cipherSuite) func(result, secret, label, seed []byte) {
+func prfForVersion(version uint16, suite *CipherSuite) func(result, secret, label, seed []byte) {
 	prf, _ := prfAndHashForVersion(version, suite)
 	return prf
 }
 
 // masterFromPreMasterSecret generates the master secret from the pre-master
 // secret. See RFC 5246, Section 8.1.
-func masterFromPreMasterSecret(version uint16, suite *cipherSuite, preMasterSecret, clientRandom, serverRandom []byte) []byte {
+func masterFromPreMasterSecret(version uint16, suite *CipherSuite, preMasterSecret, clientRandom, serverRandom []byte) []byte {
 	seed := make([]byte, 0, len(clientRandom)+len(serverRandom))
 	seed = append(seed, clientRandom...)
 	seed = append(seed, serverRandom...)
@@ -153,7 +153,7 @@ func masterFromPreMasterSecret(version uint16, suite *cipherSuite, preMasterSecr
 // keysFromMasterSecret generates the connection keys from the master
 // secret, given the lengths of the MAC key, cipher key and IV, as defined in
 // RFC 2246, Section 6.3.
-func keysFromMasterSecret(version uint16, suite *cipherSuite, masterSecret, clientRandom, serverRandom []byte, macLen, keyLen, ivLen int) (clientMAC, serverMAC, clientKey, serverKey, clientIV, serverIV []byte) {
+func keysFromMasterSecret(version uint16, suite *CipherSuite, masterSecret, clientRandom, serverRandom []byte, macLen, keyLen, ivLen int) (clientMAC, serverMAC, clientKey, serverKey, clientIV, serverIV []byte) {
 	seed := make([]byte, 0, len(serverRandom)+len(clientRandom))
 	seed = append(seed, serverRandom...)
 	seed = append(seed, clientRandom...)
@@ -192,7 +192,7 @@ func hashFromSignatureScheme(signatureAlgorithm SignatureScheme) (crypto.Hash, e
 	}
 }
 
-func newFinishedHash(version uint16, cipherSuite *cipherSuite) finishedHash {
+func newFinishedHash(version uint16, cipherSuite *CipherSuite) finishedHash {
 	var buffer []byte
 	if version == VersionSSL30 || version >= VersionTLS12 {
 		buffer = []byte{}
@@ -353,7 +353,7 @@ func noExportedKeyingMaterial(label string, context []byte, length int) ([]byte,
 }
 
 // ekmFromMasterSecret generates exported keying material as defined in RFC 5705.
-func ekmFromMasterSecret(version uint16, suite *cipherSuite, masterSecret, clientRandom, serverRandom []byte) func(string, []byte, int) ([]byte, error) {
+func ekmFromMasterSecret(version uint16, suite *CipherSuite, masterSecret, clientRandom, serverRandom []byte) func(string, []byte, int) ([]byte, error) {
 	return func(label string, context []byte, length int) ([]byte, error) {
 		switch label {
 		case "client finished", "server finished", "master secret", "key expansion":

--- a/src/crypto/tls/prf_test.go
+++ b/src/crypto/tls/prf_test.go
@@ -35,7 +35,7 @@ func TestSplitPreMasterSecret(t *testing.T) {
 
 type testKeysFromTest struct {
 	version                                        uint16
-	suite                                          *cipherSuite
+	suite                                          *CipherSuite
 	preMasterSecret                                string
 	clientRandom, serverRandom                     string
 	masterSecret                                   string


### PR DESCRIPTION
Allows to dynamically retrieve a list of available cipher suites. This change allows a variety of applicatoins:

- Enable all available ciphers programmatically, without hardcoding, and always refering to the latest set of implemented ciphers
- Filter ciphers by desired flags and use them dynamically, without hardcoding, and always refering to the latest set of implemented ciphers
- Build application configs for user-decided selection of ciphers to allow

Ciphers are returned as copies, in order to avoid messing up internal stuff.

In contrast to the already discussed solutions, this one reduced the amount of necessary changes. Maintainability will be equal to before. This should not contain any breaking changes, as it only makes former private variables public, respectively, adds functions.

Fixes #30325 and #21167