### PR TITLE
encoding/json: Fix time is empty and has value

### DIFF
--- a/src/encoding/json/encode.go
+++ b/src/encoding/json/encode.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 	"unicode"
 	"unicode/utf8"
 )
@@ -315,6 +316,8 @@ func (e *encodeState) error(err error) {
 	panic(jsonError{err})
 }
 
+var timeType = reflect.TypeOf(time.Time{})
+
 func isEmptyValue(v reflect.Value) bool {
 	switch v.Kind() {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
@@ -329,6 +332,10 @@ func isEmptyValue(v reflect.Value) bool {
 		return v.Float() == 0
 	case reflect.Interface, reflect.Ptr:
 		return v.IsNil()
+	}
+
+	if v.Type() == timeType {
+		return v.Interface().(time.Time).IsZero()
 	}
 	return false
 }

--- a/src/encoding/json/encode_test.go
+++ b/src/encoding/json/encode_test.go
@@ -13,13 +13,15 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
+	"time"
 	"unicode"
 )
 
 type Optionals struct {
-	Sr string `json:"sr"`
-	So string `json:"so,omitempty"`
-	Sw string `json:"-"`
+	Sr  string    `json:"sr"`
+	So  string    `json:"so,omitempty"`
+	Tso time.Time `json:"tso,omitempty"`
+	Sw  string    `json:"-"`
 
 	Ir int `json:"omitempty"` // actually named omitempty, not an option
 	Io int `json:"io,omitempty"`


### PR DESCRIPTION
```golang
package main

import (
	"encoding/json"
	"fmt"
	"time"
)

type Object struct {
	X int
	Y int
}

func (o *Object) IsZero() bool {
	return o.X == 0 && o.Y == 0
}

type Test struct {
	StartTime time.Time `json:"startTime,omitempty"`
	Obj       Object    `json:"obj,omitempty"`
	Z         int
}

func main() {
        //all, err := json.Marshal(&Test{})
	all, err := json.MarshalFilterStruct(&Test{}, func(v interface{}) bool {

		if v, ok := v.(Object); ok {
			if v.IsZero() {
				return true
			}
		}

		return false
	})

	fmt.Printf("err= %v, %s\n", err, all)

}
```
Marshal:
err= <nil>, {"startTime":"0001-01-01T00:00:00Z","obj":{"X":0,"Y":0},"Z":0}

MarshalFilterStruct:
err= <nil>, {"Z":0}

