### PR TITLE
Remove length check to prevent length guessing

### DIFF
--- a/src/crypto/subtle/constant_time.go
+++ b/src/crypto/subtle/constant_time.go
@@ -10,10 +10,6 @@ package subtle
 // and 0 otherwise. The time taken is a function of the length of the slices and
 // is independent of the contents.
 func ConstantTimeCompare(x, y []byte) int {
-	if len(x) != len(y) {
-		return 0
-	}
-
 	var v byte
 
 	for i := 0; i < len(x); i++ {

--- a/src/crypto/subtle/constant_time.go
+++ b/src/crypto/subtle/constant_time.go
@@ -10,9 +10,14 @@ package subtle
 // and 0 otherwise. The time taken is a function of the length of the slices and
 // is independent of the contents.
 func ConstantTimeCompare(x, y []byte) int {
+	max := len(x)
+	if len(y) < max {
+		max = len(y)
+	}
+
 	var v byte
 
-	for i := 0; i < len(x); i++ {
+	for i := 0; i < max; i++ {
 		v |= x[i] ^ y[i]
 	}
 


### PR DESCRIPTION
in crypto/subtle ConstantTime is not always constant. When the two strings length don't match, the time is always lower.