### PR TITLE
cmd/go/internal/renameio,runtime: avoid leaking temp directory in test

### DIFF
--- a/src/cmd/go/internal/renameio/umask_test.go
+++ b/src/cmd/go/internal/renameio/umask_test.go
@@ -19,6 +19,7 @@ func TestWriteFileModeAppliesUmask(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temporary directory: %v", err)
 	}
+	defer os.RemoveAll(dir)
 
 	const mode = 0644
 	const umask = 0007
@@ -29,7 +30,6 @@ func TestWriteFileModeAppliesUmask(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to write file: %v", err)
 	}
-	defer os.RemoveAll(dir)
 
 	fi, err := os.Stat(file)
 	if err != nil {

--- a/src/runtime/signal_windows_test.go
+++ b/src/runtime/signal_windows_test.go
@@ -28,7 +28,7 @@ func TestVectoredHandlerDontCrashOnLibrary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temp directory: %v", err)
 	}
-	defer os.Remove(dir)
+	defer os.RemoveAll(dir)
 
 	// build go dll
 	dll := filepath.Join(dir, "testwinlib.dll")


### PR DESCRIPTION
TestWriteFileModeAppliesUmask and TestVectoredHandlerDontCrashOnLibrary
could both leak /tmp/go-build-* directories which isn't very friendly.