### PR TITLE
golang proxy request incorrect

### DIFF
--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -1029,10 +1029,10 @@ func readRequest(b *bufio.Reader, deleteHostHeader bool) (req *Request, err erro
 	//	GET http://www.google.com/index.html HTTP/1.1
 	//	Host: doesntmatter
 	// the same. In the second case, any Host line is ignored.
-	req.Host = req.URL.Host
-	if req.Host == "" {
-		req.Host = req.Header.get("Host")
-	}
+	//req.Host = req.URL.Host
+	//if req.Host == "" {
+	//	req.Host = req.Header.get("Host")
+	//}
 	if deleteHostHeader {
 		delete(req.Header, "Host")
 	}


### PR DESCRIPTION
when use proxy to request nginx, nginx can not be use correctly, After I rewrite some code in readRequest method then it can be succeed. The code I have already upload. So you can take a look. Waiting for your reply. Thank you

So if I run the following code, ngxin won't report that it can't find "project error"
```javascript
	remote, err := url.Parse(p.path)
			if err != nil {
				panic(err)
			}
			proxy := httputil.NewSingleHostReverseProxy(remote)
			req.URL.Path = Substring(urlPath.Path, StringLen(p.pattern), -1)


			if req.Method == "OPTIONS" {
				w.Header().Set("Access-Control-Allow-Origin", "*") //
				w.Header().Add("Access-Control-Allow-Headers", "content-type, accept, x-auth-token, X-Subject-Token,x-openstack-nova-api-version")
				w.Header().Add("Access-Control-Allow-Methods", "POST")
				w.Write([]byte("{\"test\":\"OPTIONS\"}"))
				return true
			}
			w.Header().Add("Access-Control-Allow-Origin", "*") //x-openstack-nova-api-version
			w.Header().Add("Access-Control-Allow-Headers", "content-type, accept, x-auth-token, X-Subject-Token,x-openstack-nova-api-version")
			w.Header().Add("Access-Control-Expose-Headers", "X-Subject-Token, x-openstack-nova-api-version,X-Auth-Token")
			w.Header().Add("Access-Control-Allow-Methods", "PUT,POST,GET,DELETE,OPTIONS")
			w.Header().Add("Access-Control-Allow-Credentials", "true")
			proxy.ServeHTTP(w, req)
		}
```

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
