### PR TITLE
cmd/go/internal/get: automatically remove https:// prefixes

### DIFF
--- a/src/cmd/go/internal/get/get.go
+++ b/src/cmd/go/internal/get/get.go
@@ -152,6 +152,14 @@ func runGet(cmd *base.Command, args []string) {
 		os.Setenv("GIT_SSH_COMMAND", "ssh -o ControlMaster=no")
 	}
 
+	// Remove https:// prefixes from args
+	for k, a := range args {
+		if strings.HasPrefix(a, "https://") {
+			args[k] = a[:8]
+			continue
+		}
+	}
+
 	// Phase 1. Download/update.
 	var stk load.ImportStack
 	mode := 0


### PR DESCRIPTION
I often want to `go get` a Go package that I'm browsing on Github.

Nowadays all browsers hide https:// prefixes from the address bar.

After I manually select github.com/user/repo and copy it, I go the terminal and type `go get <paste>` and press enter. The browser automatically prefixed the text I copied with https://.

The go get program immediately gives an error:
```
go get https:/github.com/user/repo: malformed module path "https:/github.com/user/repo": invalid char ':'
```
With this change, we improve the UX, by quickly removing the https:// prefix and just continue.

I need to add a test to verify that this is working. What's the best practice here?