### PR TITLE
os/exec: document that cmd.Start() sets the Process field

### DIFF
--- a/src/os/exec/exec.go
+++ b/src/os/exec/exec.go
@@ -369,7 +369,7 @@ func lookExtensions(path, dir string) (string, error) {
 
 // Start starts the specified command but does not wait for it to complete.
 //
-// If Start returns successfully, the Process field will be set.
+// If Start returns successfully, the c.Process field will be set.
 //
 // The Wait method will return the exit code and release associated resources
 // once the command exits.

--- a/src/os/exec/exec.go
+++ b/src/os/exec/exec.go
@@ -369,6 +369,8 @@ func lookExtensions(path, dir string) (string, error) {
 
 // Start starts the specified command but does not wait for it to complete.
 //
+// If Start returns successfully, the Process field will be set.
+//
 // The Wait method will return the exit code and release associated resources
 // once the command exits.
 func (c *Cmd) Start() error {


### PR DESCRIPTION
I think this is also what the comment next to the process filed means.