### PR TITLE
net/smtp: change expected command for RCPT to 250

### DIFF
--- a/src/net/smtp/smtp.go
+++ b/src/net/smtp/smtp.go
@@ -267,7 +267,7 @@ func (c *Client) Rcpt(to string) error {
 	if err := validateLine(to); err != nil {
 		return err
 	}
-	_, _, err := c.cmd(25, "RCPT TO:<%s>", to)
+	_, _, err := c.cmd(250, "RCPT TO:<%s>", to)
 	return err
 }
 


### PR DESCRIPTION
According to RFC5321 https://tools.ietf.org/html/rfc5321 the RCPT command returns 250 when result is OK