### PR TITLE
cmd/go: add -Wl,-E to linker flag whitelist (shortcut of --export-dynamic)

### DIFF
--- a/src/cmd/go/internal/work/security.go
+++ b/src/cmd/go/internal/work/security.go
@@ -184,6 +184,7 @@ var validLinkerFlags = []*lazyregexp.Regexp{
 	re(`-Wl,--enable-new-dtags`),
 	re(`-Wl,--end-group`),
 	re(`-Wl,--(no-)?export-dynamic`),
+	re(`-Wl,-E`),
 	re(`-Wl,-framework,[^,@\-][^,]+`),
 	re(`-Wl,-headerpad_max_install_names`),
 	re(`-Wl,--no-undefined`),


### PR DESCRIPTION
According to https://linux.die.net/man/1/ld, `-E` is a shortcut of
`--export-dynamic`, it will be better to be added in to whitelist for the
later one has been added in https://golang.org/cl/134016.