### PR TITLE
encoding/json: marshal documentation add []uint8 the base64 encoding note

### DIFF
--- a/src/encoding/json/encode.go
+++ b/src/encoding/json/encode.go
@@ -53,7 +53,7 @@ import (
 // by calling SetEscapeHTML(false).
 //
 // Array and slice values encode as JSON arrays, except that
-// []byte encodes as a base64-encoded string, and a nil slice
+// []uint8 and []byte encodes as a base64-encoded string, and a nil slice
 // encodes as the null JSON value.
 //
 // Struct values encode as JSON objects.


### PR DESCRIPTION
Some users might not know that []uint8 is equal to []byte so it might be better to also show []uint8 in this part of the documentation