### PR TITLE
expvar: make possible to delete all exported variables

### DIFF
--- a/src/expvar/expvar.go
+++ b/src/expvar/expvar.go
@@ -283,6 +283,16 @@ func Publish(name string, v Var) {
 	sort.Strings(varKeys)
 }
 
+// RemoveAll removes all exported variables.
+func RemoveAll() {
+	varKeysMu.Lock()
+	defer varKeysMu.Unlock()
+	for _, k := range varKeys {
+		vars.Delete(k)
+	}
+	varKeys = nil
+}
+
 // Get retrieves a named exported variable. It returns nil if the name has
 // not been registered.
 func Get(name string) Var {

--- a/src/expvar/expvar_test.go
+++ b/src/expvar/expvar_test.go
@@ -19,17 +19,6 @@ import (
 	"testing"
 )
 
-// RemoveAll removes all exported variables.
-// This is for tests only.
-func RemoveAll() {
-	varKeysMu.Lock()
-	defer varKeysMu.Unlock()
-	for _, k := range varKeys {
-		vars.Delete(k)
-	}
-	varKeys = nil
-}
-
 func TestNil(t *testing.T) {
 	RemoveAll()
 	val := Get("missing")


### PR DESCRIPTION
By default `expvar` publishes `cmdline` and `memstats` which is not possible to remove. 
This PR makes it possible by moving existing function `RemoveAll` from tests

Fixes #29105 