### PR TITLE
strconv: add Unwrap to custom error types

### DIFF
--- a/src/strconv/atoi.go
+++ b/src/strconv/atoi.go
@@ -31,6 +31,8 @@ func (e *NumError) Error() string {
 	return "strconv." + e.Func + ": " + "parsing " + Quote(e.Num) + ": " + e.Err.Error()
 }
 
+func (e *NumError) Unwrap() error { return e.Err }
+
 func syntaxError(fn, str string) *NumError {
 	return &NumError{fn, str, ErrSyntax}
 }

--- a/src/strconv/atoi_test.go
+++ b/src/strconv/atoi_test.go
@@ -592,6 +592,13 @@ func TestNumError(t *testing.T) {
 	}
 }
 
+func TestNumErrorUnwrap(t *testing.T) {
+	err := &NumError{Err: ErrSyntax}
+	if !errors.Is(err, ErrSyntax) {
+		t.Error("errors.Is failed, wanted success")
+	}
+}
+
 func BenchmarkParseInt(b *testing.B) {
 	b.Run("Pos", func(b *testing.B) {
 		benchmarkParseInt(b, 1)


### PR DESCRIPTION
Updates #30322

This change adds the Unwrap method to NumError. NumError is the only custom error type of the strconv that has a nested exported error.
