### PR TITLE
text/template/parse: specify slice capacity in Pipenode.CopyPipe()

### DIFF
--- a/src/text/template/parse/node.go
+++ b/src/text/template/parse/node.go
@@ -187,7 +187,7 @@ func (p *PipeNode) CopyPipe() *PipeNode {
 	if p == nil {
 		return p
 	}
-	var vars []*VariableNode
+	vars := make([]*VariableNode, 0, len(p.Decl))
 	for _, d := range p.Decl {
 		vars = append(vars, d.Copy().(*VariableNode))
 	}


### PR DESCRIPTION
The required vars slice capacity is known so it can be specified before appending.

