### PR TITLE
go/src/io: update copy/copyn documentation dst and src ordering

### DIFF
--- a/src/io/io.go
+++ b/src/io/io.go
@@ -329,7 +329,7 @@ func ReadFull(r Reader, buf []byte) (n int, err error) {
 	return ReadAtLeast(r, buf, len(buf))
 }
 
-// CopyN copies n bytes (or until an error) from src to dst.
+// CopyN copies n bytes (or until an error) from dst to src.
 // It returns the number of bytes copied and the earliest
 // error encountered while copying.
 // On return, written == n if and only if err == nil.
@@ -348,7 +348,7 @@ func CopyN(dst Writer, src Reader, n int64) (written int64, err error) {
 	return
 }
 
-// Copy copies from src to dst until either EOF is reached
+// Copy copies from dst to src until either EOF is reached
 // on src or an error occurs. It returns the number of bytes
 // copied and the first error encountered while copying, if any.
 //


### PR DESCRIPTION
Was doing some work with `io.Copy` and noticed that the `Copy` and `CopyN` functions have a parameter order of `dst` followed by `src`. However, the documentation above it reads the opposite.

This was initially a little confusing to me, and the proposed changes should line up the documentation with the current parameter ordering.
