### PR TITLE
syscall: change mips64 architecture Stat_t struct item to uint64 and int64

### DIFF
--- a/src/syscall/syscall_linux_mips64x.go
+++ b/src/syscall/syscall_linux_mips64x.go
@@ -137,8 +137,8 @@ func Iopl(level int) (err error) {
 }
 
 type stat_t struct {
-	Dev        uint32
-	Pad0       [3]int32
+	Dev        uint64
+	Pad0       [3]int64
 	Ino        uint64
 	Mode       uint32
 	Nlink      uint32

--- a/src/syscall/ztypes_linux_mips64.go
+++ b/src/syscall/ztypes_linux_mips64.go
@@ -97,8 +97,8 @@ type Rlimit struct {
 type _Gid_t uint32
 
 type Stat_t struct {
-	Dev     uint32
-	Pad1    [3]int32
+	Dev     uint64
+	Pad1    [3]int64
 	Ino     uint64
 	Mode    uint32
 	Nlink   uint32

--- a/src/syscall/ztypes_linux_mips64le.go
+++ b/src/syscall/ztypes_linux_mips64le.go
@@ -97,8 +97,8 @@ type Rlimit struct {
 type _Gid_t uint32
 
 type Stat_t struct {
-	Dev     uint32
-	Pad1    [3]int32
+	Dev     uint64
+	Pad1    [3]int64
 	Ino     uint64
 	Mode    uint32
 	Nlink   uint32


### PR DESCRIPTION
The Dev and Pad1 item in Stat_t struct should be uint64 in 64-bits mips architecture
