### PR TITLE
strings: fixed comment of TrimSpace function

### DIFF
--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -815,7 +815,7 @@ func TrimRight(s string, cutset string) string {
 	return TrimRightFunc(s, makeCutsetFunc(cutset))
 }
 
-// TrimSpace returns a slice of the string s, with all leading
+// TrimSpace returns a string s, with all leading
 // and trailing white space removed, as defined by Unicode.
 func TrimSpace(s string) string {
 	// Fast path for ASCII: look for the first ASCII non-space byte


### PR DESCRIPTION
TrimSpace function returns just a string, but the comment had "slice of the string"