### PR TITLE
x/sys: add new func syscall.PtraceSeize

### DIFF
--- a/src/syscall/syscall_linux.go
+++ b/src/syscall/syscall_linux.go
@@ -851,6 +851,8 @@ func PtraceSingleStep(pid int) (err error) { return ptrace(PTRACE_SINGLESTEP, pi
 
 func PtraceAttach(pid int) (err error) { return ptrace(PTRACE_ATTACH, pid, 0, 0) }
 
+func PtraceSeize(pid int) (err error) { return ptrace(PTRACE_SEIZE, pid, 0, 0) }
+
 func PtraceDetach(pid int) (err error) { return ptrace(PTRACE_DETACH, pid, 0, 0) }
 
 //sys	reboot(magic1 uint, magic2 uint, cmd int, arg string) (err error)


### PR DESCRIPTION
Add new func to syscall (Linux) to create ptraces using PTRACE_SEIZE.

Fixes https://github.com/golang/go/issues/34717