### PR TITLE
testing: print extra precision in the benchmark output

### DIFF
--- a/src/testing/benchmark_test.go
+++ b/src/testing/benchmark_test.go
@@ -34,7 +34,7 @@ var prettyPrintTests = []struct {
 func TestPrettyPrint(t *testing.T) {
 	for _, tt := range prettyPrintTests {
 		buf := new(strings.Builder)
-		testing.PrettyPrint(buf, tt.v, "x")
+		testing.PrettyPrint(buf, tt.v, "x", true)
 		if tt.expected != buf.String() {
 			t.Errorf("prettyPrint(%v): expected %q, actual %q", tt.v, tt.expected, buf.String())
 		}
@@ -57,6 +57,12 @@ func TestResultString(t *testing.T) {
 	// Test sub-1 ns/op (issue #31005)
 	r.T = 40 * time.Nanosecond
 	if want, got := "     100\t         0.400 ns/op", r.String(); want != got {
+		t.Errorf("String: expected %q, actual %q", want, got)
+	}
+
+	// Test extra precision output
+	r.Chatty = true
+	if want, got := "     100\t         0.400000 ns/op", r.String(); want != got {
 		t.Errorf("String: expected %q, actual %q", want, got)
 	}
 


### PR DESCRIPTION
Makes benchmarks output extra precision of recorded performance
numbers, if the -v flag is used.

This change is backwards compatible and conforms to the 
specification in [1], which requires that the value be
parseable by strconv.ParseFloat.

[1]: https://go.googlesource.com/proposal/+/master/design/14313-benchmark-format.md

Fixes #34626