### PR TITLE
cmd/doc: make -src mode deterministic

### DIFF
--- a/src/go/ast/filter.go
+++ b/src/go/ast/filter.go
@@ -474,7 +474,8 @@ func MergePackageFiles(pkg *Package, mode MergeMode) *File {
 			}
 		}
 	} else {
-		for _, f := range pkg.Files {
+		for _, filename := range filenames {
+			f := pkg.Files[filename]
 			imports = append(imports, f.Imports...)
 		}
 	}

--- a/src/go/ast/filter.go
+++ b/src/go/ast/filter.go
@@ -484,7 +484,8 @@ func MergePackageFiles(pkg *Package, mode MergeMode) *File {
 	if mode&FilterUnassociatedComments == 0 {
 		comments = make([]*CommentGroup, ncomments)
 		i := 0
-		for _, f := range pkg.Files {
+		for _, filename := range filenames {
+			f := pkg.Files[filename]
 			i += copy(comments[i:], f.Comments)
 		}
 	}

--- a/src/go/ast/filter.go
+++ b/src/go/ast/filter.go
@@ -474,6 +474,7 @@ func MergePackageFiles(pkg *Package, mode MergeMode) *File {
 			}
 		}
 	} else {
+		// Iterate over filenames for deterministic order.
 		for _, filename := range filenames {
 			f := pkg.Files[filename]
 			imports = append(imports, f.Imports...)


### PR DESCRIPTION
These changes make cmd/doc -src deterministic, or, more precisely,
go/ast.MergePackageFiles, which is used by cmd/doc. So far the order of
comments depended on the package file map iteration order.

cmd/doc with -src flag has been inserting and omitting random comments
ever since the addition of -src flag. After investigating the code path
with the debugger, I’ve noticed that ast.File.Comments slice order changes
between invocations of the command. The bug was introduced in 3e24f2d,
which ironically claimed to “fix formatting of -src output”. The commit
implemented the collection of comments by iterating over the map and 
c7cdce1 “godoc: make ?m=src mode deterministic” did’t actually make
go/ast.MergePackageFiles deterministic.

I’ve found this issue after running “go doc -src sync.WaitGroup.Wait”.
There are likely other packages and functions affected, but the bug
should be somewhat reproducible across all Go versions.
