### PR TITLE
cmd/go: look for .go.buildinfo section when looking for ELF version

### DIFF
--- a/src/cmd/go/internal/version/exe.go
+++ b/src/cmd/go/internal/version/exe.go
@@ -103,9 +103,9 @@ func (x *elfExe) ReadData(addr, size uint64) ([]byte, error) {
 }
 
 func (x *elfExe) DataStart() uint64 {
-	for _, p := range x.f.Progs {
-		if p.Type == elf.PT_LOAD && p.Flags&(elf.PF_X|elf.PF_W) == elf.PF_W {
-			return p.Vaddr
+	for _, s := range x.f.Sections {
+		if s.Name == ".go.buildinfo" {
+			return s.Addr
 		}
 	}
 	return 0

--- a/src/cmd/go/testdata/script/version.txt
+++ b/src/cmd/go/testdata/script/version.txt
@@ -1,10 +1,16 @@
-env GO111MODULE=on
 [short] skip
 
 go build -o fortune.exe rsc.io/fortune
 go version fortune.exe
 stdout '^fortune.exe: .+'
 go version -m fortune.exe
+stdout '^\tpath\trsc.io/fortune'
+stdout '^\tmod\trsc.io/fortune\tv1.0.0'
+
+go build -buildmode=pie -o external.exe rsc.io/fortune
+go version external.exe
+stdout '^external.exe: .+'
+go version -m external.exe
 stdout '^\tpath\trsc.io/fortune'
 stdout '^\tmod\trsc.io/fortune\tv1.0.0'
 


### PR DESCRIPTION

Fixes #31861