### PR TITLE
net: update quotation marks in comment

### DIFF
--- a/src/net/ip.go
+++ b/src/net/ip.go
@@ -65,8 +65,8 @@ func IPv4Mask(a, b, c, d byte) IPMask {
 	return p
 }
 
-// CIDRMask returns an IPMask consisting of `ones' 1 bits
-// followed by 0s up to a total length of `bits' bits.
+// CIDRMask returns an IPMask consisting of 'ones' 1 bits
+// followed by 0s up to a total length of 'bits' bits.
 // For a mask of this form, CIDRMask is the inverse of IPMask.Size.
 func CIDRMask(ones, bits int) IPMask {
 	if bits != 8*IPv4len && bits != 8*IPv6len {


### PR DESCRIPTION
This change updates the use of quotation marks by replacing \`ones' with 'ones'.
Quotation like \`this' should not be used any more according to
https://www.cl.cam.ac.uk/~mgk25/ucs/quotes.html