### PR TITLE
cmd/go: set expected filename when building a local package with -o is pointing to a folder

### DIFF
--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2135,8 +2135,7 @@ func GoFilesPackage(gofiles []string) *Package {
 	pkg.Match = gofiles
 
 	if pkg.Name == "main" {
-		_, elem := filepath.Split(gofiles[0])
-		exe := elem[:len(elem)-len(".go")] + cfg.ExeSuffix
+		exe := GoFilesExe(gofiles) + cfg.ExeSuffix
 		if cfg.BuildO == "" {
 			cfg.BuildO = exe
 		}
@@ -2150,4 +2149,16 @@ func GoFilesPackage(gofiles []string) *Package {
 	setToolFlags(pkg)
 
 	return pkg
+}
+
+// GoFilesExe generate a suitable name for an executable given a collection of Go files,
+// using the first element in the collection without the prefix.
+//
+// Returns empty string in case of empty collection.
+func GoFilesExe(gofiles []string) string {
+	if len(gofiles) == 0 {
+		return ""
+	}
+	_, elem := filepath.Split(gofiles[0])
+	return elem[:len(elem)-len(".go")]
 }

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -1421,18 +1421,8 @@ func (p *Package) exeFromFiles() string {
 		src = p.GoFiles[0]
 	} else if len(p.CgoFiles) > 0 {
 		src = p.CgoFiles[0]
-	} else if len(p.TestGoFiles) > 0 {
-		src = p.TestGoFiles[0]
-	} else if len(p.XTestGoFiles) > 0 {
-		src = p.XTestGoFiles[0]
 	} else {
-		// this case could only happen if the provided source uses cgo
-		// while cgo is disabled.
-		hint := ""
-		if !cfg.BuildContext.CgoEnabled {
-			hint = " (cgo is disabled)"
-		}
-		base.Fatalf("go build: no suitable source files%s", hint)
+		return ""
 	}
 	_, elem := filepath.Split(src)
 	return elem[:len(elem)-len(".go")]

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2142,14 +2142,8 @@ func GoFilesPackage(gofiles []string) *Package {
 			pkg.Target = filepath.Join(cfg.GOBIN, exe)
 		} else if cfg.ModulesEnabled {
 			pkg.Target = filepath.Join(ModBinDir(), exe)
-		}
-
-		if cfg.BuildO == "" {
-			cfg.BuildO = exe
-		} else if fi, err := os.Stat(cfg.BuildO); err == nil && fi.IsDir() {
-			// If the named output is a directory that exists,
-			// then any resulting executables will be written to that directory.
-			pkg.Target = filepath.Join(cfg.BuildO, exe)
+		} else {
+			pkg.Target = exe
 		}
 	}
 

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -1412,14 +1412,17 @@ func (p *Package) exeFromImportPath() string {
 }
 
 // exeFromFiles returns an executable name for a package
-// using the first element in the GoFiles collection without the prefix.
+// using the first element in GoFiles or CgoFiles collections without the prefix.
 //
 // Returns empty string in case of empty collection.
 func (p *Package) exeFromFiles() string {
-	if len(p.GoFiles) == 0 {
-		return ""
+	var src string
+	if len(p.GoFiles) > 0 {
+		src = p.GoFiles[0]
+	} else if len(p.CgoFiles) > 0 {
+		src = p.CgoFiles[0]
 	}
-	_, elem := filepath.Split(p.GoFiles[0])
+	_, elem := filepath.Split(src)
 	return elem[:len(elem)-len(".go")]
 }
 
@@ -2155,7 +2158,7 @@ func GoFilesPackage(gofiles []string) *Package {
 	pkg.Match = gofiles
 
 	if pkg.Name == "main" {
-		exe := pkg.exeFromFiles() + cfg.ExeSuffix
+		exe := pkg.DefaultExecName() + cfg.ExeSuffix
 
 		if cfg.GOBIN != "" {
 			pkg.Target = filepath.Join(cfg.GOBIN, exe)

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -1421,6 +1421,18 @@ func (p *Package) exeFromFiles() string {
 		src = p.GoFiles[0]
 	} else if len(p.CgoFiles) > 0 {
 		src = p.CgoFiles[0]
+	} else if len(p.TestGoFiles) > 0 {
+		src = p.TestGoFiles[0]
+	} else if len(p.XTestGoFiles) > 0 {
+		src = p.XTestGoFiles[0]
+	} else {
+		// this case could only happen if the provided source uses cgo
+		// while cgo is disabled.
+		hint := ""
+		if !cfg.BuildContext.CgoEnabled {
+			hint = " (cgo is disabled)"
+		}
+		base.Fatalf("go build: no suitable source files%s", hint)
 	}
 	_, elem := filepath.Split(src)
 	return elem[:len(elem)-len(".go")]

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -1391,24 +1391,44 @@ var cgoSyscallExclude = map[string]bool{
 
 var foldPath = make(map[string]string)
 
-// DefaultExecName returns the default executable name
-// for a package with the import path importPath.
+// exeFromImportPath returns an executable name
+// for a package using the import path.
 //
-// The default executable name is the last element of the import path.
+// The executable name is the last element of the import path.
 // In module-aware mode, an additional rule is used on import paths
 // consisting of two or more path elements. If the last element is
 // a vN path element specifying the major version, then the
 // second last element of the import path is used instead.
-func DefaultExecName(importPath string) string {
-	_, elem := pathpkg.Split(importPath)
+func (p *Package) exeFromImportPath() string {
+	_, elem := pathpkg.Split(p.ImportPath)
 	if cfg.ModulesEnabled {
 		// If this is example.com/mycmd/v2, it's more useful to
 		// install it as mycmd than as v2. See golang.org/issue/24667.
-		if elem != importPath && isVersionElement(elem) {
-			_, elem = pathpkg.Split(pathpkg.Dir(importPath))
+		if elem != p.ImportPath && isVersionElement(elem) {
+			_, elem = pathpkg.Split(pathpkg.Dir(p.ImportPath))
 		}
 	}
 	return elem
+}
+
+// exeFromFiles returns an executable name for a package
+// using the first element in the GoFiles collection without the prefix.
+//
+// Returns empty string in case of empty collection.
+func (p *Package) exeFromFiles() string {
+	if len(p.GoFiles) == 0 {
+		return ""
+	}
+	_, elem := filepath.Split(p.GoFiles[0])
+	return elem[:len(elem)-len(".go")]
+}
+
+// DefaultExecName returns the default executable name for a package
+func (p *Package) DefaultExecName() string {
+	if p.Internal.CmdlineFiles {
+		return p.exeFromFiles()
+	}
+	return p.exeFromImportPath()
 }
 
 // load populates p using information from bp, err, which should
@@ -1451,7 +1471,7 @@ func (p *Package) load(stk *ImportStack, bp *build.Package, err error) {
 			p.Error = &PackageError{Err: e}
 			return
 		}
-		elem := DefaultExecName(p.ImportPath)
+		elem := p.DefaultExecName()
 		full := cfg.BuildContext.GOOS + "_" + cfg.BuildContext.GOARCH + "/" + elem
 		if cfg.BuildContext.GOOS != base.ToolGOOS || cfg.BuildContext.GOARCH != base.ToolGOARCH {
 			// Install cross-compiled binaries to subdirectories of bin.
@@ -2135,15 +2155,12 @@ func GoFilesPackage(gofiles []string) *Package {
 	pkg.Match = gofiles
 
 	if pkg.Name == "main" {
-		_, elem := filepath.Split(gofiles[0])
-		exe := elem[:len(elem)-len(".go")] + cfg.ExeSuffix
+		exe := pkg.exeFromFiles() + cfg.ExeSuffix
 
 		if cfg.GOBIN != "" {
 			pkg.Target = filepath.Join(cfg.GOBIN, exe)
 		} else if cfg.ModulesEnabled {
 			pkg.Target = filepath.Join(ModBinDir(), exe)
-		} else {
-			pkg.Target = exe
 		}
 	}
 

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2135,30 +2135,25 @@ func GoFilesPackage(gofiles []string) *Package {
 	pkg.Match = gofiles
 
 	if pkg.Name == "main" {
-		exe := GoFilesExe(gofiles) + cfg.ExeSuffix
-		if cfg.BuildO == "" {
-			cfg.BuildO = exe
-		}
+		_, elem := filepath.Split(gofiles[0])
+		exe := elem[:len(elem)-len(".go")] + cfg.ExeSuffix
+
 		if cfg.GOBIN != "" {
 			pkg.Target = filepath.Join(cfg.GOBIN, exe)
 		} else if cfg.ModulesEnabled {
 			pkg.Target = filepath.Join(ModBinDir(), exe)
+		}
+
+		if cfg.BuildO == "" {
+			cfg.BuildO = exe
+		} else if fi, err := os.Stat(cfg.BuildO); err == nil && fi.IsDir() {
+			// If the named output is a directory that exists,
+			// then any resulting executables will be written to that directory.
+			pkg.Target = filepath.Join(cfg.BuildO, exe)
 		}
 	}
 
 	setToolFlags(pkg)
 
 	return pkg
-}
-
-// GoFilesExe generate a suitable name for an executable given a collection of Go files,
-// using the first element in the collection without the prefix.
-//
-// Returns empty string in case of empty collection.
-func GoFilesExe(gofiles []string) string {
-	if len(gofiles) == 0 {
-		return ""
-	}
-	_, elem := filepath.Split(gofiles[0])
-	return elem[:len(elem)-len(".go")]
 }

--- a/src/cmd/go/internal/load/pkg_test.go
+++ b/src/cmd/go/internal/load/pkg_test.go
@@ -5,39 +5,49 @@ import (
 	"testing"
 )
 
-func TestDefaultExecName(t *testing.T) {
+func TestPkgDefaultExecName(t *testing.T) {
 	oldModulesEnabled := cfg.ModulesEnabled
 	defer func() { cfg.ModulesEnabled = oldModulesEnabled }()
 	for _, tt := range []struct {
 		in         string
+		files      []string
 		wantMod    string
 		wantGopath string
 	}{
-		{"example.com/mycmd", "mycmd", "mycmd"},
-		{"example.com/mycmd/v0", "v0", "v0"},
-		{"example.com/mycmd/v1", "v1", "v1"},
-		{"example.com/mycmd/v2", "mycmd", "v2"}, // Semantic import versioning, use second last element in module mode.
-		{"example.com/mycmd/v3", "mycmd", "v3"}, // Semantic import versioning, use second last element in module mode.
-		{"mycmd", "mycmd", "mycmd"},
-		{"mycmd/v0", "v0", "v0"},
-		{"mycmd/v1", "v1", "v1"},
-		{"mycmd/v2", "mycmd", "v2"}, // Semantic import versioning, use second last element in module mode.
-		{"v0", "v0", "v0"},
-		{"v1", "v1", "v1"},
-		{"v2", "v2", "v2"},
+		{"example.com/mycmd", []string{}, "mycmd", "mycmd"},
+		{"example.com/mycmd/v0", []string{}, "v0", "v0"},
+		{"example.com/mycmd/v1", []string{}, "v1", "v1"},
+		{"example.com/mycmd/v2", []string{}, "mycmd", "v2"}, // Semantic import versioning, use second last element in module mode.
+		{"example.com/mycmd/v3", []string{}, "mycmd", "v3"}, // Semantic import versioning, use second last element in module mode.
+		{"mycmd", []string{}, "mycmd", "mycmd"},
+		{"mycmd/v0", []string{}, "v0", "v0"},
+		{"mycmd/v1", []string{}, "v1", "v1"},
+		{"mycmd/v2", []string{}, "mycmd", "v2"}, // Semantic import versioning, use second last element in module mode.
+		{"v0", []string{}, "v0", "v0"},
+		{"v1", []string{}, "v1", "v1"},
+		{"v2", []string{}, "v2", "v2"},
+		{"command-line-arguments", []string{"output.go", "foo.go"}, "output", "output"},
 	} {
 		{
 			cfg.ModulesEnabled = true
-			gotMod := DefaultExecName(tt.in)
+			pkg := new(Package)
+			pkg.ImportPath = tt.in
+			pkg.GoFiles = tt.files
+			pkg.Internal.CmdlineFiles = len(tt.files) > 0
+			gotMod := pkg.DefaultExecName()
 			if gotMod != tt.wantMod {
-				t.Errorf("DefaultExecName(%q) in module mode = %v; want %v", tt.in, gotMod, tt.wantMod)
+				t.Errorf("pkg.DefaultExecName with ImportPath = %q in module mode = %v; want %v", tt.in, gotMod, tt.wantMod)
 			}
 		}
 		{
 			cfg.ModulesEnabled = false
-			gotGopath := DefaultExecName(tt.in)
+			pkg := new(Package)
+			pkg.ImportPath = tt.in
+			pkg.GoFiles = tt.files
+			pkg.Internal.CmdlineFiles = len(tt.files) > 0
+			gotGopath := pkg.DefaultExecName()
 			if gotGopath != tt.wantGopath {
-				t.Errorf("DefaultExecName(%q) in gopath mode = %v; want %v", tt.in, gotGopath, tt.wantGopath)
+				t.Errorf("pkg.DefaultExecName with ImportPath = %q in gopath mode = %v; want %v", tt.in, gotGopath, tt.wantGopath)
 			}
 		}
 	}

--- a/src/cmd/go/internal/test/test.go
+++ b/src/cmd/go/internal/test/test.go
@@ -829,7 +829,7 @@ func builderTest(b *work.Builder, p *load.Package) (buildAction, runAction, prin
 	if p.ImportPath == "command-line-arguments" {
 		elem = p.Name
 	} else {
-		elem = load.DefaultExecName(p.ImportPath)
+		elem = p.DefaultExecName()
 	}
 	testBinary := elem + ".test"
 

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -320,7 +320,7 @@ func runBuild(cmd *base.Command, args []string) {
 	explicitO := len(cfg.BuildO) > 0
 
 	if len(pkgs) == 1 && pkgs[0].Name == "main" && cfg.BuildO == "" {
-		cfg.BuildO = load.DefaultExecName(pkgs[0].ImportPath)
+		cfg.BuildO = pkgs[0].DefaultExecName()
 		cfg.BuildO += cfg.ExeSuffix
 	}
 
@@ -365,7 +365,8 @@ func runBuild(cmd *base.Command, args []string) {
 					continue
 				}
 
-				p.Target = filepath.Join(cfg.BuildO, filepath.Base(p.Target))
+				p.Target = filepath.Join(cfg.BuildO, p.DefaultExecName())
+				p.Target += cfg.ExeSuffix
 				p.Stale = true
 				p.StaleReason = "build -o flag in use"
 				a.Deps = append(a.Deps, b.AutoAction(ModeInstall, depMode, p))
@@ -586,7 +587,7 @@ func InstallPackages(patterns []string, pkgs []*load.Package) {
 	if len(patterns) == 0 && len(pkgs) == 1 && pkgs[0].Name == "main" {
 		// Compute file 'go build' would have created.
 		// If it exists and is an executable file, remove it.
-		targ := load.DefaultExecName(pkgs[0].ImportPath)
+		targ := pkgs[0].DefaultExecName()
 		targ += cfg.ExeSuffix
 		if filepath.Join(pkgs[0].Dir, targ) != pkgs[0].Target { // maybe $GOBIN is the current directory
 			fi, err := os.Stat(targ)

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -345,7 +345,7 @@ func runBuild(cmd *base.Command, args []string) {
 		if cfg.BuildO == os.DevNull {
 			goto NoOutput
 		}
-		
+
 		// If the -o name exists and is a directory, then
 		// write all main packages to that directory.
 		// Otherwise require only a single package be built.

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -339,13 +339,10 @@ func runBuild(cmd *base.Command, args []string) {
 
 	pkgs = omitTestOnly(pkgsFilter(load.Packages(args)))
 
-	if cfg.BuildO != "" {
-
-		// Special case -o /dev/null by not writing at all.
-		if cfg.BuildO == os.DevNull {
-			goto NoOutput
-		}
-
+	// Special case -o /dev/null by not writing at all.
+	if cfg.BuildO == os.DevNull {
+		cfg.BuildO = ""
+	} else if cfg.BuildO != "" {
 		// If the -o name exists and is a directory, then
 		// write all main packages to that directory.
 		// Otherwise require only a single package be built.
@@ -390,7 +387,6 @@ func runBuild(cmd *base.Command, args []string) {
 		return
 	}
 
-NoOutput:
 	a := &Action{Mode: "go build"}
 	for _, p := range pkgs {
 		a.Deps = append(a.Deps, b.AutoAction(ModeBuild, depMode, p))

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -364,12 +364,8 @@ func runBuild(cmd *base.Command, args []string) {
 				if p.Name != "main" {
 					continue
 				}
-				
-				if !p.Internal.Local {
-					p.Target = filepath.Join(cfg.BuildO, load.DefaultExecName(p.ImportPath))
-					p.Target += cfg.ExeSuffix
-				}
 
+				p.Target = filepath.Join(cfg.BuildO, filepath.Base(p.Target))
 				p.Stale = true
 				p.StaleReason = "build -o flag in use"
 				a.Deps = append(a.Deps, b.AutoAction(ModeInstall, depMode, p))

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -364,7 +364,17 @@ func runBuild(cmd *base.Command, args []string) {
 				if p.Name != "main" {
 					continue
 				}
-				p.Target = filepath.Join(cfg.BuildO, load.DefaultExecName(p.ImportPath))
+
+				var exe string
+				// Generate the exe name from files listed on 
+				// the command line in case of local packages
+				if p.Internal.Local && p.Internal.CmdlineFiles {
+					exe = load.GoFilesExe(p.GoFiles)
+				} else {
+					exe = load.DefaultExecName(p.ImportPath)
+				}
+
+				p.Target = filepath.Join(cfg.BuildO, exe)
 				p.Target += cfg.ExeSuffix
 				p.Stale = true
 				p.StaleReason = "build -o flag in use"

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -364,18 +364,12 @@ func runBuild(cmd *base.Command, args []string) {
 				if p.Name != "main" {
 					continue
 				}
-
-				var exe string
-				// Generate the exe name from files listed on 
-				// the command line in case of local packages
-				if p.Internal.Local && p.Internal.CmdlineFiles {
-					exe = load.GoFilesExe(p.GoFiles)
-				} else {
-					exe = load.DefaultExecName(p.ImportPath)
+				
+				if !p.Internal.Local {
+					p.Target = filepath.Join(cfg.BuildO, load.DefaultExecName(p.ImportPath))
+					p.Target += cfg.ExeSuffix
 				}
 
-				p.Target = filepath.Join(cfg.BuildO, exe)
-				p.Target += cfg.ExeSuffix
 				p.Stale = true
 				p.StaleReason = "build -o flag in use"
 				a.Deps = append(a.Deps, b.AutoAction(ModeInstall, depMode, p))

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -317,6 +317,13 @@ func runBuild(cmd *base.Command, args []string) {
 
 	pkgs := load.PackagesForBuild(args)
 
+	explicitO := len(cfg.BuildO) > 0
+
+	if len(pkgs) == 1 && pkgs[0].Name == "main" && cfg.BuildO == "" {
+		cfg.BuildO = pkgs[0].DefaultExecName()
+		cfg.BuildO += cfg.ExeSuffix
+	}
+
 	// sanity check some often mis-used options
 	switch cfg.BuildContext.Compiler {
 	case "gccgo":
@@ -342,11 +349,16 @@ func runBuild(cmd *base.Command, args []string) {
 	// Special case -o /dev/null by not writing at all.
 	if cfg.BuildO == os.DevNull {
 		cfg.BuildO = ""
-	} else if cfg.BuildO != "" {
+	}
+
+	if cfg.BuildO != "" {
 		// If the -o name exists and is a directory, then
 		// write all main packages to that directory.
 		// Otherwise require only a single package be built.
 		if fi, err := os.Stat(cfg.BuildO); err == nil && fi.IsDir() {
+			if !explicitO {
+				base.Fatalf("go build: build output %q already exists and is a directory", cfg.BuildO)
+			}
 			a := &Action{Mode: "go build"}
 			for _, p := range pkgs {
 				if p.Name != "main" {
@@ -374,14 +386,6 @@ func runBuild(cmd *base.Command, args []string) {
 		p.Target = cfg.BuildO
 		p.Stale = true // must build - not up to date
 		p.StaleReason = "build -o flag in use"
-		a := b.AutoAction(ModeInstall, depMode, p)
-		b.Do(a)
-		return
-	} else if len(pkgs) == 1 && pkgs[0].Name == "main" {
-		p := pkgs[0]
-		p.Target = p.DefaultExecName()
-		p.Target += cfg.ExeSuffix
-		p.Stale = true
 		a := b.AutoAction(ModeInstall, depMode, p)
 		b.Do(a)
 		return

--- a/src/cmd/go/testdata/script/build_multi_main.txt
+++ b/src/cmd/go/testdata/script/build_multi_main.txt
@@ -10,6 +10,11 @@ stderr 'no main packages'
 ! go build ./cmd/c1
 stderr 'already exists and is a directory'
 
+# Verify build -o output correctly local packages
+mkdir $WORK/local
+go build -o $WORK/local ./exec.go
+exists $WORK/local/exec
+
 -- go.mod --
 module exmod
 
@@ -28,6 +33,11 @@ package pkg1
 
 -- pkg2/pkg2.go --
 package pkg2
+
+-- exec.go --
+package main
+
+func main() {}
 
 -- c1$GOEXE/keep.txt --
 Create c1 directory.

--- a/src/cmd/go/testdata/script/build_multi_main.txt
+++ b/src/cmd/go/testdata/script/build_multi_main.txt
@@ -13,7 +13,7 @@ stderr 'already exists and is a directory'
 # Verify build -o output correctly local packages
 mkdir $WORK/local
 go build -o $WORK/local ./exec.go
-exists $WORK/local/exec
+exists $WORK/local/exec$GOEXE
 
 -- go.mod --
 module exmod


### PR DESCRIPTION
In the local package build process, when -o is pointing to an existing folder, the object 
the filename is generated from files listed on the command line like when the -o is 
not pointing to a folder instead of using the `importPath` that is going to be `command-line-arguments`

Fixes #34535