### PR TITLE
expvar: improve Map.addKey for large number of keys

### DIFF
--- a/src/expvar/expvar.go
+++ b/src/expvar/expvar.go
@@ -141,8 +141,14 @@ func (v *Map) Init() *Map {
 func (v *Map) addKey(key string) {
 	v.keysMu.Lock()
 	defer v.keysMu.Unlock()
-	v.keys = append(v.keys, key)
-	sort.Strings(v.keys)
+	// Using insertion sort to place key into the already-sorted v.keys.
+	if i := sort.SearchStrings(v.keys, key); i >= len(v.keys) {
+		v.keys = append(v.keys, key)
+	} else if v.keys[i] != key {
+		v.keys = append(v.keys, "")
+		copy(v.keys[i+1:], v.keys[i:len(v.keys)-1])
+		v.keys[i] = key
+	}
 }
 
 func (v *Map) Get(key string) Var {

--- a/src/expvar/expvar_test.go
+++ b/src/expvar/expvar_test.go
@@ -300,9 +300,9 @@ func BenchmarkMapSetDifferent(b *testing.B) {
 	})
 }
 
-// BenchmarkMapSetDifferentRandom simulates that the concerned keys of
-// Map.Set are generated dynamically and as a result insertion is out
-// of order and the number of the keys may be large.
+// BenchmarkMapSetDifferentRandom simulates such a case where the concerned
+// keys of Map.Set are generated dynamically and as a result insertion is
+// out of order and the number of the keys may be large.
 func BenchmarkMapSetDifferentRandom(b *testing.B) {
 	procKeys := make([][]string, runtime.GOMAXPROCS(0))
 	for i := range procKeys {
@@ -381,9 +381,9 @@ func BenchmarkMapAddDifferent(b *testing.B) {
 	})
 }
 
-// BenchmarkMapAddDifferentRandom simulates that the concerned keys of
-// Map.Add are generated dynamically and as a result insertion is out
-// of order and the number of the keys may be large.
+// BenchmarkMapAddDifferentRandom simulates such a case where that the concerned
+// keys of Map.Add are generated dynamically and as a result insertion is out of
+// order and the number of the keys may be large.
 func BenchmarkMapAddDifferentRandom(b *testing.B) {
 	procKeys := make([][]string, runtime.GOMAXPROCS(0))
 	for i := range procKeys {


### PR DESCRIPTION
The existing implementation has poor performance for large number of
keys because it chooses to append the new key to the sorted keys array
and sort the new array again.

The improvement tries to utilize the sorted keys array by searching the
index and doing an insertion if any. It also fixes an error that
duplicate keys may be inserted in high concurrent scenes.

Fixes #31414