### PR TITLE
crypto/x509: add SignatureAlgorithm.Hash()

### DIFF
--- a/src/crypto/x509/x509.go
+++ b/src/crypto/x509/x509.go
@@ -219,6 +219,15 @@ func (algo SignatureAlgorithm) String() string {
 	return strconv.Itoa(int(algo))
 }
 
+func (algo SignatureAlgorithm) Hash() crypto.Hash {
+	for _, details := range signatureAlgorithmDetails {
+		if details.algo == algo {
+			return details.hash
+		}
+	}
+	return crypto.Hash(0)
+}
+
 type PublicKeyAlgorithm int
 
 const (


### PR DESCRIPTION
Add method to return the hashing algorithm associated with a
certificates signature algorithm. This is useful when generating TLS
channel bindings as documented in RFC 5929.

Fixes #33317