### PR TITLE
cmd/go/internal/modfetch/codehost: add Unwrap to custom error types

### DIFF
--- a/src/cmd/go/internal/modfetch/codehost/codehost.go
+++ b/src/cmd/go/internal/modfetch/codehost/codehost.go
@@ -242,6 +242,8 @@ func (e *RunError) Error() string {
 	return text
 }
 
+func (e *RunError) Unwrap() error { return e.Err }
+
 var dirLock sync.Map
 
 // Run runs the command line in the given directory

--- a/src/cmd/go/internal/modfetch/codehost/codehost_test.go
+++ b/src/cmd/go/internal/modfetch/codehost/codehost_test.go
@@ -1,0 +1,18 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package codehost
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRunErrorUnwrap(t *testing.T) {
+	werr := errors.New("wrapped error")
+	err := &RunError{Err: werr}
+	if !errors.Is(err, werr) {
+		t.Error("errors.Is failed, wanted success")
+	}
+}

--- a/src/cmd/go/internal/modfetch/codehost/vcs.go
+++ b/src/cmd/go/internal/modfetch/codehost/vcs.go
@@ -38,6 +38,8 @@ type VCSError struct {
 
 func (e *VCSError) Error() string { return e.Err.Error() }
 
+func (e *VCSError) Unwrap() error { return e.Err }
+
 func vcsErrorf(format string, a ...interface{}) error {
 	return &VCSError{Err: fmt.Errorf(format, a...)}
 }

--- a/src/cmd/go/internal/modfetch/codehost/vcs_test.go
+++ b/src/cmd/go/internal/modfetch/codehost/vcs_test.go
@@ -1,0 +1,18 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package codehost
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestVCSErrorUnwrap(t *testing.T) {
+	werr := errors.New("wrapped error")
+	err := &VCSError{Err: werr}
+	if !errors.Is(err, werr) {
+		t.Error("errors.Is failed, wanted success")
+	}
+}


### PR DESCRIPTION
Updates #30322

This change adds the Unwrap method to RunError and VCSError. These 2 error types are the only custom error type of the codehost that has a nested exported error.