### PR TITLE
bytes, strings: make Title treat Unicode punctuation as separators

### DIFF
--- a/src/bytes/bytes.go
+++ b/src/bytes/bytes.go
@@ -622,10 +622,9 @@ func ToValidUTF8(s, replacement []byte) []byte {
 }
 
 // isSeparator reports whether the rune could mark a word boundary.
-// TODO: update when package unicode captures more of the properties.
 func isSeparator(r rune) bool {
 	// ASCII alphanumerics and underscore are not separators
-	if r <= 0x7F {
+	if r <= unicode.MaxASCII {
 		switch {
 		case '0' <= r && r <= '9':
 			return false
@@ -638,18 +637,12 @@ func isSeparator(r rune) bool {
 		}
 		return true
 	}
-	// Letters and digits are not separators
-	if unicode.IsLetter(r) || unicode.IsDigit(r) {
-		return false
-	}
-	// Otherwise, all we can do for now is treat spaces as separators.
-	return unicode.IsSpace(r)
+	// Spaces and Unicode punctuation characters are treated as separators.
+	return unicode.IsSpace(r) || unicode.IsPunct(r)
 }
 
 // Title treats s as UTF-8-encoded bytes and returns a copy with all Unicode letters that begin
 // words mapped to their title case.
-//
-// BUG(rsc): The rule Title uses for word boundaries does not handle Unicode punctuation properly.
 func Title(s []byte) []byte {
 	// Use a closure here to remember state.
 	// Hackish but effective. Depends on Map scanning in order and calling

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -1483,6 +1483,7 @@ var TitleTests = []TitleTest{
 	{"ÿøû", "Ÿøû"},
 	{"with_underscore", "With_underscore"},
 	{"unicode \xe2\x80\xa8 line separator", "Unicode \xe2\x80\xa8 Line Separator"},
+	{"^unicode\u2026punctuation", "^Unicode\u2026Punctuation"},
 }
 
 func TestTitle(t *testing.T) {

--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -683,10 +683,9 @@ func ToValidUTF8(s, replacement string) string {
 }
 
 // isSeparator reports whether the rune could mark a word boundary.
-// TODO: update when package unicode captures more of the properties.
 func isSeparator(r rune) bool {
 	// ASCII alphanumerics and underscore are not separators
-	if r <= 0x7F {
+	if r <= unicode.MaxASCII {
 		switch {
 		case '0' <= r && r <= '9':
 			return false
@@ -699,18 +698,12 @@ func isSeparator(r rune) bool {
 		}
 		return true
 	}
-	// Letters and digits are not separators
-	if unicode.IsLetter(r) || unicode.IsDigit(r) {
-		return false
-	}
-	// Otherwise, all we can do for now is treat spaces as separators.
-	return unicode.IsSpace(r)
+	// Spaces and Unicode punctuation characters are treated as separators.
+	return unicode.IsSpace(r) || unicode.IsPunct(r)
 }
 
 // Title returns a copy of the string s with all Unicode letters that begin words
 // mapped to their Unicode title case.
-//
-// BUG(rsc): The rule Title uses for word boundaries does not handle Unicode punctuation properly.
 func Title(s string) string {
 	// Use a closure here to remember state.
 	// Hackish but effective. Depends on Map scanning in order and calling

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -1371,6 +1371,7 @@ var TitleTests = []struct {
 	{"ÿøû", "Ÿøû"},
 	{"with_underscore", "With_underscore"},
 	{"unicode \xe2\x80\xa8 line separator", "Unicode \xe2\x80\xa8 Line Separator"},
+	{"^unicode\u2026punctuation", "^Unicode\u2026Punctuation"},
 }
 
 func TestTitle(t *testing.T) {


### PR DESCRIPTION
The isSeparator function, which Title relies on, has been simplified and
changed to treat Unicode punctuation characters as separators. Previous
behaviour of treating ASCII punctuation (except underscore), symbol and
other characters (control characters group) as separators remains unchanged.

Fixes #34994