### PR TITLE
net/http: fix Server.IdleTimeout and Server.ReadHeaderTimeout docs

### DIFF
--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -2512,7 +2512,9 @@ type Server struct {
 	// ReadHeaderTimeout is the amount of time allowed to read
 	// request headers. The connection's read deadline is reset
 	// after reading the headers and the Handler can decide what
-	// is considered too slow for the body.
+	// is considered too slow for the body. If ReadHeaderTimeout
+	// is zero, the value of ReadTimeout is used. If both are
+	// zero, there is no timeout.
 	ReadHeaderTimeout time.Duration
 
 	// WriteTimeout is the maximum duration before timing out
@@ -2521,10 +2523,10 @@ type Server struct {
 	// let Handlers make decisions on a per-request basis.
 	WriteTimeout time.Duration
 
-	// IdleTimeout is the maximum amount of time to wait for the
+	// IdleTimeout is the amount of time to wait for the
 	// next request when keep-alives are enabled. If IdleTimeout
 	// is zero, the value of ReadTimeout is used. If both are
-	// zero, ReadHeaderTimeout is used.
+	// zero, there is no timeout.
 	IdleTimeout time.Duration
 
 	// MaxHeaderBytes controls the maximum number of bytes the

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -2523,7 +2523,7 @@ type Server struct {
 	// let Handlers make decisions on a per-request basis.
 	WriteTimeout time.Duration
 
-	// IdleTimeout is the amount of time to wait for the
+	// IdleTimeout is the maximum amount of time to wait for the
 	// next request when keep-alives are enabled. If IdleTimeout
 	// is zero, the value of ReadTimeout is used. If both are
 	// zero, there is no timeout.


### PR DESCRIPTION
CL 46434 changed the doc for Server.IdleTimeout to include
falling back to Server.ReadHeaderTimeout if both 
Server.IdleTimeout and Server.ReadTimeout are zero.
However, we explicitly set the ReadDeadlines firstly based
off Server.IdleTimeout or Server.ReadTimeout before attempting
to read the next request, thus the current doc is incorrect.

This CL reverts CL 46434 and also updates the doc for 
Server.ReadHeaderTimeout to documenting falling back
to Server.ReadTimeout, if the former is zero, otherwise
there is no timeout.

Fixes #32053