### PR TITLE
doc/go1.13: mention faster sync.Mutex/RWMutex/Once

### DIFF
--- a/doc/go1.13.html
+++ b/doc/go1.13.html
@@ -810,6 +810,13 @@ godoc
       as opposed to releasing all objects, reducing load spikes for heavy users of <code>Pool</code>.
     </p>
 
+    <p><!-- CL 152697, 152698, 148959, 148958 -->
+      The fast paths of <code>Mutex.Lock</code>, <code>Mutex.Unlock</code>, <code>RWMutex.RLock</code>,
+      <code>RWMutex.RUnlock</code> and <code>Once.Do</code> are now inlined in their callers. 
+      On amd64 this makes <code>Once.Do</code> twice as fast, and the others up to ~10% faster in the
+      uncontented case.
+    </p>
+
 </dl><!-- sync -->
 
 <dl id="syscall"><dt><a href="/pkg/syscall/">syscall</a></dt>

--- a/doc/go1.13.html
+++ b/doc/go1.13.html
@@ -802,11 +802,11 @@ godoc
 <dl id="sync"><dt><a href="/pkg/sync/">sync</a></dt>
   <dd>
     <p><!-- CL 148958, CL 148959, CL 152697, CL 152698 -->
-      The fast paths of <a href="/pkg/sync/#Mutex.Lock><code>Mutex.Lock</code></a>, <a href="/pkg/sync/#Mutex.Unlock><code>Mutex.Unlock</code></a>,
-      <a href="/pkg/sync/#RWMutex.Lock><code>RWMutex.Lock</code></a>, <a href="/pkg/sync/#Mutex.RUnlock><code>RWMutex.RUnlock</code></a>, and
-      <a href="/pkg/sync/#Once.Do><code>Once.Do</code></a> are now inlined in their callers.
-      For the uncontended cases on amd64, these changes make <a href="/pkg/sync/#Once.Do><code>Once.Do</code></a> twice as fast, and the
-      <a href="/pkg/sync/#Mutex><code>Mutex</code></a>/<a href="/pkg/sync/#RWMutex><code>RWMutex</code></a> methods up to 10% faster.
+      The fast paths of <a href="/pkg/sync/#Mutex.Lock"><code>Mutex.Lock</code></a>, <a href="/pkg/sync/#Mutex.Unlock"><code>Mutex.Unlock</code></a>,
+      <a href="/pkg/sync/#RWMutex.Lock"><code>RWMutex.Lock</code></a>, <a href="/pkg/sync/#Mutex.RUnlock"><code>RWMutex.RUnlock</code></a>, and
+      <a href="/pkg/sync/#Once.Do"><code>Once.Do</code></a> are now inlined in their callers.
+      For the uncontended cases on amd64, these changes make <a href="/pkg/sync/#Once.Do"><code>Once.Do</code></a> twice as fast, and the
+      <a href="/pkg/sync/#Mutex"><code>Mutex</code></a>/<a href="/pkg/sync/#RWMutex"><code>RWMutex</code></a> methods up to 10% faster.
     </p>
 
     <p><!-- CL 166960 -->

--- a/doc/go1.13.html
+++ b/doc/go1.13.html
@@ -802,9 +802,9 @@ godoc
 <dl id="sync"><dt><a href="/pkg/sync/">sync</a></dt>
   <dd>
     <p><!-- CL 148958, CL 148959, CL 152697, CL 152698 -->
-      The fast paths of <a href="/pkg/sync/#Mutex.Lock><code>Mutex.Lock</code></a>, <a href="/pkg/sync/#Mutex.Unlock><code>Mutex.Unlock</code></a>, 
-      <a href="/pkg/sync/#RWMutex.Lock><code>RWMutex.Lock</code></a>, <a href="/pkg/sync/#Mutex.RUnlock><code>RWMutex.RUnlock</code></a>, and 
-      <a href="/pkg/sync/#Once.Do><code>Once.Do</code></a> are now inlined in their callers. 
+      The fast paths of <a href="/pkg/sync/#Mutex.Lock><code>Mutex.Lock</code></a>, <a href="/pkg/sync/#Mutex.Unlock><code>Mutex.Unlock</code></a>,
+      <a href="/pkg/sync/#RWMutex.Lock><code>RWMutex.Lock</code></a>, <a href="/pkg/sync/#Mutex.RUnlock><code>RWMutex.RUnlock</code></a>, and
+      <a href="/pkg/sync/#Once.Do><code>Once.Do</code></a> are now inlined in their callers.
       For the uncontended cases on amd64, these changes make <a href="/pkg/sync/#Once.Do><code>Once.Do</code></a> twice as fast, and the
       <a href="/pkg/sync/#Mutex><code>Mutex</code></a>/<a href="/pkg/sync/#RWMutex><code>RWMutex</code></a> methods up to 10% faster.
     </p>

--- a/doc/go1.13.html
+++ b/doc/go1.13.html
@@ -814,7 +814,7 @@ godoc
       The fast paths of <code>Mutex.Lock</code>, <code>Mutex.Unlock</code>, <code>RWMutex.RLock</code>,
       <code>RWMutex.RUnlock</code> and <code>Once.Do</code> are now inlined in their callers. 
       On amd64 this makes <code>Once.Do</code> twice as fast, and the others up to ~10% faster in the
-      uncontented case.
+      uncontended case.
     </p>
 
 </dl><!-- sync -->

--- a/doc/go1.13.html
+++ b/doc/go1.13.html
@@ -801,6 +801,14 @@ godoc
 
 <dl id="sync"><dt><a href="/pkg/sync/">sync</a></dt>
   <dd>
+    <p><!-- CL 148958, CL 148959, CL 152697, CL 152698 -->
+      The fast paths of <a href="/pkg/sync/#Mutex.Lock><code>Mutex.Lock</code></a>, <a href="/pkg/sync/#Mutex.Unlock><code>Mutex.Unlock</code></a>, 
+      <a href="/pkg/sync/#RWMutex.Lock><code>RWMutex.Lock</code></a>, <a href="/pkg/sync/#Mutex.RUnlock><code>RWMutex.RUnlock</code></a>, and 
+      <a href="/pkg/sync/#Once.Do><code>Once.Do</code></a> are now inlined in their callers. 
+      For the uncontended cases on amd64, these changes make <a href="/pkg/sync/#Once.Do><code>Once.Do</code></a> twice as fast, and the
+      <a href="/pkg/sync/#Mutex><code>Mutex</code></a>/<a href="/pkg/sync/#RWMutex><code>RWMutex</code></a> methods up to 10% faster.
+    </p>
+
     <p><!-- CL 166960 -->
       Large <a href="/pkg/sync/#Pool"><code>Pool</code></a> no longer increase stop-the-world pause times.
     </p>
@@ -808,13 +816,6 @@ godoc
     <p><!-- CL 166961 -->
       <code>Pool</code> no longer needs to be completely repopulated after every GC. It now retains some objects across GCs,
       as opposed to releasing all objects, reducing load spikes for heavy users of <code>Pool</code>.
-    </p>
-
-    <p><!-- CL 152697, 152698, 148959, 148958 -->
-      The fast paths of <code>Mutex.Lock</code>, <code>Mutex.Unlock</code>, <code>RWMutex.RLock</code>,
-      <code>RWMutex.RUnlock</code> and <code>Once.Do</code> are now inlined in their callers. 
-      On amd64 this makes <code>Once.Do</code> twice as fast, and the others up to ~10% faster in the
-      uncontended case.
     </p>
 
 </dl><!-- sync -->


### PR DESCRIPTION
Mention faster sync.Mutex/RWMutex/Once in the 1.13 release notes.