### PR TITLE
time: fail when Parse is given a stdNumTZ as stdTZ

### DIFF
--- a/src/time/format.go
+++ b/src/time/format.go
@@ -1264,6 +1264,11 @@ func parseSignedOffset(value string) int {
 	if err != nil || value[1:] == rem {
 		return 0
 	}
+	// fail if the value consumed by leadingInt is not a single- or
+	// double-digit value (probably a stdNumTZ)
+	if len(value)-len(rem) > 3 {
+		return 0
+	}
 	if sign == '-' {
 		x = -x
 	}

--- a/src/time/format_test.go
+++ b/src/time/format_test.go
@@ -506,6 +506,8 @@ var parseTimeZoneTests = []ParseTimeZoneTest{
 	{"+14", 3, true},
 	{"+23", 3, true},
 	{"+24", 0, false},
+	// Issue 30780
+	{"-0000", 0, false},
 }
 
 func TestParseTimeZone(t *testing.T) {


### PR DESCRIPTION
Currently, an "MST" value in the Parse layout string corresponds
to a stdTZ token. "-0000" parses successfully, but "-0700" does not.
These are both stdNumTZ values, and neither should parse as stdTZ.

Fixes #30780