### PR TITLE
runtime: fix crash during VDSO calls on arm

### DIFF
--- a/src/runtime/crash_test.go
+++ b/src/runtime/crash_test.go
@@ -143,6 +143,14 @@ func buildTestProg(t *testing.T, binary string, flags ...string) (string, error)
 	return exe, nil
 }
 
+func TestVDSO(t *testing.T) {
+	output := runTestProg(t, "testprog", "SignalInVDSO")
+	want := "success\n"
+	if output != want {
+		t.Fatalf("output:\n%s\n\nwanted:\n%s", output, want);
+	}
+}
+
 var (
 	staleRuntimeOnce sync.Once // guards init of staleRuntimeErr
 	staleRuntimeErr  error

--- a/src/runtime/crash_test.go
+++ b/src/runtime/crash_test.go
@@ -144,6 +144,7 @@ func buildTestProg(t *testing.T, binary string, flags ...string) (string, error)
 }
 
 func TestVDSO(t *testing.T) {
+	t.Parallel()
 	output := runTestProg(t, "testprog", "SignalInVDSO")
 	want := "success\n"
 	if output != want {

--- a/src/runtime/testdata/testprog/vdso.go
+++ b/src/runtime/testdata/testprog/vdso.go
@@ -33,8 +33,8 @@ func signalInVDSO() {
         t0 := time.Now()
         t1 := t0
         // We should get a profiling signal 100 times a second,
-        // so running for 10 seconds should be sufficient.
-        for t1.Sub(t0) < 10*time.Second {
+        // so running for 1 second should be sufficient.
+        for t1.Sub(t0) < time.Second {
                 t1 = time.Now()
         }
 

--- a/src/runtime/testdata/testprog/vdso.go
+++ b/src/runtime/testdata/testprog/vdso.go
@@ -1,0 +1,55 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Invoke signal hander in the VDSO context (see issue 32912).
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"runtime/pprof"
+	"time"
+)
+
+func init() {
+	register("SignalInVDSO", signalInVDSO)
+}
+
+func signalInVDSO() {
+        f, err := ioutil.TempFile("", "timeprofnow")
+        if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+        }
+
+        if err := pprof.StartCPUProfile(f); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+        }
+
+        t0 := time.Now()
+        t1 := t0
+        // We should get a profiling signal 100 times a second,
+        // so running for 10 seconds should be sufficient.
+        for t1.Sub(t0) < 10*time.Second {
+                t1 = time.Now()
+        }
+
+        pprof.StopCPUProfile()
+
+        name := f.Name()
+        if err := f.Close(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+        }
+
+        if err := os.Remove(name); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+        }
+
+	fmt.Println("success");
+}

--- a/src/runtime/vdso_linux.go
+++ b/src/runtime/vdso_linux.go
@@ -281,6 +281,7 @@ func vdsoauxv(tag, val uintptr) {
 }
 
 // vdsoMarker reports whether PC is on the VDSO page.
+//go:nosplit
 func inVDSOPage(pc uintptr) bool {
 	for _, k := range vdsoSymbolKeys {
 		if *k.ptr != 0 {


### PR DESCRIPTION
As discussed in #32912, a crash occurs when go runtime calls a VDSO function (say
__vdso_clock_gettime) and a signal arrives to that thread.
Since VDSO functions temporarily destroy the G register (R10),
Go functions asynchronously executed in that thread (i.e. Go's signal
handler) can try to load data from the destroyed G, which causes
segmentation fault.

To fix the issue a guard is inserted in front of sigtrampgo, so that the control escapes from
signal handlers without touching G in case the signal occurred in the VDSO context.
The test case included in the patch is take from discussion in a relevant thread on github:
https://github.com/golang/go/issues/32912#issuecomment-517874531.
This patch not only fixes the issue on AArch64 but also that on 32bit ARM.

Fixes #32912 