### PR TITLE
net/url: fail TestParseErrors test when getting an unwanted error

### DIFF
--- a/src/net/url/url_test.go
+++ b/src/net/url/url_test.go
@@ -1437,7 +1437,7 @@ func TestParseErrors(t *testing.T) {
 		{"http://[%10::1]", true},        // no %xx escapes in IP address
 		{"http://[::1]/%48", false},      // %xx in path is fine
 		{"http://%41:8080/", true},       // not allowed: % encoding only for non-ASCII
-		{"mysql://x@y(z:123)/foo", true}, // not well-formed per RFC 3986, github.com/golang/go/issues/33646
+		{"mysql://x@y(z:123)/foo", true}, // not well-formed per RFC 3986, golang.org/issue/33646
 		{"mysql://x@y(1.2.3.4:123)/foo", true},
 
 		{"http://[]%20%48%54%54%50%2f%31%2e%31%0a%4d%79%48%65%61%64%65%72%3a%20%31%32%33%0a%0a/", true}, // golang.org/issue/11208

--- a/src/net/url/url_test.go
+++ b/src/net/url/url_test.go
@@ -1456,7 +1456,7 @@ func TestParseErrors(t *testing.T) {
 			continue
 		}
 		if err != nil {
-			t.Logf("Parse(%q) = %v; want no error", tt.in, err)
+			t.Errorf("Parse(%q) = %v; want no error", tt.in, err)
 		}
 	}
 }

--- a/src/net/url/url_test.go
+++ b/src/net/url/url_test.go
@@ -1429,16 +1429,16 @@ func TestParseErrors(t *testing.T) {
 		{"http://[::1]/", false},
 		{"http://[::1]a", true},
 		{"http://[::1]%23", true},
-		{"http://[::1%25en0]", false},     // valid zone id
-		{"http://[::1]:", false},          // colon, but no port OK
-		{"http://x:", false},              // colon, but no port OK
-		{"http://[::1]:%38%30", true},     // not allowed: % encoding only for non-ASCII
-		{"http://[::1%25%41]", false},     // RFC 6874 allows over-escaping in zone
-		{"http://[%10::1]", true},         // no %xx escapes in IP address
-		{"http://[::1]/%48", false},       // %xx in path is fine
-		{"http://%41:8080/", true},        // not allowed: % encoding only for non-ASCII
-		{"mysql://x@y(z:123)/foo", false}, // golang.org/issue/12023
-		{"mysql://x@y(1.2.3.4:123)/foo", false},
+		{"http://[::1%25en0]", false},    // valid zone id
+		{"http://[::1]:", false},         // colon, but no port OK
+		{"http://x:", false},             // colon, but no port OK
+		{"http://[::1]:%38%30", true},    // not allowed: % encoding only for non-ASCII
+		{"http://[::1%25%41]", false},    // RFC 6874 allows over-escaping in zone
+		{"http://[%10::1]", true},        // no %xx escapes in IP address
+		{"http://[::1]/%48", false},      // %xx in path is fine
+		{"http://%41:8080/", true},       // not allowed: % encoding only for non-ASCII
+		{"mysql://x@y(z:123)/foo", true}, // not well-formed per RFC 3986, github.com/golang/go/issues/33646
+		{"mysql://x@y(1.2.3.4:123)/foo", true},
 
 		{"http://[]%20%48%54%54%50%2f%31%2e%31%0a%4d%79%48%65%61%64%65%72%3a%20%31%32%33%0a%0a/", true}, // golang.org/issue/11208
 		{"http://a b.com/", true},    // no space in host name please


### PR DESCRIPTION
The TestParseErrors test function was not strict with unwanted errors
received from url.Parse(). It was not failing in such cases, now it does

Fixes #33646
Updates #29098