### PR TITLE
errors/wrap: correct typo in TODO message

### DIFF
--- a/src/errors/wrap.go
+++ b/src/errors/wrap.go
@@ -49,7 +49,7 @@ func Is(err, target error) bool {
 		if x, ok := err.(interface{ Is(error) bool }); ok && x.Is(target) {
 			return true
 		}
-		// TODO: consider supporing target.Is(err). This would allow
+		// TODO: consider supporting target.Is(err). This would allow
 		// user-definable predicates, but also may allow for coping with sloppy
 		// APIs, thereby making it easier to get away with them.
 		if err = Unwrap(err); err == nil {


### PR DESCRIPTION
Doing this change as part of a contributor workshop, found a typo in `src/errors/wrap.go`