### PR TITLE
runtime: optimize netpoll by removing the uintptr conversions

### DIFF
--- a/src/runtime/netpoll_epoll.go
+++ b/src/runtime/netpoll_epoll.go
@@ -22,6 +22,7 @@ var (
 	epfd int32 = -1 // epoll descriptor
 
 	netpollBreakRd, netpollBreakWr uintptr // for netpollBreak
+	netpollBreakData               [8]byte
 )
 
 func netpollinit() {
@@ -50,6 +51,7 @@ func netpollinit() {
 	}
 	netpollBreakRd = uintptr(r)
 	netpollBreakWr = uintptr(w)
+	netpollBreakData = ev.data
 }
 
 func netpollIsPollDescriptor(fd uintptr) bool {
@@ -136,7 +138,7 @@ retry:
 			continue
 		}
 
-		if *(**uintptr)(unsafe.Pointer(&ev.data)) == &netpollBreakRd {
+		if ev.data == netpollBreakData {
 			if ev.events != _EPOLLIN {
 				println("runtime: netpoll: break fd ready for", ev.events)
 				throw("runtime: netpoll: break fd ready for something unexpected")

--- a/src/runtime/netpoll_kqueue.go
+++ b/src/runtime/netpoll_kqueue.go
@@ -14,6 +14,7 @@ var (
 	kq int32 = -1
 
 	netpollBreakRd, netpollBreakWr uintptr // for netpollBreak
+	netpollBreakIdent              uint64
 )
 
 func netpollinit() {
@@ -40,6 +41,7 @@ func netpollinit() {
 	}
 	netpollBreakRd = uintptr(r)
 	netpollBreakWr = uintptr(w)
+	netpollBreakIdent = ev.ident
 }
 
 func netpollIsPollDescriptor(fd uintptr) bool {
@@ -134,7 +136,7 @@ retry:
 	for i := 0; i < int(n); i++ {
 		ev := &events[i]
 
-		if uintptr(ev.ident) == netpollBreakRd {
+		if ev.ident == netpollBreakIdent {
 			if ev.filter != _EVFILT_READ {
 				println("runtime: netpoll: break fd ready for", ev.filter)
 				throw("runtime: netpoll: break fd ready for something unexpected")


### PR DESCRIPTION
Proposing an optimization to `netpoll` with which `netpoll` doesn't need to make conversions between `uintptr` and the data type from netpollBreak every time `epollwait` is called.
**netpoll_epoll test:**
```
Benchmark-name            Old time/op    New time/op    delta
netpollBreakConversion    0.429 ns/op    0.360 ns/op    -16.08%
```