### PR TITLE
runtime/cgo: pass proper argument to unsetenv

### DIFF
--- a/src/runtime/cgo/gcc_setenv.c
+++ b/src/runtime/cgo/gcc_setenv.c
@@ -20,9 +20,9 @@ x_cgo_setenv(char **arg)
 
 /* Stub for calling unsetenv */
 void
-x_cgo_unsetenv(char *arg)
+x_cgo_unsetenv(char **arg)
 {
 	_cgo_tsan_acquire();
-	unsetenv(arg);
+	unsetenv(arg[0]);
 	_cgo_tsan_release();
 }


### PR DESCRIPTION
x_cgo_unsetenv did not properly deference the arg pointer when calling unsetenv.

Fixes #36705 