### PR TITLE
math/big: add big.Int methods Inc() and Dec()

### DIFF
--- a/src/math/big/int.go
+++ b/src/math/big/int.go
@@ -133,6 +133,17 @@ func (z *Int) Add(x, y *Int) *Int {
 	return z
 }
 
+// Inc sets z to the sum z+1 and returns z.
+func (z *Int) Inc() *Int {
+	if z.neg {
+		z.abs = z.abs.sub(z.abs, intOne.abs)
+		z.neg = len(z.abs) > 0
+	} else {
+		z.abs = z.abs.add(z.abs, intOne.abs)
+	}
+	return z
+}
+
 // Sub sets z to the difference x-y and returns z.
 func (z *Int) Sub(x, y *Int) *Int {
 	neg := x.neg
@@ -151,6 +162,19 @@ func (z *Int) Sub(x, y *Int) *Int {
 		}
 	}
 	z.neg = len(z.abs) > 0 && neg // 0 has no sign
+	return z
+}
+
+// Dec sets z to the difference z-1 and returns z.
+func (z *Int) Dec() *Int {
+	if z.neg {
+		z.abs = z.abs.add(z.abs, intOne.abs)
+	} else if len(z.abs) > 0 {
+		z.abs = z.abs.sub(z.abs, intOne.abs)
+	} else {
+		z.abs = z.abs.add(z.abs, intOne.abs)
+		z.neg = true
+	}
 	return z
 }
 

--- a/src/math/big/int_test.go
+++ b/src/math/big/int_test.go
@@ -1766,6 +1766,56 @@ func TestIssue22830(t *testing.T) {
 	}
 }
 
+func TestInc(t *testing.T) {
+	var i int64
+	for i = -1; i <= 1; i++ {
+		inc := NewInt(i).Inc()
+		add := new(Int).Add(NewInt(i), intOne)
+		if inc.Cmp(add) != 0 {
+			t.Fatalf("%v != %v", inc, add)
+		}
+	}
+}
+
+func TestDec(t *testing.T) {
+	var i int64
+	for i = -1; i <= 1; i++ {
+		dec := NewInt(i).Dec()
+		sub := new(Int).Sub(NewInt(i), intOne)
+		if dec.Cmp(sub) != 0 {
+			t.Fatalf("(%v != %v", dec, sub)
+		}
+	}
+}
+
+func BenchmarkInc(b *testing.B) {
+	z := new(Int)
+	for i := 0; i < b.N; i++ {
+		z.Inc()
+	}
+}
+
+func BenchmarkIncByAdd(b *testing.B) {
+	z := new(Int)
+	for i := 0; i < b.N; i++ {
+		z.Add(z, intOne)
+	}
+}
+
+func BenchmarkDec(b *testing.B) {
+	z := new(Int)
+	for i := 0; i < b.N; i++ {
+		z.Dec()
+	}
+}
+
+func BenchmarkDecBySub(b *testing.B) {
+	z := new(Int)
+	for i := 0; i < b.N; i++ {
+		z.Sub(z, intOne)
+	}
+}
+
 func BenchmarkSqrt(b *testing.B) {
 	n, _ := new(Int).SetString("1"+strings.Repeat("0", 1001), 10)
 	b.ResetTimer()


### PR DESCRIPTION
Adding a sample implementation for big.Int methods `Inc()` and `Dec()`. #29951

Incrementing and decrementing big.Int's by one can be done with less comparisons and allocations opposed to `x.Add(x, one)` and `x.Sub(x, one)`.

Benchmark results:

```
goos: linux
goarch: amd64
pkg: math/big
BenchmarkInc-4         70917309                16.6 ns/op
BenchmarkIncByAdd-4    55380994                18.7 ns/op
```

```
goos: linux
goarch: amd64
pkg: math/big
BenchmarkDec-4         63753597                17.3 ns/op
BenchmarkDecBySub-4    57247021                21.3 ns/op
```