### PR TITLE
mime: add .json to built-in list of MIME types

### DIFF
--- a/src/mime/type.go
+++ b/src/mime/type.go
@@ -65,6 +65,7 @@ var builtinTypesLower = map[string]string{
 	".jpeg": "image/jpeg",
 	".jpg":  "image/jpeg",
 	".js":   "text/javascript; charset=utf-8",
+	".json": "application/json",
 	".mjs":  "text/javascript; charset=utf-8",
 	".pdf":  "application/pdf",
 	".png":  "image/png",


### PR DESCRIPTION
Since json is popular and mime package's builtin type does not contain
it, and some Linux distributions do not contain the '/etc/mime.types' file
with minimal installations.