### PR TITLE
html: update URL in comment

### DIFF
--- a/src/html/escape.go
+++ b/src/html/escape.go
@@ -12,7 +12,7 @@ import (
 
 // These replacements permit compatibility with old numeric entities that
 // assumed Windows-1252 encoding.
-// http://www.whatwg.org/specs/web-apps/current-work/multipage/tokenization.html#consume-a-character-reference
+// https://html.spec.whatwg.org/multipage/parsing.html#numeric-character-reference-end-state
 var replacementTable = [...]rune{
 	'\u20AC', // First entry is what 0x80 should be replaced with.
 	'\u0081',


### PR DESCRIPTION
The comment contained a link that had a file name and ID that no longer existed, so change to the URL of the corresponding part of the latest page.