### PR TITLE
encoding/binary: fix error on unexpected EOF while reading a varint

### DIFF
--- a/src/encoding/binary/varint.go
+++ b/src/encoding/binary/varint.go
@@ -109,6 +109,9 @@ func ReadUvarint(r io.ByteReader) (uint64, error) {
 	for i := 0; ; i++ {
 		b, err := r.ReadByte()
 		if err != nil {
+			if err == io.EOF && i > 0 {
+				err = io.ErrUnexpectedEOF
+			}
 			return x, err
 		}
 		if b < 0x80 {

--- a/src/encoding/binary/varint_test.go
+++ b/src/encoding/binary/varint_test.go
@@ -115,7 +115,11 @@ func TestBufferTooSmall(t *testing.T) {
 		}
 
 		x, err := ReadUvarint(bytes.NewReader(buf))
-		if x != 0 || err != io.EOF {
+		expectedErr := io.ErrUnexpectedEOF
+		if len(buf) == 0 {
+			expectedErr = io.EOF
+		}
+		if x != 0 || err != expectedErr {
 			t.Errorf("ReadUvarint(%v): got x = %d, err = %s", buf, x, err)
 		}
 	}


### PR DESCRIPTION
ReadUvarint (and ReadVarint) should return EOF when no bytes have been read and ErrUnexpectedEOF when a partial varint has been read.