### PR TITLE
 doc/articles/wiki: add missing log import to net/http tutorial

### DIFF
--- a/doc/articles/wiki/index.html
+++ b/doc/articles/wiki/index.html
@@ -257,6 +257,7 @@ To use the <code>net/http</code> package, it must be imported:
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	<b>"net/http"</b>
 )
 </pre>


### PR DESCRIPTION
The log package is used with the net/http but was not in the import clause.