### PR TITLE
reflect/DeepEqual: remove redundant type equality check

### DIFF
--- a/src/reflect/deepequal.go
+++ b/src/reflect/deepequal.go
@@ -188,10 +188,6 @@ func DeepEqual(x, y interface{}) bool {
 	if x == nil || y == nil {
 		return x == y
 	}
-	v1 := ValueOf(x)
-	v2 := ValueOf(y)
-	if v1.Type() != v2.Type() {
-		return false
-	}
+	v1, v2 := ValueOf(x), ValueOf(y)
 	return deepValueEqual(v1, v2, make(map[visit]bool), 0)
 }


### PR DESCRIPTION
This change modifies Go to remove type check in [`DeepEqual`](https://github.com/golang/go/blob/919594830f17f25c9e971934d825615463ad8a10/src/reflect/deepequal.go#L193) since it also being done in [`deepValueEqual`](https://github.com/golang/go/blob/919594830f17f25c9e971934d825615463ad8a10/src/reflect/deepequal.go#L28)