### PR TITLE
printer: check if specs exist before accessing them in genDecl printer

### DIFF
--- a/src/go/printer/nodes.go
+++ b/src/go/printer/nodes.go
@@ -1568,7 +1568,7 @@ func (p *printer) genDecl(d *ast.GenDecl) {
 		}
 		p.print(d.Rparen, token.RPAREN)
 
-	} else {
+	} else if len(d.Specs) > 0 {
 		// single declaration
 		p.spec(d.Specs[0], 1, true)
 	}


### PR DESCRIPTION
Checks that specs exist before attempting to access the first element in genDecl printer.
