### PR TITLE
cmd/api: simplify building files list in Walker.ImportFrom

### DIFF
--- a/src/cmd/api/goapi.go
+++ b/src/cmd/api/goapi.go
@@ -579,13 +579,13 @@ func (w *Walker) ImportFrom(fromPath, fromDir string, mode types.ImportMode) (*t
 	filenames := append(append([]string{}, info.GoFiles...), info.CgoFiles...)
 
 	// Parse package files.
-	var files []*ast.File
-	for _, file := range filenames {
-		f, err := w.parseFile(dir, file)
+	files := make([]*ast.File, len(filenames))
+	for i, file := range filenames {
+		f, _ := w.parseFile(dir, file)
 		if err != nil {
 			log.Fatalf("error parsing package %s: %s", name, err)
 		}
-		files = append(files, f)
+		files[i] = f
 	}
 
 	// Type-check package files.

--- a/src/cmd/api/goapi.go
+++ b/src/cmd/api/goapi.go
@@ -581,7 +581,7 @@ func (w *Walker) ImportFrom(fromPath, fromDir string, mode types.ImportMode) (*t
 	// Parse package files.
 	files := make([]*ast.File, len(filenames))
 	for i, file := range filenames {
-		f, _ := w.parseFile(dir, file)
+		f, err := w.parseFile(dir, file)
 		if err != nil {
 			log.Fatalf("error parsing package %s: %s", name, err)
 		}


### PR DESCRIPTION
The number of files is known so instead of using append to grow the list, we can allocate the files slice and use index to build the list instead.


