### PR TITLE
changed the direction of split of the format string when parsing name…

### DIFF
--- a/src/encoding/xml/typeinfo.go
+++ b/src/encoding/xml/typeinfo.go
@@ -115,7 +115,7 @@ func structFieldInfo(typ reflect.Type, f *reflect.StructField) (*fieldInfo, erro
 
 	// Split the tag from the xml namespace if necessary.
 	tag := f.Tag.Get("xml")
-	if i := strings.Index(tag, " "); i >= 0 {
+	if i := strings.LastIndex(tag, " "); i >= 0 {
 		finfo.xmlns, tag = tag[:i], tag[i+1:]
 	}
 


### PR DESCRIPTION
**encoding/json: changed the direction of split of the format string when parsing namespace and tag.**

For xml where the namespace contained a space character, functions marshal/unmarshal returned an error.

Sample of problem xml and struct:

<Authenticate  xmlns="ORION PRO">
</Authenticate>

type Authenticate struct {
     XMLName   xml.Name `xml:"ORION PRO Authenticate"`
}

Out namespace == "ORION", tag == "PRO Authenticate"