### PR TITLE
encoding/json: revert Compact HTML escaping documentation

### DIFF
--- a/src/encoding/json/indent.go
+++ b/src/encoding/json/indent.go
@@ -8,9 +8,6 @@ import "bytes"
 
 // Compact appends to dst the JSON-encoded src with
 // insignificant space characters elided.
-// Like Marshal, Compact applies HTMLEscape to any
-// string literals so that the JSON will be safe to embed
-// inside HTML <script> tags.
 func Compact(dst *bytes.Buffer, src []byte) error {
 	return compact(dst, src, false)
 }


### PR DESCRIPTION
This partly reverts CL 173417 as it incorrectly documented that Compact
performed HTML escaping and the output was safe to embed inside HTML
<script> tags. This has never been true.

Although Compact does escape U+2028 and U+2029, it doesn't escape <, >
or &. Compact is thus only performing a subset of HTML escaping and it's
output is not safe to embed inside HTML <script> tags.

A more complete fix would be for Compact to either never perform any
HTML escaping, as it was prior to CL 10883045, or to actually perform
the same HTML escaping as HTMLEscape. Neither change is likely safe
enough for go1.13.

Updates #30357