### PR TITLE
cmd/compile: return LITERAL on INDEXMAP when map and key are LITERALs

### DIFF
--- a/src/cmd/compile/internal/gc/walk.go
+++ b/src/cmd/compile/internal/gc/walk.go
@@ -1087,6 +1087,21 @@ opswitch:
 		}
 
 	case OINDEXMAP:
+		// x = m[key]; 
+		// if m is a map literal and key is a literal, 
+		// and key is defined in m, immediately return the literal
+		if n.Left.Op == OMAPLIT && n.Right.Op == OLITERAL {
+			key := n.Right
+			lit := n.Left
+
+			// Check if the key is defined
+			for _, element := range lit.List.Slice() {
+				if element.Left.E == key.E {
+					return element.Right
+				}
+			}
+		}
+		
 		// Replace m[k] with *map{access1,assign}(maptype, m, &k)
 		n.Left = walkexpr(n.Left, init)
 		n.Right = walkexpr(n.Right, init)

--- a/src/cmd/compile/internal/gc/walk.go
+++ b/src/cmd/compile/internal/gc/walk.go
@@ -434,6 +434,29 @@ func convFuncName(from, to *types.Type) (fnname string, needsaddr bool) {
 	panic("unreachable")
 }
 
+// The result of walklit MUST be assigned back to n, e.g.
+// 	n.Left = walklit(n.Left, init)
+func walklit(n *Node, init *Nodes) *Node {
+	if isStaticCompositeLiteral(n) && !canSSAType(n.Type) {
+		// n can be directly represented in the read-only data section.
+		// Make direct reference to the static data. See issue 12841.
+		vstat := staticname(n.Type)
+		vstat.Name.SetReadonly(true)
+		fixedlit(inInitFunction, initKindStatic, n, vstat, init)
+		n = vstat
+		n = typecheck(n, ctxExpr)
+		return n
+	}
+
+	if n.Op == OLITERAL {
+		return n
+	}
+
+	var_ := temp(n.Type)
+	anylit(n, var_, init)
+	return var_
+}
+
 // The result of walkexpr MUST be assigned back to n, e.g.
 // 	n.Left = walkexpr(n.Left, init)
 func walkexpr(n *Node, init *Nodes) *Node {
@@ -1090,14 +1113,14 @@ opswitch:
 		// x = m[key]; 
 		// if m is a map literal and key is a literal, 
 		// and key is defined in m, immediately return the literal
-		if n.Left.Op == OMAPLIT && n.Right.Op == OLITERAL {
+		if n.Left.Op == OMAPLIT && isStaticCompositeLiteral(n.Right) {
 			key := n.Right
 			lit := n.Left
-
 			// Check if the key is defined
 			for _, element := range lit.List.Slice() {
 				if element.Left.E == key.E {
-					return element.Right
+					n = walklit(element.Right, init)
+					break opswitch
 				}
 			}
 		}
@@ -1489,19 +1512,7 @@ opswitch:
 		n = mkcall("stringtoslicerune", n.Type, init, a, conv(n.Left, types.Types[TSTRING]))
 
 	case OARRAYLIT, OSLICELIT, OMAPLIT, OSTRUCTLIT, OPTRLIT:
-		if isStaticCompositeLiteral(n) && !canSSAType(n.Type) {
-			// n can be directly represented in the read-only data section.
-			// Make direct reference to the static data. See issue 12841.
-			vstat := staticname(n.Type)
-			vstat.Name.SetReadonly(true)
-			fixedlit(inInitFunction, initKindStatic, n, vstat, init)
-			n = vstat
-			n = typecheck(n, ctxExpr)
-			break
-		}
-		var_ := temp(n.Type)
-		anylit(n, var_, init)
-		n = var_
+		n = walklit(n, init)
 
 	case OSEND:
 		n1 := n.Right

--- a/src/cmd/compile/internal/gc/walk.go
+++ b/src/cmd/compile/internal/gc/walk.go
@@ -1093,10 +1093,17 @@ opswitch:
 		if n.Left.Op == OMAPLIT && isStaticCompositeLiteral(n.Right) {
 			key := n.Right
 			maplit := n.Left
+
+			if !key.HasVal() {
+				yyerror("literal has no value")
+			}
+
 			// Check if the key is defined
 			for _, element := range maplit.List.Slice() {
-				if element.Left.Val() == key.Val() {
-					n = walkexpr(element.Right, init)
+				elementKey := element.Left
+				elementValue := element.Right
+				if eqval(elementKey.Val(), key.Val()) {
+					n = walkexpr(elementValue, init)
 					break opswitch
 				}
 			}

--- a/src/cmd/compile/internal/gc/walk.go
+++ b/src/cmd/compile/internal/gc/walk.go
@@ -1087,10 +1087,10 @@ opswitch:
 		}
 
 	case OINDEXMAP:
-		// x = m[key]; 
-		// if m is a map literal and key is a literal, 
+		// x = m[key];
+		// if m is a map literal and key is a literal,
 		// and key is defined in m, immediately return the literal
-		if n.Left.Op == OMAPLIT && isStaticCompositeLiteral(n.Right){
+		if n.Left.Op == OMAPLIT && isStaticCompositeLiteral(n.Right) {
 			key := n.Right
 			maplit := n.Left
 			// Check if the key is defined
@@ -1101,7 +1101,7 @@ opswitch:
 				}
 			}
 		}
-		
+
 		// Replace m[k] with *map{access1,assign}(maptype, m, &k)
 		n.Left = walkexpr(n.Left, init)
 		n.Right = walkexpr(n.Right, init)

--- a/src/cmd/compile/internal/gc/walk.go
+++ b/src/cmd/compile/internal/gc/walk.go
@@ -1090,14 +1090,14 @@ opswitch:
 		// x = m[key]; 
 		// if m is a map literal and key is a literal, 
 		// and key is defined in m, immediately return the literal
-		if n.Left.Op == OMAPLIT && n.Right.Op == OLITERAL {
+		if n.Left.Op == OMAPLIT && isStaticCompositeLiteral(n.Right){
 			key := n.Right
-			lit := n.Left
-
+			maplit := n.Left
 			// Check if the key is defined
-			for _, element := range lit.List.Slice() {
-				if element.Left.E == key.E {
-					return element.Right
+			for _, element := range maplit.List.Slice() {
+				if element.Left.Val() == key.Val() {
+					n = walkexpr(element.Right, init)
+					break opswitch
 				}
 			}
 		}

--- a/test/codegen/maps.go
+++ b/test/codegen/maps.go
@@ -122,3 +122,37 @@ func MapClearSideEffect(m map[int]int) int {
 	}
 	return k
 }
+
+// --------------------- //
+//  Map literal lookup   //
+// --------------------- //
+
+// Optimization of lookups on map literals (Issue #35763)
+
+func MapLitLookupStringLit() int{
+	v := map[string]int{
+		"a": 33333, // amd64:-".*mapassign"
+		"b": 66666,
+		"c": 99999,
+	}["b"] // amd64:-".*mapaccess"
+	return v
+}
+
+func MapLitLookupStringLitStructLitVal() int {
+	type S struct {a int}
+	v := map[string]S{
+		"a": S{42344}, // amd64:-".*mapassign"
+		"b": S{a:33242}, // amd64:-".*mapassign"
+		"c": S{},
+	}["b"] // amd64:-".*mapaccess"
+	return v.a
+}
+
+func MapLitLookupUndefinedLit() int {
+	v := map[string]int{
+		"a": 33333,
+		"b": 66666,
+		"c": 99999,
+	}["X"] // amd64:".*mapaccess"
+	return v
+}

--- a/test/codegen/maps.go
+++ b/test/codegen/maps.go
@@ -129,21 +129,21 @@ func MapClearSideEffect(m map[int]int) int {
 
 // Optimization of lookups on map literals (Issue #35763)
 
-func MapLitLookupStringLit() int{
+func MapLitLookupStringLit() int {
 	v := map[string]int{
 		"a": 33333, // amd64:-".*mapassign"
-		"b": 66666,
-		"c": 99999,
+		"b": 66666, // amd64:-".*mapassign"
+		"c": 99999, // amd64:-".*mapassign"
 	}["b"] // amd64:-".*mapaccess"
 	return v
 }
 
 func MapLitLookupStringLitStructLitVal() int {
-	type S struct {a int}
+	type S struct{ a int }
 	v := map[string]S{
-		"a": S{42344}, // amd64:-".*mapassign"
-		"b": S{a:33242}, // amd64:-".*mapassign"
-		"c": S{},
+		"a": S{42344},    // amd64:-".*mapassign"
+		"b": S{a: 33242}, // amd64:-".*mapassign"
+		"c": S{},         // amd64:-".*mapassign"
 	}["b"] // amd64:-".*mapaccess"
 	return v.a
 }

--- a/test/maplit.go
+++ b/test/maplit.go
@@ -1,0 +1,53 @@
+// run
+
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Test map literals lookup
+
+package main
+
+import "fmt"
+
+const (
+	stringlit  = "a"
+	intlit     = 22323
+	float64lit = 34.3423
+)
+
+type S struct{ a int }
+
+func main() {
+	v1 := map[string]int{
+		"a": 33333,
+		"b": 66666,
+	}[stringlit]
+	if v1 != 33333 {
+		panic(fmt.Sprintf("wanted %v got %v", 33333, v1))
+	}
+
+	v2 := map[int]string{
+		22323: "a",
+		4323:  "g",
+	}[intlit]
+	if v2 != "a" {
+		panic(fmt.Sprintf("wanted %v got %v", "a", v2))
+	}
+
+	v3 := map[float64]S{
+		34.3423: S{a: 1},
+		2.33:    S{a: 2},
+	}[float64lit]
+	if v3 != (S{a: 1}) {
+		panic(fmt.Sprintf("wanted %#v got %#v", S{a: 1}, v3))
+	}
+
+	v4 := map[float64]S{
+		34.3423: S{a: 1},
+		2.33:    S{a: 2},
+	}[34.34] // Literal not defined on the map lit
+	if v4 != (S{a: 0}) {
+		panic(fmt.Sprintf("wanted %#v got %#v", S{a: 0}, v4))
+	}
+}

--- a/test/maplit.go
+++ b/test/maplit.go
@@ -1,6 +1,6 @@
 // run
 
-// Copyright 2009 The Go Authors. All rights reserved.
+// Copyright 2019 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -28,8 +28,8 @@ func main() {
 	}
 
 	v2 := map[int]string{
-		22323: "a",
 		4323:  "g",
+		22323: "a",
 	}[intlit]
 	if v2 != "a" {
 		panic(fmt.Sprintf("wanted %v got %v", "a", v2))

--- a/test/maplit.go
+++ b/test/maplit.go
@@ -35,19 +35,28 @@ func main() {
 		panic(fmt.Sprintf("wanted %v got %v", "a", v2))
 	}
 
-	v3 := map[float64]S{
-		34.3423: S{a: 1},
-		2.33:    S{a: 2},
-	}[float64lit]
-	if v3 != (S{a: 1}) {
+	v3 := map[string]S{
+		"f":  S{a: 3},
+		"a":  S{a: 2231},
+		"bb": S{a: 2},
+	}[stringlit]
+	if v3 != (S{a: 2231}) {
 		panic(fmt.Sprintf("wanted %#v got %#v", S{a: 1}, v3))
 	}
 
 	v4 := map[float64]S{
 		34.3423: S{a: 1},
 		2.33:    S{a: 2},
-	}[34.34] // Literal not defined on the map lit
-	if v4 != (S{a: 0}) {
-		panic(fmt.Sprintf("wanted %#v got %#v", S{a: 0}, v4))
+	}[float64lit]
+	if v4 != (S{a: 1}) {
+		panic(fmt.Sprintf("wanted %#v got %#v", S{a: 1}, v4))
+	}
+
+	v5 := map[string]S{
+		"f": S{a: 1},
+		"v": S{a: 2},
+	}["not_defined"] // Literal not defined on the map lit, should return type zero value.
+	if v5 != (S{a: 0}) {
+		panic(fmt.Sprintf("wanted %#v got %#v", S{a: 0}, v5))
 	}
 }

--- a/test/maplit.go
+++ b/test/maplit.go
@@ -59,4 +59,17 @@ func main() {
 	if v5 != (S{a: 0}) {
 		panic(fmt.Sprintf("wanted %#v got %#v", S{a: 0}, v5))
 	}
+
+	// check for map construction side effect.
+	i := 0
+	v6 := map[string]int{
+		"a": func() int { i++; return 7 }(),
+		"b": 8,
+	}["b"]
+	if i != 1 {
+		panic(fmt.Sprintf("i value should be changed to 1 got %d", i))
+	}
+	if v6 != 8 {
+		panic(fmt.Sprintf("wanted %#v got %#v", 8, v6))
+	}
 }


### PR DESCRIPTION
Currently if a MAPINDEX is done on a MAPLIT where the key is also a LITERAL
defined in the map we still build the map and assign all the keys,
where we can at compile-time change the INDEXMAP node by the LITERAL.

Fixes #35763 