### PR TITLE
WIP: Typo Fixes

### DIFF
--- a/doc/devel/weekly.html
+++ b/doc/devel/weekly.html
@@ -1829,7 +1829,7 @@ before committing them to your version control system.
 	refer to tour.golang.org instead of go-tour.appspot.com.
 * exp/norm: fixed bug that crept in with moving to the new regexp.
 * exp/ssh: fix length header leaking into channel data (thanks Dave Cheney).
-* fmt: handle os.Error values explicity (as distinct from Stringer).
+* fmt: handle os.Error values explicitly (as distinct from Stringer).
 * gc: clean up printing,
 	fix [568]g -V crash (thanks Mikio Hara),
 	test + fix escape analysis bug.
@@ -3776,7 +3776,7 @@ Code that uses the Addr method will have to call UnsafeAddr instead.
 The path package has been split into two packages: path and path/filepath.
 Package path manipulates slash-separated paths, regardless of operating system.
 Package filepath implements the local operating system's native file paths.
-OS-specific functioanlity in pacakge path, such as Walk, moved to filepath.
+OS-specific functioanlity in package path, such as Walk, moved to filepath.
 
 Other changes:
 * build: fixes and simplifications (thanks Dave Cheney),
@@ -6076,7 +6076,7 @@ syscall: add Nanosleep on FreeBSD (thanks Devon H. O'Dell)
 template: can use map in .repeated section
 
 There is now a public road map, in the repository and online
-at <a href="http://golang.org/doc/devel/roadmap.html">http://golang.org/doc/devel/roadmap.html</a>.
+at <a href="https://golang.org/doc/devel/roadmap.html">http://golang.org/doc/devel/roadmap.html</a>.
 </pre>
 
 <h2 id="2009-12-22">2009-12-22</h2>


### PR DESCRIPTION
```
doc/devel/weekly.html:1832:30: "explicity" is a misspelling of "explicitly"
doc/devel/weekly.html:3779:29: "pacakge" is a misspelling of "package"
doc/go1.13.html:607:39: "interperted" is a misspelling of "interpreted"
misc/trace/trace_viewer_full.html:5905:1695: "PRIMATIVES" is a misspelling of "PRIMITIVES"
misc/trace/trace_viewer_full.html:6310:124: "prototye" is a misspelling of "prototype"
src/cmd/compile/internal/ssa/gen/ARM64.rules:361:12: "comparision" is a misspelling of "comparison"
src/cmd/compile/internal/ssa/gen/S390XOps.go:492:14: "conditon" is a misspelling of "condition"
src/cmd/compile/internal/ssa/gen/generic.rules:1184:18: "peformed" is a misspelling of "performed"
src/cmd/go/internal/modfetch/coderepo.go:600:57: "futher" is a misspelling of "further"
src/cmd/go/internal/note/note_test.go:102:28: "succceeded" is a misspelling of "succeeded"
src/cmd/go/internal/note/note_test.go:107:28: "succceeded" is a misspelling of "succeeded"
src/cmd/go/internal/tlog/tlog.go:158:25: "commited" is a misspelling of "committed"
src/cmd/internal/obj/arm64/asm7.go:1555:63: "Becuase" is a misspelling of "Because"
src/cmd/vendor/golang.org/x/arch/ppc64/ppc64asm/inst.go:241:36: "conditon" is a misspelling of "condition"
src/cmd/vendor/golang.org/x/sys/unix/zerrors_aix_ppc.go:79:5: "PROPOGATE" is a misspelling of "PROPAGATE"
src/cmd/vendor/golang.org/x/sys/unix/zerrors_aix_ppc64.go:79:5: "PROPOGATE" is a misspelling of "PROPAGATE"
src/cmd/vendor/golang.org/x/sys/windows/zerrors_windows.go:609:11: "OCCURED" is a misspelling of "OCCURRED"
src/cmd/vendor/golang.org/x/sys/windows/zerrors_windows.go:2940:25: "HEXIDECIMAL" is a misspelling of "HEXADECIMAL"
src/cmd/vendor/golang.org/x/sys/windows/zerrors_windows.go:6370:8: "UNCHANGABLE" is a misspelling of "UNCHANGEABLE"
src/cmd/vendor/golang.org/x/tools/go/analysis/passes/cgocall/cgocall.go:136:3: "orginal" is a misspelling of "original"
src/cmd/vendor/golang.org/x/tools/go/analysis/passes/errorsas/errorsas.go:5:72: "arugment" is a misspelling of "argument"
src/database/sql/convert.go:568:26: "coefficent" is a misspelling of "coefficient"
src/database/sql/convert.go:568:80: "coefficent" is a misspelling of "coefficient"
src/database/sql/convert_test.go:528:21: "coefficent" is a misspelling of "coefficient"
src/database/sql/convert_test.go:561:21: "coefficent" is a misspelling of "coefficient"
src/debug/elf/file_test.go:821:50: "suceeded" is a misspelling of "succeeded"
src/html/entity.go:626:3: "andd" is a misspelling of "and"
src/html/entity.go:1141:3: "infintie" is a misspelling of "infinite"
src/image/gif/writer_test.go:55:3: "calulated" is a misspelling of "calculated"
src/mime/quotedprintable/writer_test.go:144:118: "exemple" is a misspelling of "example"
src/mime/quotedprintable/writer_test.go:148:11: "correspondant" is a misspelling of "correspondent"
src/mime/quotedprintable/writer_test.go:148:296: "respectifs" is a misspelling of "respects"
src/runtime/mgcscavenge.go:77:6: "accomodate" is a misspelling of "accommodate"
src/testdata/Isaac.Newton-Opticks.txt:4077:0: "surprized" is a misspelling of "surprised"
src/testdata/Isaac.Newton-Opticks.txt:5087:39: "deficience" is a misspelling of "deficiencies"
src/testdata/Isaac.Newton-Opticks.txt:5422:16: "ther" is a misspelling of "there"
src/testdata/Isaac.Newton-Opticks.txt:6214:20: "inflamable" is a misspelling of "inflatable"
src/testdata/Isaac.Newton-Opticks.txt:6228:34: "inflamable" is a misspelling of "inflatable"
src/testdata/Isaac.Newton-Opticks.txt:6235:48: "fermentating" is a misspelling of "fermentation"
src/testdata/Isaac.Newton-Opticks.txt:6555:4: "surprizing" is a misspelling of "surprising"
src/testdata/Isaac.Newton-Opticks.txt:8438:16: "throughly" is a misspelling of "thoroughly"
src/testdata/Isaac.Newton-Opticks.txt:8776:15: "inflamable" is a misspelling of "inflatable"
src/testdata/Isaac.Newton-Opticks.txt:9240:6: "Mathematicks" is a misspelling of "Mathematics"
src/vendor/golang.org/x/net/idna/idna9.0.0.go:97:38: "permissable" is a misspelling of "permissible"
```