### PR TITLE
mime/multipart: Always show cte header 

### DIFF
--- a/src/mime/multipart/multipart.go
+++ b/src/mime/multipart/multipart.go
@@ -137,7 +137,6 @@ func newPart(mr *Reader) (*Part, error) {
 	bp.r = partReader{bp}
 	const cte = "Content-Transfer-Encoding"
 	if strings.EqualFold(bp.Header.Get(cte), "quoted-printable") {
-		bp.Header.Del(cte)
 		bp.r = quotedprintable.NewReader(bp.r)
 	}
 	return bp, nil


### PR DESCRIPTION
I need to reconstruct a message after reading it using the original headers. Currently there is no way to know if the "Content-Transfer-Encoding" was set to "quoted-printable" or not after it was parsed.

This stops removing the Content-Transfer-Encoding if it was set to quoted-printable.