### PR TITLE
os: error testing functions respect Unwrapper interface

### DIFF
--- a/src/os/error.go
+++ b/src/os/error.go
@@ -139,6 +139,8 @@ func underlyingError(err error) error {
 		return err.Err
 	case *SyscallError:
 		return err.Err
+	case interface{ Unwrap() error }:
+		return underlyingError(err.Unwrap())
 	}
 	return err
 }

--- a/src/os/error_test.go
+++ b/src/os/error_test.go
@@ -103,7 +103,24 @@ var isExistTests = []isExistTest{
 	{&os.LinkError{Err: os.ErrClosed}, false, false},
 	{&os.SyscallError{Err: os.ErrNotExist}, false, true},
 	{&os.SyscallError{Err: os.ErrExist}, true, false},
+	{&os.SyscallError{Err: os.ErrExist}, true, false},
 	{nil, false, false},
+	// All the above examples with error wrapped.
+	{fmt.Errorf("wrapped: %w", &os.PathError{Err: os.ErrInvalid}), false, false},
+	{fmt.Errorf("wrapped: %w", &os.PathError{Err: os.ErrPermission}), false, false},
+	{fmt.Errorf("wrapped: %w", &os.PathError{Err: os.ErrExist}), true, false},
+	{fmt.Errorf("wrapped: %w", &os.PathError{Err: os.ErrNotExist}), false, true},
+	{fmt.Errorf("wrapped: %w", &os.PathError{Err: os.ErrClosed}), false, false},
+	{fmt.Errorf("wrapped: %w", &os.LinkError{Err: os.ErrInvalid}), false, false},
+	{fmt.Errorf("wrapped: %w", &os.LinkError{Err: os.ErrPermission}), false, false},
+	{fmt.Errorf("wrapped: %w", &os.LinkError{Err: os.ErrExist}), true, false},
+	{fmt.Errorf("wrapped: %w", &os.LinkError{Err: os.ErrNotExist}), false, true},
+	{fmt.Errorf("wrapped: %w", &os.LinkError{Err: os.ErrClosed}), false, false},
+	{fmt.Errorf("wrapped: %w", &os.SyscallError{Err: os.ErrNotExist}), false, true},
+	{fmt.Errorf("wrapped: %w", &os.SyscallError{Err: os.ErrExist}), true, false},
+	{fmt.Errorf("wrapped: %w", &os.SyscallError{Err: os.ErrExist}), true, false},
+	// Multiple layers of wrapping.
+	{fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", &os.SyscallError{Err: os.ErrExist})), true, false},
 }
 
 func TestIsExist(t *testing.T) {

--- a/src/os/error_test.go
+++ b/src/os/error_test.go
@@ -103,7 +103,6 @@ var isExistTests = []isExistTest{
 	{&os.LinkError{Err: os.ErrClosed}, false, false},
 	{&os.SyscallError{Err: os.ErrNotExist}, false, true},
 	{&os.SyscallError{Err: os.ErrExist}, true, false},
-	{&os.SyscallError{Err: os.ErrExist}, true, false},
 	{nil, false, false},
 	// All the above examples with error wrapped.
 	{fmt.Errorf("wrapped: %w", &os.PathError{Err: os.ErrInvalid}), false, false},
@@ -117,7 +116,6 @@ var isExistTests = []isExistTest{
 	{fmt.Errorf("wrapped: %w", &os.LinkError{Err: os.ErrNotExist}), false, true},
 	{fmt.Errorf("wrapped: %w", &os.LinkError{Err: os.ErrClosed}), false, false},
 	{fmt.Errorf("wrapped: %w", &os.SyscallError{Err: os.ErrNotExist}), false, true},
-	{fmt.Errorf("wrapped: %w", &os.SyscallError{Err: os.ErrExist}), true, false},
 	{fmt.Errorf("wrapped: %w", &os.SyscallError{Err: os.ErrExist}), true, false},
 	// Multiple layers of wrapping.
 	{fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", &os.SyscallError{Err: os.ErrExist})), true, false},


### PR DESCRIPTION
Go 1.13 introduced an optional support for the Unwrap method. This
change to the os package updates that package error testing functions to
consider Unwrap method of the tested error.