### PR TITLE
encoding/json: don't reset before returning buffer to pool

### DIFF
--- a/src/encoding/json/encode.go
+++ b/src/encoding/json/encode.go
@@ -164,7 +164,6 @@ func Marshal(v interface{}) ([]byte, error) {
 	}
 	buf := append([]byte(nil), e.Bytes()...)
 
-	e.Reset()
 	encodeStatePool.Put(e)
 
 	return buf, nil


### PR DESCRIPTION
Reset is already performed when retrieving from pool