### PR TITLE
internal/singleflight: format someErr

### DIFF
--- a/src/internal/singleflight/singleflight_test.go
+++ b/src/internal/singleflight/singleflight_test.go
@@ -28,7 +28,7 @@ func TestDo(t *testing.T) {
 
 func TestDoErr(t *testing.T) {
 	var g Group
-	someErr := errors.New("Some error")
+	someErr := errors.New("some error")
 	v, err, _ := g.Do("key", func() (interface{}, error) {
 		return nil, someErr
 	})


### PR DESCRIPTION
Error string should not be capitalized.