### PR TITLE
cmd/go: fix RevInfo.Time which was wrong when using git in other time zones 

### DIFF
--- a/src/cmd/go/internal/modfetch/codehost/git.go
+++ b/src/cmd/go/internal/modfetch/codehost/git.go
@@ -459,7 +459,7 @@ func (r *gitRepo) statLocal(version, rev string) (*RevInfo, error) {
 	info := &RevInfo{
 		Name:    hash,
 		Short:   ShortenSHA1(hash),
-		Time:    time.Unix(t, 0).UTC(),
+		Time:    time.Unix(t, 0).Local(),
 		Version: hash,
 	}
 


### PR DESCRIPTION
I'm in China. The time zone is GMT+8. However, when in version validation, console print this error message "go: github.com/apache/dubbo-go@v1.0.1-0.20191115170623-d82e97f30baf: invalid pseudo-version: does not match version-control timestamp (2019-11-15T09:06:23Z)". 
v1.0.1-0.20191115170623-d82e97f30baf should be correct.