### PR TITLE
cmd/help: fix the help prompt for unknown sub-commands

### DIFF
--- a/src/cmd/go/internal/help/help.go
+++ b/src/cmd/go/internal/help/help.go
@@ -63,7 +63,7 @@ Args:
 		// helpSuccess is the help command using as many args as possible that would succeed.
 		helpSuccess := "go help"
 		if i > 0 {
-			helpSuccess = " " + strings.Join(args[:i], " ")
+			helpSuccess = fmt.Sprintf("%s %s", helpSuccess, strings.Join(args[:i], " "))
 		}
 		fmt.Fprintf(os.Stderr, "go help %s: unknown help topic. Run '%s'.\n", strings.Join(args, " "), helpSuccess)
 		base.SetExitStatus(2) // failed at 'go help cmd'


### PR DESCRIPTION
When help for a missing sub-command is requested it responds with:

`go help get asdfasd: unknown help topic. Run ' get'.`

This PR fixes it to respond with:

`go help get asdfasd: unknown help topic. Run 'go help get'.`