### PR TITLE
cmd/doc: fix merging comments in -src mode

### DIFF
--- a/src/cmd/doc/doc_test.go
+++ b/src/cmd/doc/doc_test.go
@@ -724,6 +724,40 @@ var tests = []test{
 		},
 	},
 
+	// Merging comments with -src.
+	{
+		"merge comments with -src A",
+		[]string{"-src", p + "/merge", `A`},
+		[]string{
+			`A doc`,
+			`func A`,
+			`A comment`,
+		},
+		[]string{
+			`Package A doc`,
+			`Package B doc`,
+			`B doc`,
+			`B comment`,
+			`B doc`,
+		},
+	},
+	{
+		"merge comments with -src B",
+		[]string{"-src", p + "/merge", `B`},
+		[]string{
+			`B doc`,
+			`func B`,
+			`B comment`,
+		},
+		[]string{
+			`Package A doc`,
+			`Package B doc`,
+			`A doc`,
+			`A comment`,
+			`A doc`,
+		},
+	},
+
 	// No dups with -u. Issue 21797.
 	{
 		"case matching on, no dups",

--- a/src/cmd/doc/testdata/merge/aa.go
+++ b/src/cmd/doc/testdata/merge/aa.go
@@ -1,0 +1,7 @@
+// Package comment A.
+package merge
+
+// A doc.
+func A() {
+	// A comment.
+}

--- a/src/cmd/doc/testdata/merge/bb.go
+++ b/src/cmd/doc/testdata/merge/bb.go
@@ -1,0 +1,7 @@
+// Package comment B.
+package merge
+
+// B doc.
+func B() {
+	// B comment.
+}

--- a/src/go/parser/interface.go
+++ b/src/go/parser/interface.go
@@ -133,13 +133,7 @@ func ParseFile(fset *token.FileSet, filename string, src interface{}, mode Mode)
 // first error encountered are returned.
 //
 func ParseDir(fset *token.FileSet, path string, filter func(os.FileInfo) bool, mode Mode) (pkgs map[string]*ast.Package, first error) {
-	fd, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer fd.Close()
-
-	list, err := fd.Readdir(-1)
+	list, err := ioutil.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
These changes fix go doc -src mode that vomits comments from random files if
filesystem does not sort files by name. The issue was with parse.ParseDir
using the Readdir order of files, which varies between platforms and filesystem
implementations. Another option is to merge comments using token.FileSet.Iterate
order in cmd/doc, but since ParseDir is mostly used in go doc, I’ve opted for
smaller change because it’s unlikely to break other uses or cause any perfomance
issues.

Example (macOS APFS): `go doc -src net.ListenPacket`
