### PR TITLE
doc: clarify interaction of ioutil.WriteFile with umask

### DIFF
--- a/src/io/ioutil/ioutil.go
+++ b/src/io/ioutil/ioutil.go
@@ -74,8 +74,8 @@ func ReadFile(filename string) ([]byte, error) {
 }
 
 // WriteFile writes data to a file named by filename.
-// If the file does not exist, WriteFile creates it with permissions perm;
-// otherwise WriteFile truncates it before writing.
+// If the file does not exist, WriteFile creates it with permissions perm
+// (before umask); otherwise WriteFile truncates it before writing.
 func WriteFile(filename string, data []byte, perm os.FileMode) error {
 	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
 	if err != nil {


### PR DESCRIPTION
Note that ioutil.WriteFile's perm argument is the value before the
umask is applied.

Fixes #35835

Change-Id: I61cd9c88bced3be52b616d86e060cd3fd912ab1f