### PR TITLE
cmd/dist: fix go_tls.h not found issue

### DIFF
--- a/doc/asm.html
+++ b/doc/asm.html
@@ -584,11 +584,12 @@ Here follow some descriptions of key Go-specific details for the supported archi
 The runtime pointer to the <code>g</code> structure is maintained
 through the value of an otherwise unused (as far as Go is concerned) register in the MMU.
 A OS-dependent macro <code>get_tls</code> is defined for the assembler if the source includes
-a special header, <code>go_asm.h</code>:
+a header, <code>go_tls.h</code>:
 </p>
 
 <pre>
-#include "go_asm.h"
+#include "go_asm.h" ; for g, g_m etc.
+#include "go_tls.h"
 </pre>
 
 <p>

--- a/src/cmd/dist/build.go
+++ b/src/cmd/dist/build.go
@@ -749,6 +749,8 @@ func runInstall(dir string, ch chan struct{}) {
 			pathf("%s/src/runtime/funcdata.h", goroot), 0)
 		copyfile(pathf("%s/pkg/include/asm_ppc64x.h", goroot),
 			pathf("%s/src/runtime/asm_ppc64x.h", goroot), 0)
+		copyfile(pathf("%s/pkg/include/go_tls.h", goroot),
+			pathf("%s/src/runtime/go_tls.h", goroot), 0)
 	}
 
 	// Generate any missing files; regenerate existing ones.


### PR DESCRIPTION
Header go_tls.h is not found while running example at document https://golang.org/doc/asm#x86.
And aslo fix the documentation. Thanks!