### PR TITLE
bytes: except "slice bounds out of range" error

### DIFF
--- a/src/bytes/buffer.go
+++ b/src/bytes/buffer.go
@@ -206,13 +206,14 @@ func (b *Buffer) ReadFrom(r io.Reader) (n int64, err error) {
 			panic(errNegativeRead)
 		}
 
+		if e != nil && e != io.EOF {
+			return n, e
+		}
+		
 		b.buf = b.buf[:i+m]
 		n += int64(m)
 		if e == io.EOF {
 			return n, nil // e is EOF, so return nil explicitly
-		}
-		if e != nil {
-			return n, e
 		}
 	}
 }


### PR DESCRIPTION
Currently bytes.Buffer do not check error before use read length.
If io.Reader return invalid read length with error, raise "slice bounds out of range".