### PR TITLE
runtime: follow Windows calling convention for _cgo_sys_thread_create

### DIFF
--- a/src/runtime/rt0_windows_amd64.s
+++ b/src/runtime/rt0_windows_amd64.s
@@ -14,11 +14,8 @@ TEXT _rt0_amd64_windows(SB),NOSPLIT,$-8
 // library is loaded. For static libraries it is called when the
 // final executable starts, during the C runtime initialization
 // phase.
-// based on ms windows x64 calling convention and stack usage
-// https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention?view=vs-2017
-// https://docs.microsoft.com/en-us/cpp/build/stack-usage?view=vs-2017
-// function call need extra 4 pointer in stack to reserve for 4 register parameters
-// otherwise the code will randomly crash
+// Leave space for four pointers on the stack as required
+// by the Windows amd64 calling convention.
 TEXT _rt0_amd64_windows_lib(SB),NOSPLIT,$0x48
 	MOVQ	BP, 0x20(SP)
 	MOVQ	BX, 0x28(SP)

--- a/src/runtime/rt0_windows_amd64.s
+++ b/src/runtime/rt0_windows_amd64.s
@@ -14,12 +14,17 @@ TEXT _rt0_amd64_windows(SB),NOSPLIT,$-8
 // library is loaded. For static libraries it is called when the
 // final executable starts, during the C runtime initialization
 // phase.
-TEXT _rt0_amd64_windows_lib(SB),NOSPLIT,$0x28
-	MOVQ	BP, 0x00(SP)
-	MOVQ	BX, 0x08(SP)
-	MOVQ	AX, 0x10(SP)
-	MOVQ  CX, 0x18(SP)
-	MOVQ  DX, 0x20(SP)
+// based on ms windows x64 calling convention and stack usage
+// https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention?view=vs-2017
+// https://docs.microsoft.com/en-us/cpp/build/stack-usage?view=vs-2017
+// function call need extra 4 pointer in stack to reserve for 4 register parameters
+// otherwise the code will randomly crash
+TEXT _rt0_amd64_windows_lib(SB),NOSPLIT,$0x48
+	MOVQ	BP, 0x20(SP)
+	MOVQ	BX, 0x28(SP)
+	MOVQ	AX, 0x30(SP)
+	MOVQ  CX, 0x38(SP)
+	MOVQ  DX, 0x40(SP)
 
 	// Create a new thread to do the runtime initialization and return.
 	MOVQ	_cgo_sys_thread_create(SB), AX
@@ -27,11 +32,11 @@ TEXT _rt0_amd64_windows_lib(SB),NOSPLIT,$0x28
 	MOVQ	$0, DX
 	CALL	AX
 
-	MOVQ	0x00(SP), BP
-	MOVQ	0x08(SP), BX
-	MOVQ	0x10(SP), AX
-	MOVQ	0x18(SP), CX
-	MOVQ	0x20(SP), DX
+	MOVQ	0x20(SP), BP
+	MOVQ	0x28(SP), BX
+	MOVQ	0x30(SP), AX
+	MOVQ	0x38(SP), CX
+	MOVQ	0x40(SP), DX
 	RET
 
 TEXT _rt0_amd64_windows_lib_go(SB),NOSPLIT,$0


### PR DESCRIPTION
Windows requires space for four pointers on the stack.