### PR TITLE
net/http/httputil: add docs about X-Forwarded-For in ReverseProxy

### DIFF
--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -24,12 +24,13 @@ import (
 // ReverseProxy is an HTTP Handler that takes an incoming request and
 // sends it to another server, proxying the response back to the
 // client.
-// ReverseProxy automatically sets the client IP as value of the
+//
+// ReverseProxy automatically sets the client IP as the value of the
 // X-Forwarded-For header.
-// If a X-Forwarded-For header already exists, the client IP is
-// appended to existing values.
+// If an X-Forwarded-For header already exists, the client IP is
+// appended to the existing values.
 // To prevent IP spoofing, be sure to delete any pre-existing
-// X-Forwarded-For header comming from the client or
+// X-Forwarded-For header coming from the client or
 // an untrusted proxy.
 type ReverseProxy struct {
 	// Director must be a function which modifies

--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -24,6 +24,13 @@ import (
 // ReverseProxy is an HTTP Handler that takes an incoming request and
 // sends it to another server, proxying the response back to the
 // client.
+// ReverseProxy automatically sets the client IP as value of the
+// X-Forwarded-For header.
+// If a X-Forwarded-For header already exists, the client IP is
+// appended to existing values.
+// To prevent IP spoofing, be sure to delete any pre-existing
+// X-Forwarded-For header comming from the client or
+// an untrusted proxy.
 type ReverseProxy struct {
 	// Director must be a function which modifies
 	// the request into a new request to be sent


### PR DESCRIPTION
ReverseProxy automatically sets the X-Forwarded-For header, if the request
already contains a X-Forwarded-For header, the value of the client IP is
appended to the existing header value.
This behavior isn't documented anywhere, and can lead to IP spoofing
security issues is the client is untrusted (the most common situation).
This PR documents this behavior.

For future versions, I proposed #36678 that implements a more secure
default behavior and adds support for other forwarded headers.