### PR TITLE
os: check whence value before trying to seek

### DIFF
--- a/src/os/file.go
+++ b/src/os/file.go
@@ -205,6 +205,9 @@ func (f *File) WriteAt(b []byte, off int64) (n int, err error) {
 // It returns the new offset and an error, if any.
 // The behavior of Seek on a file opened with O_APPEND is not specified.
 func (f *File) Seek(offset int64, whence int) (ret int64, err error) {
+	if whence < 0 || 2 < whence {
+		return 0, errors.New("invalid whence")
+	}
 	if err := f.checkValid("seek"); err != nil {
 		return 0, err
 	}

--- a/src/os/os_test.go
+++ b/src/os/os_test.go
@@ -1445,6 +1445,14 @@ func TestSeekError(t *testing.T) {
 	if err == nil {
 		t.Fatal("Seek on pipe should fail")
 	}
+	_, err = w.Seek(0, -1)
+	if err == nil {
+		t.Fatal("Seek with invalid whence should fail")
+	}
+	_, err = w.Seek(0, 3)
+	if err == nil {
+		t.Fatal("Seek with invalid whence should fail")
+	}
 	if perr, ok := err.(*PathError); !ok || perr.Err != syscall.ESPIPE {
 		t.Errorf("Seek returned error %v, want &PathError{Err: syscall.ESPIPE}", err)
 	}


### PR DESCRIPTION
This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
