### PR TITLE
`runtime:Modify runtime.Stack issu`

### DIFF
--- a/src/runtime/mprof.go
+++ b/src/runtime/mprof.go
@@ -783,7 +783,7 @@ func Stack(buf []byte, all bool) int {
 	}
 
 	n := 0
-	if len(buf) > 0 {
+	if cap(buf) > 0 {
 		gp := getg()
 		sp := getcallersp()
 		pc := getcallerpc()
@@ -793,7 +793,7 @@ func Stack(buf []byte, all bool) int {
 			// so that Stack's results are consistent.
 			// GOTRACEBACK is only about crash dumps.
 			g0.m.traceback = 1
-			g0.writebuf = buf[0:0:len(buf)]
+			g0.writebuf = buf[0:0:cap(buf)]
 			goroutineheader(gp)
 			traceback(pc, sp, 0, gp)
 			if all {


### PR DESCRIPTION
sorry，My English is very poor.But I have to try to be clear again.
Examples：
	buf:=make([]byte,200,1200)
	runtime.Stack(buf,false)
Question one：
The call stack trace is formatted and written to buf。
Suppose the stack trace data is 500
Then only 200 of the data can be saved in buf。But cap (buf) = 1200

Question two：
If stack trace data is 100，
Then output to the terminal，As shown：
![`E_4ABKGHOZ)%4H%2`RSMOR](https://user-images.githubusercontent.com/48403565/70542412-a5975900-1ba3-11ea-8dc6-d452ac0f6da1.png)
The other 100 extra squares, all replaced by spaces。
This is because we are not sure about the size of the stack trace data.
so
	buf:=make([]byte,0,1200)
Let him automatically adjust the buffer space he needs.
If it's what you used to do,
if len(buf)=0, Then no data will be written to buf.
