### PR TITLE
net/http: avoid sending unspecified time for directories

### DIFF
--- a/src/net/http/fs.go
+++ b/src/net/http/fs.go
@@ -610,7 +610,7 @@ func serveFile(w ResponseWriter, r *Request, fs FileSystem, name string, redirec
 			writeNotModified(w)
 			return
 		}
-		w.Header().Set("Last-Modified", d.ModTime().UTC().Format(TimeFormat))
+		setLastModified(w, d.ModTime())
 		dirList(w, r, f)
 		return
 	}


### PR DESCRIPTION
Change applies to sendFile.
This is already done for sendContent.