### PR TITLE
runtime: remove stray errno check from TestSignalM

### DIFF
--- a/src/runtime/crash_unix_test.go
+++ b/src/runtime/crash_unix_test.go
@@ -326,13 +326,9 @@ func TestSignalM(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		runtime.LockOSThread()
-		var errno int32
 		want, got = runtime.WaitForSigusr1(r, w, func(mp *runtime.M) {
 			ready <- mp
 		})
-		if errno != 0 {
-			t.Error(syscall.Errno(errno))
-		}
 		runtime.UnlockOSThread()
 		wg.Done()
 	}()


### PR DESCRIPTION
CL 206078 introduced a stray errno check that was always false. This CL removes it.

Updates #35276