### PR TITLE
crypto/tls: fix a typo in TLS handshake comment

### DIFF
--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -1344,7 +1344,7 @@ func (c *Conn) Handshake() error {
 	if c.handshakeErr == nil {
 		c.handshakes++
 	} else {
-		// If an error occurred during the hadshake try to flush the
+		// If an error occurred during the handshake try to flush the
 		// alert that might be left in the buffer.
 		c.flush()
 	}


### PR DESCRIPTION
Fix a minor typo in the TLS handshake comment.