### PR TITLE
os: remove unused argument

### DIFF
--- a/src/os/file.go
+++ b/src/os/file.go
@@ -110,7 +110,7 @@ func (e *LinkError) Unwrap() error {
 // It returns the number of bytes read and any error encountered.
 // At end of file, Read returns 0, io.EOF.
 func (f *File) Read(b []byte) (n int, err error) {
-	if err := f.checkValid("read"); err != nil {
+	if err := f.checkValid(); err != nil {
 		return 0, err
 	}
 	n, e := f.read(b)
@@ -122,7 +122,7 @@ func (f *File) Read(b []byte) (n int, err error) {
 // ReadAt always returns a non-nil error when n < len(b).
 // At end of file, that error is io.EOF.
 func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
-	if err := f.checkValid("read"); err != nil {
+	if err := f.checkValid(); err != nil {
 		return 0, err
 	}
 
@@ -147,7 +147,7 @@ func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
 // It returns the number of bytes written and an error, if any.
 // Write returns a non-nil error when n != len(b).
 func (f *File) Write(b []byte) (n int, err error) {
-	if err := f.checkValid("write"); err != nil {
+	if err := f.checkValid(); err != nil {
 		return 0, err
 	}
 	n, e := f.write(b)
@@ -175,7 +175,7 @@ var errWriteAtInAppendMode = errors.New("os: invalid use of WriteAt on file open
 //
 // If file was opened with the O_APPEND flag, WriteAt returns an error.
 func (f *File) WriteAt(b []byte, off int64) (n int, err error) {
-	if err := f.checkValid("write"); err != nil {
+	if err := f.checkValid(); err != nil {
 		return 0, err
 	}
 	if f.appendMode {
@@ -205,7 +205,7 @@ func (f *File) WriteAt(b []byte, off int64) (n int, err error) {
 // It returns the new offset and an error, if any.
 // The behavior of Seek on a file opened with O_APPEND is not specified.
 func (f *File) Seek(offset int64, whence int) (ret int64, err error) {
-	if err := f.checkValid("seek"); err != nil {
+	if err := f.checkValid(); err != nil {
 		return 0, err
 	}
 	r, e := f.seek(offset, whence)
@@ -556,7 +556,7 @@ func (f *File) SetWriteDeadline(t time.Time) error {
 // SyscallConn returns a raw file.
 // This implements the syscall.Conn interface.
 func (f *File) SyscallConn() (syscall.RawConn, error) {
-	if err := f.checkValid("SyscallConn"); err != nil {
+	if err := f.checkValid(); err != nil {
 		return nil, err
 	}
 	return newRawConn(f)

--- a/src/os/file_posix.go
+++ b/src/os/file_posix.go
@@ -39,7 +39,7 @@ func chmod(name string, mode FileMode) error {
 
 // See docs in file.go:(*File).Chmod.
 func (f *File) chmod(mode FileMode) error {
-	if err := f.checkValid("chmod"); err != nil {
+	if err := f.checkValid(); err != nil {
 		return err
 	}
 	if e := f.pfd.Fchmod(syscallMode(mode)); e != nil {
@@ -81,7 +81,7 @@ func Lchown(name string, uid, gid int) error {
 // On Windows, it always returns the syscall.EWINDOWS error, wrapped
 // in *PathError.
 func (f *File) Chown(uid, gid int) error {
-	if err := f.checkValid("chown"); err != nil {
+	if err := f.checkValid(); err != nil {
 		return err
 	}
 	if e := f.pfd.Fchown(uid, gid); e != nil {
@@ -94,7 +94,7 @@ func (f *File) Chown(uid, gid int) error {
 // It does not change the I/O offset.
 // If there is an error, it will be of type *PathError.
 func (f *File) Truncate(size int64) error {
-	if err := f.checkValid("truncate"); err != nil {
+	if err := f.checkValid(); err != nil {
 		return err
 	}
 	if e := f.pfd.Ftruncate(size); e != nil {
@@ -107,7 +107,7 @@ func (f *File) Truncate(size int64) error {
 // Typically, this means flushing the file system's in-memory copy
 // of recently written data to disk.
 func (f *File) Sync() error {
-	if err := f.checkValid("sync"); err != nil {
+	if err := f.checkValid(); err != nil {
 		return err
 	}
 	if e := f.pfd.Fsync(); e != nil {
@@ -136,7 +136,7 @@ func Chtimes(name string, atime time.Time, mtime time.Time) error {
 // which must be a directory.
 // If there is an error, it will be of type *PathError.
 func (f *File) Chdir() error {
-	if err := f.checkValid("chdir"); err != nil {
+	if err := f.checkValid(); err != nil {
 		return err
 	}
 	if e := f.pfd.Fchdir(); e != nil {
@@ -147,7 +147,7 @@ func (f *File) Chdir() error {
 
 // setDeadline sets the read and write deadline.
 func (f *File) setDeadline(t time.Time) error {
-	if err := f.checkValid("SetDeadline"); err != nil {
+	if err := f.checkValid(); err != nil {
 		return err
 	}
 	return f.pfd.SetDeadline(t)
@@ -155,7 +155,7 @@ func (f *File) setDeadline(t time.Time) error {
 
 // setReadDeadline sets the read deadline.
 func (f *File) setReadDeadline(t time.Time) error {
-	if err := f.checkValid("SetReadDeadline"); err != nil {
+	if err := f.checkValid(); err != nil {
 		return err
 	}
 	return f.pfd.SetReadDeadline(t)
@@ -163,7 +163,7 @@ func (f *File) setReadDeadline(t time.Time) error {
 
 // setWriteDeadline sets the write deadline.
 func (f *File) setWriteDeadline(t time.Time) error {
-	if err := f.checkValid("SetWriteDeadline"); err != nil {
+	if err := f.checkValid(); err != nil {
 		return err
 	}
 	return f.pfd.SetWriteDeadline(t)
@@ -171,7 +171,7 @@ func (f *File) setWriteDeadline(t time.Time) error {
 
 // checkValid checks whether f is valid for use.
 // If not, it returns an appropriate error, perhaps incorporating the operation name op.
-func (f *File) checkValid(op string) error {
+func (f *File) checkValid() error {
 	if f == nil {
 		return ErrInvalid
 	}

--- a/src/os/rawconn.go
+++ b/src/os/rawconn.go
@@ -16,7 +16,7 @@ type rawConn struct {
 }
 
 func (c *rawConn) Control(f func(uintptr)) error {
-	if err := c.file.checkValid("SyscallConn.Control"); err != nil {
+	if err := c.file.checkValid(); err != nil {
 		return err
 	}
 	err := c.file.pfd.RawControl(f)
@@ -25,7 +25,7 @@ func (c *rawConn) Control(f func(uintptr)) error {
 }
 
 func (c *rawConn) Read(f func(uintptr) bool) error {
-	if err := c.file.checkValid("SyscallConn.Read"); err != nil {
+	if err := c.file.checkValid(); err != nil {
 		return err
 	}
 	err := c.file.pfd.RawRead(f)
@@ -34,7 +34,7 @@ func (c *rawConn) Read(f func(uintptr) bool) error {
 }
 
 func (c *rawConn) Write(f func(uintptr) bool) error {
-	if err := c.file.checkValid("SyscallConn.Write"); err != nil {
+	if err := c.file.checkValid(); err != nil {
 		return err
 	}
 	err := c.file.pfd.RawWrite(f)


### PR DESCRIPTION
`os.File.checkValid` argument doesn't used.