### PR TITLE
path/filepath: Glob fails if it has a wildcard and ends with /

### DIFF
--- a/src/path/filepath/match_test.go
+++ b/src/path/filepath/match_test.go
@@ -123,6 +123,7 @@ var globTests = []struct {
 	{"mat?h.go", "match.go"},
 	{"*", "match.go"},
 	{"../*/match.go", "../filepath/match.go"},
+	{"../../*/filepath/", "../../path/filepath"},
 }
 
 func TestGlob(t *testing.T) {


### PR DESCRIPTION
The function Glob tries to get the parent directory of the given path.
When a trailing slash is present, filepath.Split returns the path as it is as it can not split it further.
This fix cleans the path first by removing any trailing slash before getting the parent directory.

Fixes #33617
