### PR TITLE
cmd/go: mod init outside of GOPATH silently fails

### DIFF
--- a/src/cmd/go/internal/modcmd/init.go
+++ b/src/cmd/go/internal/modcmd/init.go
@@ -35,6 +35,9 @@ func runInit(cmd *base.Command, args []string) {
 	if len(args) == 1 {
 		modload.CmdModModule = args[0]
 	}
+	if os.Getenv("GO111MODULE") == "off" {
+		base.Fatalf("go mod init: modules disabled by GO111MODULE=off; see 'go help modules'")
+	}
 	if _, err := os.Stat("go.mod"); err == nil {
 		base.Fatalf("go mod init: go.mod already exists")
 	}

--- a/src/cmd/go/internal/modload/init.go
+++ b/src/cmd/go/internal/modload/init.go
@@ -99,9 +99,7 @@ func Init() {
 	case "on", "":
 		mustUseModules = true
 	case "off":
-		base.Fatalf("go: modules disabled by GO111MODULE=off; see 'go help modules'")
-		mustUseModules = false
-		return
+		die()
 	}
 
 	// Disable any prompting for passwords by Git.

--- a/src/cmd/go/internal/modload/init.go
+++ b/src/cmd/go/internal/modload/init.go
@@ -99,6 +99,7 @@ func Init() {
 	case "on", "":
 		mustUseModules = true
 	case "off":
+		base.Fatalf("go: modules disabled by GO111MODULE=off; see 'go help modules'")
 		mustUseModules = false
 		return
 	}

--- a/src/cmd/go/internal/modload/init.go
+++ b/src/cmd/go/internal/modload/init.go
@@ -99,7 +99,8 @@ func Init() {
 	case "on", "":
 		mustUseModules = true
 	case "off":
-		die()
+		mustUseModules = false
+		return
 	}
 
 	// Disable any prompting for passwords by Git.

--- a/src/cmd/go/testdata/script/mod_off_init.txt
+++ b/src/cmd/go/testdata/script/mod_off_init.txt
@@ -4,4 +4,4 @@ env GO111MODULE=off
 # GO111MODULE=off when outside of GOPATH will fatal
 # with an error message.
 ! go mod init
-stderr 'go: modules disabled by GO111MODULE=off; see ''go help modules'''
+stderr 'go mod init: modules disabled by GO111MODULE=off; see ''go help modules'''

--- a/src/cmd/go/testdata/script/mod_off_init.txt
+++ b/src/cmd/go/testdata/script/mod_off_init.txt
@@ -1,0 +1,7 @@
+env GO111MODULE=off
+
+# This script tests that running go mod init with
+# GO111MODULE=off when outside of GOPATH will fatal
+# with an error message.
+! go mod init
+stderr 'go: modules disabled by GO111MODULE=off; see ''go help modules'''


### PR DESCRIPTION
Running `go mod init` outside of GOPATH with `GO111MODULE=off`
silently fails. This behavior was undocumented.

This CL makes go mod fail with the error:

   go: modules disabled by GO111MODULE=off; see 'go help modules'
Comparing with already erroring GO111MODULE=<value> conditions:

* With GO111MODULE=auto, inside GOPATH:
    go modules disabled inside GOPATH/src by GO111MODULE=auto; see 'go help modules'
* With GO111MODULE=auto outside of GOPATH:
    go: cannot determine module path for source directory /path/to/dir (outside GOPATH, no import comments)

Fixes #31342 