### PR TITLE
strings, bytes: clarify usage of EqualFolds

### DIFF
--- a/src/bytes/bytes.go
+++ b/src/bytes/bytes.go
@@ -935,7 +935,8 @@ func ReplaceAll(s, old, new []byte) []byte {
 }
 
 // EqualFold reports whether s and t, interpreted as UTF-8 strings,
-// are equal under Unicode case folding (case-insensitively).
+// are equal under Unicode case-folding, which is a more general
+// form of case-insensitivity.
 func EqualFold(s, t []byte) bool {
 	for len(s) != 0 && len(t) != 0 {
 		// Extract first rune from each.

--- a/src/bytes/bytes.go
+++ b/src/bytes/bytes.go
@@ -935,7 +935,7 @@ func ReplaceAll(s, old, new []byte) []byte {
 }
 
 // EqualFold reports whether s and t, interpreted as UTF-8 strings,
-// are equal under Unicode case-folding.
+// are equal under Unicode case folding (case-insensitively).
 func EqualFold(s, t []byte) bool {
 	for len(s) != 0 && len(t) != 0 {
 		// Extract first rune from each.

--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -969,7 +969,8 @@ func ReplaceAll(s, old, new string) string {
 }
 
 // EqualFold reports whether s and t, interpreted as UTF-8 strings,
-// are equal under Unicode case folding (case-insensitively).
+// are equal under Unicode case-folding, which is a more general
+// form of case-insensitivity.
 func EqualFold(s, t string) bool {
 	for s != "" && t != "" {
 		// Extract first rune from each string.

--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -969,7 +969,7 @@ func ReplaceAll(s, old, new string) string {
 }
 
 // EqualFold reports whether s and t, interpreted as UTF-8 strings,
-// are equal under Unicode case-folding.
+// are equal under Unicode case folding (case-insensitively).
 func EqualFold(s, t string) bool {
 	for s != "" && t != "" {
 		// Extract first rune from each string.


### PR DESCRIPTION
This clarifies meaning of "case folding" Unicode equality with more familiar "case insensitive" wording. 
For case folding properties see ftp://ftp.unicode.org/Public/UNIDATA/CaseFolding.txt.

Fixes #33447