### PR TITLE
runtime: state more explicitly the behavior for buffered channels in the chansend's fast path under extreme conditions.

### DIFF
--- a/src/runtime/chan.go
+++ b/src/runtime/chan.go
@@ -187,6 +187,9 @@ func chansend(c *hchan, ep unsafe.Pointer, block bool, callerpc uintptr) bool {
 	// channel wasn't closed during the first observation. However, nothing here
 	// guarantees forward progress. We rely on the side effects of lock release in
 	// chanrecv() and closechan() to update this thread's view of c.closed and full().
+	//
+	// After lock release in chanrecv() and closechan(), c.closed and full() is guaranteed to be observed here.
+	// For buffered channels, this fast path will always be false right after a successful chanrecv().
 	if !block && c.closed == 0 && full(c) {
 		return false
 	}


### PR DESCRIPTION
This information can be useful when implement something like this:

write side:

```golang
eventCh := make(chan struct{}, 1) // buffer size of exactly 1, shared between read/write side
// something happened before (X)
// notify via chan
select {
case eventCh <- struct{}{}:
default:
}
```

read side:

```golang
for {
     select {
         case <-eventCh:
         // new event came, handle them (Y)
    }
}
```

This doc makes it explicit that right after `<-eventCh` in the read side, the `selectnbsend` in the write side is guaranteed to succeed(it won't observe a stale `full()`).

