### PR TITLE
bufio: Fix typo in scan.go documentation

### DIFF
--- a/src/bufio/scan.go
+++ b/src/bufio/scan.go
@@ -73,7 +73,7 @@ var (
 
 const (
 	// MaxScanTokenSize is the maximum size used to buffer a token
-	// unless the user provides an explicit buffer with Scan.Buffer.
+	// unless the user provides an explicit buffer with Scanner.Buffer.
 	// The actual maximum token size may be smaller as the buffer
 	// may need to include, for instance, a newline.
 	MaxScanTokenSize = 64 * 1024


### PR DESCRIPTION
Apologies for the the nitpicky PR. I believe there is a minor typo in the documentation of `MaxScanTokenSize`, which confused me for a moment when I went to search for the referenced method, `Scan.Buffer`. Thanks!