### PR TITLE
mime: add javascript module mime type (.mjs)

### DIFF
--- a/src/mime/type.go
+++ b/src/mime/type.go
@@ -68,6 +68,7 @@ var builtinTypesLower = map[string]string{
 	".png":  "image/png",
 	".svg":  "image/svg+xml",
 	".xml":  "text/xml; charset=utf-8",
+	".mjs":  "text/javascript",
 }
 
 var once sync.Once // guards initMime


### PR DESCRIPTION
There are default mime types in this package for handling static content, but there's
a new one missing ".mjs"  that is "Content-Type: text/javascript".

https://developers.google.com/web/fundamentals/primers/modules#mjs
