### PR TITLE
runtime: move linux specific code into linux specific files

### DIFF
--- a/src/cmd/vet/all/whitelist/darwin_arm.txt
+++ b/src/cmd/vet/all/whitelist/darwin_arm.txt
@@ -1,5 +1,0 @@
-// darwin/arm-specific vet whitelist. See readme.txt for details.
-
-// Ok.
-
-runtime/asm_arm.s: [arm] sigreturn: function sigreturn missing Go declaration

--- a/src/cmd/vet/all/whitelist/darwin_arm64.txt
+++ b/src/cmd/vet/all/whitelist/darwin_arm64.txt
@@ -1,3 +1,0 @@
-// darwin/arm64-specific vet whitelist. See readme.txt for details.
-
-runtime/asm_arm64.s: [arm64] sigreturn: function sigreturn missing Go declaration

--- a/src/cmd/vet/all/whitelist/freebsd_arm.txt
+++ b/src/cmd/vet/all/whitelist/freebsd_arm.txt
@@ -1,4 +1,3 @@
 // freebsd/arm-specific vet whitelist. See readme.txt for details.
 
-runtime/asm_arm.s: [arm] sigreturn: function sigreturn missing Go declaration
 runtime/sys_freebsd_arm.s: [arm] read_tls_fallback: function read_tls_fallback missing Go declaration

--- a/src/cmd/vet/all/whitelist/nacl_arm.txt
+++ b/src/cmd/vet/all/whitelist/nacl_arm.txt
@@ -1,6 +1,5 @@
 // nacl/arm-specific vet whitelist. See readme.txt for details.
 
-runtime/asm_arm.s: [arm] sigreturn: function sigreturn missing Go declaration
 runtime/sys_nacl_arm.s: [arm] nacl_clock_gettime: function nacl_clock_gettime missing Go declaration
 runtime/sys_nacl_arm.s: [arm] nacl_sysinfo: function nacl_sysinfo missing Go declaration
 runtime/sys_nacl_arm.s: [arm] read_tls_fallback: function read_tls_fallback missing Go declaration

--- a/src/cmd/vet/all/whitelist/netbsd_arm.txt
+++ b/src/cmd/vet/all/whitelist/netbsd_arm.txt
@@ -1,5 +1,4 @@
 // netbsd/arm-specific vet whitelist. See readme.txt for details.
 
-runtime/asm_arm.s: [arm] sigreturn: function sigreturn missing Go declaration
 runtime/sys_netbsd_arm.s: [arm] read_tls_fallback: function read_tls_fallback missing Go declaration
 syscall/asm_netbsd_arm.s: [arm] Syscall9: unknown variable trap; offset 0 is num+0(FP)

--- a/src/cmd/vet/all/whitelist/openbsd_arm.txt
+++ b/src/cmd/vet/all/whitelist/openbsd_arm.txt
@@ -1,4 +1,3 @@
 // openbsd/arm-specific vet whitelist. See readme.txt for details.
 
-runtime/asm_arm.s: [arm] sigreturn: function sigreturn missing Go declaration
 runtime/sys_openbsd_arm.s: [arm] read_tls_fallback: function read_tls_fallback missing Go declaration

--- a/src/cmd/vet/all/whitelist/plan9_arm.txt
+++ b/src/cmd/vet/all/whitelist/plan9_arm.txt
@@ -1,4 +1,3 @@
 // plan9/arm-specific vet whitelist. See readme.txt for details.
 
-runtime/asm_arm.s: [arm] sigreturn: function sigreturn missing Go declaration
 runtime/sys_plan9_arm.s: [arm] read_tls_fallback: function read_tls_fallback missing Go declaration

--- a/src/runtime/asm_arm.s
+++ b/src/runtime/asm_arm.s
@@ -891,9 +891,6 @@ TEXT runtime·usplitR0(SB),NOSPLIT,$0
 	SUB	R1, R3, R1
 	RET
 
-TEXT runtime·sigreturn(SB),NOSPLIT,$0-0
-	RET
-
 #ifndef GOOS_nacl
 // This is called from .init_array and follows the platform, not Go, ABI.
 TEXT runtime·addmoduledata(SB),NOSPLIT,$0-8

--- a/src/runtime/asm_arm64.s
+++ b/src/runtime/asm_arm64.s
@@ -1128,9 +1128,6 @@ TEXT runtime·goexit(SB),NOSPLIT|NOFRAME|TOPFRAME,$0-0
 	MOVD	R0, R0	// NOP
 	BL	runtime·goexit1(SB)	// does not return
 
-TEXT runtime·sigreturn(SB),NOSPLIT,$0-0
-	RET
-
 // This is called from .init_array and follows the platform, not Go, ABI.
 TEXT runtime·addmoduledata(SB),NOSPLIT,$0-0
 	SUB	$0x10, RSP

--- a/src/runtime/sys_linux_arm.s
+++ b/src/runtime/sys_linux_arm.s
@@ -606,3 +606,6 @@ TEXT runtime·sbrk0(SB),NOSPLIT,$0-4
 	SWI	$0
 	MOVW	R0, ret+0(FP)
 	RET
+
+TEXT runtime·sigreturn(SB),NOSPLIT,$0-0
+	RET

--- a/src/runtime/sys_linux_arm64.s
+++ b/src/runtime/sys_linux_arm64.s
@@ -599,3 +599,6 @@ TEXT runtime·sbrk0(SB),NOSPLIT,$0-8
 	SVC
 	MOVD	R0, ret+0(FP)
 	RET
+
+TEXT runtime·sigreturn(SB),NOSPLIT,$0-0
+	RET


### PR DESCRIPTION
Allows us to stop whitelisting this error on many OS/arch combinations

XXX I'm not sure I am running vet correctly, and testing all platforms right.