### PR TITLE
log: expose Writer() method of the standard logger

### DIFF
--- a/src/log/log.go
+++ b/src/log/log.go
@@ -288,6 +288,11 @@ func SetPrefix(prefix string) {
 	std.SetPrefix(prefix)
 }
 
+// Writer returns the output destination for the standard logger.
+func Writer() io.Writer {
+	return std.Writer()
+}
+
 // These functions write to the standard logger.
 
 // Print calls Output to print to the standard logger.


### PR DESCRIPTION
The Go 1.12 introduced Writer() method for logger objects, but
it was not exposed as log package function for standard logger.
This commit adds such Writer() function.