### PR TITLE
syscall/js: improve documentation of js.FuncOf

### DIFF
--- a/src/syscall/js/func.go
+++ b/src/syscall/js/func.go
@@ -22,19 +22,24 @@ type Func struct {
 	id    uint32
 }
 
-// FuncOf returns a wrapped function.
-//
-// Invoking the JavaScript function will synchronously call the Go function fn with the value of JavaScript's
-// "this" keyword and the arguments of the invocation.
-// The return value of the invocation is the result of the Go function mapped back to JavaScript according to ValueOf.
-//
-// A wrapped function triggered during a call from Go to JavaScript gets executed on the same goroutine.
-// A wrapped function triggered by JavaScript's event loop gets executed on an extra goroutine.
-// Blocking operations in the wrapped function will block the event loop.
-// As a consequence, if one wrapped function blocks, other wrapped funcs will not be processed.
-// A blocking function should therefore explicitly start a new goroutine.
+// FuncOf registers a function to be used by JavaScript.
 //
 // Func.Release must be called to free up resources when the function will not be used any more.
+//
+// The Go function fn is called with the value of JavaScript's "this" keyword and the
+// arguments of the invocation. The return value of the invocation is
+// the result of the Go function mapped back to JavaScript according to ValueOf.
+// 
+// Invoking the wrapped Go function from JavaScript will
+// pause the event loop and spawns a new go routine.
+// Other wrapped functions which are triggered during a call from Go to JavaScript
+// gets executed on the same goroutine.
+//
+// As a consequence, if one wrapped function blocks, JavaScript's event loop
+// is blocked until that func returns.
+// Hence, calling any async JavaScript API, which requires the event loop,
+// like fetch (http.Client), will cause an immediate deadlock.
+// Therefore a blocking function should explicitly start a new goroutine.
 func FuncOf(fn func(this Value, args []Value) interface{}) Func {
 	funcsMu.Lock()
 	id := nextFuncID

--- a/src/syscall/js/func.go
+++ b/src/syscall/js/func.go
@@ -31,12 +31,12 @@ type Func struct {
 // Invoking the wrapped Go function from JavaScript will
 // pause the event loop and spawn a new goroutine.
 // Other wrapped functions which are triggered during a call from Go to JavaScript
-// gets executed on the same goroutine.
+// get executed on the same goroutine.
 //
 // As a consequence, if one wrapped function blocks, JavaScript's event loop
-// is blocked until that function returns. Hence, calling any async JavaScript 
-// API, which requires the event loop, like fetch (http.Client), will cause an 
-// immediate deadlock. Therefore a blocking function should explicitly start a 
+// is blocked until that function returns. Hence, calling any async JavaScript
+// API, which requires the event loop, like fetch (http.Client), will cause an
+// immediate deadlock. Therefore a blocking function should explicitly start a
 // new goroutine.
 //
 // Func.Release must be called to free up resources when the function will not be used any more.

--- a/src/syscall/js/func.go
+++ b/src/syscall/js/func.go
@@ -22,24 +22,24 @@ type Func struct {
 	id    uint32
 }
 
-// FuncOf registers a function to be used by JavaScript.
-//
-// Func.Release must be called to free up resources when the function will not be used any more.
+// FuncOf returns a function to be used by JavaScript.
 //
 // The Go function fn is called with the value of JavaScript's "this" keyword and the
 // arguments of the invocation. The return value of the invocation is
 // the result of the Go function mapped back to JavaScript according to ValueOf.
-// 
+//
 // Invoking the wrapped Go function from JavaScript will
-// pause the event loop and spawns a new go routine.
+// pause the event loop and spawn a new goroutine.
 // Other wrapped functions which are triggered during a call from Go to JavaScript
 // gets executed on the same goroutine.
 //
 // As a consequence, if one wrapped function blocks, JavaScript's event loop
-// is blocked until that func returns.
-// Hence, calling any async JavaScript API, which requires the event loop,
-// like fetch (http.Client), will cause an immediate deadlock.
-// Therefore a blocking function should explicitly start a new goroutine.
+// is blocked until that function returns. Hence, calling any async JavaScript 
+// API, which requires the event loop, like fetch (http.Client), will cause an 
+// immediate deadlock. Therefore a blocking function should explicitly start a 
+// new goroutine.
+//
+// Func.Release must be called to free up resources when the function will not be used any more.
 func FuncOf(fn func(this Value, args []Value) interface{}) Func {
 	funcsMu.Lock()
 	id := nextFuncID


### PR DESCRIPTION
The existing documentation is improved to be more
explicit about the lifecycle and its consequences.

Fixes #34324