### PR TITLE
net/http: fix reading cookie mistake if ";;" exists, most browsers like Chrome, Safari can handle such a cookie 

### DIFF
--- a/src/net/http/cookie.go
+++ b/src/net/http/cookie.go
@@ -246,7 +246,7 @@ func readCookies(h Header, filter string) []*Cookie {
 
 		var part string
 		for len(line) > 0 { // continue since we have rest
-			if splitIndex := strings.Index(line, ";"); splitIndex > 0 {
+			if splitIndex := strings.Index(line, ";"); splitIndex >= 0 {
 				part, line = line[:splitIndex], line[splitIndex+1:]
 			} else {
 				part, line = line, ""


### PR DESCRIPTION
If cookies is something like this: "a=xxx1;; b=xxx2", func readCookies just ignore "b=xxx2" because of this mistake. This PR can fix it.
