### PR TITLE
runtime: fix typo in comment

### DIFF
--- a/src/runtime/os_linux.go
+++ b/src/runtime/os_linux.go
@@ -343,7 +343,7 @@ func minit() {
 	minitSignals()
 
 	// Cgo-created threads and the bootstrap m are missing a
-	// procid. We need this for asynchronous preemption and its
+	// procid. We need this for asynchronous preemption and it's
 	// useful in debuggers.
 	getg().m.procid = uint64(gettid())
 }


### PR DESCRIPTION
Fix minor typo in runtime comment.