### PR TITLE
encoding/csv: optimize Write by giving fieldNeedsQuotes a fast path for when Comma is ascii

### DIFF
--- a/src/encoding/csv/writer.go
+++ b/src/encoding/csv/writer.go
@@ -158,8 +158,22 @@ func (w *Writer) fieldNeedsQuotes(field string) bool {
 	if field == "" {
 		return false
 	}
-	if field == `\.` || strings.ContainsRune(field, w.Comma) || strings.ContainsAny(field, "\"\r\n") {
+
+	if field == `\.` {
 		return true
+	}
+
+	if w.Comma < utf8.RuneSelf {
+		for i := 0; i < len(field); i++ {
+			c := field[i]
+			if c == '\n' || c == '\r' || c == '"' || c == byte(w.Comma) {
+				return true
+			}
+		}
+	} else {
+		if strings.ContainsRune(field, w.Comma) || strings.ContainsAny(field, "\"\r\n") {
+			return true
+		}
 	}
 
 	r1, _ := utf8.DecodeRuneInString(field)

--- a/src/encoding/csv/writer_test.go
+++ b/src/encoding/csv/writer_test.go
@@ -93,3 +93,20 @@ func TestError(t *testing.T) {
 		t.Error("Error should not be nil")
 	}
 }
+
+var benchmarkWriteData = [][]string{
+	{"abc", "def", "12356", "1234567890987654311234432141542132"},
+	{"abc", "def", "12356", "1234567890987654311234432141542132"},
+	{"abc", "def", "12356", "1234567890987654311234432141542132"},
+}
+
+func BenchmarkWrite(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		w := NewWriter(&bytes.Buffer{})
+		err := w.WriteAll(benchmarkWriteData)
+		if err != nil {
+			b.Fatal(err)
+		}
+		w.Flush()
+	}
+}


### PR DESCRIPTION
name     old time/op  new time/op  delta
Write-4  2.37µs ±20%  1.90µs ±19%  -19.54%  (p=0.015 n=6+6)
