### PR TITLE
crypto/x509: add RevocationList and CreateRevocationList

### DIFF
--- a/src/crypto/x509/x509.go
+++ b/src/crypto/x509/x509.go
@@ -2666,18 +2666,20 @@ func (c *CertificateRequest) CheckSignature() error {
 	return checkSignature(c.SignatureAlgorithm, c.RawTBSCertificateRequest, c.Signature, c.PublicKey)
 }
 
-// CRLTemplate contains the fields used to create an X.509 v2 Certificate
+// RevocationList contains the fields used to create an X.509 v2 Certificate
 // Revocation list.
-type CRLTemplate struct {
-	SignatureAlgorithm  SignatureAlgorithm
+type RevocationList struct {
+	SignatureAlgorithm SignatureAlgorithm
+
 	RevokedCertificates []pkix.RevokedCertificate
-	Number              *big.Int
-	ThisUpdate          time.Time
-	NextUpdate          time.Time
-	ExtraExtensions     []pkix.Extension
+
+	Number          *big.Int
+	ThisUpdate      time.Time
+	NextUpdate      time.Time
+	ExtraExtensions []pkix.Extension
 }
 
-// CreateCRL creates a new x509 v2 Certificate Revocation List.
+// CreateRevocationList creates a new x509 v2 Certificate Revocation List.
 //
 // The CRL is signed by priv which should be the private key associated with
 // the public key in the issuer certificate.
@@ -2702,9 +2704,12 @@ type CRLTemplate struct {
 // This method is differentiated from the Certificate.CreateCRL method as
 // it creates X509 v2 conformant CRLs as defined by the RFC 5280 CRL profile.
 // This method should be used if created CRLs need to be standards compliant.
-func CreateCRL(rand io.Reader, issuer *Certificate, priv crypto.Signer, template CRLTemplate) ([]byte, error) {
+func CreateRevocationList(rand io.Reader, template *RevocationList, issuer *Certificate, priv crypto.Signer) ([]byte, error) {
+	if template == nil {
+		return nil, errors.New("x509: template can not be nil")
+	}
 	if issuer == nil {
-		return nil, errors.New("x509: issuer may not be nil")
+		return nil, errors.New("x509: issuer can not be nil")
 	}
 	if (issuer.KeyUsage & KeyUsageCRLSign) == 0 {
 		return nil, errors.New("x509: issuer must have the crlSign key usage bit set")

--- a/src/crypto/x509/x509.go
+++ b/src/crypto/x509/x509.go
@@ -2678,19 +2678,22 @@ type CRLTemplate struct {
 
 // CreateCRL creates a new x509 v2 Certificate Revocation List.
 //
-// The CRL is signed by priv.
+// The CRL is signed by priv which should be the private key associated with
+// the public key in the issuer certificate.
 //
-// revokedCerts may be nil, in which case an empty CRL will be created.
-//
-// The issuer distinguished name CRL field and authority key identifier extension
-// are populated using the issuer certificate. issuer must have SubjectKeyId set.
+// The issuer distinguished name CRL field and authority key identifier
+// extension are populated using the issuer certificate. issuer must have
+// SubjectKeyId set.
 //
 // The CRL number extension is populated using the Number field of template.
 //
+// The template field RevokedCertificates may be nil, in which case an empty
+// CRL will be created.
+//
 // The template fields NextUpdate must be greater than ThisUpdate.
 //
-// Any extensions in the Extensions field of template will be copied directly into
-// the CRL.
+// Any extensions in the Extensions field of template will be copied directly
+// into the CRL.
 //
 // This method is differentiated from the Certificate.CreateCRL method as
 // it creates X509 v2 conformant CRLs as defined by the RFC 5280 CRL profile.

--- a/src/crypto/x509/x509.go
+++ b/src/crypto/x509/x509.go
@@ -2682,6 +2682,9 @@ type CRLTemplate struct {
 // The CRL is signed by priv which should be the private key associated with
 // the public key in the issuer certificate.
 //
+// The issuer may not be nil, and the crlSign bit must be set in KeyUsage in
+// order to use it as a CRL issuer.
+//
 // The issuer distinguished name CRL field and authority key identifier
 // extension are populated using the issuer certificate. issuer must have
 // SubjectKeyId set.

--- a/src/crypto/x509/x509.go
+++ b/src/crypto/x509/x509.go
@@ -2700,6 +2700,12 @@ type CRLTemplate struct {
 // it creates X509 v2 conformant CRLs as defined by the RFC 5280 CRL profile.
 // This method should be used if created CRLs need to be standards compliant.
 func CreateCRL(rand io.Reader, issuer *Certificate, priv crypto.Signer, template CRLTemplate) ([]byte, error) {
+	if issuer == nil {
+		return nil, errors.New("x509: issuer may not be nil")
+	}
+	if (issuer.KeyUsage & KeyUsageCRLSign) == 0 {
+		return nil, errors.New("x509: issuer must have the crlSign key usage bit set")
+	}
 	if len(issuer.SubjectKeyId) == 0 {
 		return nil, errors.New("x509: issuer certificate doesn't contain a subject key identifier")
 	}

--- a/src/crypto/x509/x509_test.go
+++ b/src/crypto/x509/x509_test.go
@@ -2293,3 +2293,121 @@ func TestPKCS1MismatchKeyFormat(t *testing.T) {
 		}
 	}
 }
+
+func TestCreateCRLExt(t *testing.T) {
+	ecdsaPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate ECDSA key: %s", err)
+	}
+	tests := []struct {
+		name          string
+		issuer        Certificate
+		template      CRLTemplate
+		expectedError string
+	}{
+		{
+			name:          "issuer missing SubjectKeyId",
+			issuer:        Certificate{},
+			template:      CRLTemplate{},
+			expectedError: "x509: issuer certificate doesn't contain a subject key identifier",
+		},
+		{
+			name: "nextUpdate before thisUpdate",
+			issuer: Certificate{
+				Subject: pkix.Name{
+					CommonName: "testing",
+				},
+				SubjectKeyId: []byte{1, 2, 3},
+			},
+			template: CRLTemplate{
+				ThisUpdate: time.Time{}.Add(time.Hour),
+				NextUpdate: time.Time{},
+			},
+			expectedError: "x509: template.ThisUpdate is after template.NextUpdate",
+		},
+		{
+			name: "valid, extra extension",
+			issuer: Certificate{
+				Subject: pkix.Name{
+					CommonName: "testing",
+				},
+				SubjectKeyId: []byte{1, 2, 3},
+			},
+			template: CRLTemplate{
+				RevokedCertificates: []pkix.RevokedCertificate{
+					{
+						SerialNumber:   big.NewInt(2),
+						RevocationTime: time.Time{}.Add(time.Hour),
+					},
+				},
+				Number:     5,
+				ThisUpdate: time.Time{}.Add(time.Hour * 24),
+				NextUpdate: time.Time{}.Add(time.Hour * 48),
+				Extensions: []pkix.Extension{
+					{
+						Id:    []int{2, 5, 29, 99},
+						Value: []byte{5, 0},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			crl, err := CreateCRL(rand.Reader, &tc.issuer, ecdsaPriv, tc.template)
+			if err != nil && tc.expectedError == "" {
+				t.Fatalf("CreateCRL failed unexpectedly: %s", err)
+			} else if err != nil && tc.expectedError != err.Error() {
+				t.Fatalf("CreateCRL failed unexpectedly, wanted: %s, got: %s", tc.expectedError, err)
+			} else if err == nil && tc.expectedError != "" {
+				t.Fatalf("CreateCRL didn't fail, expected: %s", tc.expectedError)
+			}
+			if tc.expectedError != "" {
+				return
+			}
+
+			parsedCRL, err := ParseDERCRL(crl)
+			if err != nil {
+				t.Fatalf("Failed to parse generated CRL: %s", err)
+			}
+
+			if !reflect.DeepEqual(parsedCRL.TBSCertList.RevokedCertificates, tc.template.RevokedCertificates) {
+				t.Fatalf("RevokedCertificates mismatch: got %v; want %v.",
+					parsedCRL.TBSCertList.RevokedCertificates, tc.template.RevokedCertificates)
+			}
+
+			if len(parsedCRL.TBSCertList.Extensions) != 2+len(tc.template.Extensions) {
+				t.Fatalf("Generated CRL has wrong number of extensions, wanted: %d, got: %d", 2+len(tc.template.Extensions), len(parsedCRL.TBSCertList.Extensions))
+			}
+			expectedAKI, err := asn1.Marshal(authKeyId{Id: tc.issuer.SubjectKeyId})
+			if err != nil {
+				t.Fatalf("asn1.Marshal failed: %s", err)
+			}
+			akiExt := pkix.Extension{
+				Id:    oidExtensionAuthorityKeyId,
+				Value: expectedAKI,
+			}
+			if !reflect.DeepEqual(parsedCRL.TBSCertList.Extensions[0], akiExt) {
+				t.Fatalf("Unexpected first extension: got %v, want %v",
+					parsedCRL.TBSCertList.Extensions[0], akiExt)
+			}
+			expectedNum, err := asn1.Marshal(tc.template.Number)
+			if err != nil {
+				t.Fatalf("asn1.Marshal failed: %s", err)
+			}
+			crlExt := pkix.Extension{
+				Id:    oidExtensionCRLNumber,
+				Value: expectedNum,
+			}
+			if !reflect.DeepEqual(parsedCRL.TBSCertList.Extensions[1], crlExt) {
+				t.Fatalf("Unexpected second extension: got %v, want %v",
+					parsedCRL.TBSCertList.Extensions[1], crlExt)
+			}
+			if !reflect.DeepEqual(parsedCRL.TBSCertList.Extensions[2:], tc.template.Extensions) {
+				t.Fatalf("Extensions mismatch: got %v; want %v.",
+					parsedCRL.TBSCertList.Extensions[2:], tc.template.Extensions)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The existing Certificate.CreateCRL method generates non-conformant CRLs and
as such cannot be used for implementations that require standards
compliance. This change implements a new top level method, CreateCRL, which
generates compliant CRLs, and offers an extensible API if any
extensions/fields need to be supported in the future.

Here is an example Issuer/CRL generated using this change:
-----BEGIN CERTIFICATE-----
MIIBNjCB3aADAgECAgEWMAoGCCqGSM49BAMCMBIxEDAOBgNVBAMTB3Rlc3Rpbmcw
IhgPMDAwMTAxMDEwMDAwMDBaGA8wMDAxMDEwMTAwMDAwMFowEjEQMA4GA1UEAxMH
dGVzdGluZzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABLHrudbSM36sn1VBrmm/
OfQTyEsI4tIUV1VmneOKHL9ENBGCiec4GhQm2SGnDT/sZy2bB3c3yozh/roS6cZJ
UZqjIDAeMA4GA1UdDwEB/wQEAwIBAjAMBgNVHQ4EBQQDAQIDMAoGCCqGSM49BAMC
A0gAMEUCIQCoAYN6CGZPgd5Sw5a1rd5VexciT5MCxTfXj+ZfJNfoiAIgQVCTB8AE
Nm2xset7+HOgtQYlKNw/rGd8cFcv5Y9aUzo=
-----END CERTIFICATE-----
-----BEGIN X509 CRL-----
MIHWMH0CAQEwCgYIKoZIzj0EAwIwEjEQMA4GA1UEAxMHdGVzdGluZxgPMDAwMTAx
MDIwMDAwMDBaGA8wMDAxMDEwMzAwMDAwMFowFjAUAgECGA8wMDAxMDEwMTAxMDAw
MFqgHjAcMA4GA1UdIwQHMAWAAwECAzAKBgNVHRQEAwIBBTAKBggqhkjOPQQDAgNJ
ADBGAiEAjqfj/IG4ys5WkjrbTNpDbr+saHGO/NujLJotlLL9KzgCIQDm8VZPzj0f
NYEQgAW4nsiUzlvEUCoHMw0141VCZXv67A==
-----END X509 CRL-----

Fixes #35428