### PR TITLE
net/http: add additional doc regarding http request context cancel behaviour

### DIFF
--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -335,6 +335,9 @@ type Request struct {
 // For incoming server requests, the context is canceled when the
 // client's connection closes, the request is canceled (with HTTP/2),
 // or when the ServeHTTP method returns.
+//
+// For request with non-nil body, the context will never be cancelled
+// unless the application starts reading the request body.
 func (r *Request) Context() context.Context {
 	if r.ctx != nil {
 		return r.ctx

--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -336,8 +336,8 @@ type Request struct {
 // client's connection closes, the request is canceled (with HTTP/2),
 // or when the ServeHTTP method returns.
 //
-// For request with non-nil body, the context will never be cancelled
-// unless the application starts reading the request body.
+// For request with non-nil body, the request body must be read first,
+// only then the context will be cancelled when the client's connection closes.
 func (r *Request) Context() context.Context {
 	if r.ctx != nil {
 		return r.ctx


### PR DESCRIPTION
for incoming request which have nil body, the request context will be cancelled when client's connection closes.

However for incoming request which have non-nil body, the request context will **never** be cancelled unless the application starts reading the body.

I think it would be good if we can have this non-nil request context cancel behaviour documented.

Related discussion on StackOverflow https://stackoverflow.com/a/57247158/1467988