### PR TITLE
mime: add .webp for builtin

### DIFF
--- a/src/mime/type.go
+++ b/src/mime/type.go
@@ -69,6 +69,7 @@ var builtinTypesLower = map[string]string{
 	".png":  "image/png",
 	".svg":  "image/svg+xml",
 	".wasm": "application/wasm",
+	".webp": "image/webp",
 	".xml":  "text/xml; charset=utf-8",
 }
 


### PR DESCRIPTION
This change modifies Go to include image/webp as a built-in mime type for the .webp file extension.