### PR TITLE
cmd/dist: add BOOT_GO_LDFLAGS - counterpart of BOOT_GO_GCFLAGS

### DIFF
--- a/src/cmd/dist/build.go
+++ b/src/cmd/dist/build.go
@@ -198,6 +198,7 @@ func xinit() {
 	}
 
 	gogcflags = os.Getenv("BOOT_GO_GCFLAGS")
+	goldflags = os.Getenv("BOOT_GO_LDFLAGS")
 
 	cc, cxx := "gcc", "g++"
 	if defaultclang {
@@ -660,6 +661,9 @@ func runInstall(dir string, ch chan struct{}) {
 		link = []string{pathf("%s/link", tooldir)}
 		if goos == "android" {
 			link = append(link, "-buildmode=pie")
+		}
+		if goldflags != "" {
+			link = append(link, goldflags)
 		}
 		link = append(link, "-o", pathf("%s/%s%s", tooldir, elem, exe))
 		targ = len(link) - 1
@@ -1265,7 +1269,7 @@ func cmdbootstrap() {
 	}
 
 	gogcflags = os.Getenv("GO_GCFLAGS") // we were using $BOOT_GO_GCFLAGS until now
-	goldflags = os.Getenv("GO_LDFLAGS")
+	goldflags = os.Getenv("GO_LDFLAGS") // we were using $BOOT_GO_LDFLAGS until now
 	goBootstrap := pathf("%s/go_bootstrap", tooldir)
 	cmdGo := pathf("%s/go", gobin)
 	if debug {


### PR DESCRIPTION
This allows passing custom LDFLAGS while building the bootstrapping
tool.

Afterwards, GO_LDFLAGS will be used as usual.