### PR TITLE
database/sql: refactor err returning value from Scan to if stmt

### DIFF
--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -3132,8 +3132,8 @@ func (r *Row) Scan(dest ...interface{}) error {
 		}
 		return ErrNoRows
 	}
-	err := r.rows.Scan(dest...)
-	if err != nil {
+
+	if err := r.rows.Scan(dest...); err != nil {
 		return err
 	}
 	// Make sure the query can be processed to completion with no errors.


### PR DESCRIPTION
database/sql: refactor err returning value from Scan to if stmt

This change modifies Go to satisfy it's own code-style rules and readability + compiler parsing boosting
