### PR TITLE
runtime: fix stack layout typo

### DIFF
--- a/src/runtime/stack.go
+++ b/src/runtime/stack.go
@@ -501,7 +501,7 @@ var ptrnames = []string{
 // +------------------+ <- frame->varp
 // |     locals       |
 // +------------------+
-// |  args to callee  |
+// |  args to caller  |
 // +------------------+ <- frame->sp
 //
 // (arm)
@@ -512,7 +512,7 @@ var ptrnames = []string{
 // +------------------+ <- frame->varp
 // |     locals       |
 // +------------------+
-// |  args to callee  |
+// |  args to caller  |
 // +------------------+
 // |  return address  |
 // +------------------+ <- frame->sp


### PR DESCRIPTION
There is a typo in stack layout comment. Return value should be args to "caller" not args to "callee". Thanks!