### PR TITLE
net/http: make Transport.roundTrip close body on invalid method

### DIFF
--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -492,6 +492,7 @@ func (t *Transport) roundTrip(req *Request) (*Response, error) {
 		return nil, &badStringError{"unsupported protocol scheme", scheme}
 	}
 	if req.Method != "" && !validMethod(req.Method) {
+		req.closeBody()
 		return nil, fmt.Errorf("net/http: invalid method %q", req.Method)
 	}
 	if req.URL.Host == "" {


### PR DESCRIPTION
Updates #35015