### PR TITLE
index/suffixarray: add LongestCommonPrefix method to Index

### DIFF
--- a/src/index/suffixarray/sais.go
+++ b/src/index/suffixarray/sais.go
@@ -897,3 +897,79 @@ func induceS_8_32(text []byte, sa, freq, bucket []int32) {
 		sa[b] = int32(k)
 	}
 }
+
+func newLcp_32(sa []int32, data []byte) []int32 {
+	n := len(sa)
+	lcp := make([]int32, n)
+
+	var common, s1, s2 int32
+
+	for i := 1; i < n; i++ {
+		s1 = sa[i-1]
+		s2 = sa[i]
+
+		for int(s1) < len(data) && int(s2) < len(data) && data[s1] == data[s2] {
+			common++
+			s1++
+			s2++
+		}
+		lcp[i] = common
+		common = 0
+	}
+	return lcp
+}
+
+func longestRepeatedSubs_32(sa []int32, lcp []int32, data []byte) [][]byte {
+	var max int32
+	var key int
+	lrs := make([][]byte, 0)
+
+	for k, v := range lcp {
+		if v > max {
+			max = v
+			key = k
+		}
+	}
+
+	lrs = append(lrs, data[sa[key]:sa[key]+max])
+
+	for i := key + 1; i < len(lcp); i++ {
+		if lcp[i] == max {
+			lrs = append(lrs, data[sa[i]:sa[i]+max])
+		}
+	}
+	return lrs
+}
+
+func subCount(data []byte) int {
+	return (len(data) * (len(data) + 1)) / 2
+}
+
+func distinctSubCount_32(lcp []int32, data []byte) int {
+	var dup int32
+
+	for _, v := range lcp {
+		dup += v
+	}
+
+	return subCount(data) - int(dup)
+}
+
+func distinctSub_32(sa []int32, lcp []int32, data []byte) [][]byte {
+	n := distinctSubCount_32(lcp, data)
+	dist := make([][]byte, n)
+
+	var x int32
+	var k int
+	for i, n := range sa {
+		x = lcp[i] + n
+
+		for int(x) < len(sa) {
+			dist[k] = data[n : x+1]
+			k++
+			x += 1
+		}
+	}
+
+	return dist
+}

--- a/src/index/suffixarray/sais2.go
+++ b/src/index/suffixarray/sais2.go
@@ -1739,3 +1739,75 @@ func induceS_64(text []int64, sa, freq, bucket []int64) {
 		sa[b] = int64(k)
 	}
 }
+
+func newLcp_64(sa []int64, data []byte) []int64 {
+	n := len(sa)
+	lcp := make([]int64, n)
+
+	var common, s1, s2 int64
+
+	for i := 1; i < n; i++ {
+		s1 = sa[i-1]
+		s2 = sa[i]
+
+		for int(s1) < len(data) && int(s2) < len(data) && data[s1] == data[s2] {
+			common++
+			s1++
+			s2++
+		}
+		lcp[i] = common
+		common = 0
+	}
+	return lcp
+}
+
+func longestRepeatedSubs_64(sa []int64, lcp []int64, data []byte) [][]byte {
+	var max int64
+	var key int
+	lrs := make([][]byte, 0)
+
+	for k, v := range lcp {
+		if v > max {
+			max = v
+			key = k
+		}
+	}
+
+	lrs = append(lrs, data[sa[key]:sa[key]+max])
+
+	for i := key + 1; i < len(lcp); i++ {
+		if lcp[i] == max {
+			lrs = append(lrs, data[sa[i]:sa[i]+max])
+		}
+	}
+	return lrs
+}
+
+func distinctSubCount_64(lcp []int64, data []byte) int {
+	var dup int64
+
+	for _, v := range lcp {
+		dup += v
+	}
+
+	return subCount(data) - int(dup)
+}
+
+func distinctSub_64(sa []int64, lcp []int64, data []byte) [][]byte {
+	n := distinctSubCount_64(lcp, data)
+	dist := make([][]byte, n)
+
+	var x int64
+	var k int
+	for i, n := range sa {
+		x = lcp[i] + n
+
+		for int(x) < len(sa) {
+			dist[k] = data[n : x+1]
+			k++
+			x += 1
+		}
+	}
+
+	return dist
+}

--- a/src/index/suffixarray/suffixarray_test.go
+++ b/src/index/suffixarray/suffixarray_test.go
@@ -466,6 +466,79 @@ func testSA(t *testing.T, x []byte, build func([]byte) []int) bool {
 	return true
 }
 
+func TestDistinctSub(t *testing.T) {
+	sa := New([]byte("azaza"))
+	sub := sa.DistinctSubs()
+
+	if len(sub) != 9 {
+		t.Errorf("Distinct substrings should be [a az aza azaz azaza z za zaz zaza]   %+v returned\n", sub)
+	}
+
+	r := [][]byte{
+		{'a'},
+		{'a', 'z'},
+		{'a', 'z', 'a'},
+		{'a', 'z', 'a', 'z'},
+		{'a', 'z', 'a', 'z', 'a'},
+		{'z'},
+		{'z', 'a'},
+		{'z', 'a', 'z'},
+		{'z', 'a', 'z', 'a'},
+	}
+
+	for kk, vv := range sub {
+		for k, v := range vv {
+			if v != r[kk][k] {
+				t.Errorf("substring %v should be %v %v given", kk, string(vv), string(r[kk]))
+			}
+		}
+	}
+}
+
+func TestLongestRepeatedSubs(t *testing.T) {
+	sa := New([]byte("abracadabra"))
+	lrs := sa.LongestRepeatedSubs()
+
+	if len(lrs) != 1 {
+		t.Errorf("expected 1 longest repeated substring got %v\n", len(lrs))
+	}
+
+	if string(lrs[0]) != "abra" {
+		t.Errorf("expected 'abra' got %v\n", string(lrs[0]))
+	}
+
+	sa = New([]byte("ababbaabaa"))
+	lrs = sa.LongestRepeatedSubs()
+
+	if len(lrs) != 2 {
+		t.Errorf("expected 2 longest repeated substring got %v\n", len(lrs))
+	}
+
+	if string(lrs[0]) != "aba" {
+		t.Errorf("expected 'aba' got %v\n", string(lrs[0]))
+	}
+
+	if string(lrs[1]) != "baa" {
+		t.Errorf("expected 'baa' got %v\n", string(lrs[0]))
+	}
+}
+
+func BenchmarkDistinctSub(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		var bb bytes.Buffer
+
+		for i := 0; i < b.N; i++ {
+			bb.WriteRune(rune(rand.Intn(256)))
+		}
+		sa := New(bb.Bytes())
+		b.StartTimer()
+		for i := 0; i < b.N; i++ {
+			sa.DistinctSubs()
+		}
+	}
+}
+
 var (
 	benchdata = make([]byte, 1e6)
 	benchrand = make([]byte, 1e6)


### PR DESCRIPTION
Adds 3 new methods to Index:
* func (*Index) DistinctSubsCount() int
* func (*Index) DistinctSubs() [][]byte
* func (*Index) LongestRepeatedSubs() [][]byte

Fixes #36450.
