### PR TITLE
gofmt: add struct tag format and sort 

### DIFF
--- a/src/cmd/gofmt/doc.go
+++ b/src/cmd/gofmt/doc.go
@@ -95,6 +95,31 @@ When invoked with -s gofmt will make the following source transformations where 
 	will be simplified to:
 		for range v {...}
 
+When invoke with -tf gofmt will format struct tag.
+
+	struct tag format example:
+	struct User struct {
+		Name     string `json:"name" xml:"name" yaml:"name"`
+		Password string `json:"password" xml:"password" yaml:"password"`
+	}
+
+	struct User struct {
+		Name     string `json:"name"     xml:"name"     yaml:"name"    `
+		Password string `json:"password" xml:"password" yaml:"password"`
+	}
+
+When invoke with -ts gofmt will sort struct tags by key.
+
+	struct tag key example:
+	struct User struct {
+		Name     string `xml:"name" json:"name" yaml:"name"`
+	}
+
+	struct User struct {
+		Name     string `json:"name" xml:"name" yaml:"name"`
+	}
+
+
 This may result in changes that are incompatible with earlier versions of Go.
 */
 package main

--- a/src/cmd/gofmt/gofmt.go
+++ b/src/cmd/gofmt/gofmt.go
@@ -30,6 +30,8 @@ var (
 	write       = flag.Bool("w", false, "write result to (source) file instead of stdout")
 	rewriteRule = flag.String("r", "", "rewrite rule (e.g., 'a[b:len(a)] -> a[b:]')")
 	simplifyAST = flag.Bool("s", false, "simplify code")
+	tagFormat   = flag.Bool("tf", false, "format struct tags")
+	tagSort     = flag.Bool("ts", false, "sort struct tag by key")
 	doDiff      = flag.Bool("d", false, "display diffs instead of rewriting files")
 	allErrors   = flag.Bool("e", false, "report all errors (not just the first 10 on different lines)")
 
@@ -111,6 +113,20 @@ func processFile(filename string, in io.Reader, out io.Writer, stdin bool) error
 
 	if *simplifyAST {
 		simplify(file)
+	}
+
+	if *tagSort {
+		err := tagSortByKey(file)
+		if err != nil {
+			return err
+		}
+	}
+
+	if *tagFormat {
+		err := tagFmt(file, fileSet)
+		if err != nil {
+			return err
+		}
 	}
 
 	ast.Inspect(file, normalizeNumbers)

--- a/src/cmd/gofmt/tagfmt.go
+++ b/src/cmd/gofmt/tagfmt.go
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 bigpigeon. All rights reserved.
+ * Use of this source code is governed by a MIT style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+package main
+
+import (
+	"go/ast"
+	"go/token"
+	"strings"
+)
+
+type tagFormatter struct {
+	Err error
+	fs  *token.FileSet
+}
+
+func (s *tagFormatter) Visit(node ast.Node) ast.Visitor {
+	switch n := node.(type) {
+	case *ast.StructType:
+		if n.Fields != nil {
+			var longestList []int
+			var start int
+			var end int
+			var preFieldLine int
+			for i, field := range n.Fields.List {
+				line := s.fs.Position(field.Pos()).Line
+				if preFieldLine+1 < line {
+					fieldsTagFormat(n.Fields.List[start:end], longestList)
+					start = i
+					end = i
+					longestList = nil
+				}
+				preFieldLine = line
+				if field.Tag != nil {
+					end = i
+					_, keyValues, err := ParseTag(field.Tag.Value)
+					if err != nil {
+						s.Err = err
+						return nil
+					}
+					for i, kv := range keyValues {
+						if len(longestList) <= i {
+							longestList = append(longestList, 0)
+						}
+						longestList[i] = max(len(kv.KeyValue), longestList[i])
+					}
+				} else {
+
+				}
+			}
+			fieldsTagFormat(n.Fields.List[start:], longestList)
+		}
+	}
+	return s
+}
+
+func fieldsTagFormat(fields []*ast.Field, longestList []int) {
+	for _, f := range fields {
+		if f.Tag != nil {
+			quote, keyValues, err := ParseTag(f.Tag.Value)
+			if err != nil {
+				// must be nil error
+				panic(err)
+			}
+			var keyValueRaw []string
+			for i, kv := range keyValues {
+				keyValueRaw = append(keyValueRaw, kv.KeyValue+strings.Repeat(" ", longestList[i]-len(kv.KeyValue)))
+			}
+
+			f.Tag.Value = quote + strings.TrimRight(strings.Join(keyValueRaw, " "), " ") + quote
+			f.Tag.ValuePos = 0
+		}
+	}
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func tagFmt(f *ast.File, fs *token.FileSet) error {
+	s := &tagFormatter{fs: fileSet}
+	ast.Walk(s, f)
+	return s.Err
+}

--- a/src/cmd/gofmt/tagsort.go
+++ b/src/cmd/gofmt/tagsort.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2020 bigpigeon. All rights reserved.
+ * Use of this source code is governed by a MIT style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+package main
+
+import (
+	"errors"
+	"go/ast"
+	"sort"
+	"strings"
+)
+
+var ErrInvalidTag = errors.New("Invalid tag ")
+
+type tagSorter struct {
+	Err error
+}
+
+func (s *tagSorter) Visit(node ast.Node) ast.Visitor {
+	switch n := node.(type) {
+	case *ast.StructType:
+		if n.Fields != nil {
+
+			for _, field := range n.Fields.List {
+				if field.Tag != nil {
+
+					quote, keyValues, err := ParseTag(field.Tag.Value)
+					if err != nil {
+						s.Err = err
+						return nil
+					}
+					sort.Slice(keyValues, func(i, j int) bool {
+						return keyValues[i].Key < keyValues[j].Key
+					})
+					var keyValuesRaw []string
+					for _, kv := range keyValues {
+						keyValuesRaw = append(keyValuesRaw, kv.KeyValue)
+					}
+
+					field.Tag.Value = quote + strings.Join(keyValuesRaw, " ") + quote
+					field.Tag.ValuePos = 0
+
+				}
+			}
+		}
+	}
+	return s
+}
+
+func tagSortByKey(f *ast.File) error {
+	s := &tagSorter{}
+	ast.Walk(s, f)
+	return s.Err
+}
+
+type KeyValue struct {
+	Key      string
+	KeyValue string
+}
+
+// ParseTag returns all tag keys and tags key:"Value" list
+func ParseTag(tag string) (quote string, keyValues []KeyValue, err error) {
+	if len(tag) < 2 {
+		err = ErrInvalidTag
+		return
+	}
+	quote = tag[:1]
+	tag = tag[1 : len(tag)-1]
+
+	for tag != "" {
+		// Skip leading space.
+		i := 0
+		for i < len(tag) && tag[i] == ' ' {
+			i++
+		}
+		tag = tag[i:]
+		if tag == "" {
+			break
+		}
+
+		// Scan to colon. A space, a quote or a control character is a syntax error.
+		// Strictly speaking, control chars include the range [0x7f, 0x9f], not just
+		// [0x00, 0x1f], but in practice, we ignore the multi-byte control characters
+		// as it is simpler to inspect the tag's bytes than the tag's runes.
+		i = 0
+		for i < len(tag) && tag[i] > ' ' && tag[i] != ':' && tag[i] != '"' && tag[i] != 0x7f {
+			i++
+		}
+		if i == 0 || i+1 >= len(tag) || tag[i] != ':' || tag[i+1] != '"' {
+			break
+		}
+		name := string(tag[:i])
+
+		// Scan quoted string to find value.
+		i = i + 2
+		for i < len(tag) && tag[i] != '"' {
+			if tag[i] == '\\' {
+				i++
+			}
+			i++
+		}
+		if i >= len(tag) {
+			return "", nil, ErrInvalidTag
+		}
+		keyValue := string(tag[:i+1])
+		keyValues = append(keyValues, KeyValue{
+			Key:      name,
+			KeyValue: keyValue,
+		})
+
+		tag = tag[i+1:]
+	}
+	return
+}

--- a/src/cmd/gofmt/testdata/tagfmt1.golden
+++ b/src/cmd/gofmt/testdata/tagfmt1.golden
@@ -1,0 +1,7 @@
+//gofmt -tf
+package main
+
+type Example struct {
+	Data      string `xml:"data"       yaml:"data"                 json:"data"`
+	OtherData string `xml:"other_data" json:"other_data:omitempty" yaml:"other_data"`
+}

--- a/src/cmd/gofmt/testdata/tagfmt1.input
+++ b/src/cmd/gofmt/testdata/tagfmt1.input
@@ -1,0 +1,6 @@
+//gofmt -tf
+package main
+type Example struct {
+	Data string `xml:"data" yaml:"data"  json:"data"`
+	OtherData string `xml:"other_data" json:"other_data:omitempty" yaml:"other_data"`
+}

--- a/src/cmd/gofmt/testdata/tagfmt2.golden
+++ b/src/cmd/gofmt/testdata/tagfmt2.golden
@@ -1,0 +1,10 @@
+//gofmt -tf
+package main
+
+type Example struct {
+	Data      string `xml:"data"       yaml:"data"                 json:"data"`
+	OtherData string `xml:"other_data" json:"other_data:omitempty" yaml:"other_data"`
+
+	NewLineData      string `xml:"new_line_data"       yaml:"new_line_data"       json:"new_line_data"`
+	NewLineOtherData string `xml:"new_line_other_data" yaml:"new_line_other_data" json:"new_line_other_data"`
+}

--- a/src/cmd/gofmt/testdata/tagfmt2.input
+++ b/src/cmd/gofmt/testdata/tagfmt2.input
@@ -1,0 +1,9 @@
+//gofmt -tf
+package main
+type Example struct {
+	Data string `xml:"data" yaml:"data"  json:"data"`
+	OtherData string `xml:"other_data" json:"other_data:omitempty" yaml:"other_data"`
+
+    NewLineData string `xml:"new_line_data" yaml:"new_line_data" json:"new_line_data"`
+    NewLineOtherData string `xml:"new_line_other_data" yaml:"new_line_other_data"  json:"new_line_other_data"`
+}

--- a/src/cmd/gofmt/testdata/tagfmt3.golden
+++ b/src/cmd/gofmt/testdata/tagfmt3.golden
@@ -1,0 +1,8 @@
+//gofmt -tf
+package main
+
+type Example struct {
+	Data      string `xml:"data"       yaml:"data"       json:"data"`
+	OtherData string `xml:"other_data" yaml:"other_data"`
+	FullData  string `xml:"full_data"  json:"full_data"  gorm:"full_data" yaml:"full_data"`
+}

--- a/src/cmd/gofmt/testdata/tagfmt3.input
+++ b/src/cmd/gofmt/testdata/tagfmt3.input
@@ -1,0 +1,7 @@
+//gofmt -tf
+package main
+type Example struct {
+	Data string `xml:"data" yaml:"data"  json:"data"`
+	OtherData string `xml:"other_data"  yaml:"other_data"`
+    FullData string `xml:"full_data" json:"full_data" gorm:"full_data" yaml:"full_data"`
+}

--- a/src/cmd/gofmt/testdata/tagsort1.golden
+++ b/src/cmd/gofmt/testdata/tagsort1.golden
@@ -1,0 +1,6 @@
+//gofmt -ts
+package main
+
+type Example struct {
+	Data string `json:"data" xml:"data" yaml:"data"`
+}

--- a/src/cmd/gofmt/testdata/tagsort1.input
+++ b/src/cmd/gofmt/testdata/tagsort1.input
@@ -1,0 +1,5 @@
+//gofmt -ts
+package main
+type Example struct {
+	Data string `xml:"data" yaml:"data"  json:"data"  `
+}


### PR DESCRIPTION
When the structure is slender and has too many labels, it will become untidy.
eg:
```go
type User struct {
	Name     string `json:"name" xml:"name" gorm:"type:varchar(64);unique_index"`
	Password string `json:"password" gorm:"type:varchar(128)" xml:"password"`
}
```

format it for reading

```
type User struct {
	Name     string `gorm:"type:varchar(64);unique_index" json:"name"     xml:"name"`
	Password string `gorm:"type:varchar(128)"             json:"password" xml:"password"`
}

```