### PR TITLE
path/filepath: fix readDirNames to not unconditionally read a directory

### DIFF
--- a/src/path/filepath/path.go
+++ b/src/path/filepath/path.go
@@ -360,17 +360,20 @@ func walk(path string, info os.FileInfo, walkFn WalkFunc) error {
 		return walkFn(path, info, nil)
 	}
 
-	names, err := readDirNames(path)
-	err1 := walkFn(path, info, err)
+	err1 := walkFn(path, info, nil)
 	// If err != nil, walk can't walk into this directory.
 	// err1 != nil means walkFn want walk to skip this directory or stop walking.
 	// Therefore, if one of err and err1 isn't nil, walk will return.
-	if err != nil || err1 != nil {
+	if err1 != nil {
 		// The caller's behavior is controlled by the return value, which is decided
 		// by walkFn. walkFn may ignore err and return nil.
 		// If walkFn returns SkipDir, it will be handled by the caller.
 		// So walk should return whatever walkFn returns.
 		return err1
+	}
+	names, err := readDirNames(path)
+	if err !=nil {
+		return err
 	}
 
 	for _, name := range names {

--- a/src/path/filepath/path.go
+++ b/src/path/filepath/path.go
@@ -361,9 +361,6 @@ func walk(path string, info os.FileInfo, walkFn WalkFunc) error {
 	}
 
 	err1 := walkFn(path, info, nil)
-	// If err != nil, walk can't walk into this directory.
-	// err1 != nil means walkFn want walk to skip this directory or stop walking.
-	// Therefore, if one of err and err1 isn't nil, walk will return.
 	if err1 != nil {
 		// The caller's behavior is controlled by the return value, which is decided
 		// by walkFn. walkFn may ignore err and return nil.
@@ -372,7 +369,10 @@ func walk(path string, info os.FileInfo, walkFn WalkFunc) error {
 		return err1
 	}
 	names, err := readDirNames(path)
-	if err !=nil {
+	// If err != nil, walk can't walk into this directory.
+	// err1 != nil means walkFn want walk to skip this directory or stop walking.
+	// Therefore, if one of err and err1 isn't nil, walk will return.
+	if err != nil {
 		return err
 	}
 

--- a/src/path/filepath/path.go
+++ b/src/path/filepath/path.go
@@ -366,12 +366,12 @@ func walk(path string, info os.FileInfo, walkFn WalkFunc) error {
 		// by walkFn. walkFn may ignore err and return nil.
 		// If walkFn returns SkipDir, it will be handled by the caller.
 		// So walk should return whatever walkFn returns.
+		// err1 != nil means walkFn want walk to skip this directory or stop walking.
+		// Therefore, if err1 isn't nil, walk will return
 		return err1
 	}
 	names, err := readDirNames(path)
 	// If err != nil, walk can't walk into this directory.
-	// err1 != nil means walkFn want walk to skip this directory or stop walking.
-	// Therefore, if one of err and err1 isn't nil, walk will return.
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
readDirNames was always called first to read a directory. And then depending on the value of skipDir,
we would stop walking further down. This defeated the purpose of skipDir and can possibly hold on to
a large amount of memory if the directory has a large number of files.

Fixes #36197 