### PR TITLE
encoding/xml: use a depth counter rather than recursion in Decoder.Skip()

### DIFF
--- a/src/encoding/xml/read.go
+++ b/src/encoding/xml/read.go
@@ -738,18 +738,18 @@ Loop:
 // It returns nil if it finds an end element matching the start
 // element; otherwise it returns an error describing the problem.
 func (d *Decoder) Skip() error {
-	for {
-		tok, err := d.Token()
+	depth := 1
+	for depth > 0 {
+		t, err := d.Token()
 		if err != nil {
 			return err
 		}
-		switch tok.(type) {
+		switch t := t.(type) {
 		case StartElement:
-			if err := d.Skip(); err != nil {
-				return err
-			}
+			depth++
 		case EndElement:
-			return nil
+			depth--
 		}
 	}
+	return nil
 }


### PR DESCRIPTION
The `depth` counter technique is already used in the
`unmarshalTextInterface()` function.

My expectation is for the recursion removal to yield
a marginal performance gain, especially on deeply nested
XML documents, however I did not verify this.

The behavior of the `Skip()` function should not be
altered in any way by this change.