### PR TITLE
net/http: stop ExampleServer_Shutdown from hanging on error

### DIFF
--- a/src/net/http/example_test.go
+++ b/src/net/http/example_test.go
@@ -132,7 +132,7 @@ func ExampleServer_Shutdown() {
 
 	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
 		// Error starting or closing listener:
-		log.Printf("HTTP server ListenAndServe: %v", err)
+		log.Fatalf("HTTP server ListenAndServe: %v", err)
 	}
 
 	<-idleConnsClosed


### PR DESCRIPTION
Running the example code when not having permissions
to bind to port 80 will cause the program to hang after
printing the error message.