### PR TITLE
os: close the handle returned by OpenProcess

### DIFF
--- a/src/os/exec_windows.go
+++ b/src/os/exec_windows.go
@@ -94,6 +94,7 @@ func findProcess(pid int) (p *Process, err error) {
 	if e != nil {
 		return nil, NewSyscallError("OpenProcess", e)
 	}
+	defer syscall.CloseHandle(h)
 	return newProcess(pid, uintptr(h)), nil
 }
 


### PR DESCRIPTION
Close the handle to avoid process becoming zombie. Fixes #33814