### PR TITLE
runtime: call osyield directly in lockextra

### DIFF
--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -1678,8 +1678,7 @@ func lockextra(nilokay bool) *m {
 	for {
 		old := atomic.Loaduintptr(&extram)
 		if old == locked {
-			yield := osyield
-			yield()
+			osyield()
 			continue
 		}
 		if old == 0 && !nilokay {
@@ -1696,8 +1695,7 @@ func lockextra(nilokay bool) *m {
 		if atomic.Casuintptr(&extram, old, locked) {
 			return (*m)(unsafe.Pointer(old))
 		}
-		yield := osyield
-		yield()
+		osyield()
 		continue
 	}
 }


### PR DESCRIPTION
The `yield := osyield` line doesn't serve any purpose,  it's committed in `2015`, time to delete that line:)