### PR TITLE
cmd/asm: remove support for old assembly style AX:CX

### DIFF
--- a/src/cmd/asm/internal/asm/testdata/386.s
+++ b/src/cmd/asm/internal/asm/testdata/386.s
@@ -65,7 +65,7 @@ label:
 // LTYPES spec5	{ outcode(int($1), &$2); }
 	SHLL	$4, BX
 	SHLL	$4, foo+4(SB)
-	SHLL	$4, foo+4(SB):AX // SHLL $4, AX, foo+4(SB)
+//	SHLL	$4, foo+4(SB):AX // Old syntax, equivalent to: SHLL $4, AX, foo+4(SB)
 
 // LTYPEM spec6	{ outcode(int($1), &$2); }
 	MOVL	AX, BX

--- a/src/cmd/asm/internal/asm/testdata/amd64.s
+++ b/src/cmd/asm/internal/asm/testdata/amd64.s
@@ -92,8 +92,7 @@ label:
 // LTYPES spec5	{ outcode($1, &$2); }
 	SHLL	CX, R12
 	SHLL	CX, foo+4(SB)
-	// Old syntax, still accepted:
-	SHLL	CX, R11:AX // SHLL CX, AX, R11
+//	SHLL	CX, R11:AX // Old syntax, equivalent to: SHLL CX, AX, R11
 
 // LTYPEM spec6	{ outcode($1, &$2); }
 	MOVL	AX, R11


### PR DESCRIPTION
An error message is provided to help with possible migration.