### PR TITLE
fix for issue #31514 - implement partial flush for decompressor

### DIFF
--- a/src/compress/flate/inflate.go
+++ b/src/compress/flate/inflate.go
@@ -273,7 +273,7 @@ type Reader interface {
 
 // Decompress state.
 type decompressor struct {
-	// Read Limit on unerlying Reader
+	// Read Limit(Number of bytes to be read) from unerlying Reader
 	l int
 
 	// Input source.
@@ -708,14 +708,16 @@ func (f *decompressor) SetReadLimit(n int) {
 }
 
 func (f *decompressor) readByte() (byte, error) {
-    if f.l == 0 {
-        return 0, errors.New("ReadLimitReached")
-    }
-    b, e := f.r.ReadByte()
-    if e == nil && f.l > 0 {
-        f.l -= 1
-    }
-    return b, e
+	if f.l == 0 {
+		// maximum read limit is reached, return error
+		return 0, errors.New("ReadLimitReached")
+	}
+	b, e := f.r.ReadByte()
+	if e == nil && f.l > 0 {
+		// decreament number of bytes to be read
+		f.l -= 1
+	}
+	return b, e
 }
 
 func (f *decompressor) moreBits() error {


### PR DESCRIPTION
This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
