### PR TITLE
cmd/link: fix nil dereference

### DIFF
--- a/src/cmd/link/internal/ld/dwarf.go
+++ b/src/cmd/link/internal/ld/dwarf.go
@@ -1402,7 +1402,7 @@ func writeinfo(ctxt *Link, syms []*sym.Symbol, units []*sym.CompilationUnit, abb
 		s := dtolsym(compunit.Sym)
 
 		if s == nil {
-			continue
+			log.Fatalf("compilation unit symbol is nil")
 		}
 
 		if len(u.Textp) == 0 && u.DWInfo.Child == nil {

--- a/src/cmd/link/internal/ld/dwarf.go
+++ b/src/cmd/link/internal/ld/dwarf.go
@@ -1401,6 +1401,10 @@ func writeinfo(ctxt *Link, syms []*sym.Symbol, units []*sym.CompilationUnit, abb
 		compunit := u.DWInfo
 		s := dtolsym(compunit.Sym)
 
+		if s == nil {
+			continue
+		}
+
 		if len(u.Textp) == 0 && u.DWInfo.Child == nil {
 			continue
 		}


### PR DESCRIPTION
Fixes https://github.com/golang/go/issues/34249