### PR TITLE
io/ioutil: don't check for short write in WriteFile

### DIFF
--- a/src/io/ioutil/ioutil.go
+++ b/src/io/ioutil/ioutil.go
@@ -81,10 +81,7 @@ func WriteFile(filename string, data []byte, perm os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	n, err := f.Write(data)
-	if err == nil && n < len(data) {
-		err = io.ErrShortWrite
-	}
+	_, err = f.Write(data)
 	if err1 := f.Close(); err == nil {
 		err = err1
 	}


### PR DESCRIPTION
*os.File already does it.

Fixes #33064
