### PR TITLE
math/big: simplify shlVU_g and shrVU_g

### DIFF
--- a/src/math/big/arith.go
+++ b/src/math/big/arith.go
@@ -160,14 +160,11 @@ func shlVU_g(z, x []Word, s uint) (c Word) {
 	s &= _W - 1 // hint to the compiler that shifts by s don't need guard code
 	ŝ := _W - s
 	ŝ &= _W - 1 // ditto
-	w1 := x[len(z)-1]
-	c = w1 >> ŝ
+	c = x[len(z)-1] >> ŝ
 	for i := len(z) - 1; i > 0; i-- {
-		w := w1
-		w1 = x[i-1]
-		z[i] = w<<s | w1>>ŝ
+		z[i] = x[i]<<s | x[i-1]>>ŝ
 	}
-	z[0] = w1 << s
+	z[0] = x[0] << s
 	return
 }
 
@@ -182,14 +179,11 @@ func shrVU_g(z, x []Word, s uint) (c Word) {
 	s &= _W - 1 // hint to the compiler that shifts by s don't need guard code
 	ŝ := _W - s
 	ŝ &= _W - 1 // ditto
-	w1 := x[0]
-	c = w1 << ŝ
+	c = x[0] << ŝ
 	for i := 0; i < len(z)-1; i++ {
-		w := w1
-		w1 = x[i+1]
-		z[i] = w>>s | w1<<ŝ
+		z[i] = x[i]>>s | x[i+1]<<ŝ
 	}
-	z[len(z)-1] = w1 >> s
+	z[len(z)-1] = x[len(z)-1] >> s
 	return
 }
 


### PR DESCRIPTION
Rewrote a few lines to be more idiomatic/less assembly-ish.

Benchmarked with `go test -bench Float -tags math_big_pure_go`:

name                  old time/op    new time/op    delta
FloatString/100-8        751ns ± 0%     746ns ± 1%  -0.71%  (p=0.000 n=10+10)
FloatString/1000-8      22.9µs ± 0%    22.9µs ± 0%    ~     (p=0.271 n=10+10)
FloatString/10000-8     1.89ms ± 0%    1.89ms ± 0%    ~     (p=0.481 n=10+10)
FloatString/100000-8     184ms ± 0%     184ms ± 0%    ~     (p=0.094 n=9+9)
FloatAdd/10-8           56.4ns ± 1%    56.5ns ± 0%    ~     (p=0.170 n=9+9)
FloatAdd/100-8          59.7ns ± 0%    59.3ns ± 0%  -0.70%  (p=0.000 n=8+9)
FloatAdd/1000-8          101ns ± 0%      99ns ± 0%  -1.89%  (p=0.000 n=8+8)
FloatAdd/10000-8         553ns ± 0%     536ns ± 0%  -3.00%  (p=0.000 n=9+10)
FloatAdd/100000-8       4.94µs ± 0%    4.74µs ± 0%  -3.94%  (p=0.000 n=9+10)
FloatSub/10-8           50.3ns ± 0%    50.5ns ± 0%  +0.52%  (p=0.000 n=8+8)
FloatSub/100-8          52.0ns ± 0%    52.2ns ± 1%  +0.46%  (p=0.012 n=8+10)
FloatSub/1000-8         77.9ns ± 0%    77.3ns ± 0%  -0.80%  (p=0.000 n=7+8)
FloatSub/10000-8         371ns ± 0%     362ns ± 0%  -2.67%  (p=0.000 n=10+10)
FloatSub/100000-8       3.20µs ± 0%    3.10µs ± 0%  -3.16%  (p=0.000 n=10+10)
ParseFloatSmallExp-8    7.84µs ± 0%    7.82µs ± 0%  -0.17%  (p=0.037 n=9+9)
ParseFloatLargeExp-8    29.3µs ± 1%    29.5µs ± 0%    ~     (p=0.059 n=9+8)
FloatSqrt/64-8           516ns ± 0%     519ns ± 0%  +0.54%  (p=0.000 n=9+9)
FloatSqrt/128-8         1.07µs ± 0%    1.07µs ± 0%    ~     (p=0.109 n=8+9)
FloatSqrt/256-8         1.23µs ± 0%    1.23µs ± 0%  +0.50%  (p=0.000 n=9+9)
FloatSqrt/1000-8        3.43µs ± 0%    3.44µs ± 0%  +0.53%  (p=0.000 n=9+8)
FloatSqrt/10000-8       40.9µs ± 0%    40.7µs ± 0%  -0.39%  (p=0.000 n=9+8)
FloatSqrt/100000-8      1.07ms ± 0%    1.07ms ± 0%  -0.10%  (p=0.017 n=10+9)
FloatSqrt/1000000-8     89.3ms ± 0%    89.2ms ± 0%  -0.07%  (p=0.015 n=9+8)