### PR TITLE
runtime: remove outdated comment in select sortkey

### DIFF
--- a/src/runtime/select.go
+++ b/src/runtime/select.go
@@ -493,8 +493,6 @@ sclose:
 }
 
 func (c *hchan) sortkey() uintptr {
-	// TODO(khr): if we have a moving garbage collector, we'll need to
-	// change this function.
 	return uintptr(unsafe.Pointer(c))
 }
 


### PR DESCRIPTION
This CL removes an outdated comment regarding converting a pointer to `uintptr`. 
The comment was introduced in Go 1.4 and runtime GC was under the consideration of major revisions. According to the current situation, Go runtime memory allocator has no fragmentation issue. Therefore compact GC won't be implemented in the near future.