### PR TITLE
testing/iotest: add missing tests

### DIFF
--- a/src/testing/iotest/logger_test.go
+++ b/src/testing/iotest/logger_test.go
@@ -1,0 +1,121 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package iotest
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log"
+	"regexp"
+	"testing"
+)
+
+var writeLoggerTests = []struct {
+	prefix string
+	data   string
+}{
+	{"", "hello, world"},
+	{"prefix", ""},
+	{"", ""},
+	{"prefix", "hello, world"},
+}
+
+type errWriter struct {
+	err error
+}
+
+func (w errWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+func TestWriteLogger(t *testing.T) {
+	for i, tt := range writeLoggerTests {
+		re := regexp.MustCompile(`\d{4}\/\d{2}\/\d{2}\s\d{2}:\d{2}:\d{2}\s` + tt.prefix + `\s` + fmt.Sprintf("%x", tt.data))
+		out := new(bytes.Buffer)
+		log.SetOutput(out)
+
+		r := new(bytes.Buffer)
+		wl := NewWriteLogger(tt.prefix, r)
+		wl.Write([]byte(tt.data))
+
+		if re.MatchString(out.String()) == false {
+			t.Errorf("%d: No match on log output, got %q", i, out.String())
+		}
+	}
+}
+
+func TestWriteLoggerError(t *testing.T) {
+	prefix := "prefix"
+	data := "hello, world"
+	err := errors.New("write error")
+	re := regexp.MustCompile(`\d{4}\/\d{2}\/\d{2}\s\d{2}:\d{2}:\d{2}\s` + prefix + `\s:\s` + fmt.Sprintf("%s", err))
+	out := new(bytes.Buffer)
+	log.SetOutput(out)
+
+	r := errWriter{err: err}
+	wl := NewWriteLogger("prefix", r)
+	wl.Write([]byte(data))
+
+	if re.MatchString(out.String()) == false {
+		t.Errorf("No match on log output, got %q", out.String())
+	}
+
+}
+
+var readLoggerTests = []struct {
+	prefix string
+	data   string
+}{
+	{"", "hello, world"},
+	{"prefix", ""},
+	{"", ""},
+	{"prefix", "hello, world"},
+}
+
+type errReader struct {
+	err error
+}
+
+func (r errReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func TestReadLogger(t *testing.T) {
+	for i, tt := range readLoggerTests {
+		re := regexp.MustCompile(`\d{4}\/\d{2}\/\d{2}\s\d{2}:\d{2}:\d{2}\s` + tt.prefix + `\s` + fmt.Sprintf("%x", tt.data))
+
+		p := make([]byte, len(tt.data))
+		out := new(bytes.Buffer)
+		log.SetOutput(out)
+
+		r := bytes.NewReader([]byte(tt.data))
+		rl := NewReadLogger(tt.prefix, r)
+		rl.Read(p)
+
+		if re.MatchString(out.String()) == false {
+			t.Errorf("%d: No match on log output, got %q", i, out.String())
+		}
+	}
+}
+
+func TestReadLoggerError(t *testing.T) {
+	prefix := "prefix"
+	data := "hello, world"
+	err := errors.New("read error")
+	re := regexp.MustCompile(`\d{4}\/\d{2}\/\d{2}\s\d{2}:\d{2}:\d{2}\s` + prefix + `\s:\s` + fmt.Sprintf("%s", err))
+
+	p := make([]byte, len(data))
+	out := new(bytes.Buffer)
+	log.SetOutput(out)
+
+	r := errReader{err: err}
+	rl := NewReadLogger(prefix, r)
+	rl.Read(p)
+
+	if re.MatchString(out.String()) == false {
+		t.Errorf("No match on log output, got %q", out.String())
+	}
+}

--- a/src/testing/iotest/logger_test.go
+++ b/src/testing/iotest/logger_test.go
@@ -37,8 +37,8 @@ func TestWriteLogger(t *testing.T) {
 		out := new(bytes.Buffer)
 		log.SetOutput(out)
 
-		r := new(bytes.Buffer)
-		wl := NewWriteLogger(tt.prefix, r)
+		w := new(bytes.Buffer)
+		wl := NewWriteLogger(tt.prefix, w)
 		wl.Write([]byte(tt.data))
 
 		if re.MatchString(out.String()) == false {
@@ -55,8 +55,8 @@ func TestWriteLoggerError(t *testing.T) {
 	out := new(bytes.Buffer)
 	log.SetOutput(out)
 
-	r := errWriter{err: err}
-	wl := NewWriteLogger("prefix", r)
+	w := errWriter{err: err}
+	wl := NewWriteLogger("prefix", w)
 	wl.Write([]byte(data))
 
 	if re.MatchString(out.String()) == false {

--- a/src/testing/iotest/reader_test.go
+++ b/src/testing/iotest/reader_test.go
@@ -1,4 +1,4 @@
-// Copyright 2009 The Go Authors. All rights reserved.
+// Copyright 2019 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/src/testing/iotest/reader_test.go
+++ b/src/testing/iotest/reader_test.go
@@ -1,0 +1,128 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package iotest
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"testing"
+)
+
+var oneByteReaderTests = []struct {
+	data []byte
+	p    []byte
+	n    int
+}{
+	{[]byte(""), []byte(""), 0},
+	{[]byte("h"), []byte("h"), 1},
+	{[]byte("hello, world"), []byte("h"), 1},
+}
+
+func TestOneByteReader(t *testing.T) {
+	for _, tt := range oneByteReaderTests {
+		r := OneByteReader(bytes.NewReader(tt.data))
+		p := make([]byte, len(tt.data))
+		n, err := r.Read(p)
+		if err != nil {
+			t.Error(err)
+		}
+		if n != tt.n {
+			t.Errorf("expected to have read %d bytes, but read %d", tt.n, n)
+		}
+		got := p[:n]
+		want := tt.p
+		if reflect.DeepEqual(got, want) != true {
+			t.Errorf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+var halfReaderTests = []struct {
+	data []byte
+	p    []byte
+	n    int
+}{
+	{[]byte("h"), []byte("h"), 1},
+	{[]byte("hello, world"), []byte("hello,"), 6},
+}
+
+func TestHalfReader(t *testing.T) {
+	for _, tt := range halfReaderTests {
+		r := HalfReader(bytes.NewReader(tt.data))
+		p := make([]byte, len(tt.data))
+		n, err := r.Read(p)
+		if err != nil {
+			t.Error(err)
+		}
+		if n != tt.n {
+			t.Errorf("expected to have read %d bytes, but read %d", tt.n, n)
+		}
+		got := p[:n]
+		want := tt.p
+		if reflect.DeepEqual(got, want) != true {
+			t.Errorf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestTimeoutReader(t *testing.T) {
+	data := []byte("hello, world")
+	r := TimeoutReader(bytes.NewReader(data))
+	p := make([]byte, 2)
+	n, err := r.Read(p)
+	if err != nil {
+		t.Error(err)
+	}
+	if n != 2 {
+		t.Errorf("expected to have read %d bytes, but read %d", 2, n)
+	}
+
+	n, err = r.Read(p)
+	if err != ErrTimeout {
+		t.Errorf("Second call to Read should return %v, got %v", ErrTimeout, err)
+	}
+	if n != 0 {
+		t.Errorf("expected to have read %d bytes, but read %d", 0, n)
+	}
+
+	n, err = r.Read(p)
+	if err != nil {
+		t.Errorf("Subsequent calls to read succeed. Got %v", err)
+	}
+	if n != 2 {
+		t.Errorf("expected to have read %d bytes, but read %d", 2, n)
+	}
+}
+
+var dataErrReaderTests = []struct {
+	data []byte
+	p    []byte
+	n    int
+}{
+	{[]byte("hello"), []byte("o"), 1},
+	{[]byte("hello,"), []byte("o,"), 2},
+}
+
+func TestDataErrReader(t *testing.T) {
+	for _, tt := range dataErrReaderTests {
+		var n int
+		var err error
+		p := make([]byte, 2)
+		r := DataErrReader(bytes.NewReader(tt.data))
+		for {
+			n, err = r.Read(p)
+			if err == io.EOF {
+				break
+			}
+		}
+		if n != tt.n {
+			t.Errorf("Last call to Read should read %d bytes instead of %d", n, tt.n)
+		}
+		if reflect.DeepEqual(p[:n], tt.p) != true {
+			t.Errorf("Wanted %v got %v", tt.p, p[:n])
+		}
+	}
+}

--- a/src/testing/iotest/reader_test.go
+++ b/src/testing/iotest/reader_test.go
@@ -10,32 +10,55 @@ import (
 	"testing"
 )
 
-var oneByteReaderTests = []struct {
-	data []byte
-	p    []byte
-	n    int
-}{
-	{[]byte(""), []byte(""), 0},
-	{[]byte("h"), []byte("h"), 1},
-	{[]byte("hello, world"), []byte("h"), 1},
+func TestOneByteReader_nonEmptyReader(t *testing.T) {
+	msg := "Hello, World!"
+	buf := new(bytes.Buffer)
+	buf.WriteString(msg)
+
+	obr := OneByteReader(buf)
+	var b []byte
+	n, err := obr.Read(b)
+	if err != nil || n != 0 {
+		t.Errorf("Empty buffer read returned n=%d err=%v", n, err)
+	}
+
+	b = make([]byte, 3)
+	// Read from obr until EOF.
+	got := new(bytes.Buffer)
+	for i := 0; ; i++ {
+		n, err = obr.Read(b)
+		if err != nil {
+			break
+		}
+		if g, w := n, 1; g != w {
+			t.Errorf("Iteration #%d read %d bytes, want %d", i, g, w)
+		}
+		got.Write(b[:n])
+	}
+	if g, w := err, io.EOF; g != w {
+		t.Errorf("Unexpected error after reading all bytes\n\tGot:  %v\n\tWant: %v", g, w)
+	}
+	if g, w := got.String(), "Hello, World!"; g != w {
+		t.Errorf("Read mismatch\n\tGot:  %q\n\tWant: %q", g, w)
+	}
 }
 
-func TestOneByteReader(t *testing.T) {
-	for _, tt := range oneByteReaderTests {
-		r := OneByteReader(bytes.NewReader(tt.data))
-		p := make([]byte, len(tt.data))
-		n, err := r.Read(p)
-		if err != nil {
-			t.Error(err)
-		}
-		if n != tt.n {
-			t.Errorf("read %d, but expected to have read %d bytes", n, tt.n)
-		}
-		got := p[:n]
-		want := tt.p
-		if !bytes.Equal(got, want) {
-			t.Errorf("got %q, expected %q", got, want)
-		}
+func TestOneByteReader_emptyReader(t *testing.T) {
+	r := new(bytes.Buffer)
+
+	obr := OneByteReader(r)
+	var b []byte
+	if n, err := obr.Read(b); err != nil || n != 0 {
+		t.Errorf("Empty buffer read returned n=%d err=%v", n, err)
+	}
+
+	b = make([]byte, 5)
+	n, err := obr.Read(b)
+	if g, w := err, io.EOF; g != w {
+		t.Errorf("Error mismatch\n\tGot:  %v\n\tWant: %v", g, w)
+	}
+	if g, w := n, 0; g != w {
+		t.Errorf("Unexpectedly read %d bytes, wanted %d", g, w)
 	}
 }
 

--- a/src/testing/iotest/reader_test.go
+++ b/src/testing/iotest/reader_test.go
@@ -7,7 +7,6 @@ package iotest
 import (
 	"bytes"
 	"io"
-	"reflect"
 	"testing"
 )
 
@@ -34,7 +33,7 @@ func TestOneByteReader(t *testing.T) {
 		}
 		got := p[:n]
 		want := tt.p
-		if reflect.DeepEqual(got, want) != true {
+		if !bytes.Equal(got, want) {
 			t.Errorf("got %q, expected %q", got, want)
 		}
 	}
@@ -62,7 +61,7 @@ func TestHalfReader(t *testing.T) {
 		}
 		got := p[:n]
 		want := tt.p
-		if reflect.DeepEqual(got, want) != true {
+		if !bytes.Equal(got, want) {
 			t.Errorf("got %q, expected %q", got, want)
 		}
 	}
@@ -122,7 +121,7 @@ func TestDataErrReader(t *testing.T) {
 		if n != tt.n {
 			t.Errorf("Last call to Read should have read %d bytes instead of %d", n, tt.n)
 		}
-		if reflect.DeepEqual(p[:n], tt.p) != true {
+		if !bytes.Equal(p[:n], tt.p) {
 			t.Errorf("got %q, expected %q ", p[:n], tt.p)
 		}
 	}

--- a/src/testing/iotest/reader_test.go
+++ b/src/testing/iotest/reader_test.go
@@ -90,7 +90,7 @@ func TestTimeoutReader(t *testing.T) {
 
 	n, err = r.Read(p)
 	if err != nil {
-		t.Errorf("Subsequent calls to read succeed. Got %v", err)
+		t.Errorf("Subsequent call to read succeed. Got %v", err)
 	}
 	if n != 2 {
 		t.Errorf("expected to have read %d bytes, but read %d", 2, n)
@@ -119,7 +119,7 @@ func TestDataErrReader(t *testing.T) {
 			}
 		}
 		if n != tt.n {
-			t.Errorf("Last call to Read should read %d bytes instead of %d", n, tt.n)
+			t.Errorf("Last call to Read should have read %d bytes instead of %d", n, tt.n)
 		}
 		if reflect.DeepEqual(p[:n], tt.p) != true {
 			t.Errorf("Wanted %v got %v", tt.p, p[:n])

--- a/src/testing/iotest/reader_test.go
+++ b/src/testing/iotest/reader_test.go
@@ -124,6 +124,7 @@ func TestTimeOutReader_nonEmptyReader(t *testing.T) {
 	if err != nil || n != 0 {
 		t.Errorf("Empty buffer read returned n=%d err=%v", n, err)
 	}
+	// Second call should timeout
 	n, err = tor.Read(b)
 	if g, w := err, ErrTimeout; g != w {
 		t.Errorf("Error mismatch\n\tGot:  %v\n\tWant: %v", g, w)

--- a/src/testing/iotest/reader_test.go
+++ b/src/testing/iotest/reader_test.go
@@ -30,12 +30,12 @@ func TestOneByteReader(t *testing.T) {
 			t.Error(err)
 		}
 		if n != tt.n {
-			t.Errorf("expected to have read %d bytes, but read %d", tt.n, n)
+			t.Errorf("read %d, but expected to have read %d bytes", n, tt.n)
 		}
 		got := p[:n]
 		want := tt.p
 		if reflect.DeepEqual(got, want) != true {
-			t.Errorf("expected %v, got %v", want, got)
+			t.Errorf("got %q, expected %q", got, want)
 		}
 	}
 }
@@ -58,12 +58,12 @@ func TestHalfReader(t *testing.T) {
 			t.Error(err)
 		}
 		if n != tt.n {
-			t.Errorf("expected to have read %d bytes, but read %d", tt.n, n)
+			t.Errorf("read %d, but expected to have read %d bytes", n, tt.n)
 		}
 		got := p[:n]
 		want := tt.p
 		if reflect.DeepEqual(got, want) != true {
-			t.Errorf("expected %v, got %v", want, got)
+			t.Errorf("got %q, expected %q", got, want)
 		}
 	}
 }
@@ -72,28 +72,29 @@ func TestTimeoutReader(t *testing.T) {
 	data := []byte("hello, world")
 	r := TimeoutReader(bytes.NewReader(data))
 	p := make([]byte, 2)
+
 	n, err := r.Read(p)
 	if err != nil {
 		t.Error(err)
 	}
 	if n != 2 {
-		t.Errorf("expected to have read %d bytes, but read %d", 2, n)
+		t.Errorf("read %d, but expected to have read %d bytes", n, 2)
 	}
 
 	n, err = r.Read(p)
 	if err != ErrTimeout {
-		t.Errorf("Second call to Read should return %v, got %v", ErrTimeout, err)
+		t.Errorf("got %v, but second call to Read should return %v", err, ErrTimeout)
 	}
 	if n != 0 {
-		t.Errorf("expected to have read %d bytes, but read %d", 0, n)
+		t.Errorf("read %d, but expected to have read %d bytes", n, 0)
 	}
 
 	n, err = r.Read(p)
 	if err != nil {
-		t.Errorf("Subsequent call to read succeed. Got %v", err)
+		t.Errorf("got %v, but subsequent call to Read should succeed.", err)
 	}
 	if n != 2 {
-		t.Errorf("expected to have read %d bytes, but read %d", 2, n)
+		t.Errorf("read %d, but expected to have read %d bytes", n, 2)
 	}
 }
 
@@ -103,7 +104,7 @@ var dataErrReaderTests = []struct {
 	n    int
 }{
 	{[]byte("hello"), []byte("o"), 1},
-	{[]byte("hello,"), []byte("o,"), 2},
+	{[]byte("abcdef"), []byte("ef"), 2},
 }
 
 func TestDataErrReader(t *testing.T) {
@@ -122,7 +123,7 @@ func TestDataErrReader(t *testing.T) {
 			t.Errorf("Last call to Read should have read %d bytes instead of %d", n, tt.n)
 		}
 		if reflect.DeepEqual(p[:n], tt.p) != true {
-			t.Errorf("Wanted %v got %v", tt.p, p[:n])
+			t.Errorf("got %q, expected %q ", p[:n], tt.p)
 		}
 	}
 }

--- a/src/testing/iotest/writer_test.go
+++ b/src/testing/iotest/writer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2009 The Go Authors. All rights reserved.
+// Copyright 2019 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/src/testing/iotest/writer_test.go
+++ b/src/testing/iotest/writer_test.go
@@ -29,11 +29,11 @@ func TestTruncateWriter(t *testing.T) {
 		if err != nil {
 			t.Errorf("Unexpected error %v for\n\t%+v", err, tt)
 		}
-		if buf.String() != tt.want {
-			t.Errorf("got %q, expected %q", buf.String(), tt.want)
+		if g, w := buf.String(), tt.want; g != w {
+			t.Errorf("got %q, expected %q", g, w)
 		}
-		if n != tt.n {
-			t.Errorf("read %d bytes, but expected to have read %d bytes", n, tt.n)
+		if g, w := n, tt.n; g != w {
+			t.Errorf("read %d bytes, but expected to have read %d bytes", g, w)
 		}
 	}
 }

--- a/src/testing/iotest/writer_test.go
+++ b/src/testing/iotest/writer_test.go
@@ -16,24 +16,24 @@ var truncateWriterTests = []struct {
 	n   int
 }{
 	{"hello", "", -1, 5},
-	{"hello", "", 0, 5},
-	{"hello", "hel", 3, 5},
-	{"hello", "hello", 7, 5},
+	{"world", "", 0, 5},
+	{"abcde", "abc", 3, 5},
+	{"edcba", "edcba", 7, 5},
 }
 
 func TestTruncateWriter(t *testing.T) {
 	for _, tt := range truncateWriterTests {
-		rb := new(bytes.Buffer)
-		trb := TruncateWriter(rb, tt.twn)
+		w := new(bytes.Buffer)
+		trb := TruncateWriter(w, tt.twn)
 		n, err := trb.Write([]byte(tt.in))
 		if err != nil {
 			t.Error(err)
 		}
-		if rb.String() != tt.out {
-			t.Errorf("expected %s, got %s", tt.out, rb.String())
+		if w.String() != tt.out {
+			t.Errorf("got %q, expected %q", w.String(), tt.out)
 		}
 		if n != tt.n {
-			t.Errorf("expected to have read %d bytes, but read %d", tt.n, n)
+			t.Errorf("read %d bytes, but expected to have read %d bytes", n, tt.n)
 		}
 	}
 }

--- a/src/testing/iotest/writer_test.go
+++ b/src/testing/iotest/writer_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 var truncateWriterTests = []struct {
-	in  string
-	out string
-	twn int64
-	n   int
+	in    string
+	want  string
+	trunc int64
+	n     int
 }{
 	{"hello", "", -1, 5},
 	{"world", "", 0, 5},
@@ -23,14 +23,14 @@ var truncateWriterTests = []struct {
 
 func TestTruncateWriter(t *testing.T) {
 	for _, tt := range truncateWriterTests {
-		w := new(bytes.Buffer)
-		trb := TruncateWriter(w, tt.twn)
-		n, err := trb.Write([]byte(tt.in))
+		buf := new(bytes.Buffer)
+		tw := TruncateWriter(buf, tt.trunc)
+		n, err := tw.Write([]byte(tt.in))
 		if err != nil {
 			t.Error(err)
 		}
-		if w.String() != tt.out {
-			t.Errorf("got %q, expected %q", w.String(), tt.out)
+		if buf.String() != tt.want {
+			t.Errorf("got %q, expected %q", buf.String(), tt.want)
 		}
 		if n != tt.n {
 			t.Errorf("read %d bytes, but expected to have read %d bytes", n, tt.n)

--- a/src/testing/iotest/writer_test.go
+++ b/src/testing/iotest/writer_test.go
@@ -33,7 +33,7 @@ func TestTruncateWriter(t *testing.T) {
 			t.Errorf("got %q, expected %q", g, w)
 		}
 		if g, w := n, tt.n; g != w {
-			t.Errorf("read %d bytes, but expected to have read %d bytes", g, w)
+			t.Errorf("read %d bytes, but expected to have read %d bytes for\n\t%+v", g, w, tt)
 		}
 	}
 }

--- a/src/testing/iotest/writer_test.go
+++ b/src/testing/iotest/writer_test.go
@@ -27,7 +27,7 @@ func TestTruncateWriter(t *testing.T) {
 		tw := TruncateWriter(buf, tt.trunc)
 		n, err := tw.Write([]byte(tt.in))
 		if err != nil {
-			t.Error(err)
+			t.Errorf("Unexpected error %v for\n\t%+v", err, tt)
 		}
 		if buf.String() != tt.want {
 			t.Errorf("got %q, expected %q", buf.String(), tt.want)

--- a/src/testing/iotest/writer_test.go
+++ b/src/testing/iotest/writer_test.go
@@ -1,3 +1,7 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package iotest
 
 import (

--- a/src/testing/iotest/writer_test.go
+++ b/src/testing/iotest/writer_test.go
@@ -1,0 +1,35 @@
+package iotest
+
+import (
+	"bytes"
+	"testing"
+)
+
+var truncateWriterTests = []struct {
+	in  string
+	out string
+	twn int64
+	n   int
+}{
+	{"hello", "", -1, 5},
+	{"hello", "", 0, 5},
+	{"hello", "hel", 3, 5},
+	{"hello", "hello", 7, 5},
+}
+
+func TestTruncateWriter(t *testing.T) {
+	for _, tt := range truncateWriterTests {
+		rb := new(bytes.Buffer)
+		trb := TruncateWriter(rb, tt.twn)
+		n, err := trb.Write([]byte(tt.in))
+		if err != nil {
+			t.Error(err)
+		}
+		if rb.String() != tt.out {
+			t.Errorf("expected %s, got %s", tt.out, rb.String())
+		}
+		if n != tt.n {
+			t.Errorf("expected to have read %d bytes, but read %d", tt.n, n)
+		}
+	}
+}


### PR DESCRIPTION
Adds missing tests for all the types:
* OneByteReader
* HalfReader
* DataErrReader
* TimeoutReader
* TruncateWriter
* writeLogger
* readLogger

Fixes #33650