### PR TITLE
cmd/link: load symbols from .syso in external link mode

### DIFF
--- a/src/cmd/go/testdata/script/link_syso_issue33139.txt
+++ b/src/cmd/go/testdata/script/link_syso_issue33139.txt
@@ -1,0 +1,29 @@
+# Test that we can use the external linker with a host syso file that is
+# embedded in a package, that is referenced by a Go assembly stub.
+# See issue 33139.
+[!gc] stop
+cc -c -o syso/objTestImpl.syso syso/src/objTestImpl.c
+go build -ldflags='-linkmode=external' ./cmd/main.go
+
+-- syso/objTest.s --
+#include "textflag.h"
+
+TEXT ·ObjTest(SB), NOSPLIT, $0
+	JMP objTestImpl(SB)
+
+-- syso/pkg.go --
+package syso
+
+func ObjTest()
+
+-- syso/src/objTestImpl.c --
+void objTestImpl() { /* Empty */ }
+
+-- cmd/main.go --
+package main
+
+import "syso"
+
+func main() {
+	syso.ObjTest()
+}

--- a/src/cmd/link/internal/ld/ar.go
+++ b/src/cmd/link/internal/ld/ar.go
@@ -127,7 +127,9 @@ func hostArchive(ctxt *Link, name string) {
 			libgcc := sym.Library{Pkg: "libgcc"}
 			h := ldobj(ctxt, f, &libgcc, l, pname, name)
 			f.MustSeek(h.off, 0)
-			h.ld(ctxt, f, h.pkg, h.length, h.pn)
+			if err := h.ld(ctxt, f, h.pkg, h.length, h.pn); err != nil {
+				Errorf(nil, "%v", err)
+			}
 		}
 
 		any = len(load) > 0

--- a/src/cmd/link/internal/sym/attribute.go
+++ b/src/cmd/link/internal/sym/attribute.go
@@ -81,7 +81,9 @@ const (
 	// AttrReadOnly indicates whether the symbol's content (Symbol.P) is backed by
 	// read-only memory.
 	AttrReadOnly
-	// 19 attributes defined so far.
+	// AttrNotRelative indicates that the symbol's relocation is not relative.
+	AttrNotRelative
+	// 20 attributes defined so far.
 )
 
 func (a Attribute) DuplicateOK() bool      { return a&AttrDuplicateOK != 0 }
@@ -103,6 +105,7 @@ func (a Attribute) SubSymbol() bool        { return a&AttrSubSymbol != 0 }
 func (a Attribute) Container() bool        { return a&AttrContainer != 0 }
 func (a Attribute) TopFrame() bool         { return a&AttrTopFrame != 0 }
 func (a Attribute) ReadOnly() bool         { return a&AttrReadOnly != 0 }
+func (a Attribute) Relative() bool         { return a&AttrNotRelative == 0 }
 
 func (a Attribute) CgoExport() bool {
 	return a.CgoExportDynamic() || a.CgoExportStatic()

--- a/src/cmd/link/internal/sym/library.go
+++ b/src/cmd/link/internal/sym/library.go
@@ -17,6 +17,7 @@ type Library struct {
 	DupTextSyms   []*Symbol // dupok text symbols defined in this library
 	Main          bool
 	Safe          bool
+	Cgo           bool
 }
 
 func (l Library) String() string {


### PR DESCRIPTION
Fix linking with a package having a .syso file in external link mode,
that would otherwise cause an error before executing the external
linker because it can't find symbols that are exported in the said
.syso file.

Fixes #33139