### PR TITLE
crypto/tls: implement Stringer for CurveID and SignatureScheme

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -118,6 +118,21 @@ const (
 	X25519    CurveID = 29
 )
 
+var curveIDs = map[CurveID]string{
+	CurveP256: "CurveP256",
+	CurveP384: "CurveP384",
+	CurveP521: "CurveP521",
+	X25519:    "X25519",
+}
+
+func (c CurveID) String() string {
+	s, ok := curveIDs[c]
+	if !ok {
+		return "unsupported CurveID"
+	}
+	return s
+}
+
 // TLS 1.3 Key Share. See RFC 8446, Section 4.2.8.
 type keyShare struct {
 	group CurveID

--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -386,6 +386,29 @@ func typeAndHashFromSignatureScheme(signatureAlgorithm SignatureScheme) (sigType
 	return sigType, hash, nil
 }
 
+var signatureSchemes = map[SignatureScheme]string{
+	PKCS1WithSHA256:        "PKCS1WithSHA256",
+	PKCS1WithSHA384:        "PKCS1WithSHA384",
+	PKCS1WithSHA512:        "PKCS1WithSHA512",
+	PSSWithSHA256:          "PSSWithSHA256",
+	PSSWithSHA384:          "PSSWithSHA384",
+	PSSWithSHA512:          "PSSWithSHA512",
+	ECDSAWithP256AndSHA256: "ECDSAWithP256AndSHA256",
+	ECDSAWithP384AndSHA384: "ECDSAWithP384AndSHA384",
+	ECDSAWithP521AndSHA512: "ECDSAWithP521AndSHA512",
+	Ed25519:                "Ed25519",
+	PKCS1WithSHA1:          "PKCS1WithSHA1",
+	ECDSAWithSHA1:          "ECDSAWithSHA1",
+}
+
+func (ss SignatureScheme) String() string {
+	s, ok := signatureSchemes[ss]
+	if !ok {
+		return "unsupported SignatureScheme"
+	}
+	return s
+}
+
 // ClientHelloInfo contains information from a ClientHello message in order to
 // guide certificate selection in the GetCertificate callback.
 type ClientHelloInfo struct {


### PR DESCRIPTION
Implement the String() method for the CurveID and SignatureScheme types.
This can be useful for logging or printing these constants.