### PR TITLE
mime/multipart: make sure all contents are read from multipart form

### DIFF
--- a/src/mime/multipart/multipart.go
+++ b/src/mime/multipart/multipart.go
@@ -334,6 +334,9 @@ func (r *Reader) NextPart() (*Part, error) {
 		}
 
 		if r.isFinalBoundary(line) {
+			// https://github.com/golang/go/issues/32935
+			// Read once more in case chunkedReader hasn't finished reading yet
+			r.bufReader.ReadSlice('\n')
 			// Expected EOF
 			return nil, io.EOF
 		}


### PR DESCRIPTION
Fixes #32935 
Previously, when ParseMultipartForm reaches final boundary line, there
might still be contents (e.g. Trailer) left unread after HTTP request body.
This commit fixes it by reading once more upon final boundary line.