### PR TITLE
errors: fix comment referencing the Wrapper interface

### DIFF
--- a/src/errors/wrap.go
+++ b/src/errors/wrap.go
@@ -34,7 +34,7 @@ func (e noWrapper) FormatError(p Printer) (next error) {
 }
 
 // Unwrap returns the result of calling the Unwrap method on err, if err
-// implements Unwrap. Otherwise, Unwrap returns nil.
+// implements Wrapper. Otherwise, Unwrap returns nil.
 func Unwrap(err error) error {
 	u, ok := err.(Wrapper)
 	if !ok {


### PR DESCRIPTION
The Unwrap function performs a type assertion looking for the Wrapper
interface. The method of that interface is called Unwrap but the
interface itself is called Wrapper.