### PR TITLE
crypto/x509: check for default alpine ca bundle

### DIFF
--- a/src/crypto/x509/root_linux.go
+++ b/src/crypto/x509/root_linux.go
@@ -11,4 +11,5 @@ var certFiles = []string{
 	"/etc/ssl/ca-bundle.pem",                            // OpenSUSE
 	"/etc/pki/tls/cacert.pem",                           // OpenELEC
 	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
+	"/etc/ssl/cert.pem",                                 // Alpine Linux
 }


### PR DESCRIPTION
Alpine Linux uses /etc/ssl/cert.pem as default ca-bundle which
is preinstalled since 3.7 and was installed as part of the libressl
package in 3.5 and 3.6.

The path /etc/ssl/certs/ca-certificates.crt is only valid if the full
ca-certificates package is installed by hand, which contains all
single CA certs and uses update-ca-certificates to bundle them.

The priority for /etc/ssl/certs/ca-certificates.crt should be kept
higher than /etc/ssl/cert.pem in case the user installed custom
CA certs.