### PR TITLE
net/http/httputil: add support for X-Forwarded-Proto, X-Forwarded-Host and an option to not trust forwarded headers in ReverseProxy

### DIFF
--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -39,7 +39,8 @@ import (
 //
 // To prevent IP spoofing, be sure to delete any pre-existing
 // X-Forwarded-For header coming from the client or
-// an untrusted proxy.
+// an untrusted proxy, for instance, by setting
+// OverwriteForwardedHeaders to true.
 type ReverseProxy struct {
 	// Director must be a function which modifies
 	// the request into a new request to be sent
@@ -94,11 +95,15 @@ type ReverseProxy struct {
 	ErrorHandler func(http.ResponseWriter, *http.Request, error)
 
 	// TrustForwardedHeaders specifies if X-Forwarded-For,
-	// X-Forwarded-Proto and X-Forwarded-Host headers comming from
+	// X-Forwarded-Proto and X-Forwarded-Host headers coming from
 	// the previous proxy must be trusted or not.
+	//
 	// If true, existing values of X-Forwarded-Proto and
 	// X-Forwarded-Host will be preserved, and the current client IP
-	// will be appended to the list in X-Forwarded-For.
+	// will be appended to the list in X-Forwarded-For. In this case
+	// be sure that these 3 headers are removed from the request if
+	// sent by the client to prevent spoofing attacks.
+	//
 	// If false, values of these headers will be set regardless of
 	// any existing value.
 	TrustForwardedHeaders bool

--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -98,7 +98,7 @@ type ReverseProxy struct {
 	// X-Forwarded-Proto and X-Forwarded-Host headers coming from
 	// the previous proxy must be replaced or not.
 	//
-	// If true, these headers 3 headers will be set regardless of any
+	// If true, these 3 headers will be set regardless of any
 	// existing value.
 	//
 	// If false, X-Forwarded-Proto and X-Forwarded-Host will not be

--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -92,6 +92,16 @@ type ReverseProxy struct {
 	// If nil, the default is to log the provided error and return
 	// a 502 Status Bad Gateway response.
 	ErrorHandler func(http.ResponseWriter, *http.Request, error)
+
+	// TrustForwardedHeaders specifies if X-Forwarded-For,
+	// X-Forwarded-Proto and X-Forwarded-Host headers comming from
+	// the previous proxy must be trusted or not.
+	// If true, existing values of X-Forwarded-Proto and
+	// X-Forwarded-Host will be preserved, and the current client IP
+	// will be appended to the list in X-Forwarded-For.
+	// If false, values of these headers will be set regardless of
+	// any existing value.
+	TrustForwardedHeaders bool
 }
 
 // A BufferPool is an interface for getting and returning temporary
@@ -280,6 +290,23 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if reqUpType != "" {
 		outreq.Header.Set("Connection", "Upgrade")
 		outreq.Header.Set("Upgrade", reqUpType)
+	}
+
+	if _, ok := outreq.Header["X-Forwarded-Proto"]; !ok || !p.TrustForwardedHeaders {
+		proto := "https"
+		if req.TLS == nil {
+			proto = "http"
+		}
+
+		outreq.Header.Set("X-Forwarded-Proto", proto)
+	}
+
+	if _, ok := outreq.Header["X-Forwarded-Host"]; !ok || !p.TrustForwardedHeaders {
+		outreq.Header.Set("X-Forwarded-Host", outreq.Host)
+	}
+
+	if !p.TrustForwardedHeaders {
+		outreq.Header.Del("X-Forwarded-For")
 	}
 
 	if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {

--- a/src/net/http/httputil/reverseproxy_test.go
+++ b/src/net/http/httputil/reverseproxy_test.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -295,16 +296,24 @@ func TestReverseProxyStripEmptyConnection(t *testing.T) {
 	}
 }
 
-func TestXForwardedFor(t *testing.T) {
+func TestDontTrustForwardedHeaders(t *testing.T) {
 	const prevForwardedFor = "client ip"
+	const prevForwardedProto = "https"
+	const prevForwardedHost = "example.com"
 	const backendResponse = "I am the backend"
 	const backendStatus = 404
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("X-Forwarded-For") == "" {
 			t.Errorf("didn't get X-Forwarded-For header")
 		}
-		if !strings.Contains(r.Header.Get("X-Forwarded-For"), prevForwardedFor) {
-			t.Errorf("X-Forwarded-For didn't contain prior data")
+		if strings.Contains(r.Header.Get("X-Forwarded-For"), prevForwardedFor) {
+			t.Errorf("X-Forwarded-For contains prior data")
+		}
+		if strings.Contains(r.Header.Get("X-Forwarded-Proto"), prevForwardedProto) {
+			t.Errorf("X-Forwarded-Proto contains prior data")
+		}
+		if strings.Contains(r.Header.Get("X-Forwarded-Host"), prevForwardedHost) {
+			t.Errorf("X-Forwarded-Host contains prior data")
 		}
 		w.WriteHeader(backendStatus)
 		w.Write([]byte(backendResponse))
@@ -322,6 +331,60 @@ func TestXForwardedFor(t *testing.T) {
 	getReq.Host = "some-name"
 	getReq.Header.Set("Connection", "close")
 	getReq.Header.Set("X-Forwarded-For", prevForwardedFor)
+	getReq.Header.Set("X-Forwarded-Proto", prevForwardedProto)
+	getReq.Header.Set("X-Forwarded-Host", prevForwardedHost)
+	getReq.Close = true
+	res, err := frontend.Client().Do(getReq)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if g, e := res.StatusCode, backendStatus; g != e {
+		t.Errorf("got res.StatusCode %d; expected %d", g, e)
+	}
+	bodyBytes, _ := ioutil.ReadAll(res.Body)
+	if g, e := string(bodyBytes), backendResponse; g != e {
+		t.Errorf("got body %q; expected %q", g, e)
+	}
+}
+
+func TestXForwardedFor(t *testing.T) {
+	const prevForwardedFor = "client ip"
+	const prevForwardedProto = "https"
+	const prevForwardedHost = "example.com"
+	const backendResponse = "I am the backend"
+	const backendStatus = 404
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Forwarded-For") == "" {
+			t.Errorf("didn't get X-Forwarded-For header")
+		}
+		if !strings.Contains(r.Header.Get("X-Forwarded-For"), prevForwardedFor) {
+			t.Errorf("X-Forwarded-For didn't contain prior data")
+		}
+		if !strings.Contains(r.Header.Get("X-Forwarded-Proto"), prevForwardedProto) {
+			t.Errorf("X-Forwarded-Proto didn't contain prior data")
+		}
+		if !strings.Contains(r.Header.Get("X-Forwarded-Host"), prevForwardedHost) {
+			t.Errorf("X-Forwarded-Host didn't contain prior data")
+		}
+		w.WriteHeader(backendStatus)
+		w.Write([]byte(backendResponse))
+	}))
+	defer backend.Close()
+	backendURL, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxyHandler := NewSingleHostReverseProxy(backendURL)
+	proxyHandler.TrustForwardedHeaders = true
+	frontend := httptest.NewServer(proxyHandler)
+	defer frontend.Close()
+
+	getReq, _ := http.NewRequest("GET", frontend.URL, nil)
+	getReq.Host = "some-name"
+	getReq.Header.Set("Connection", "close")
+	getReq.Header.Set("X-Forwarded-For", prevForwardedFor)
+	getReq.Header.Set("X-Forwarded-Proto", prevForwardedProto)
+	getReq.Header.Set("X-Forwarded-Host", prevForwardedHost)
 	getReq.Close = true
 	res, err := frontend.Client().Do(getReq)
 	if err != nil {

--- a/src/net/http/httputil/reverseproxy_test.go
+++ b/src/net/http/httputil/reverseproxy_test.go
@@ -324,7 +324,6 @@ func TestXForwardedFor(t *testing.T) {
 		t.Fatal(err)
 	}
 	proxyHandler := NewSingleHostReverseProxy(backendURL)
-	proxyHandler.TrustForwardedHeaders = true
 	frontend := httptest.NewServer(proxyHandler)
 	defer frontend.Close()
 


### PR DESCRIPTION
In addition to X-Forwarded-For, which is already supported but undocumented
(#36672), this patch adds support for the X-Forwarded-Proto (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto)
and X-Forwarded-Host (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host)
headers in ReverseProxy.
It also introduces a new option, ReverseProxy.TrustForwardedHeaders
that must be explicitly set to true to trust forwarded headers coming from
the client or previous proxies.

Setting these headers is a standard behavior expected from reverse
proxies, especially when X-Forwarded-For is set (which is already the
case).

The new ReverseProxy.TrustForwardedHeaders option fixes a potential
common security issue in user land code. It forces the user to explicitly
opt-in to trust reverse proxies in front of the Go application using
ReverseProxy.

The current behavior of blindly trusting the X-Forwarded-For header
provided by the client is very dangerous.
For instance, because of the current (undocumented) behavior, the Vulcain
gateway server (https://vulcain.rocks) was sensible to a potential security
issue.

If this flag is not set to true, previous values set by the client or
untrusted proxies will be discarded (replaced by the values computed
by ReverseProxy).
Technically, this is a BC break, but, in my opinion, it is a necessary one
to improve the security of the whole Go ecosystem using this module.

Edit: added a backward compatible implementation, see https://github.com/golang/go/pull/36678#issuecomment-577163525