### PR TITLE
net: add text marshalling and unmarshalling for HardwareAddr

### DIFF
--- a/src/net/mac.go
+++ b/src/net/mac.go
@@ -39,7 +39,7 @@ func (a *HardwareAddr) UnmarshalText(text []byte) error {
 		return nil
 	}
 
-	// first attempt to decode raw bytes in case the mac address
+	// First, attempt to decode raw bytes in case the mac address
 	// was encoded as a raw byte slice in an older verison of golang.
 	b64buf := make([]byte, 6)
 	if _, err := base64.StdEncoding.Decode(b64buf, text); err == nil {
@@ -47,6 +47,7 @@ func (a *HardwareAddr) UnmarshalText(text []byte) error {
 		return nil
 	}
 
+	// Otherwise, fallback to normal MAC address parsing.
 	v, err := ParseMAC(string(text))
 	if err != nil {
 		return err

--- a/src/net/mac.go
+++ b/src/net/mac.go
@@ -39,7 +39,7 @@ func (a *HardwareAddr) UnmarshalText(text []byte) error {
 		return nil
 	}
 
-	// First, attempt to decode raw bytes in case the mac address
+	// First, attempt to decode raw bytes in case the MAC address
 	// was encoded as a raw byte slice in an older verison of golang.
 	b64buf := make([]byte, 6)
 	if _, err := base64.StdEncoding.Decode(b64buf, text); err == nil {

--- a/src/net/mac.go
+++ b/src/net/mac.go
@@ -24,6 +24,26 @@ func (a HardwareAddr) String() string {
 	return string(buf)
 }
 
+// MarshalText implements encoding.TextMarshaler using the
+// standard string representation of a HardwareAddr.
+func (a HardwareAddr) MarshalText() ([]byte, error) {
+	return []byte(a.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (a *HardwareAddr) UnmarshalText(text []byte) error {
+	if len(text) == 0 {
+		*a = nil
+		return nil
+	}
+	v, err := ParseMAC(string(text))
+	if err != nil {
+		return err
+	}
+	*a = v
+	return nil
+}
+
 // ParseMAC parses s as an IEEE 802 MAC-48, EUI-48, EUI-64, or a 20-octet
 // IP over InfiniBand link-layer address using one of the following formats:
 //	00:00:5e:00:53:01

--- a/src/net/mac.go
+++ b/src/net/mac.go
@@ -4,6 +4,8 @@
 
 package net
 
+import "encoding/base64"
+
 const hexDigit = "0123456789abcdef"
 
 // A HardwareAddr represents a physical hardware address.
@@ -36,6 +38,15 @@ func (a *HardwareAddr) UnmarshalText(text []byte) error {
 		*a = nil
 		return nil
 	}
+
+	// first attempt to decode raw bytes in case the mac address
+	// was encoded as a raw byte slice in an older verison of golang.
+	b64buf := make([]byte, 6)
+	if _, err := base64.StdEncoding.Decode(b64buf, text); err == nil {
+		*a = b64buf
+		return nil
+	}
+
 	v, err := ParseMAC(string(text))
 	if err != nil {
 		return err

--- a/src/net/mac_test.go
+++ b/src/net/mac_test.go
@@ -138,7 +138,8 @@ func TestHardwareAddr_UnmarshalText(t *testing.T) {
 			text:    "",
 			wantStr: "",
 			wantErr: "",
-		}, {
+		},
+		{
 			msg:     "invalid text",
 			text:    "foo-bar-baz",
 			wantStr: "",
@@ -149,17 +150,19 @@ func TestHardwareAddr_UnmarshalText(t *testing.T) {
 		t.Run(tt.msg, func(t *testing.T) {
 			var a HardwareAddr
 			err := a.UnmarshalText([]byte(tt.text))
-			if tt.wantErr != "" && err.Error() != tt.wantErr {
-				t.Errorf("Wanted err %q got %q", tt.wantErr, err.Error())
-			} else if tt.wantErr == "" && err != nil {
-				t.Errorf("Unexpected error %q", err)
-			}
-
-			if tt.wantStr != a.String() {
-				t.Errorf("Wanted address string %q but got %q", tt.wantStr, a.String())
+			gotStr := a.String()
+			if tt.wantStr != gotStr || !matchErr(tt.wantErr, err) {
+				t.Errorf("want: addr = %q, err = %q, got: addr = %q, err = %q", tt.wantStr, tt.wantErr, gotStr, err)
 			}
 		})
 	}
+}
+
+func matchErr(s string, err error) bool {
+	if s == "" {
+		return err == nil
+	}
+	return err != nil && strings.Contains(err.Error(), s)
 }
 
 func TestHardwareAddr_MarshalText(t *testing.T) {
@@ -167,18 +170,19 @@ func TestHardwareAddr_MarshalText(t *testing.T) {
 
 	var a HardwareAddr
 	if err := a.UnmarshalText([]byte(input)); err != nil {
-		t.Fatalf("Unexpected error while unmarashaling: %q", err)
+		t.Fatal(err)
 	}
 
 	output, err := a.MarshalText()
 	if err != nil {
-		t.Fatalf("Error marshaling: %s", err)
+		t.Fatal(err)
 	}
 
 	if err := a.UnmarshalText([]byte(input)); err != nil {
-		t.Fatalf("Unexpected error while marshaling: %q", err)
+		t.Fatal(err)
 	}
+
 	if input != string(output) {
-		t.Errorf("Input/Output mismatch: %q and %q", input, string(output))
+		t.Errorf("want %q, got %q", input, string(output))
 	}
 }

--- a/src/net/mac_test.go
+++ b/src/net/mac_test.go
@@ -107,3 +107,65 @@ func TestParseMAC(t *testing.T) {
 		}
 	}
 }
+
+func TestHardwareAddr_UnmarshalText(t *testing.T) {
+	tests := []struct {
+		msg     string
+		text    string
+		wantStr string
+		wantErr string
+	}{
+		{
+			msg:     "valid mac",
+			text:    "aa:bb:cc:dd:ee:ff",
+			wantStr: "aa:bb:cc:dd:ee:ff",
+			wantErr: "",
+		}, {
+			msg:     "empty text",
+			text:    "",
+			wantStr: "",
+			wantErr: "",
+		}, {
+			msg:     "invalid text",
+			text:    "foo-bar-baz",
+			wantStr: "",
+			wantErr: "address foo-bar-baz: invalid MAC address",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			var a HardwareAddr
+			err := a.UnmarshalText([]byte(tt.text))
+			if tt.wantErr != "" && err.Error() != tt.wantErr {
+				t.Errorf("Wanted err %q got %q", tt.wantErr, err.Error())
+			} else if tt.wantErr == "" && err != nil {
+				t.Errorf("Unexpected error %q", err)
+			}
+
+			if tt.wantStr != a.String() {
+				t.Errorf("Wanted address string %q but got %q", tt.wantStr, a.String())
+			}
+		})
+	}
+}
+
+func TestHardwareAddr_MarshalText(t *testing.T) {
+	input := "aa:bb:cc:dd:ee:ff"
+
+	var a HardwareAddr
+	if err := a.UnmarshalText([]byte(input)); err != nil {
+		t.Fatalf("Unexpected error while unmarashaling: %q", err)
+	}
+
+	output, err := a.MarshalText()
+	if err != nil {
+		t.Fatalf("Error marshaling: %s", err)
+	}
+
+	if err := a.UnmarshalText([]byte(input)); err != nil {
+		t.Fatalf("Unexpected error while marshaling: %q", err)
+	}
+	if input != string(output) {
+		t.Errorf("Input/Output mismatch: %q and %q", input, string(output))
+	}
+}

--- a/src/net/mac_test.go
+++ b/src/net/mac_test.go
@@ -116,11 +116,24 @@ func TestHardwareAddr_UnmarshalText(t *testing.T) {
 		wantErr string
 	}{
 		{
-			msg:     "valid mac",
+			msg:     "valid mac1",
 			text:    "aa:bb:cc:dd:ee:ff",
 			wantStr: "aa:bb:cc:dd:ee:ff",
 			wantErr: "",
-		}, {
+		},
+		{
+			msg:     "valid mac2",
+			text:    "00-00-5e-00-63-01",
+			wantStr: "00:00:5e:00:63:01",
+			wantErr: "",
+		},
+		{
+			msg:     "binary mac",
+			text:    "VCKpL053",
+			wantStr: "54:22:a9:2f:4e:77",
+			wantErr: "",
+		},
+		{
 			msg:     "empty text",
 			text:    "",
 			wantStr: "",

--- a/src/net/mac_test.go
+++ b/src/net/mac_test.go
@@ -109,6 +109,13 @@ func TestParseMAC(t *testing.T) {
 }
 
 func TestHardwareAddr_UnmarshalText(t *testing.T) {
+	matchErr := func(s string, err error) bool {
+		if s == "" {
+			return err == nil
+		}
+		return err != nil && strings.Contains(err.Error(), s)
+	}
+
 	tests := []struct {
 		msg     string
 		text    string
@@ -156,13 +163,6 @@ func TestHardwareAddr_UnmarshalText(t *testing.T) {
 			}
 		})
 	}
-}
-
-func matchErr(s string, err error) bool {
-	if s == "" {
-		return err == nil
-	}
-	return err != nil && strings.Contains(err.Error(), s)
 }
 
 func TestHardwareAddr_MarshalText(t *testing.T) {


### PR DESCRIPTION
The HardwareAddr type has the ability to be transformed to and from a
string. However, this capability is not exposed in a manner suitable
for use with various forms of marshalling and unmarshaling of text
(e.g. JSON or YAML). Let's add the proper functions so that
HardwareAddr implements the TextMarshaller and TextUnmarshaler
interfaces from the encoding package.

Fixes #29678