### PR TITLE
runtime: syscall_forkx on Solaris can return error on success

### DIFF
--- a/src/runtime/syscall_solaris.go
+++ b/src/runtime/syscall_solaris.go
@@ -142,6 +142,9 @@ func syscall_forkx(flags uintptr) (pid uintptr, err uintptr) {
 		args: uintptr(unsafe.Pointer(&flags)),
 	}
 	asmcgocall(unsafe.Pointer(&asmsysvicall6x), unsafe.Pointer(&call))
+	if int(call.r1) != -1 {
+		call.err = 0
+	}
 	return call.r1, call.err
 }
 


### PR DESCRIPTION
The syscall_forkx function returns the value of errno even on success.  This can be a problem when using cgo where an atfork handler might be registered; if the atfork handler does something which causes errno to be set the caller of syscall_forkx can be misled into thinking the fork has failed.  This causes the various exec functions in the runtime package to hang.