### PR TITLE
cmd/go: handle ldflag escapes in pkg-config output

### DIFF
--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -1348,7 +1348,10 @@ func (b *Builder) getPkgConfigFlags(p *load.Package) (cflags, ldflags []string, 
 			return nil, nil, errPrintedOutput
 		}
 		if len(out) > 0 {
-			ldflags = strings.Fields(string(out))
+			ldflags, err = splitPkgConfigOutput(out)
+			if err != nil {
+				return nil, nil, err
+			}
 			if err := checkLinkerFlags("LDFLAGS", "pkg-config --libs", ldflags); err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
Go's pkg-config ldflags parsing cannot handle whitespaces correctly. 

This PR applies the same fix that was done in https://go-review.googlesource.com/c/go/+/43072 for 
the cflags to the ldflags of a package-config.