### PR TITLE
html/template: remove RawGit link from docs

### DIFF
--- a/src/html/template/doc.go
+++ b/src/html/template/doc.go
@@ -216,7 +216,7 @@ that would have been produced if {{.}} was a regular string.
 
 Security Model
 
-https://rawgit.com/mikesamuel/sanitized-jquery-templates/trunk/safetemplate.html#problem_definition defines "safe" as used by this package.
+https://rawcdn.githack.com/mikesamuel/sanitized-jquery-templates/trunk/safetemplate.html#problem_definition defines "safe" as used by this package.
 
 This package assumes that template authors are trusted, that Execute's data
 parameter is not, and seeks to preserve the properties below in the face


### PR DESCRIPTION
RawGit will soon shut down soon, according to the author:
https://rawgit.com/

This replaces the documentation link with raw.githack.com.