### PR TITLE
io: add error check on pipe close functions to avoid error overwriting

### DIFF
--- a/src/io/pipe_test.go
+++ b/src/io/pipe_test.go
@@ -326,8 +326,8 @@ func TestPipeCloseError(t *testing.T) {
 		t.Errorf("Write error: got %T, want testError1", err)
 	}
 	r.CloseWithError(testError2{})
-	if _, err := w.Write(nil); err != (testError2{}) {
-		t.Errorf("Write error: got %T, want testError2", err)
+	if _, err := w.Write(nil); err != (testError1{}) {
+		t.Errorf("Write error: got %T, want testError1", err)
 	}
 
 	r, w = Pipe()
@@ -336,8 +336,8 @@ func TestPipeCloseError(t *testing.T) {
 		t.Errorf("Read error: got %T, want testError1", err)
 	}
 	w.CloseWithError(testError2{})
-	if _, err := r.Read(nil); err != (testError2{}) {
-		t.Errorf("Read error: got %T, want testError2", err)
+	if _, err := r.Read(nil); err != (testError1{}) {
+		t.Errorf("Read error: got %T, want testError1", err)
 	}
 }
 


### PR DESCRIPTION
The current implementation allows multiple calls `Close` and `CloseWithError` in every side of the pipe, as a result, the original error can be overwritten.

This CL fixes this behavior adding an error existence check on `atomicError` type
and keeping the first error still available.

Fixes #24283