### PR TITLE
syscall/js: make wasm_exec.js compatible with Webpack

### DIFF
--- a/misc/wasm/wasm_exec.js
+++ b/misc/wasm/wasm_exec.js
@@ -26,7 +26,7 @@
 		global.require = require;
 	}
 
-	if (!global.fs && global.require) {
+	if (!global.fs && global.require && typeof __webpack_public_path__ === "undefined")) {
 		global.fs = require("fs");
 	}
 

--- a/misc/wasm/wasm_exec.js
+++ b/misc/wasm/wasm_exec.js
@@ -27,9 +27,9 @@
 	}
 
 	if (!global.fs && global.require) {
-		const tempFs = require("fs");
-		if (Object.keys(tempFs) !== 0) {
-			global.fs = tempFs;
+		const fs = require("fs");
+		if (Object.keys(fs) !== 0) {
+			global.fs = fs;
 		}
 	}
 

--- a/misc/wasm/wasm_exec.js
+++ b/misc/wasm/wasm_exec.js
@@ -26,8 +26,11 @@
 		global.require = require;
 	}
 
-	if (!global.fs && global.require && typeof __webpack_public_path__ === "undefined")) {
-		global.fs = require("fs");
+	if (!global.fs && global.require) {
+		const tempFs = require("fs");
+		if (Object.keys(tempFs) !== 0) {
+			global.fs = tempFs;
+		}
 	}
 
 	const enosys = () => {


### PR DESCRIPTION
In Webpack, require("fs") will always be empty. This behavior throws an error: "fs.writeSync is not function". It happens when you did "fmt.Println".
This PR avoids such problem and use polyfill in wasm_exec.js on Webpack.