### PR TITLE
encoding/json: This CL adds Decoder.InternKeys

### DIFF
--- a/src/encoding/json/bench_test.go
+++ b/src/encoding/json/bench_test.go
@@ -170,6 +170,75 @@ func BenchmarkCodeDecoder(b *testing.B) {
 	b.SetBytes(int64(len(codeJSON)))
 }
 
+func BenchmarkCodeDecodeToInterfaceNoIntern(b *testing.B) {
+	b.ReportAllocs()
+	if codeJSON == nil {
+		b.StopTimer()
+		codeInit()
+		b.StartTimer()
+	}
+	b.RunParallel(func(pb *testing.PB) {
+		var buf bytes.Buffer
+		dec := NewDecoder(&buf)
+		var r interface{}
+		for pb.Next() {
+			buf.Write(codeJSON)
+			// hide EOF
+			buf.WriteByte('\n')
+			buf.WriteByte('\n')
+			buf.WriteByte('\n')
+			if err := dec.Decode(&r); err != nil {
+				b.Fatal("Decode:", err)
+			}
+		}
+	})
+	b.SetBytes(int64(len(codeJSON)))
+}
+
+func BenchmarkCodeDecodeToInterfaceIntern(b *testing.B) {
+	b.ReportAllocs()
+	if codeJSON == nil {
+		b.StopTimer()
+		codeInit()
+		b.StartTimer()
+	}
+	b.RunParallel(func(pb *testing.PB) {
+		var buf bytes.Buffer
+		dec := NewDecoder(&buf)
+		dec.InternKeys()
+		var r interface{}
+		for pb.Next() {
+			buf.Write(codeJSON)
+			// hide EOF
+			buf.WriteByte('\n')
+			buf.WriteByte('\n')
+			buf.WriteByte('\n')
+			if err := dec.Decode(&r); err != nil {
+				b.Fatal("Decode:", err)
+			}
+		}
+	})
+	b.SetBytes(int64(len(codeJSON)))
+}
+
+func BenchmarkCodeUnmarshalToInterface(b *testing.B) {
+	b.ReportAllocs()
+	if codeJSON == nil {
+		b.StopTimer()
+		codeInit()
+		b.StartTimer()
+	}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			var r interface{}
+			if err := Unmarshal(codeJSON, &r); err != nil {
+				b.Fatal("Unmarshal:", err)
+			}
+		}
+	})
+	b.SetBytes(int64(len(codeJSON)))
+}
+
 func BenchmarkUnicodeDecoder(b *testing.B) {
 	b.ReportAllocs()
 	j := []byte(`"\uD83D\uDE01"`)

--- a/src/encoding/json/decode.go
+++ b/src/encoding/json/decode.go
@@ -212,6 +212,9 @@ type decodeState struct {
 	savedError            error
 	useNumber             bool
 	disallowUnknownFields bool
+
+	// If non-nil, keys are interned in this map
+	internedKeys map[string]string
 }
 
 // readIndex returns the position of the last byte read.
@@ -1084,6 +1087,13 @@ func (d *decodeState) objectInterface() map[string]interface{} {
 		key, ok := unquote(item)
 		if !ok {
 			panic(phasePanicMsg)
+		}
+		if d.internedKeys != nil {
+			if s, ok := d.internedKeys[key]; ok {
+				key = s
+			} else {
+				d.internedKeys[key] = key
+			}
 		}
 
 		// Read : before value.

--- a/src/encoding/json/stream.go
+++ b/src/encoding/json/stream.go
@@ -41,6 +41,15 @@ func (dec *Decoder) UseNumber() { dec.d.useNumber = true }
 // non-ignored, exported fields in the destination.
 func (dec *Decoder) DisallowUnknownFields() { dec.d.disallowUnknownFields = true }
 
+// InternKeys causes the Decoder to intern object keys to prevent
+// allocating multiple copies of the same string. This is only useful
+// if the JSON stream has repeated keys.
+func (dec *Decoder) InternKeys() {
+	if dec.d.internedKeys == nil {
+		dec.d.internedKeys = make(map[string]string)
+	}
+}
+
 // Decode reads the next JSON-encoded value from its
 // input and stores it in the value pointed to by v.
 //
@@ -444,6 +453,13 @@ func (dec *Decoder) Token() (Token, error) {
 					return nil, err
 				}
 				dec.tokenState = tokenObjectColon
+				if dec.d.internedKeys != nil {
+					if s, ok := dec.d.internedKeys[x]; ok {
+						x = s
+					} else {
+						dec.d.internedKeys[x] = x
+					}
+				}
 				return x, nil
 			}
 			fallthrough


### PR DESCRIPTION
The existing decoder creates a new string for every key.
For large JSON input where keys are repeated, we can avoid
this by interning keys. This change adds a Decoder.InternKeys
function that causes the decoder to store keys in a
map[string]string and uses a single copy for repeated keys.
The default behavior is not to intern keys.
    
This change only affects Decoder when decoding to an interface{}
or, when tokenizing the input. It does not affect Unmarshal, or
decoding to a struct.

Fixes #32779

