### PR TITLE
cmd/test2json: attribute output to the correct test

### DIFF
--- a/src/cmd/internal/test2json/test2json.go
+++ b/src/cmd/internal/test2json/test2json.go
@@ -211,8 +211,18 @@ func (c *converter) handleInputLine(line []byte) {
 		}
 	}
 
+	// Not a special test output line.
 	if !ok {
-		// Not a special test output line.
+		// Lookup the name of the test which produced the output using the
+		// indentation of the output as an index into the stack of the current
+		// subtests.
+		// If the indentation is greater than the number of current subtests
+		// then the output must have included extra indentation. We can't
+		// determine which subtest produced this output, so we default to the
+		// old behaviour of assuming the most recently run subtest produced it.
+		if indent > 0 && indent <= len(c.report) {
+			c.testName = c.report[indent-1].Test
+		}
 		c.output.write(origLine)
 		return
 	}

--- a/src/cmd/internal/test2json/testdata/issue29755.json
+++ b/src/cmd/internal/test2json/testdata/issue29755.json
@@ -1,0 +1,15 @@
+{"Action":"run","Test":"TestOutputWithSubtest"}
+{"Action":"output","Test":"TestOutputWithSubtest","Output":"=== RUN   TestOutputWithSubtest\n"}
+{"Action":"run","Test":"TestOutputWithSubtest/sub_test"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test","Output":"=== RUN   TestOutputWithSubtest/sub_test\n"}
+{"Action":"output","Test":"TestOutputWithSubtest","Output":"--- FAIL: TestOutputWithSubtest (0.00s)\n"}
+{"Action":"output","Test":"TestOutputWithSubtest","Output":"    foo_test.go:6: output before sub tests\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test","Output":"    --- PASS: TestOutputWithSubtest/sub_test (0.00s)\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test","Output":"        foo_test.go:9: output from sub test\n"}
+{"Action":"output","Test":"TestOutputWithSubtest","Output":"    foo_test.go:12: output after sub test\n"}
+{"Action":"pass","Test":"TestOutputWithSubtest/sub_test"}
+{"Action":"fail","Test":"TestOutputWithSubtest"}
+{"Action":"output","Output":"FAIL\n"}
+{"Action":"output","Output":"FAIL    gotest.tools/gotestsum/foo      0.001s\n"}
+{"Action":"output","Output":"FAIL\n"}
+{"Action":"fail"}

--- a/src/cmd/internal/test2json/testdata/issue29755.json
+++ b/src/cmd/internal/test2json/testdata/issue29755.json
@@ -2,14 +2,37 @@
 {"Action":"output","Test":"TestOutputWithSubtest","Output":"=== RUN   TestOutputWithSubtest\n"}
 {"Action":"run","Test":"TestOutputWithSubtest/sub_test"}
 {"Action":"output","Test":"TestOutputWithSubtest/sub_test","Output":"=== RUN   TestOutputWithSubtest/sub_test\n"}
+{"Action":"run","Test":"TestOutputWithSubtest/sub_test/sub2"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test/sub2","Output":"=== RUN   TestOutputWithSubtest/sub_test/sub2\n"}
+{"Action":"run","Test":"TestOutputWithSubtest/sub_test2"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test2","Output":"=== RUN   TestOutputWithSubtest/sub_test2\n"}
+{"Action":"run","Test":"TestOutputWithSubtest/sub_test2/sub2"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test2/sub2","Output":"=== RUN   TestOutputWithSubtest/sub_test2/sub2\n"}
 {"Action":"output","Test":"TestOutputWithSubtest","Output":"--- FAIL: TestOutputWithSubtest (0.00s)\n"}
 {"Action":"output","Test":"TestOutputWithSubtest","Output":"    foo_test.go:6: output before sub tests\n"}
+{"Action":"output","Test":"TestOutputWithSubtest","Output":"    foo_test.go:10: output from root test\n"}
+{"Action":"output","Test":"TestOutputWithSubtest","Output":"    foo_test.go:15: output from root test\n"}
 {"Action":"output","Test":"TestOutputWithSubtest/sub_test","Output":"    --- PASS: TestOutputWithSubtest/sub_test (0.00s)\n"}
 {"Action":"output","Test":"TestOutputWithSubtest/sub_test","Output":"        foo_test.go:9: output from sub test\n"}
-{"Action":"output","Test":"TestOutputWithSubtest","Output":"    foo_test.go:12: output after sub test\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test","Output":"        foo_test.go:11: more output from sub test\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test","Output":"        foo_test.go:16: more output from sub test\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test/sub2","Output":"        --- PASS: TestOutputWithSubtest/sub_test/sub2 (0.00s)\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test/sub2","Output":"            foo_test.go:14: output from sub2 test\n"}
+{"Action":"output","Test":"TestOutputWithSubtest","Output":"    foo_test.go:22: output from root test\n"}
+{"Action":"output","Test":"TestOutputWithSubtest","Output":"    foo_test.go:27: output from root test\n"}
+{"Action":"pass","Test":"TestOutputWithSubtest/sub_test/sub2"}
 {"Action":"pass","Test":"TestOutputWithSubtest/sub_test"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test2","Output":"    --- PASS: TestOutputWithSubtest/sub_test2 (0.00s)\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test2","Output":"        foo_test.go:21: output from sub test2\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test2","Output":"        foo_test.go:23: more output from sub test2\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test2","Output":"        foo_test.go:28: more output from sub test2\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test2/sub2","Output":"        --- PASS: TestOutputWithSubtest/sub_test2/sub2 (0.00s)\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test2/sub2","Output":"            foo_test.go:26: output from sub2 test\n"}
+{"Action":"output","Test":"TestOutputWithSubtest","Output":"    foo_test.go:32: output after sub test\n"}
+{"Action":"pass","Test":"TestOutputWithSubtest/sub_test2/sub2"}
+{"Action":"pass","Test":"TestOutputWithSubtest/sub_test2"}
 {"Action":"fail","Test":"TestOutputWithSubtest"}
 {"Action":"output","Output":"FAIL\n"}
-{"Action":"output","Output":"FAIL    gotest.tools/gotestsum/foo      0.001s\n"}
+{"Action":"output","Output":"FAIL\tgotest.tools/gotestsum/foo\t0.001s\n"}
 {"Action":"output","Output":"FAIL\n"}
 {"Action":"fail"}

--- a/src/cmd/internal/test2json/testdata/issue29755.test
+++ b/src/cmd/internal/test2json/testdata/issue29755.test
@@ -1,0 +1,10 @@
+=== RUN   TestOutputWithSubtest
+=== RUN   TestOutputWithSubtest/sub_test
+--- FAIL: TestOutputWithSubtest (0.00s)
+    foo_test.go:6: output before sub tests
+    --- PASS: TestOutputWithSubtest/sub_test (0.00s)
+        foo_test.go:9: output from sub test
+    foo_test.go:12: output after sub test
+FAIL
+FAIL    gotest.tools/gotestsum/foo      0.001s
+FAIL

--- a/src/cmd/internal/test2json/testdata/issue29755.test
+++ b/src/cmd/internal/test2json/testdata/issue29755.test
@@ -1,10 +1,27 @@
 === RUN   TestOutputWithSubtest
 === RUN   TestOutputWithSubtest/sub_test
+=== RUN   TestOutputWithSubtest/sub_test/sub2
+=== RUN   TestOutputWithSubtest/sub_test2
+=== RUN   TestOutputWithSubtest/sub_test2/sub2
 --- FAIL: TestOutputWithSubtest (0.00s)
     foo_test.go:6: output before sub tests
+    foo_test.go:10: output from root test
+    foo_test.go:15: output from root test
     --- PASS: TestOutputWithSubtest/sub_test (0.00s)
         foo_test.go:9: output from sub test
-    foo_test.go:12: output after sub test
+        foo_test.go:11: more output from sub test
+        foo_test.go:16: more output from sub test
+        --- PASS: TestOutputWithSubtest/sub_test/sub2 (0.00s)
+            foo_test.go:14: output from sub2 test
+    foo_test.go:22: output from root test
+    foo_test.go:27: output from root test
+    --- PASS: TestOutputWithSubtest/sub_test2 (0.00s)
+        foo_test.go:21: output from sub test2
+        foo_test.go:23: more output from sub test2
+        foo_test.go:28: more output from sub test2
+        --- PASS: TestOutputWithSubtest/sub_test2/sub2 (0.00s)
+            foo_test.go:26: output from sub2 test
+    foo_test.go:32: output after sub test
 FAIL
-FAIL    gotest.tools/gotestsum/foo      0.001s
+FAIL	gotest.tools/gotestsum/foo	0.001s
 FAIL

--- a/src/cmd/internal/test2json/testdata/smiley.json
+++ b/src/cmd/internal/test2json/testdata/smiley.json
@@ -116,13 +116,13 @@
 {"Action":"output","Test":"Test☺☹/2","Output":"=== CONT  Test☺☹/2\n"}
 {"Action":"output","Test":"TestTags","Output":"--- PASS: TestTags (0.00s)\n"}
 {"Action":"output","Test":"TestTags/x_testtag_y","Output":"    --- PASS: TestTags/x_testtag_y (0.04s)\n"}
-{"Action":"output","Test":"TestTags/x_testtag_y","Output":"    \tvet_test.go:187: -tags=x testtag y\n"}
+{"Action":"output","Test":"TestTags/x_testtag_y","Output":"        vet_test.go:187: -tags=x testtag y\n"}
 {"Action":"pass","Test":"TestTags/x_testtag_y"}
 {"Action":"output","Test":"TestTags/x,testtag,y","Output":"    --- PASS: TestTags/x,testtag,y (0.04s)\n"}
-{"Action":"output","Test":"TestTags/x,testtag,y","Output":"    \tvet_test.go:187: -tags=x,testtag,y\n"}
+{"Action":"output","Test":"TestTags/x,testtag,y","Output":"        vet_test.go:187: -tags=x,testtag,y\n"}
 {"Action":"pass","Test":"TestTags/x,testtag,y"}
 {"Action":"output","Test":"TestTags/testtag","Output":"    --- PASS: TestTags/testtag (0.04s)\n"}
-{"Action":"output","Test":"TestTags/testtag","Output":"    \tvet_test.go:187: -tags=testtag\n"}
+{"Action":"output","Test":"TestTags/testtag","Output":"        vet_test.go:187: -tags=testtag\n"}
 {"Action":"pass","Test":"TestTags/testtag"}
 {"Action":"pass","Test":"TestTags"}
 {"Action":"cont","Test":"Test☺☹/1"}
@@ -139,28 +139,28 @@
 {"Action":"output","Test":"Test☺☹Dirs/cgo","Output":"=== CONT  Test☺☹Dirs/cgo\n"}
 {"Action":"output","Test":"Test☺☹","Output":"--- PASS: Test☺☹ (0.39s)\n"}
 {"Action":"output","Test":"Test☺☹/5","Output":"    --- PASS: Test☺☹/5 (0.07s)\n"}
-{"Action":"output","Test":"Test☺☹/5","Output":"    \tvet_test.go:114: φιλεσ: [\"testdata/copylock_func.go\" \"testdata/rangeloop.go\"]\n"}
+{"Action":"output","Test":"Test☺☹/5","Output":"        vet_test.go:114: φιλεσ: [\"testdata/copylock_func.go\" \"testdata/rangeloop.go\"]\n"}
 {"Action":"pass","Test":"Test☺☹/5"}
 {"Action":"output","Test":"Test☺☹/3","Output":"    --- PASS: Test☺☹/3 (0.07s)\n"}
-{"Action":"output","Test":"Test☺☹/3","Output":"    \tvet_test.go:114: φιλεσ: [\"testdata/composite.go\" \"testdata/nilfunc.go\"]\n"}
+{"Action":"output","Test":"Test☺☹/3","Output":"        vet_test.go:114: φιλεσ: [\"testdata/composite.go\" \"testdata/nilfunc.go\"]\n"}
 {"Action":"pass","Test":"Test☺☹/3"}
 {"Action":"output","Test":"Test☺☹/6","Output":"    --- PASS: Test☺☹/6 (0.07s)\n"}
-{"Action":"output","Test":"Test☺☹/6","Output":"    \tvet_test.go:114: φιλεσ: [\"testdata/copylock_range.go\" \"testdata/shadow.go\"]\n"}
+{"Action":"output","Test":"Test☺☹/6","Output":"        vet_test.go:114: φιλεσ: [\"testdata/copylock_range.go\" \"testdata/shadow.go\"]\n"}
 {"Action":"pass","Test":"Test☺☹/6"}
 {"Action":"output","Test":"Test☺☹/2","Output":"    --- PASS: Test☺☹/2 (0.07s)\n"}
-{"Action":"output","Test":"Test☺☹/2","Output":"    \tvet_test.go:114: φιλεσ: [\"testdata/bool.go\" \"testdata/method.go\" \"testdata/unused.go\"]\n"}
+{"Action":"output","Test":"Test☺☹/2","Output":"        vet_test.go:114: φιλεσ: [\"testdata/bool.go\" \"testdata/method.go\" \"testdata/unused.go\"]\n"}
 {"Action":"pass","Test":"Test☺☹/2"}
 {"Action":"output","Test":"Test☺☹/0","Output":"    --- PASS: Test☺☹/0 (0.13s)\n"}
-{"Action":"output","Test":"Test☺☹/0","Output":"    \tvet_test.go:114: φιλεσ: [\"testdata/assign.go\" \"testdata/httpresponse.go\" \"testdata/structtag.go\"]\n"}
+{"Action":"output","Test":"Test☺☹/0","Output":"        vet_test.go:114: φιλεσ: [\"testdata/assign.go\" \"testdata/httpresponse.go\" \"testdata/structtag.go\"]\n"}
 {"Action":"pass","Test":"Test☺☹/0"}
 {"Action":"output","Test":"Test☺☹/4","Output":"    --- PASS: Test☺☹/4 (0.16s)\n"}
-{"Action":"output","Test":"Test☺☹/4","Output":"    \tvet_test.go:114: φιλεσ: [\"testdata/copylock.go\" \"testdata/print.go\"]\n"}
+{"Action":"output","Test":"Test☺☹/4","Output":"        vet_test.go:114: φιλεσ: [\"testdata/copylock.go\" \"testdata/print.go\"]\n"}
 {"Action":"pass","Test":"Test☺☹/4"}
 {"Action":"output","Test":"Test☺☹/1","Output":"    --- PASS: Test☺☹/1 (0.07s)\n"}
-{"Action":"output","Test":"Test☺☹/1","Output":"    \tvet_test.go:114: φιλεσ: [\"testdata/atomic.go\" \"testdata/lostcancel.go\" \"testdata/unsafeptr.go\"]\n"}
+{"Action":"output","Test":"Test☺☹/1","Output":"        vet_test.go:114: φιλεσ: [\"testdata/atomic.go\" \"testdata/lostcancel.go\" \"testdata/unsafeptr.go\"]\n"}
 {"Action":"pass","Test":"Test☺☹/1"}
 {"Action":"output","Test":"Test☺☹/7","Output":"    --- PASS: Test☺☹/7 (0.19s)\n"}
-{"Action":"output","Test":"Test☺☹/7","Output":"    \tvet_test.go:114: φιλεσ: [\"testdata/deadcode.go\" \"testdata/shift.go\"]\n"}
+{"Action":"output","Test":"Test☺☹/7","Output":"        vet_test.go:114: φιλεσ: [\"testdata/deadcode.go\" \"testdata/shift.go\"]\n"}
 {"Action":"pass","Test":"Test☺☹/7"}
 {"Action":"pass","Test":"Test☺☹"}
 {"Action":"output","Test":"Test☺☹Dirs","Output":"--- PASS: Test☺☹Dirs (0.01s)\n"}

--- a/src/cmd/internal/test2json/testdata/smiley.test
+++ b/src/cmd/internal/test2json/testdata/smiley.test
@@ -58,11 +58,11 @@
 === CONT  Test☺☹/2
 --- PASS: TestTags (0.00s)
     --- PASS: TestTags/x_testtag_y (0.04s)
-    	vet_test.go:187: -tags=x testtag y
+        vet_test.go:187: -tags=x testtag y
     --- PASS: TestTags/x,testtag,y (0.04s)
-    	vet_test.go:187: -tags=x,testtag,y
+        vet_test.go:187: -tags=x,testtag,y
     --- PASS: TestTags/testtag (0.04s)
-    	vet_test.go:187: -tags=testtag
+        vet_test.go:187: -tags=testtag
 === CONT  Test☺☹/1
 === CONT  Test☺☹Dirs/testingpkg
 === CONT  Test☺☹Dirs/buildtag
@@ -71,21 +71,21 @@
 === CONT  Test☺☹Dirs/cgo
 --- PASS: Test☺☹ (0.39s)
     --- PASS: Test☺☹/5 (0.07s)
-    	vet_test.go:114: φιλεσ: ["testdata/copylock_func.go" "testdata/rangeloop.go"]
+        vet_test.go:114: φιλεσ: ["testdata/copylock_func.go" "testdata/rangeloop.go"]
     --- PASS: Test☺☹/3 (0.07s)
-    	vet_test.go:114: φιλεσ: ["testdata/composite.go" "testdata/nilfunc.go"]
+        vet_test.go:114: φιλεσ: ["testdata/composite.go" "testdata/nilfunc.go"]
     --- PASS: Test☺☹/6 (0.07s)
-    	vet_test.go:114: φιλεσ: ["testdata/copylock_range.go" "testdata/shadow.go"]
+        vet_test.go:114: φιλεσ: ["testdata/copylock_range.go" "testdata/shadow.go"]
     --- PASS: Test☺☹/2 (0.07s)
-    	vet_test.go:114: φιλεσ: ["testdata/bool.go" "testdata/method.go" "testdata/unused.go"]
+        vet_test.go:114: φιλεσ: ["testdata/bool.go" "testdata/method.go" "testdata/unused.go"]
     --- PASS: Test☺☹/0 (0.13s)
-    	vet_test.go:114: φιλεσ: ["testdata/assign.go" "testdata/httpresponse.go" "testdata/structtag.go"]
+        vet_test.go:114: φιλεσ: ["testdata/assign.go" "testdata/httpresponse.go" "testdata/structtag.go"]
     --- PASS: Test☺☹/4 (0.16s)
-    	vet_test.go:114: φιλεσ: ["testdata/copylock.go" "testdata/print.go"]
+        vet_test.go:114: φιλεσ: ["testdata/copylock.go" "testdata/print.go"]
     --- PASS: Test☺☹/1 (0.07s)
-    	vet_test.go:114: φιλεσ: ["testdata/atomic.go" "testdata/lostcancel.go" "testdata/unsafeptr.go"]
+        vet_test.go:114: φιλεσ: ["testdata/atomic.go" "testdata/lostcancel.go" "testdata/unsafeptr.go"]
     --- PASS: Test☺☹/7 (0.19s)
-    	vet_test.go:114: φιλεσ: ["testdata/deadcode.go" "testdata/shift.go"]
+        vet_test.go:114: φιλεσ: ["testdata/deadcode.go" "testdata/shift.go"]
 --- PASS: Test☺☹Dirs (0.01s)
     --- PASS: Test☺☹Dirs/testingpkg (0.06s)
     --- PASS: Test☺☹Dirs/divergent (0.05s)

--- a/src/cmd/internal/test2json/testdata/vet.json
+++ b/src/cmd/internal/test2json/testdata/vet.json
@@ -116,13 +116,13 @@
 {"Action":"output","Test":"TestVet/2","Output":"=== CONT  TestVet/2\n"}
 {"Action":"output","Test":"TestTags","Output":"--- PASS: TestTags (0.00s)\n"}
 {"Action":"output","Test":"TestTags/x_testtag_y","Output":"    --- PASS: TestTags/x_testtag_y (0.04s)\n"}
-{"Action":"output","Test":"TestTags/x_testtag_y","Output":"    \tvet_test.go:187: -tags=x testtag y\n"}
+{"Action":"output","Test":"TestTags/x_testtag_y","Output":"        vet_test.go:187: -tags=x testtag y\n"}
 {"Action":"pass","Test":"TestTags/x_testtag_y"}
 {"Action":"output","Test":"TestTags/x,testtag,y","Output":"    --- PASS: TestTags/x,testtag,y (0.04s)\n"}
-{"Action":"output","Test":"TestTags/x,testtag,y","Output":"    \tvet_test.go:187: -tags=x,testtag,y\n"}
+{"Action":"output","Test":"TestTags/x,testtag,y","Output":"        vet_test.go:187: -tags=x,testtag,y\n"}
 {"Action":"pass","Test":"TestTags/x,testtag,y"}
 {"Action":"output","Test":"TestTags/testtag","Output":"    --- PASS: TestTags/testtag (0.04s)\n"}
-{"Action":"output","Test":"TestTags/testtag","Output":"    \tvet_test.go:187: -tags=testtag\n"}
+{"Action":"output","Test":"TestTags/testtag","Output":"        vet_test.go:187: -tags=testtag\n"}
 {"Action":"pass","Test":"TestTags/testtag"}
 {"Action":"pass","Test":"TestTags"}
 {"Action":"cont","Test":"TestVet/1"}
@@ -139,28 +139,28 @@
 {"Action":"output","Test":"TestVetDirs/cgo","Output":"=== CONT  TestVetDirs/cgo\n"}
 {"Action":"output","Test":"TestVet","Output":"--- PASS: TestVet (0.39s)\n"}
 {"Action":"output","Test":"TestVet/5","Output":"    --- PASS: TestVet/5 (0.07s)\n"}
-{"Action":"output","Test":"TestVet/5","Output":"    \tvet_test.go:114: files: [\"testdata/copylock_func.go\" \"testdata/rangeloop.go\"]\n"}
+{"Action":"output","Test":"TestVet/5","Output":"        vet_test.go:114: files: [\"testdata/copylock_func.go\" \"testdata/rangeloop.go\"]\n"}
 {"Action":"pass","Test":"TestVet/5"}
 {"Action":"output","Test":"TestVet/3","Output":"    --- PASS: TestVet/3 (0.07s)\n"}
-{"Action":"output","Test":"TestVet/3","Output":"    \tvet_test.go:114: files: [\"testdata/composite.go\" \"testdata/nilfunc.go\"]\n"}
+{"Action":"output","Test":"TestVet/3","Output":"        vet_test.go:114: files: [\"testdata/composite.go\" \"testdata/nilfunc.go\"]\n"}
 {"Action":"pass","Test":"TestVet/3"}
 {"Action":"output","Test":"TestVet/6","Output":"    --- PASS: TestVet/6 (0.07s)\n"}
-{"Action":"output","Test":"TestVet/6","Output":"    \tvet_test.go:114: files: [\"testdata/copylock_range.go\" \"testdata/shadow.go\"]\n"}
+{"Action":"output","Test":"TestVet/6","Output":"        vet_test.go:114: files: [\"testdata/copylock_range.go\" \"testdata/shadow.go\"]\n"}
 {"Action":"pass","Test":"TestVet/6"}
 {"Action":"output","Test":"TestVet/2","Output":"    --- PASS: TestVet/2 (0.07s)\n"}
-{"Action":"output","Test":"TestVet/2","Output":"    \tvet_test.go:114: files: [\"testdata/bool.go\" \"testdata/method.go\" \"testdata/unused.go\"]\n"}
+{"Action":"output","Test":"TestVet/2","Output":"        vet_test.go:114: files: [\"testdata/bool.go\" \"testdata/method.go\" \"testdata/unused.go\"]\n"}
 {"Action":"pass","Test":"TestVet/2"}
 {"Action":"output","Test":"TestVet/0","Output":"    --- PASS: TestVet/0 (0.13s)\n"}
-{"Action":"output","Test":"TestVet/0","Output":"    \tvet_test.go:114: files: [\"testdata/assign.go\" \"testdata/httpresponse.go\" \"testdata/structtag.go\"]\n"}
+{"Action":"output","Test":"TestVet/0","Output":"        vet_test.go:114: files: [\"testdata/assign.go\" \"testdata/httpresponse.go\" \"testdata/structtag.go\"]\n"}
 {"Action":"pass","Test":"TestVet/0"}
 {"Action":"output","Test":"TestVet/4","Output":"    --- PASS: TestVet/4 (0.16s)\n"}
-{"Action":"output","Test":"TestVet/4","Output":"    \tvet_test.go:114: files: [\"testdata/copylock.go\" \"testdata/print.go\"]\n"}
+{"Action":"output","Test":"TestVet/4","Output":"        vet_test.go:114: files: [\"testdata/copylock.go\" \"testdata/print.go\"]\n"}
 {"Action":"pass","Test":"TestVet/4"}
 {"Action":"output","Test":"TestVet/1","Output":"    --- PASS: TestVet/1 (0.07s)\n"}
-{"Action":"output","Test":"TestVet/1","Output":"    \tvet_test.go:114: files: [\"testdata/atomic.go\" \"testdata/lostcancel.go\" \"testdata/unsafeptr.go\"]\n"}
+{"Action":"output","Test":"TestVet/1","Output":"        vet_test.go:114: files: [\"testdata/atomic.go\" \"testdata/lostcancel.go\" \"testdata/unsafeptr.go\"]\n"}
 {"Action":"pass","Test":"TestVet/1"}
 {"Action":"output","Test":"TestVet/7","Output":"    --- PASS: TestVet/7 (0.19s)\n"}
-{"Action":"output","Test":"TestVet/7","Output":"    \tvet_test.go:114: files: [\"testdata/deadcode.go\" \"testdata/shift.go\"]\n"}
+{"Action":"output","Test":"TestVet/7","Output":"        vet_test.go:114: files: [\"testdata/deadcode.go\" \"testdata/shift.go\"]\n"}
 {"Action":"pass","Test":"TestVet/7"}
 {"Action":"pass","Test":"TestVet"}
 {"Action":"output","Test":"TestVetDirs","Output":"--- PASS: TestVetDirs (0.01s)\n"}

--- a/src/cmd/internal/test2json/testdata/vet.test
+++ b/src/cmd/internal/test2json/testdata/vet.test
@@ -58,11 +58,11 @@
 === CONT  TestVet/2
 --- PASS: TestTags (0.00s)
     --- PASS: TestTags/x_testtag_y (0.04s)
-    	vet_test.go:187: -tags=x testtag y
+        vet_test.go:187: -tags=x testtag y
     --- PASS: TestTags/x,testtag,y (0.04s)
-    	vet_test.go:187: -tags=x,testtag,y
+        vet_test.go:187: -tags=x,testtag,y
     --- PASS: TestTags/testtag (0.04s)
-    	vet_test.go:187: -tags=testtag
+        vet_test.go:187: -tags=testtag
 === CONT  TestVet/1
 === CONT  TestVetDirs/testingpkg
 === CONT  TestVetDirs/buildtag
@@ -71,21 +71,21 @@
 === CONT  TestVetDirs/cgo
 --- PASS: TestVet (0.39s)
     --- PASS: TestVet/5 (0.07s)
-    	vet_test.go:114: files: ["testdata/copylock_func.go" "testdata/rangeloop.go"]
+        vet_test.go:114: files: ["testdata/copylock_func.go" "testdata/rangeloop.go"]
     --- PASS: TestVet/3 (0.07s)
-    	vet_test.go:114: files: ["testdata/composite.go" "testdata/nilfunc.go"]
+        vet_test.go:114: files: ["testdata/composite.go" "testdata/nilfunc.go"]
     --- PASS: TestVet/6 (0.07s)
-    	vet_test.go:114: files: ["testdata/copylock_range.go" "testdata/shadow.go"]
+        vet_test.go:114: files: ["testdata/copylock_range.go" "testdata/shadow.go"]
     --- PASS: TestVet/2 (0.07s)
-    	vet_test.go:114: files: ["testdata/bool.go" "testdata/method.go" "testdata/unused.go"]
+        vet_test.go:114: files: ["testdata/bool.go" "testdata/method.go" "testdata/unused.go"]
     --- PASS: TestVet/0 (0.13s)
-    	vet_test.go:114: files: ["testdata/assign.go" "testdata/httpresponse.go" "testdata/structtag.go"]
+        vet_test.go:114: files: ["testdata/assign.go" "testdata/httpresponse.go" "testdata/structtag.go"]
     --- PASS: TestVet/4 (0.16s)
-    	vet_test.go:114: files: ["testdata/copylock.go" "testdata/print.go"]
+        vet_test.go:114: files: ["testdata/copylock.go" "testdata/print.go"]
     --- PASS: TestVet/1 (0.07s)
-    	vet_test.go:114: files: ["testdata/atomic.go" "testdata/lostcancel.go" "testdata/unsafeptr.go"]
+        vet_test.go:114: files: ["testdata/atomic.go" "testdata/lostcancel.go" "testdata/unsafeptr.go"]
     --- PASS: TestVet/7 (0.19s)
-    	vet_test.go:114: files: ["testdata/deadcode.go" "testdata/shift.go"]
+        vet_test.go:114: files: ["testdata/deadcode.go" "testdata/shift.go"]
 --- PASS: TestVetDirs (0.01s)
     --- PASS: TestVetDirs/testingpkg (0.06s)
     --- PASS: TestVetDirs/divergent (0.05s)


### PR DESCRIPTION
When printing regular test output check the indentation of the output, and use
the report stack to find the appropriate test name for that output.

This change includes a whitespace change to some golden test files. The
indentation of tests was changed in CL 113177
from tabs to spaces. The golden files have been updated to match the new
output format. The tabs in the golden files cause problems because the indentation check
looks for 4 spaces.

Fixes #29755
Updates #25369