### PR TITLE
runtime: WIP: fix infinite loop in lockextra on linux/arm

### DIFF
--- a/src/runtime/crash_test.go
+++ b/src/runtime/crash_test.go
@@ -143,9 +143,18 @@ func buildTestProg(t *testing.T, binary string, flags ...string) (string, error)
 	return exe, nil
 }
 
-func TestVDSO(t *testing.T) {
+func TestSIGPROFInVDSO(t *testing.T) {
 	t.Parallel()
-	output := runTestProg(t, "testprog", "SignalInVDSO")
+	output := runTestProg(t, "testprog", "SIGPROFInVDSO")
+	want := "success\n"
+	if output != want {
+		t.Fatalf("output:\n%s\n\nwanted:\n%s", output, want)
+	}
+}
+
+func TestSIGUSR1InVDSO(t *testing.T) {
+	t.Parallel()
+	output := runTestProg(t, "testprog", "SIGUSR1InVDSO")
 	want := "success\n"
 	if output != want {
 		t.Fatalf("output:\n%s\n\nwanted:\n%s", output, want)

--- a/src/runtime/sys_linux_arm.s
+++ b/src/runtime/sys_linux_arm.s
@@ -247,6 +247,15 @@ noswitch:
 	B.EQ	fallback
 
 	BL	(R11)
+
+	SUB	$24, R13
+	MOVW	R4, 8(R13)
+	MOVW	R5, 12(R13)
+	BL	runtime·sigClearPending(SB)
+	MOVW	12(R13), R5
+	MOVW	8(R13), R4
+	ADD	$24, R13
+
 	JMP	finish
 
 fallback:
@@ -298,6 +307,15 @@ noswitch:
 	B.EQ	fallback
 
 	BL	(R11)
+
+	SUB	$24, R13
+	MOVW	R4, 8(R13)
+	MOVW	R5, 12(R13)
+	BL	runtime·sigClearPending(SB)
+	MOVW	12(R13), R5
+	MOVW	8(R13), R4
+	ADD	$24, R13
+
 	JMP	finish
 
 fallback:

--- a/src/runtime/sys_linux_arm64.s
+++ b/src/runtime/sys_linux_arm64.s
@@ -208,6 +208,13 @@ noswitch:
 	MOVD	runtime·vdsoClockgettimeSym(SB), R2
 	CBZ	R2, fallback
 	BL	(R2)
+
+	SUB	$24, RSP
+	MOVD	R20, 16(RSP)
+	BL	runtime·sigClearPending(SB)
+	MOVD	16(RSP), R20
+	ADD	$24, RSP
+
 	B	finish
 
 fallback:
@@ -251,6 +258,13 @@ noswitch:
 	MOVD	runtime·vdsoClockgettimeSym(SB), R2
 	CBZ	R2, fallback
 	BL	(R2)
+
+	SUB	$24, RSP
+	MOVD	R20, 16(RSP)
+	BL	runtime·sigClearPending(SB)
+	MOVD	16(RSP), R20
+	ADD	$24, RSP
+
 	B	finish
 
 fallback:

--- a/src/runtime/testdata/testprog/vdso.go
+++ b/src/runtime/testdata/testprog/vdso.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Invoke signal hander in the VDSO context (see issue 32912).
+// Invoke signal hander in the VDSO context.
+// See issue 32912 and 34391.
 
 package main
 
@@ -11,14 +12,16 @@ import (
 	"io/ioutil"
 	"os"
 	"runtime/pprof"
+	"syscall"
 	"time"
 )
 
 func init() {
-	register("SignalInVDSO", signalInVDSO)
+	register("SIGPROFInVDSO", signalSIGPROFInVDSO)
+	register("SIGUSR1InVDSO", signalSIGUSR1InVDSO)
 }
 
-func signalInVDSO() {
+func signalSIGPROFInVDSO() {
 	f, err := ioutil.TempFile("", "timeprofnow")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -50,6 +53,31 @@ func signalInVDSO() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
 	}
+
+	fmt.Println("success")
+}
+
+func signalSIGUSR1InVDSO() {
+	done := make(chan struct {})
+
+	p, _ := os.FindProcess(os.Getpid())
+	go func() {
+		for {
+			p.Signal(syscall.SIGUSR1)
+			select {
+			case <- done:
+				return
+			default:
+			}
+		}
+	}()
+
+	t0 := time.Now()
+	t1 := t0
+	for t1.Sub(t0) < time.Second {
+		t1 = time.Now()
+	}
+	close(done)
 
 	fmt.Println("success")
 }


### PR DESCRIPTION
This commit fixes issue #34391, which is due to an incorrect patch
merged in CL 192937.

sigtrampgo is modified to record incoming signals in a globally shared
atomic bitmask when the G register is clobbered. When the execution
exits from vdso it checks if there are pending signals and in that
case it re-raises them to its own process.

Fixes #34391 

----

*This PR is work in progress.*
Following the discussion in #34391, I implemented a patch to fix signal handling during VDSO on arm.
However, my patch is still incomplete due to the following concerns

1. Some tests are still failing on my arm machine (raspberry pi3). Specifically `os/signal` and `TestSIGUSR1InVDSO` in `runtime` fail because of stack overflows:

```sh
...
fatal: morestack on g0
FAIL    os/signal       0.092s
...
--- FAIL: TestSIGUSR1InVDSO (20.67s)
    crash_test.go:95: testprog SIGUSR1InVDSO exit status: exit status 2
    crash_test.go:160: output:
        runtime: newstack sp=0xc09c24 stack=[0xc2a000, 0xc2a800]
                morebuf={pc:0x4fb44 sp:0xc09c24 lr:0x0}
                sched={pc:0x4f9ec sp:0xc09c24 lr:0x4fb44 ctxt:0x0}
        runtime: gp=0xc000e0, goid=1, gp->status=0x2
         runtime: split stack overflow: 0xc09c24 < 0xc2a000
        fatal error: runtime: split stack overflow

        runtime stack:
        runtime.throw(0xfc0a0, 0x1d)
                /home/pi/go/src/runtime/panic.go:774 +0x5c
        runtime.newstack()
                /home/pi/go/src/runtime/stack.go:1008 +0x728
        runtime.morestack()
                /home/pi/go/src/runtime/asm_arm.s:420 +0x60

        goroutine 1 [running]:
        runtime.sigAddPending(0xa)
                /home/pi/go/src/runtime/signal_unix.go:293 +0x6c fp=0xc09c24 sp=0xc09c24 pc=0x4f9ec
        runtime.sigtrampgo(0xa, 0xc09c88, 0xc09d08)
                /home/pi/go/src/runtime/signal_unix.go:351 +0x90 fp=0xc09c78 sp=0xc09c24 pc=0x4fb44
        runtime: unexpected return pc for runtime.sigtramp called from 0x7ed37668
        stack: frame={sp:0xc09c78, fp:0xc09c88} stack=[0xc2a000,0xc2a800)

        runtime.sigtramp(0x0, 0x0, 0x7721, 0x3e8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
                /home/pi/go/src/runtime/sys_linux_arm.s:467 +0x28 fp=0xc09c88 sp=0xc09c78 pc=0x67310

        goroutine 6 [runnable]:
        sync.(*RWMutex).RUnlock(0xc1415c)
                /home/pi/go/src/sync/rwmutex.go:62 +0x58
        os.(*Process).signal(0xc14150, 0x117738, 0x115d30, 0x0, 0x0)
                /home/pi/go/src/os/exec_unix.go:77 +0x140
        os.(*Process).Signal(...)
                /home/pi/go/src/os/exec.go:131
        main.signalSIGUSR1InVDSO.func1(0xc14150, 0xc1c100)
                /home/pi/go/src/runtime/testdata/testprog/vdso.go:66 +0x30
        created by main.signalSIGUSR1InVDSO
                /home/pi/go/src/runtime/testdata/testprog/vdso.go:64 +0x84


        wanted:
        success
FAIL
FAIL    runtime 274.555s
```

2. Perfomance is pretty bad. As found in the above code snippet, runtime test takes about 4.5 minutes to finish. Overall time of `./all.bash` is more than 1 hour. This should be caused by heavy contention on the new signal pending queue introduced in my patch.

3. Assembly code is incomplete. I am unfamiliar with the calling convention of Go on arm and I think my assembly code to call sigClearPending from vdso callers can be incorrect or at least improvable.

Could you possibly review this and give some comments? (cc: @ianlancetaylor)