### PR TITLE
check validation when parse CIDR

### DIFF
--- a/src/net/ip.go
+++ b/src/net/ip.go
@@ -744,6 +744,12 @@ func ParseCIDR(s string) (IP, *IPNet, error) {
 	if i < 0 {
 		return nil, nil, &ParseError{Type: "CIDR address", Text: s}
 	}
+
+	err := checkCIDRValid(s)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	addr, mask := s[:i], s[i+1:]
 	iplen := IPv4len
 	ip := parseIPv4(addr)


### PR DESCRIPTION
To setup network environment, if specify invalid CIDR address, the setup would be failed which is hard to debug which is common when setup CNI in k8s.

So add validation check when parse CIDR address.

Check way refers to https://stackoverflow.com/questions/50084229/bash-check-if-cidr-address-is-valid.