### PR TITLE
container/ring: optimize the Move method of the Ring struct

### DIFF
--- a/src/container/ring/ring.go
+++ b/src/container/ring/ring.go
@@ -45,6 +45,7 @@ func (r *Ring) Move(n int) *Ring {
 	if r.next == nil {
 		return r.init()
 	}
+	n = n % r.Len()
 	switch {
 	case n < 0:
 		for ; n < 0; n++ {


### PR DESCRIPTION
This adds a mod operation before doing the real movement in `Move(n int) *Ring` method of the Ring struct.
It optimizes the Move method to limit the maximum number of moves to `Len()-1`.