### PR TITLE
crypto/tls: add StrictVersionNegotiation config field for TLS 1.2

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -563,6 +563,15 @@ type Config struct {
 	// which is currently TLS 1.3.
 	MaxVersion uint16
 
+	// StrictVersionNegotiation only applies to TLS 1.2 ClientHello messages
+	// or when the highest supported version resolves to VersionTLS12.
+	// If true, the TLS version sent in the record layer of the initial
+	// ClientHello is matched with the one from the handshake layer, effectively
+	// disabling the default behavior that accounts for TLS 1.2's version
+	// negotiation interoperability with buggy server implementations. This
+	// problem is described in RFC 5246 Appendix E.1.
+	StrictVersionNegotiation bool
+
 	// CurvePreferences contains the elliptic curves that will be used in
 	// an ECDHE handshake, in preference order. If empty, the default will
 	// be used. The client will use the first preference as the type for
@@ -660,6 +669,7 @@ func (c *Config) Clone() *Config {
 		ClientSessionCache:          c.ClientSessionCache,
 		MinVersion:                  c.MinVersion,
 		MaxVersion:                  c.MaxVersion,
+		StrictVersionNegotiation:	 c.StrictVersionNegotiation,
 		CurvePreferences:            c.CurvePreferences,
 		DynamicRecordSizingDisabled: c.DynamicRecordSizingDisabled,
 		Renegotiation:               c.Renegotiation,

--- a/src/crypto/tls/handshake_client.go
+++ b/src/crypto/tls/handshake_client.go
@@ -55,6 +55,11 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, ecdheParameters, error) {
 	}
 
 	clientHelloVersion := supportedVersions[0]
+	if config.StrictVersionNegotiation && clientHelloVersion == VersionTLS12 {
+		// Make sure that the TLS version in the record layer matches
+		// the one in the handshake layer for the initial ClientHello.
+		c.vers = VersionTLS12
+	}
 	// The version at the beginning of the ClientHello was capped at TLS 1.2
 	// for compatibility reasons. The supported_versions extension is used
 	// to negotiate versions now. See RFC 8446, Section 4.2.1.


### PR DESCRIPTION
This PR exposes a new configuration field 'StrictVersionNegotiation' to customize whether the version field in the record layer of the TLS 1.2 ClientHello should match or not the one advertised in the handshake layer.
The current default behavior just sets the version in the record layer to 1.0 to maintain compatibility with legacy/buggy TLS server implementations.

This problem is described in [RFC 5246 Appendix E.1](https://tools.ietf.org/html/rfc5246#appendix-E.1) 