### PR TITLE
encoding/base64: improve performance up to 20% total

### DIFF
--- a/src/encoding/base64/base64.go
+++ b/src/encoding/base64/base64.go
@@ -480,15 +480,16 @@ func (enc *Encoding) Decode(dst, src []byte) (n int, err error) {
 
 	si := 0
 	for strconv.IntSize >= 64 && len(src)-si >= 8 && len(dst)-n >= 8 {
+		src2 := src[si : si+8]
 		if dn, ok := assemble64(
-			enc.decodeMap[src[si+0]],
-			enc.decodeMap[src[si+1]],
-			enc.decodeMap[src[si+2]],
-			enc.decodeMap[src[si+3]],
-			enc.decodeMap[src[si+4]],
-			enc.decodeMap[src[si+5]],
-			enc.decodeMap[src[si+6]],
-			enc.decodeMap[src[si+7]],
+			enc.decodeMap[src2[0]],
+			enc.decodeMap[src2[1]],
+			enc.decodeMap[src2[2]],
+			enc.decodeMap[src2[3]],
+			enc.decodeMap[src2[4]],
+			enc.decodeMap[src2[5]],
+			enc.decodeMap[src2[6]],
+			enc.decodeMap[src2[7]],
 		); ok {
 			binary.BigEndian.PutUint64(dst[n:], dn)
 			n += 6
@@ -504,11 +505,12 @@ func (enc *Encoding) Decode(dst, src []byte) (n int, err error) {
 	}
 
 	for len(src)-si >= 4 && len(dst)-n >= 4 {
+		src2 := src[si : si+4]
 		if dn, ok := assemble32(
-			enc.decodeMap[src[si+0]],
-			enc.decodeMap[src[si+1]],
-			enc.decodeMap[src[si+2]],
-			enc.decodeMap[src[si+3]],
+			enc.decodeMap[src2[0]],
+			enc.decodeMap[src2[1]],
+			enc.decodeMap[src2[2]],
+			enc.decodeMap[src2[3]],
 		); ok {
 			binary.BigEndian.PutUint32(dst[n:], dn)
 			n += 3


### PR DESCRIPTION
Improve base64 encoding/decoding performance by
suppressing compiler boundary checks on decode.

name                 old speed      new speed      delta
EncodeToString-8      570MB/s ± 1%   573MB/s ± 1%     ~     (p=0.421 n=5+5)
DecodeString/2-8     88.6MB/s ± 3%  91.6MB/s ± 2%   +3.37%  (p=0.016 n=5+5)
DecodeString/4-8      162MB/s ± 1%   168MB/s ± 0%   +4.12%  (p=0.008 n=5+5)
DecodeString/8-8      203MB/s ± 0%   214MB/s ± 0%   +5.18%  (p=0.008 n=5+5)
DecodeString/64-8     471MB/s ± 1%   520MB/s ± 1%  +10.50%  (p=0.008 n=5+5)
DecodeString/8192-8   757MB/s ± 0%   895MB/s ± 1%  +18.29%  (p=0.008 n=5+5)