### PR TITLE
database/sql: prevent ErrBadConn from driver.Open()

### DIFF
--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -685,7 +685,11 @@ type dsnConnector struct {
 }
 
 func (t dsnConnector) Connect(_ context.Context) (driver.Conn, error) {
-	return t.driver.Open(t.dsn)
+	conn, err := t.driver.Open(t.dsn)
+	if err == driver.ErrBadConn {
+		return conn, fmt.Errorf("sql: driver open() returned ErrBadConn. ErrBadConn should only be returned from existing connections")
+	}
+	return conn, err
 }
 
 func (t dsnConnector) Driver() driver.Driver {

--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -687,7 +687,7 @@ type dsnConnector struct {
 func (t dsnConnector) Connect(_ context.Context) (driver.Conn, error) {
 	conn, err := t.driver.Open(t.dsn)
 	if err == driver.ErrBadConn {
-		return conn, fmt.Errorf("sql: driver open() returned ErrBadConn. ErrBadConn should only be returned from existing connections")
+		return conn, fmt.Errorf("sql: driver Open() returned ErrBadConn. ErrBadConn should only be returned from existing connections")
 	}
 	return conn, err
 }


### PR DESCRIPTION
because it seems this error is only meant to be internal, and if `ErrBadConn` is returned from here it can also be returned from the public api.

See some confusion about this here: https://github.com/go-sql-driver/mysql/pull/1020

And a fix in the postgres driver here: https://github.com/lib/pq/commit/04c77ed03f9b391050bec3b5f2f708f204df48b2

If we already had this check a while back, then https://github.com/go-sql-driver/mysql/pull/867 would never have been accepted and we'd have gone down the route of a custom dial function, preventing the concern now that users of https://github.com/go-sql-driver/mysql will start seeing higher error rates if the PR is reverted.
