### PR TITLE
runtime/type: change fieldalign to use mixedCaps

### DIFF
--- a/src/runtime/type.go
+++ b/src/runtime/type.go
@@ -32,7 +32,7 @@ type _type struct {
 	hash       uint32
 	tflag      tflag
 	align      uint8
-	fieldalign uint8
+	fieldAlign uint8
 	kind       uint8
 	// function for comparing objects of this type
 	// (ptr to object A, ptr to object B) -> ==?


### PR DESCRIPTION
All spelling in source code is "fieldAlign", except this place, so change
"fieldalign" to use mixedCaps.