### PR TITLE
cmd/go: make env -w and -u validate GOOS and GOARCH values

### DIFF
--- a/src/cmd/go/internal/envcmd/env.go
+++ b/src/cmd/go/internal/envcmd/env.go
@@ -284,10 +284,16 @@ func runEnv(cmd *base.Command, args []string) {
 		if del["GOOS"] || del["GOARCH"] {
 			goos, goarch := cfg.Goos, cfg.Goarch
 			if del["GOOS"] {
-				goos = build.Default.GOOS
+				goos = getOrigEnv("GOOS")
+				if goos == "" {
+					goos = build.Default.GOOS
+				}
 			}
 			if del["GOARCH"] {
-				goarch = build.Default.GOARCH
+				goarch = getOrigEnv("GOARCH")
+				if goarch == "" {
+					goarch = build.Default.GOARCH
+				}
 			}
 			if err := work.CheckGOOSARCHPair(goos, goarch); err != nil {
 				base.Fatalf("go env -u: %v", err)
@@ -357,6 +363,15 @@ func printEnvAsJSON(env []cfg.EnvVar) {
 	if err := enc.Encode(m); err != nil {
 		base.Fatalf("go env -json: %s", err)
 	}
+}
+
+func getOrigEnv(key string) string {
+	for _, v := range cfg.OrigEnv {
+		if strings.HasPrefix(v, key+"=") {
+			return strings.TrimPrefix(v, key+"=")
+		}
+	}
+	return ""
 }
 
 func checkEnvWrite(key, val string) error {

--- a/src/cmd/go/internal/envcmd/env.go
+++ b/src/cmd/go/internal/envcmd/env.go
@@ -8,6 +8,7 @@ package envcmd
 import (
 	"encoding/json"
 	"fmt"
+	"go/build"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -15,7 +16,6 @@ import (
 	"sort"
 	"strings"
 	"unicode/utf8"
-	"go/build"
 
 	"cmd/go/internal/base"
 	"cmd/go/internal/cache"
@@ -251,8 +251,8 @@ func runEnv(cmd *base.Command, args []string) {
 			}
 		}
 
-		goos,okGOOS := add["GOOS"]
-		goarch,okGOARCH := add["GOARCH"]
+		goos, okGOOS := add["GOOS"]
+		goarch, okGOARCH := add["GOARCH"]
 		if okGOOS || okGOARCH {
 			if !okGOOS {
 				goos = cfg.Goos

--- a/src/cmd/go/internal/work/action.go
+++ b/src/cmd/go/internal/work/action.go
@@ -290,11 +290,12 @@ func (b *Builder) Init() {
 		}
 	}
 
-	if _, ok := cfg.OSArchSupportsCgo[cfg.Goos+"/"+cfg.Goarch]; !ok && cfg.BuildContext.Compiler == "gc" {
-		fmt.Fprintf(os.Stderr, "cmd/go: unsupported GOOS/GOARCH pair %s/%s\n", cfg.Goos, cfg.Goarch)
+	if err := CheckGOOSARCHPair(cfg.Goos, cfg.Goarch); err != nil {
+		fmt.Fprintf(os.Stderr, "cmd/go: %v", err)
 		base.SetExitStatus(2)
 		base.Exit()
 	}
+
 	for _, tag := range cfg.BuildContext.BuildTags {
 		if strings.Contains(tag, ",") {
 			fmt.Fprintf(os.Stderr, "cmd/go: -tags space-separated list contains comma\n")
@@ -302,6 +303,13 @@ func (b *Builder) Init() {
 			base.Exit()
 		}
 	}
+}
+
+func CheckGOOSARCHPair(goos, goarch string) error {
+	if _, ok := cfg.OSArchSupportsCgo[goos+"/"+goarch]; !ok && cfg.BuildContext.Compiler == "gc" {
+		return fmt.Errorf("unsupported GOOS/GOARCH pair %s/%s", goos, goarch)
+	}	
+	return nil
 }
 
 // NewObjdir returns the name of a fresh object directory under b.WorkDir.

--- a/src/cmd/go/internal/work/action.go
+++ b/src/cmd/go/internal/work/action.go
@@ -308,7 +308,7 @@ func (b *Builder) Init() {
 func CheckGOOSARCHPair(goos, goarch string) error {
 	if _, ok := cfg.OSArchSupportsCgo[goos+"/"+goarch]; !ok && cfg.BuildContext.Compiler == "gc" {
 		return fmt.Errorf("unsupported GOOS/GOARCH pair %s/%s", goos, goarch)
-	}	
+	}
 	return nil
 }
 

--- a/src/cmd/go/testdata/script/env_write.txt
+++ b/src/cmd/go/testdata/script/env_write.txt
@@ -96,3 +96,29 @@ stderr 'GOPATH entry cannot start with shell metacharacter'
 
 ! go env -w GOPATH=./go
 stderr 'GOPATH entry is relative; must be absolute path'
+
+# go env -w/-u checks validity of GOOS/ARCH combinations
+env GOOS=
+env GOARCH=
+# check -w doesn't allow invalid GOOS
+! go env -w GOOS=linuxx
+stderr 'unsupported GOOS/GOARCH pair linuxx'
+# check -w doesn't allow invalid GOARCH
+! go env -w GOARCH=amd644
+stderr 'unsupported GOOS/GOARCH.*/amd644$'
+# check -w doesn't allow invalid GOOS with valid GOARCH
+! go env -w GOOS=linuxx GOARCH=amd64
+stderr 'unsupported GOOS/GOARCH pair linuxx'
+# check that -u won't allow an invalid combination after a successful -w
+go env -w GOOS=nacl GOARCH=amd64p32 
+! go env -u GOOS
+stderr 'unsupported GOOS/GOARCH.*/amd64p32$'
+# check that -u considers explicit envs in action validation
+go env -u GOOS GOARCH
+env GOOS=nacl
+env GOARCH=amd64p32
+go env -w GOOS=linux GOARCH=amd64
+env GOOS=
+! go env -u GOARCH
+stderr 'linux/amd64p32'
+

--- a/src/cmd/go/testdata/script/env_write.txt
+++ b/src/cmd/go/testdata/script/env_write.txt
@@ -109,6 +109,9 @@ stderr 'unsupported GOOS/GOARCH.*/amd644$'
 # check -w doesn't allow invalid GOOS with valid GOARCH
 ! go env -w GOOS=linuxx GOARCH=amd64
 stderr 'unsupported GOOS/GOARCH pair linuxx'
+# check a valid GOOS and GOARCH values but an incompatible combinations
+! go env -w GOOS=android GOARCH=s390x
+stderr 'unsupported GOOS/GOARCH pair android/s390x'
 # check that -u considers explicit envs
 go env -w GOOS=linux GOARCH=mips
 env GOOS=windows

--- a/src/cmd/go/testdata/script/env_write.txt
+++ b/src/cmd/go/testdata/script/env_write.txt
@@ -109,16 +109,8 @@ stderr 'unsupported GOOS/GOARCH.*/amd644$'
 # check -w doesn't allow invalid GOOS with valid GOARCH
 ! go env -w GOOS=linuxx GOARCH=amd64
 stderr 'unsupported GOOS/GOARCH pair linuxx'
-# check that -u won't allow an invalid combination after a successful -w
-go env -w GOOS=nacl GOARCH=amd64p32 
+# check that -u considers explicit envs
+go env -w GOOS=linux GOARCH=mips
+env GOOS=windows
 ! go env -u GOOS
-stderr 'unsupported GOOS/GOARCH.*/amd64p32$'
-# check that -u considers explicit envs in action validation
-go env -u GOOS GOARCH
-env GOOS=nacl
-env GOARCH=amd64p32
-go env -w GOOS=linux GOARCH=amd64
-env GOOS=
-! go env -u GOARCH
-stderr 'linux/amd64p32'
-
+stderr 'unsupported GOOS/GOARCH.*windows/mips$'


### PR DESCRIPTION
This change makes go env -w and -u check invalid GOOS and GOARCH values and abort if that's the case.

Fixes #34194