### PR TITLE
src/run.bash: print version when running tests

### DIFF
--- a/src/run.bash
+++ b/src/run.bash
@@ -45,4 +45,5 @@ if ulimit -T &> /dev/null; then
 	[ "$(ulimit -H -T)" = "unlimited" ] || ulimit -S -T $(ulimit -H -T)
 fi
 
+go version
 exec go tool dist test -rebuild "$@"


### PR DESCRIPTION
While running tests, I was paranoid about whether I'm accidentally testing the bootstrap package go, which is likely in my PATH.
Printing 'go version' should give a strong indication whether that's the case.

I don't know if it will cause problems to automated scripts processing info. I'm happy to drop it if it seems risky.