### PR TITLE
net/http: improve FileServer error logging

### DIFF
--- a/src/net/http/export_test.go
+++ b/src/net/http/export_test.go
@@ -29,6 +29,7 @@ var (
 	ExportErrRequestCanceledConn      = errRequestCanceledConn
 	ExportErrServerClosedIdle         = errServerClosedIdle
 	ExportServeFile                   = serveFile
+	ExportCopyNIgnoreWriteError       = copyNIgnoreWriteError
 	ExportScanETag                    = scanETag
 	ExportHttp2ConfigureServer        = http2ConfigureServer
 	Export_shouldCopyHeaderOnRedirect = shouldCopyHeaderOnRedirect


### PR DESCRIPTION
The errors returned during copying the file content in ServeContent,
ServeFile and FileServer were ignored to avoid excessive, meaningless
logging. This commit introduces error filtering and logging to ensure
that the errors occurring during reading the content are logged.

Updates #27128