### PR TITLE
net/http: fix not setting request host from Host header fixes #34124

### DIFF
--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -556,10 +556,14 @@ func (r *Request) write(w io.Writer, usingProxy bool, extraHeaders Header, waitF
 	// Clean the host, in case it arrives with unexpected stuff in it.
 	host := cleanHost(r.Host)
 	if host == "" {
-		if r.URL == nil {
-			return errMissingHost
+		if r.Header.has("Host") {
+			host = r.Header.Get("Host")
+		} else {
+			if r.URL == nil {
+				return errMissingHost
+			}
+			host = cleanHost(r.URL.Host)
 		}
-		host = cleanHost(r.URL.Host)
 	}
 
 	// According to RFC 6874, an HTTP client, proxy, or other

--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -556,13 +556,14 @@ func (r *Request) write(w io.Writer, usingProxy bool, extraHeaders Header, waitF
 	// Clean the host, in case it arrives with unexpected stuff in it.
 	host := cleanHost(r.Host)
 	if host == "" {
-		if r.Header.has("Host") {
-			host = r.Header.Get("Host")
+		if r.URL == nil {
+			return errMissingHost
 		} else {
-			if r.URL == nil {
-				return errMissingHost
+			if r.Header.has("Host") {
+				host = cleanHost(r.Header.Get("Host"))
+			}else{
+				host = cleanHost(r.URL.Host)
 			}
-			host = cleanHost(r.URL.Host)
 		}
 	}
 

--- a/src/net/http/requestwrite_test.go
+++ b/src/net/http/requestwrite_test.go
@@ -411,12 +411,12 @@ var reqWriteTests = []reqWriteTest{
 			ProtoMajor: 1,
 			ProtoMinor: 1,
 			Header: Header{
-				"Host": []string{"bad.example.com"},
+				"Host": []string{"good.example.com"},
 			},
 		},
 
 		WantWrite: "GET /search HTTP/1.1\r\n" +
-			"Host: \r\n" +
+			"Host: good.example.com\r\n" +
 			"User-Agent: Go-http-client/1.1\r\n\r\n",
 	},
 


### PR DESCRIPTION
The comment actually says it will prefer the Host header if is that given. But it does not.
