### PR TITLE
bufio.go : Fix io.Copy will lost some data

### DIFF
--- a/src/bufio/bufio.go
+++ b/src/bufio/bufio.go
@@ -737,9 +737,9 @@ func (b *Writer) ReadFrom(r io.Reader) (n int64, err error) {
 	if err == io.EOF {
 		// If we filled the buffer exactly, flush preemptively.
 		if b.Available() == 0 {
-			err = b.Flush()
-		} else {
 			err = nil
+		} else {
+			err = b.Flush()
 		}
 	}
 	return n, err


### PR DESCRIPTION
I submitted a Issue[Issue:31957](https://github.com/golang/go/issues/31957) for this bug.
Wen I use io.Copy to copy a file, I find, new file's size less than old file's size  
I uesd many files to tried many times, find a rule : 

if   old file size  % 4K == 0
    No problem
if   old file size  % 4K > 0
    new file can be lost  some data

The lost data is old file's end data 
The lost data's size is old file's size % 4K
**(Code at the bottom)**

So I tracking code, I find
in bufio.go, some codes write counter

**bufio.io: line 739**

When if b.Available() == 0 
Because file's size % 4k == 0
So not use Flush

When if b.Available() > 0
Because file's size % 4k > 0
So must to be  Flush

code:
`	

	oldfile := "E:/aa.txt"		// size: 6K
	newfile := "E:/bb.txt"		// When program done,  this file size: 4K
    FileOld,_ := os.Open(oldfile)
	reader := bufio.NewReader(FileOld)

	FileNew,_ := os.OpenFile(newfile, os.O_WRONLY | os.O_CREATE | os.O_TRUNC, 0666)
	writer := bufio.NewWriter(FileNew)
	io.Copy(writer, reader)

	// When the program has been executed, new file size is 4K , but old file size is 6K
`