### PR TITLE
net/http: allow sensitive headers in redirects from http to https

### DIFF
--- a/src/net/http/client.go
+++ b/src/net/http/client.go
@@ -913,6 +913,10 @@ func shouldCopyHeaderOnRedirect(headerKey string, initial, dest *url.URL) bool {
 //
 // Both domains must already be in canonical form.
 func isDomainOrSubdomain(sub, parent string) bool {
+	// remove the port from the url
+	sub = stripPort(sub)
+	parent = stripPort(parent)
+
 	if sub == parent {
 		return true
 	}
@@ -923,6 +927,16 @@ func isDomainOrSubdomain(sub, parent string) bool {
 		return false
 	}
 	return sub[len(sub)-len(parent)-1] == '.'
+}
+
+// stripPort simply removes the port from the url
+func stripPort(url string) string {
+	colon := strings.Index(url, ":")
+	if colon == -1 {
+		// we couldn't find a colon in the url
+		return url
+	}
+	return url[:colon]
 }
 
 func stripPassword(u *url.URL) string {

--- a/src/net/http/client_test.go
+++ b/src/net/http/client_test.go
@@ -1709,6 +1709,7 @@ func TestShouldCopyHeaderOnRedirect(t *testing.T) {
 		{"www-authenticate", "http://foo.com/", "http://sub.foo.com/", true},
 		{"www-authenticate", "http://foo.com/", "http://notfoo.com/", false},
 		{"www-authenticate", "http://foo.com/", "https://foo.com/", false},
+		{"www-authenticate", "http://foo.com/", "https://foo.com/", true},
 		{"www-authenticate", "http://foo.com:80/", "http://foo.com/", true},
 		{"www-authenticate", "http://foo.com:80/", "http://sub.foo.com/", true},
 		{"www-authenticate", "http://foo.com:443/", "https://foo.com/", true},


### PR DESCRIPTION
Fixes https://github.com/golang/go/issues/32240