### PR TITLE
encoding/json: fix byte counter increments when using decoder.Token()

### DIFF
--- a/src/encoding/json/stream.go
+++ b/src/encoding/json/stream.go
@@ -369,6 +369,7 @@ func (d Delim) String() string {
 // Commas and colons are elided.
 func (dec *Decoder) Token() (Token, error) {
 	for {
+		dec.scan.bytes++
 		c, err := dec.peek()
 		if err != nil {
 			return nil, err
@@ -438,6 +439,9 @@ func (dec *Decoder) Token() (Token, error) {
 				var x string
 				old := dec.tokenState
 				dec.tokenState = tokenTopValue
+				// Counter the increment done at the start of the iteration, since
+				// dec.readValue manages this counter on its own.
+				dec.scan.bytes--
 				err := dec.Decode(&x)
 				dec.tokenState = old
 				if err != nil {
@@ -452,6 +456,9 @@ func (dec *Decoder) Token() (Token, error) {
 			if !dec.tokenValueAllowed() {
 				return dec.tokenError(c)
 			}
+			// Counter the increment done at the start of the iteration, since
+			// dec.readValue manages this counter on its own.
+			dec.scan.bytes--
 			var x interface{}
 			if err := dec.Decode(&x); err != nil {
 				return nil, err


### PR DESCRIPTION
decoder.Token() goes through the bytes of the JSON payload and return the
next JSON token. When it encounters a token which isn't a square bracket,
a curly bracket, a colon or a comma, it calls decoder.Decode() to process
it. This last function increments the decoder's internal scanner's byte
counter on each byte it encounters.

However, this increment isn't done if the character appears in the list
mentioned previously. This causes the scanner's bytes counter to not
correctly reflect the amount of bytes it has processed in the payload, and
to show incoherent values when returning errors to the caller, e.g. with
SyntaxError instances.

Fixes #34543