### PR TITLE
encoding/json: make Number with the ,string option marshal with quotes

### DIFF
--- a/src/encoding/json/encode.go
+++ b/src/encoding/json/encode.go
@@ -600,7 +600,13 @@ func stringEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 		if !isValidNumber(numStr) {
 			e.error(fmt.Errorf("json: invalid number literal %q", numStr))
 		}
+		if opts.quoted {
+			e.WriteByte('"')
+		}
 		e.WriteString(numStr)
+		if opts.quoted {
+			e.WriteByte('"')
+		}
 		return
 	}
 	if opts.quoted {

--- a/src/encoding/json/encode_test.go
+++ b/src/encoding/json/encode_test.go
@@ -76,13 +76,15 @@ type StringTag struct {
 	IntStr     int64   `json:",string"`
 	UintptrStr uintptr `json:",string"`
 	StrStr     string  `json:",string"`
+	NumberStr  Number  `json:",string"`
 }
 
 var stringTagExpected = `{
  "BoolStr": "true",
  "IntStr": "42",
  "UintptrStr": "44",
- "StrStr": "\"xzbit\""
+ "StrStr": "\"xzbit\"",
+ "NumberStr": "46"
 }`
 
 func TestStringTag(t *testing.T) {
@@ -91,6 +93,7 @@ func TestStringTag(t *testing.T) {
 	s.IntStr = 42
 	s.UintptrStr = 44
 	s.StrStr = "xzbit"
+	s.NumberStr = "46"
 	got, err := MarshalIndent(&s, "", " ")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Add quotes when marshaling a json.Number with the string option
set via a struct tag. This ensures that the resulting json
can be unmarshaled into the source struct without error.

Fixes #34268