### PR TITLE
syscall: fix duplicate comments

### DIFF
--- a/src/syscall/syscall_js.go
+++ b/src/syscall/syscall_js.go
@@ -45,7 +45,7 @@ const PathMax = 256
 //		err = errno
 //	}
 //
-// Errno values can be tested against error values from the the os package
+// Errno values can be tested against error values from the os package
 // using errors.Is. For example:
 //
 //	_, _, err := syscall.Syscall(...)

--- a/src/syscall/syscall_nacl.go
+++ b/src/syscall/syscall_nacl.go
@@ -52,7 +52,7 @@ const PathMax = 256
 //		err = errno
 //	}
 //
-// Errno values can be tested against error values from the the os package
+// Errno values can be tested against error values from the os package
 // using errors.Is. For example:
 //
 //	_, _, err := syscall.Syscall(...)

--- a/src/syscall/syscall_plan9.go
+++ b/src/syscall/syscall_plan9.go
@@ -21,7 +21,7 @@ const bitSize16 = 2
 
 // ErrorString implements Error's String method by returning itself.
 //
-// ErrorString values can be tested against error values from the the os package
+// ErrorString values can be tested against error values from the os package
 // using errors.Is. For example:
 //
 //	_, _, err := syscall.Syscall(...)

--- a/src/syscall/syscall_unix.go
+++ b/src/syscall/syscall_unix.go
@@ -108,7 +108,7 @@ func (m *mmapper) Munmap(data []byte) (err error) {
 //		err = errno
 //	}
 //
-// Errno values can be tested against error values from the the os package
+// Errno values can be tested against error values from the os package
 // using errors.Is. For example:
 //
 //	_, _, err := syscall.Syscall(...)

--- a/src/syscall/syscall_windows.go
+++ b/src/syscall/syscall_windows.go
@@ -78,7 +78,7 @@ func UTF16PtrFromString(s string) (*uint16, error) {
 
 // Errno is the Windows error number.
 //
-// Errno values can be tested against error values from the the os package
+// Errno values can be tested against error values from the os package
 // using errors.Is. For example:
 //
 //	_, _, err := syscall.Syscall(...)


### PR DESCRIPTION
Removed repetitions of "the" in some comments.