### PR TITLE
cmd/compile: output err when append only has only one argument

### DIFF
--- a/src/cmd/compile/internal/gc/typecheck.go
+++ b/src/cmd/compile/internal/gc/typecheck.go
@@ -1585,6 +1585,12 @@ func typecheck1(n *Node, top int) (res *Node) {
 
 			args.SetSecond(assignconv(args.Second(), t.Orig, "append"))
 			break
+		} else {
+			if args.Len() == 1 {
+				yyerror("append need two or more arguments")
+				n.Type = nil
+				return n
+			}
 		}
 
 		as := args.Slice()[1:]


### PR DESCRIPTION
Signed-off-by: jingyugao <1121087373@qq.com>

This change modify go to output err when "append" has only one argument.
Before:
<img width="331" alt="image" src="https://user-images.githubusercontent.com/16934055/62015904-9fe73b00-b1e1-11e9-9343-5af177e7089c.png">
After Change:
<img width="436" alt="image" src="https://user-images.githubusercontent.com/16934055/62015944-d02ed980-b1e1-11e9-9ca9-6004b7cb3a8f.png">

I think append with only one argument has no meaning.I think no one will use it to replace "assignment".
Sometimes we will forget to type the second argument by mistake,but it is still an legal gram.
So I suggest to make it an error.

