### PR TITLE
archive/zip: fix zip64 extra headers problems

### DIFF
--- a/src/archive/zip/writer.go
+++ b/src/archive/zip/writer.go
@@ -111,7 +111,7 @@ func (w *Writer) Close() error {
 		}
 
 		// append a zip64 extra block to Extra
-		if h.CompressedSize64 > uint32max || h.UncompressedSize > uint32max || h.offset > uint32max {
+		if h.CompressedSize64 > uint32max || h.UncompressedSize64 > uint32max || h.offset > uint32max {
 
 			zip64ExtraSize := uint16(0)
 			if h.CompressedSize64 > uint32max {


### PR DESCRIPTION
The central-directory extra fields can contain either 8, 16 or 24 data bytes for ONLY the fields > uint32max (0xFFFFFFFF).

They should not be all set when either CompressedSize, UncompressedSize or offset  > uint32max

Fixes #33116 