### PR TITLE
doc/artices: format error string as per go style

### DIFF
--- a/doc/articles/wiki/final-noclosure.go
+++ b/doc/articles/wiki/final-noclosure.go
@@ -90,7 +90,7 @@ func getTitle(w http.ResponseWriter, r *http.Request) (string, error) {
 	m := validPath.FindStringSubmatch(r.URL.Path)
 	if m == nil {
 		http.NotFound(w, r)
-		return "", errors.New("Invalid Page Title")
+		return "", errors.New("invalid Page Title")
 	}
 	return m[2], nil // The title is the second subexpression.
 }


### PR DESCRIPTION
First letter of an error string should not be capitalized, as prescribed in the [wiki](https://github.com/golang/go/wiki/Errors). 