### PR TITLE
doc/articles/wiki: use correct variable name in closures guide

### DIFF
--- a/doc/articles/wiki/index.html
+++ b/doc/articles/wiki/index.html
@@ -674,7 +674,7 @@ The closure returned by <code>makeHandler</code> is a function that takes
 an <code>http.ResponseWriter</code> and <code>http.Request</code> (in other
 words, an <code>http.HandlerFunc</code>).
 The closure extracts the <code>title</code> from the request path, and
-validates it with the <code>TitleValidator</code> regexp. If the
+validates it with the <code>validPath</code> regexp. If the
 <code>title</code> is invalid, an error will be written to the
 <code>ResponseWriter</code> using the <code>http.NotFound</code> function.
 If the <code>title</code> is valid, the enclosed handler function


### PR DESCRIPTION
Fixes non-existent variable TitleValidator to be validPath in
the closures, functions literal section.

Fixes #36779