### PR TITLE
runtime: move forcegchelper to gcenable

### DIFF
--- a/src/runtime/mgc.go
+++ b/src/runtime/mgc.go
@@ -200,11 +200,32 @@ func readgogc() int32 {
 	return 100
 }
 
+func forcegchelper() {
+	forcegc.g = getg()
+	for {
+		lock(&forcegc.lock)
+		if forcegc.idle != 0 {
+			throw("forcegc: phase error")
+		}
+		atomic.Store(&forcegc.idle, 1)
+		goparkunlock(&forcegc.lock, waitReasonForceGGIdle, traceEvGoBlock, 1)
+		// this goroutine is explicitly resumed by sysmon
+		if debug.gctrace > 0 {
+			println("GC forced")
+		}
+		// Time-triggered, fully concurrent.
+		gcStart(gcTrigger{kind: gcTriggerTime, now: nanotime()})
+	}
+}
+
 // gcenable is called after the bulk of the runtime initialization,
 // just before we're about to start letting user code run.
-// It kicks off the background sweeper goroutine, the background
+// It kicks off the forcegc helper goroutine, background sweeper goroutine, the background
 // scavenger goroutine, and enables GC.
 func gcenable() {
+	// Start forcegc helper goroutine
+	go forcegchelper()
+
 	// Kick off sweeping and scavenging.
 	c := make(chan int, 2)
 	go bgsweep(c)

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -237,29 +237,6 @@ func os_beforeExit() {
 	}
 }
 
-// start forcegc helper goroutine
-func init() {
-	go forcegchelper()
-}
-
-func forcegchelper() {
-	forcegc.g = getg()
-	for {
-		lock(&forcegc.lock)
-		if forcegc.idle != 0 {
-			throw("forcegc: phase error")
-		}
-		atomic.Store(&forcegc.idle, 1)
-		goparkunlock(&forcegc.lock, waitReasonForceGGIdle, traceEvGoBlock, 1)
-		// this goroutine is explicitly resumed by sysmon
-		if debug.gctrace > 0 {
-			println("GC forced")
-		}
-		// Time-triggered, fully concurrent.
-		gcStart(gcTrigger{kind: gcTriggerTime, now: nanotime()})
-	}
-}
-
 //go:nosplit
 
 // Gosched yields the processor, allowing other goroutines to run. It does not


### PR DESCRIPTION
This CL moves runtime.forcegchelper out of runtime.init and puts it in
runtime.gcenable.

forcegchelper goroutine was placed in runtime.init and there is no
specific reason that requires it to be executed in the runtime_inittask
since the forcegchelper goroutine is not guaranteed to be scheduled
before runtime.gcenable. For better readability to all GC related helpers
start, move runtime.forcegchelper out from proc.go to runtime.gcenable
in mgc.go.