### PR TITLE
Add a cancel function which can cancel a context due to an error

### DIFF
--- a/src/context/context.go
+++ b/src/context/context.go
@@ -552,3 +552,12 @@ func (c *valueCtx) Value(key interface{}) interface{} {
 	}
 	return c.Context.Value(key)
 }
+
+// A ErrorCancelFunc tells an opertion to abandon due to the error.
+type ErrorCancelFunc func(error)
+
+func WithErrorCancel(parent Context) (Context, CancelFunc, ErrorCancelFunc) {
+	c := newCancelCtx(parent)
+	propagateCancel(parent, &c)
+	return &c, func() { c.cancel(true, Canceled) }, func(err error) { c.cancel(true, err) }
+}

--- a/src/context/x_test.go
+++ b/src/context/x_test.go
@@ -28,3 +28,4 @@ func TestWithCancelCanceledParent(t *testing.T)        { XTestWithCancelCanceled
 func TestWithValueChecksKey(t *testing.T)              { XTestWithValueChecksKey(t) }
 func TestDeadlineExceededSupportsTimeout(t *testing.T) { XTestDeadlineExceededSupportsTimeout(t) }
 func TestCustomContextGoroutines(t *testing.T)         { XTestCustomContextGoroutines(t) }
+func TestWithErrorCancel(t *testing.T)                 { XTestWithErrorCancel(t) }


### PR DESCRIPTION
Sometimes, we run mutilple go routines in a context, if one go routine
failed due to an error, we want to cancel the context and record the
error in it. So I added a function called WithErrorCancel function which
returns both CancelFunc and ErrorCancelFunc. CancelFunc is the same as
the function which is returned by WithCancel, ErrorCancelFunc is used to
cancel a context with an error.