### PR TITLE
net: add KeepAlive field to ListenConfig

### DIFF
--- a/src/net/dial.go
+++ b/src/net/dial.go
@@ -596,6 +596,14 @@ type ListenConfig struct {
 	// necessarily the ones passed to Listen. For example, passing "tcp" to
 	// Listen will cause the Control function to be called with "tcp4" or "tcp6".
 	Control func(network, address string, c syscall.RawConn) error
+
+	// KeepAlive specifies the keep-alive period for network
+	// connections accepted by this listener.
+	// If zero, keep-alives are enabled if supported by the protocol
+	// and operating system. Network protocols or operating systems
+	// that do not support keep-alives ignore this field.
+	// If negative, keep-alives are disabled.
+	KeepAlive time.Duration
 }
 
 // Listen announces on the local network address.

--- a/src/net/file_plan9.go
+++ b/src/net/file_plan9.go
@@ -127,7 +127,7 @@ func fileListener(f *os.File) (Listener, error) {
 		return nil, errors.New("file does not represent a listener")
 	}
 
-	return &TCPListener{fd}, nil
+	return &TCPListener{fd: fd}, nil
 }
 
 func filePacketConn(f *os.File) (PacketConn, error) {

--- a/src/net/file_unix.go
+++ b/src/net/file_unix.go
@@ -93,7 +93,7 @@ func fileListener(f *os.File) (Listener, error) {
 	}
 	switch laddr := fd.laddr.(type) {
 	case *TCPAddr:
-		return &TCPListener{fd}, nil
+		return &TCPListener{fd: fd}, nil
 	case *UnixAddr:
 		return &UnixListener{fd: fd, path: laddr.Name, unlink: false}, nil
 	}

--- a/src/net/tcpsock.go
+++ b/src/net/tcpsock.go
@@ -224,6 +224,7 @@ func DialTCP(network string, laddr, raddr *TCPAddr) (*TCPConn, error) {
 // use variables of type Listener instead of assuming TCP.
 type TCPListener struct {
 	fd *netFD
+	lc ListenConfig
 }
 
 // SyscallConn returns a raw network connection.


### PR DESCRIPTION
This commit adds a KeepAlive field to ListenConfig and uses it
analogously to Dialer.KeepAlive to set TCP KeepAlives per default on
Accept()

Fixes #23378 