### PR TITLE
os: do not use procfs for os.Executable in dragonfly

### DIFF
--- a/src/os/executable_dragonfly.go
+++ b/src/os/executable_dragonfly.go
@@ -4,9 +4,9 @@
 
 package os
 
-// From FreeBSD's <sys/sysctl.h>
+// From DragonFly's <sys/sysctl.h>
 const (
         _CTL_KERN           = 1
         _KERN_PROC          = 14
-        _KERN_PROC_PATHNAME = 12
+        _KERN_PROC_PATHNAME = 9
 )

--- a/src/os/executable_procfs.go
+++ b/src/os/executable_procfs.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build linux netbsd dragonfly js,wasm
+// +build linux netbsd js,wasm
 
 package os
 
@@ -23,8 +23,6 @@ var executablePath, executablePathErr = func() (string, error) {
 		procfn = "/proc/self/exe"
 	case "netbsd":
 		procfn = "/proc/curproc/exe"
-	case "dragonfly":
-		procfn = "/proc/curproc/file"
 	}
 	return Readlink(procfn)
 }()

--- a/src/os/executable_sysctl.go
+++ b/src/os/executable_sysctl.go
@@ -1,0 +1,35 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build freebsd dragonfly
+
+package os
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func executable() (string, error) {
+	mib := [4]int32{_CTL_KERN, _KERN_PROC, _KERN_PROC_PATHNAME, -1}
+
+	n := uintptr(0)
+	// get length
+	_, _, err := syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 4, 0, uintptr(unsafe.Pointer(&n)), 0, 0)
+	if err != 0 {
+		return "", err
+	}
+	if n == 0 { // shouldn't happen
+		return "", nil
+	}
+	buf := make([]byte, n)
+	_, _, err = syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 4, uintptr(unsafe.Pointer(&buf[0])), uintptr(unsafe.Pointer(&n)), 0, 0)
+	if err != 0 {
+		return "", err
+	}
+	if n == 0 { // shouldn't happen
+		return "", nil
+	}
+	return string(buf[:n-1]), nil
+}


### PR DESCRIPTION
  procfs(5) is not always mounted in DragonFly BSD, for example during
  the binary package build with synth. os.Executable() consumers
  will then fail, we've spotted this when trying to build tinygo:

    [...]

    copying source files
    ./build/tinygo build-builtins -target=armv6m-none-eabi [...]
    panic: could not get executable path: readlink /proc/curproc/file:
    no such file or directory

    [...]

  Use KERN_PROC_PATHNAME as FreeBSD does.
