### PR TITLE
net: support TCP half-close when HTTP is upgraded in ReverseProxy

### DIFF
--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -538,7 +538,17 @@ func (p *ReverseProxy) handleUpgradeResponse(rw http.ResponseWriter, req *http.R
 	spc := switchProtocolCopier{user: conn, backend: backConn}
 	go spc.copyToBackend(errc)
 	go spc.copyFromBackend(errc)
-	<-errc
+
+	err = <-errc
+	// If nil, wait until the data transfer is finished.
+	if err == nil {
+		err = <-errc
+	}
+
+	if err != nil {
+		p.getErrorHandler()(rw, req, fmt.Errorf("can't copy: %v", err))
+	}
+
 	return
 }
 
@@ -550,10 +560,16 @@ type switchProtocolCopier struct {
 
 func (c switchProtocolCopier) copyFromBackend(errc chan<- error) {
 	_, err := io.Copy(c.user, c.backend)
+	if closeWriter, ok := c.user.(net.CloseWriter); ok {
+		closeWriter.CloseWrite()
+	}
 	errc <- err
 }
 
 func (c switchProtocolCopier) copyToBackend(errc chan<- error) {
 	_, err := io.Copy(c.backend, c.user)
+	if closeWriter, ok := c.backend.(net.CloseWriter); ok {
+		closeWriter.CloseWrite()
+	}
 	errc <- err
 }

--- a/src/net/net.go
+++ b/src/net/net.go
@@ -706,3 +706,8 @@ func (v *Buffers) consume(n int64) {
 		*v = (*v)[1:]
 	}
 }
+
+// CloseWriter is the interface that wraps the basic CloseWrite method.
+type CloseWriter interface {
+	CloseWrite() error
+}


### PR DESCRIPTION
In order to support TCP half-close in ReverseProxy,
ReverseProxy.handleUpgradeResponse should not close all sockets
immediately when the one side gets an EOF. But we should close the
write stream on the socket to inform the transfer is complete.

Fixes #35892 