### PR TITLE
runtime/runtime2: pack the sudog struct

### DIFF
--- a/src/runtime/export_test.go
+++ b/src/runtime/export_test.go
@@ -483,6 +483,8 @@ func GetNextArenaHint() uintptr {
 
 type G = g
 
+type Sudog = sudog
+
 func Getg() *G {
 	return getg()
 }

--- a/src/runtime/runtime2.go
+++ b/src/runtime/runtime2.go
@@ -346,9 +346,6 @@ type sudog struct {
 
 	g *g
 
-	// isSelect indicates g is participating in a select, so
-	// g.selectDone must be CAS'd to win the wake-up race.
-	isSelect bool
 	next     *sudog
 	prev     *sudog
 	elem     unsafe.Pointer // data element (may point to stack)
@@ -361,6 +358,11 @@ type sudog struct {
 	acquiretime int64
 	releasetime int64
 	ticket      uint32
+
+	// isSelect indicates g is participating in a select, so
+	// g.selectDone must be CAS'd to win the wake-up race.
+	isSelect bool
+
 	parent      *sudog // semaRoot binary tree
 	waitlink    *sudog // g.waiting list or semaRoot
 	waittail    *sudog // semaRoot

--- a/src/runtime/sizeof_test.go
+++ b/src/runtime/sizeof_test.go
@@ -22,6 +22,7 @@ func TestSizeof(t *testing.T) {
 		_64bit uintptr     // size on 64bit platforms
 	}{
 		{runtime.G{}, 216, 376}, // g, but exported for testing
+		{runtime.Sudog{}, 56, 88}, // sudog, but exported for testing
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This commit moves the isSelect bool below the ticket uint32.  The
boolean was consuming 8 bytes of the struct.  The uint32 was also
consuming 8 bytes, so we can pack isSelect below the uint32 and save 8
bytes.  This reduces the sudog struct from 96 bytes to 88 bytes.