### PR TITLE
database/sql: preallocate list slice in Drivers()

### DIFF
--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -64,7 +64,7 @@ func unregisterAllDrivers() {
 func Drivers() []string {
 	driversMu.RLock()
 	defer driversMu.RUnlock()
-	var list []string
+	list := make([]string, 0, len(drivers))
 	for name := range drivers {
 		list = append(list, name)
 	}


### PR DESCRIPTION
The required slice capacity is already known. Thus, preallocate a slice with the correct capacity before appending to it.