### PR TITLE
gofmt/utils: and fix/utils: moved same functions to common file like src/cmd/gofmt/internal.go

### DIFF
--- a/src/cmd/fix/main_test.go
+++ b/src/cmd/fix/main_test.go
@@ -123,7 +123,7 @@ func TestRewrite(t *testing.T) {
 }
 
 func tdiff(t *testing.T, a, b string) {
-	data, err := diff([]byte(a), []byte(b))
+	data, err := diff("go-fix-test", []byte(a), []byte(b))
 	if err != nil {
 		t.Error(err)
 		return

--- a/src/cmd/fix/utils.go
+++ b/src/cmd/fix/utils.go
@@ -1,0 +1,70 @@
+
+// Does not change this file without his clone (src/cmd/gofmt/utils.go, src/cmd/fix/utils.go)
+// This file and the file are the same. Do not modify
+// one without the other. Determine if we can factor out functionality
+// in a public API.
+
+package main
+
+import (
+	"go/scanner"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+func diff(prefix string, b1, b2 []byte) (data []byte, err error) {
+	f1, err := writeTempFile("", prefix, b1)
+	if err != nil {
+		return
+	}
+	defer os.Remove(f1)
+
+	f2, err := writeTempFile("", prefix, b2)
+	if err != nil {
+		return
+	}
+	defer os.Remove(f2)
+
+	cmd := "diff"
+	if runtime.GOOS == "plan9" {
+		cmd = "/bin/ape/diff"
+	}
+
+	data, err = exec.Command(cmd, "-u", f1, f2).CombinedOutput()
+	if len(data) > 0 {
+		// diff exits with a non-zero status when the files don't match.
+		// Ignore that failure as long as we get output.
+		err = nil
+	}
+	return
+}
+
+func writeTempFile(dir, prefix string, data []byte) (string, error) {
+	file, err := ioutil.TempFile(dir, prefix)
+	if err != nil {
+		return "", err
+	}
+	_, err = file.Write(data)
+	if err1 := file.Close(); err == nil {
+		err = err1
+	}
+	if err != nil {
+		os.Remove(file.Name())
+		return "", err
+	}
+	return file.Name(), nil
+}
+
+func report(err error) {
+	scanner.PrintError(os.Stderr, err)
+	exitCode = 2
+}
+
+func isGoFile(f os.FileInfo) bool {
+	// ignore non-Go files
+	name := f.Name()
+	return !f.IsDir() && !strings.HasPrefix(name, ".") && strings.HasSuffix(name, ".go")
+}

--- a/src/cmd/gofmt/gofmt_test.go
+++ b/src/cmd/gofmt/gofmt_test.go
@@ -112,7 +112,7 @@ func runTest(t *testing.T, in, out string) {
 		}
 
 		t.Errorf("(gofmt %s) != %s (see %s.gofmt)", in, out, in)
-		d, err := diff(expected, got, in)
+		d, err := diffWithReplaceTempFile(expected, got, in)
 		if err == nil {
 			t.Errorf("%s", d)
 		}
@@ -194,7 +194,7 @@ func TestDiff(t *testing.T) {
 	in := []byte("first\nsecond\n")
 	out := []byte("first\nthird\n")
 	filename := "difftest.txt"
-	b, err := diff(in, out, filename)
+	b, err := diffWithReplaceTempFile(in, out, filename)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/cmd/gofmt/utils.go
+++ b/src/cmd/gofmt/utils.go
@@ -1,0 +1,70 @@
+
+// Does not change this file without his clone (src/cmd/gofmt/utils.go, src/cmd/fix/utils.go)
+// This file and the file are the same. Do not modify
+// one without the other. Determine if we can factor out functionality
+// in a public API.
+
+package main
+
+import (
+	"go/scanner"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+func diff(prefix string, b1, b2 []byte) (data []byte, err error) {
+	f1, err := writeTempFile("", prefix, b1)
+	if err != nil {
+		return
+	}
+	defer os.Remove(f1)
+
+	f2, err := writeTempFile("", prefix, b2)
+	if err != nil {
+		return
+	}
+	defer os.Remove(f2)
+
+	cmd := "diff"
+	if runtime.GOOS == "plan9" {
+		cmd = "/bin/ape/diff"
+	}
+
+	data, err = exec.Command(cmd, "-u", f1, f2).CombinedOutput()
+	if len(data) > 0 {
+		// diff exits with a non-zero status when the files don't match.
+		// Ignore that failure as long as we get output.
+		err = nil
+	}
+	return
+}
+
+func writeTempFile(dir, prefix string, data []byte) (string, error) {
+	file, err := ioutil.TempFile(dir, prefix)
+	if err != nil {
+		return "", err
+	}
+	_, err = file.Write(data)
+	if err1 := file.Close(); err == nil {
+		err = err1
+	}
+	if err != nil {
+		os.Remove(file.Name())
+		return "", err
+	}
+	return file.Name(), nil
+}
+
+func report(err error) {
+	scanner.PrintError(os.Stderr, err)
+	exitCode = 2
+}
+
+func isGoFile(f os.FileInfo) bool {
+	// ignore non-Go files
+	name := f.Name()
+	return !f.IsDir() && !strings.HasPrefix(name, ".") && strings.HasSuffix(name, ".go")
+}


### PR DESCRIPTION
Moved function to private utils.go, that is copypaste
We should improve this somehow, to use it normally without copying,

for example, we have 6 or 8 copies of isGoFIle and they are all the same but with small differences