### PR TITLE
net/http: fix a typo in comments

### DIFF
--- a/src/net/http/httptrace/trace.go
+++ b/src/net/http/httptrace/trace.go
@@ -133,8 +133,8 @@ type ClientTrace struct {
 	ConnectDone func(network, addr string, err error)
 
 	// TLSHandshakeStart is called when the TLS handshake is started. When
-	// connecting to a HTTPS site via a HTTP proxy, the handshake happens after
-	// the CONNECT request is processed by the proxy.
+	// connecting to an HTTPS site via an HTTP proxy, the handshake happens
+	// after the CONNECT request is processed by the proxy.
 	TLSHandshakeStart func()
 
 	// TLSHandshakeDone is called after the TLS handshake with either the

--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -763,7 +763,7 @@ func removeZone(host string) string {
 	return host[:j] + host[i:]
 }
 
-// ParseHTTPVersion parses a HTTP version string.
+// ParseHTTPVersion parses an HTTP version string.
 // "HTTP/1.0" returns (1, 0, true).
 func ParseHTTPVersion(vers string) (major, minor int, ok bool) {
 	const Big = 1000000 // arbitrary upper bound


### PR DESCRIPTION
HTTP is an initialism, not an acronym, where you pronounce each letter as a
word. It's "an H", not "a H".

Running `find src/net/http -type f | xargs grep -n 'an HTTP' | wc -l` shows
that the "an HTTP" form is used 67 times across the `net/http` package.
Furthermore, `find src/net/http -type f | xargs grep -n 'a HTTP' | wc -l`
yields only 4 results.