### PR TITLE
cmd: ignore the directory named go.mod

### DIFF
--- a/src/cmd/go/internal/modload/import.go
+++ b/src/cmd/go/internal/modload/import.go
@@ -233,8 +233,8 @@ func dirInModule(path, mpath, mdir string, isLocal bool) (dir string, haveGoFile
 	if isLocal {
 		for d := dir; d != mdir && len(d) > len(mdir); {
 			haveGoMod := haveGoModCache.Do(d, func() interface{} {
-				_, err := os.Stat(filepath.Join(d, "go.mod"))
-				return err == nil
+				fi, err := os.Stat(filepath.Join(d, "go.mod"))
+				return err == nil && !fi.IsDir()
 			}).(bool)
 
 			if haveGoMod {

--- a/src/cmd/go/internal/modload/search.go
+++ b/src/cmd/go/internal/modload/search.go
@@ -76,7 +76,7 @@ func matchPackages(pattern string, tags map[string]bool, useStd bool, modules []
 			}
 			// Stop at module boundaries.
 			if path != root {
-				if _, err := os.Stat(filepath.Join(path, "go.mod")); err == nil {
+				if fi, err := os.Stat(filepath.Join(path, "go.mod")); err == nil && !fi.IsDir() {
 					return filepath.SkipDir
 				}
 			}

--- a/src/cmd/go/internal/search/search.go
+++ b/src/cmd/go/internal/search/search.go
@@ -190,7 +190,7 @@ func MatchPackagesInFS(pattern string) *Match {
 
 		if !top && cfg.ModulesEnabled {
 			// Ignore other modules found in subdirectories.
-			if _, err := os.Stat(filepath.Join(path, "go.mod")); err == nil {
+			if fi, err := os.Stat(filepath.Join(path, "go.mod")); err == nil && !fi.IsDir() {
 				return filepath.SkipDir
 			}
 		}

--- a/src/cmd/go/testdata/script/mod_dir.txt
+++ b/src/cmd/go/testdata/script/mod_dir.txt
@@ -1,0 +1,20 @@
+# The directory named go.mod should be ignored
+
+env GO111MODULE=on
+
+cd $WORK/sub
+
+go list .
+stdout 'x/sub'
+
+mkdir go.mod
+exists go.mod
+
+go list .
+stdout 'x/sub'
+
+-- $WORK/go.mod --
+module x
+
+-- $WORK/sub/x.go --
+package x


### PR DESCRIPTION
The existing implementation does not check in all cases whether go.mod is a regular file.

Fixes #30788