### PR TITLE
net/mail: skip empty entries in parseAddressList

### DIFF
--- a/src/net/mail/message.go
+++ b/src/net/mail/message.go
@@ -274,6 +274,15 @@ func (p *addrParser) parseAddressList() ([]*Address, error) {
 	var list []*Address
 	for {
 		p.skipSpace()
+
+		// allow skipping empty entries (RFC5322 obs-addr-list)
+		if p.consume(',') {
+			continue
+		}
+		if p.empty() {
+			break
+		}
+
 		addrs, err := p.parseAddress(true)
 		if err != nil {
 			return nil, err

--- a/src/net/mail/message_test.go
+++ b/src/net/mail/message_test.go
@@ -431,6 +431,20 @@ func TestAddressParsing(t *testing.T) {
 				},
 			},
 		},
+		// RFC5322 4.4 obs-addr-list
+		{
+			` , joe@where.test,,John <jdoe@one.test>,`,
+			[]*Address{
+				{
+					Name:    "",
+					Address: "joe@where.test",
+				},
+				{
+					Name:    "John",
+					Address: "jdoe@one.test",
+				},
+			},
+		},
 		{
 			`Group1: <addr1@example.com>;, Group 2: addr2@example.com;, John <addr3@example.com>`,
 			[]*Address{


### PR DESCRIPTION
RFC 5322 has a section 4.4 where it says that address-list could
have "null" members: "That is, there could be two or more commas in
such a list with nothing in between them, or commas at the beginning
or end of the list." This change handles such a case so that mail
clients using this method on actual email messages get a reasonable
return value when they parse email.

Fixes #36959
