### PR TITLE
io, net: implement WriterTo for pipes

### DIFF
--- a/src/net/pipe_test.go
+++ b/src/net/pipe_test.go
@@ -5,6 +5,8 @@
 package net_test
 
 import (
+	"bytes"
+	"fmt"
 	"io"
 	"net"
 	"testing"
@@ -45,5 +47,46 @@ func TestPipeCloseError(t *testing.T) {
 	}
 	if err := c2.SetDeadline(time.Time{}); err != io.ErrClosedPipe {
 		t.Errorf("c2.SetDeadline() = %v, want io.ErrClosedPipe", err)
+	}
+}
+
+// Test WriteTo
+func TestPipeCopy(t *testing.T) {
+	done := make(chan struct{})
+	r, w := net.Pipe()
+
+	var expected bytes.Buffer
+	go func() {
+		defer close(done)
+		defer w.Close()
+		for i := 0; i < 10; i++ {
+			n1, _ := fmt.Fprintf(&expected, "message: %d\n", i)
+			n2, err := fmt.Fprintf(w, "message: %d\n", i)
+			if err != nil {
+				t.Errorf("write: %v", err)
+				return
+			}
+			if n1 != n2 {
+				t.Errorf("expected to write %d bytes, wrote %d", n1, n2)
+			}
+		}
+	}()
+
+	var actual bytes.Buffer
+	n, err := io.Copy(&actual, r)
+	if err != nil {
+		t.Errorf("read: %v", err)
+	}
+
+	// cleanup
+	r.Close()
+	<-done
+
+	if int(n) != actual.Len() {
+		t.Errorf("amount copied doesn't match amount read: %d != %d", n, actual.Len())
+	}
+
+	if !bytes.Equal(actual.Bytes(), expected.Bytes()) {
+		t.Errorf("did not read expected data")
 	}
 }


### PR DESCRIPTION
This implements the WriterTo interface on pipes, forwarding buffers directly
from the write half through to a writer on the read half. This allows for zero
copy write pipelines when copying between pipes.

Fixes #34624