### PR TITLE
io:add comment for io.CopyBuffer

### DIFF
--- a/src/io/io.go
+++ b/src/io/io.go
@@ -368,6 +368,12 @@ func Copy(dst Writer, src Reader) (written int64, err error) {
 // provided buffer (if one is required) rather than allocating a
 // temporary one. If buf is nil, one is allocated; otherwise if it has
 // zero length, CopyBuffer panics.
+//
+// If src implements the WriterTo interface,
+// the copy is implemented by calling src.WriteTo(dst).
+// Otherwise, if dst implements the ReaderFrom interface,
+// the copy is implemented by calling dst.ReadFrom(src). In both cases,
+//buf will be ignored and will not be use.
 func CopyBuffer(dst Writer, src Reader, buf []byte) (written int64, err error) {
 	if buf != nil && len(buf) == 0 {
 		panic("empty buffer in io.CopyBuffer")


### PR DESCRIPTION
The follow is the comment for io.CopyBuffer,
// CopyBuffer is identical to Copy except that it stages through the
// provided buffer (if one is required) rather than allocating a
// temporary one. If buf is nil, one is allocated; otherwise if it has
// zero length, CopyBuffer panics.
func CopyBuffer(dst Writer, src Reader, buf []byte) (written int64, err error)

which is not precise enough, in the case of src implements the WriterTo interface or the case of if dst implements the ReaderFrom interface , buf will be ignore ,which is not mentioned at all. Which is very easy to lead people to wrong way.
Instead, add comment below:
// If src implements the WriterTo interface,
// the copy is implemented by calling src.WriteTo(dst).
// Otherwise, if dst implements the ReaderFrom interface,
// the copy is implemented by calling dst.ReadFrom(src). In both cases,
//buf will be ignored and will not be use.
fixed https://github.com/golang/go/issues/32276