### PR TITLE
cmd/go: remove --first-parent for git tag discovery

### DIFF
--- a/src/cmd/go/internal/modfetch/codehost/git.go
+++ b/src/cmd/go/internal/modfetch/codehost/git.go
@@ -650,7 +650,7 @@ func (r *gitRepo) RecentTag(rev, prefix string) (tag string, err error) {
 	// result is definitive.
 	describe := func() (definitive bool) {
 		var out []byte
-		out, err = Run(r.dir, "git", "describe", "--first-parent", "--always", "--abbrev=0", "--match", prefix+"v[0-9]*.[0-9]*.[0-9]*", "--tags", rev)
+		out, err = Run(r.dir, "git", "describe", "--always", "--abbrev=0", "--match", prefix+"v[0-9]*.[0-9]*.[0-9]*", "--tags", rev)
 		if err != nil {
 			return true // Because we use "--always", describe should never fail.
 		}


### PR DESCRIPTION
This commit fixes an invalid last tag retrieval for go modules by
including git tag from merge branches.

Fixes #31673
