### PR TITLE
doc: Rewrite godoc.org links to pkg.go.dev

### DIFF
--- a/doc/articles/go_command.html
+++ b/doc/articles/go_command.html
@@ -87,7 +87,7 @@ git clone https://github.com/golang/example
 
 <p>and thus the import path for the root directory of that repository is
 "<code>github.com/golang/example</code>".
-The <a href="https://godoc.org/github.com/golang/example/stringutil">stringutil</a>
+The <a href="https://pkg.go.dev/github.com/golang/example/stringutil">stringutil</a>
 package is stored in a subdirectory, so its import path is
 "<code>github.com/golang/example/stringutil</code>".</p>
 

--- a/doc/cmd.html
+++ b/doc/cmd.html
@@ -81,7 +81,7 @@ gofmt</a> command with more general options.</td>
 </tr>
 
 <tr>
-<td><a href="//godoc.org/golang.org/x/tools/cmd/godoc/">godoc</a></td>
+<td><a href="//pkg.go.dev/golang.org/x/tools/cmd/godoc/">godoc</a></td>
 <td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
 <td>Godoc extracts and generates documentation for Go packages.</td>
 </tr>

--- a/doc/contribute.html
+++ b/doc/contribute.html
@@ -699,7 +699,7 @@ Don't use HTML, Markdown, or any other markup language.
 <p>
 Add any relevant information, such as benchmark data if the change
 affects performance.
-The <a href="https://godoc.org/golang.org/x/perf/cmd/benchstat">benchstat</a>
+The <a href="https://pkg.go.dev/golang.org/x/perf/cmd/benchstat">benchstat</a>
 tool is conventionally used to format
 benchmark data for change descriptions.
 </p>

--- a/doc/diagnostics.html
+++ b/doc/diagnostics.html
@@ -213,7 +213,7 @@ func main() {
 <p>
 Tracing is a way to instrument code to analyze latency throughout the
 lifecycle of a chain of calls. Go provides
-<a href="https://godoc.org/golang.org/x/net/trace">golang.org/x/net/trace</a>
+<a href="https://pkg.go.dev/golang.org/x/net/trace">golang.org/x/net/trace</a>
 package as a minimal tracing backend per Go node and provides a minimal
 instrumentation library with a simple dashboard. Go also provides
 an execution tracer to trace the runtime events within an interval.

--- a/doc/go1.11.html
+++ b/doc/go1.11.html
@@ -166,7 +166,7 @@ Do not send CLs removing the interior tags from such phrases.
 
 <p>
   The new package
-  <a href="https://godoc.org/golang.org/x/tools/go/packages"><code>golang.org/x/tools/go/packages</code></a>
+  <a href="https://pkg.go.dev/golang.org/x/tools/go/packages"><code>golang.org/x/tools/go/packages</code></a>
   provides a simple API for locating and loading packages of Go source code.
   Although not yet part of the standard library, for many tasks it
   effectively replaces the <a href="/pkg/go/build"><code>go/build</code></a>
@@ -868,7 +868,7 @@ for k := range m {
       On Windows, several fields were changed from <code>uintptr</code> to a new
       <a href="/pkg/syscall/?GOOS=windows&GOARCH=amd64#Pointer"><code>Pointer</code></a>
       type to avoid problems with Go's garbage collector. The same change was made
-      to the <a href="https://godoc.org/golang.org/x/sys/windows"><code>golang.org/x/sys/windows</code></a>
+      to the <a href="https://pkg.go.dev/golang.org/x/sys/windows"><code>golang.org/x/sys/windows</code></a>
       package. For any code affected, users should first migrate away from the <code>syscall</code>
       package to the <code>golang.org/x/sys/windows</code> package, and then change
       to using the <code>Pointer</code>, while obeying the

--- a/doc/go1.12.html
+++ b/doc/go1.12.html
@@ -93,7 +93,7 @@ Do not send CLs removing the interior tags from such phrases.
 <p>
   The <code>go vet</code> command has been rewritten to serve as the
   base for a range of different source code analysis tools. See
-  the <a href="https://godoc.org/golang.org/x/tools/go/analysis">golang.org/x/tools/go/analysis</a>
+  the <a href="https://pkg.go.dev/golang.org/x/tools/go/analysis">golang.org/x/tools/go/analysis</a>
   package for details. A side-effect is that <code>go tool vet</code>
   is no longer supported. External tools that use <code>go tool
   vet</code> must be changed to use <code>go
@@ -683,9 +683,9 @@ for {
       active and then new TCP connections are created as needed. In Go 1.10 and Go 1.11 the <code>http2</code> package
       would block and wait for requests to finish instead of creating new connections.
       To get the stricter behavior back, import the
-      <a href="https://godoc.org/golang.org/x/net/http2"><code>golang.org/x/net/http2</code></a> package
+      <a href="https://pkg.go.dev/golang.org/x/net/http2"><code>golang.org/x/net/http2</code></a> package
       directly and set
-      <a href="https://godoc.org/golang.org/x/net/http2#Transport.StrictMaxConcurrentStreams"><code>Transport.StrictMaxConcurrentStreams</code></a> to
+      <a href="https://pkg.go.dev/golang.org/x/net/http2#Transport.StrictMaxConcurrentStreams"><code>Transport.StrictMaxConcurrentStreams</code></a> to
       <code>true</code>.
     </p>
 

--- a/doc/go1.13.html
+++ b/doc/go1.13.html
@@ -517,7 +517,7 @@ godoc
   The new <a href="/pkg/crypto/ed25519/"><code>crypto/ed25519</code></a>
   package implements the Ed25519 signature
   scheme. This functionality was previously provided by the
-  <a href="https://godoc.org/golang.org/x/crypto/ed25519"><code>golang.org/x/crypto/ed25519</code></a>
+  <a href="https://pkg.go.dev/golang.org/x/crypto/ed25519"><code>golang.org/x/crypto/ed25519</code></a>
   package, which becomes a wrapper for
   <code>crypto/ed25519</code> when used with Go 1.13+.
 </p>

--- a/doc/go1.14.html
+++ b/doc/go1.14.html
@@ -315,7 +315,7 @@ appropriately.)
   releases.
   This means that programs that use packages
   like <a href="/pkg/syscall/"><code>syscall</code></a>
-  or <a href="https://godoc.org/golang.org/x/sys/unix"><code>golang.org/x/sys/unix</code></a>
+  or <a href="https://pkg.go.dev/golang.org/x/sys/unix"><code>golang.org/x/sys/unix</code></a>
   will see more slow system calls fail with <code>EINTR</code> errors.
   Those programs will have to handle those errors in some way, most
   likely looping to try the system call again.  For more

--- a/doc/go1.3.html
+++ b/doc/go1.3.html
@@ -298,7 +298,7 @@ For example,
 <h3 id="godoc">Changes to godoc</h3>
 <p>
 When invoked with the <code>-analysis</code> flag, 
-<a href="//godoc.org/golang.org/x/tools/cmd/godoc">godoc</a>
+<a href="//pkg.go.dev/golang.org/x/tools/cmd/godoc">godoc</a>
 now performs sophisticated <a href="/lib/godoc/analysis/help.html">static
 analysis</a> of the code it indexes.  
 The results of analysis are presented in both the source view and the
@@ -318,7 +318,7 @@ call sites and their callees.
 The program <code>misc/benchcmp</code> that compares
 performance across benchmarking runs has been rewritten.
 Once a shell and awk script in the main repository, it is now a Go program in the <code>go.tools</code> repo.
-Documentation is <a href="//godoc.org/golang.org/x/tools/cmd/benchcmp">here</a>.
+Documentation is <a href="//pkg.go.dev/golang.org/x/tools/cmd/benchcmp">here</a>.
 </p>
 
 <p>

--- a/doc/go1.4.html
+++ b/doc/go1.4.html
@@ -420,7 +420,7 @@ to automate the running of tools to generate source code before compilation.
 For example, it can be used to run the <a href="/cmd/yacc"><code>yacc</code></a>
 compiler-compiler on a <code>.y</code> file to produce the Go source file implementing the grammar,
 or to automate the generation of <code>String</code> methods for typed constants using the new
-<a href="https://godoc.org/golang.org/x/tools/cmd/stringer">stringer</a>
+<a href="https://pkg.go.dev/golang.org/x/tools/cmd/stringer">stringer</a>
 tool in the <code>golang.org/x/tools</code> subrepository.
 </p>
 
@@ -619,9 +619,9 @@ has been created to serve as the location for new developments to support system
 calls on all kernels.
 It has a nicer structure, with three packages that each hold the implementation of
 system calls for one of
-<a href="https://godoc.org/golang.org/x/sys/unix">Unix</a>,
-<a href="https://godoc.org/golang.org/x/sys/windows">Windows</a> and
-<a href="https://godoc.org/golang.org/x/sys/plan9">Plan 9</a>.
+<a href="https://pkg.go.dev/golang.org/x/sys/unix">Unix</a>,
+<a href="https://pkg.go.dev/golang.org/x/sys/windows">Windows</a> and
+<a href="https://pkg.go.dev/golang.org/x/sys/plan9">Plan 9</a>.
 These packages will be curated more generously, accepting all reasonable changes
 that reflect kernel interfaces in those operating systems.
 See the documentation and the article mentioned above for more information.

--- a/doc/go1.5.html
+++ b/doc/go1.5.html
@@ -1170,7 +1170,7 @@ There is a new method to cancel a <a href="/pkg/net/http/"><code>net/http</code>
 field.
 It is supported by <code>http.Transport</code>.
 The <code>Cancel</code> field's type is compatible with the
-<a href="https://godoc.org/golang.org/x/net/context"><code>context.Context.Done</code></a>
+<a href="https://pkg.go.dev/golang.org/x/net/context"><code>context.Context.Done</code></a>
 return value.
 </li>
 

--- a/doc/go1.6.html
+++ b/doc/go1.6.html
@@ -282,9 +282,9 @@ to a non-nil, empty map.
 Programs that must adjust HTTP/2 protocol-specific details can import and use
 <a href="https://golang.org/x/net/http2"><code>golang.org/x/net/http2</code></a>,
 in particular its
-<a href="https://godoc.org/golang.org/x/net/http2/#ConfigureServer">ConfigureServer</a>
+<a href="https://pkg.go.dev/golang.org/x/net/http2/#ConfigureServer">ConfigureServer</a>
 and
-<a href="https://godoc.org/golang.org/x/net/http2/#ConfigureTransport">ConfigureTransport</a>
+<a href="https://pkg.go.dev/golang.org/x/net/http2/#ConfigureTransport">ConfigureTransport</a>
 functions.
 </p>
 

--- a/doc/go1.8.html
+++ b/doc/go1.8.html
@@ -229,7 +229,7 @@ The <code>yacc</code> tool (previously available by running
 “<code>go</code> <code>tool</code> <code>yacc</code>”) has been removed.
 As of Go 1.7 it was no longer used by the Go compiler.
 It has moved to the “tools” repository and is now available at
-<code><a href="https://godoc.org/golang.org/x/tools/cmd/goyacc">golang.org/x/tools/cmd/goyacc</a></code>.
+<code><a href="https://pkg.go.dev/golang.org/x/tools/cmd/goyacc">golang.org/x/tools/cmd/goyacc</a></code>.
 </p>
 
 <h3 id="tool_fix">Fix</h3>
@@ -1168,7 +1168,7 @@ crypto/x509: return error for missing SerialNumber (CL 27238)
     </p>
     <p><i>Updating:</i> implementations of the <code>Conn</code> interface should verify
       they implement the documented semantics. The
-      <a href="https://godoc.org/golang.org/x/net/nettest">golang.org/x/net/nettest</a>
+      <a href="https://pkg.go.dev/golang.org/x/net/nettest">golang.org/x/net/nettest</a>
       package will exercise a <code>Conn</code> and validate it behaves properly.
     </p>
 

--- a/doc/go_faq.html
+++ b/doc/go_faq.html
@@ -2029,7 +2029,7 @@ via the <a href="/cmd/go/"><code>go</code> tool</a>'s
 Such code can have its own maintainers, release cycle,
 and compatibility guarantees.
 Users can find packages and read their documentation at
-<a href="https://godoc.org/">godoc.org</a>.
+<a href="https://pkg.go.dev/">pkg.go.dev</a>.
 </p>
 
 <p>
@@ -2212,7 +2212,7 @@ func main() {
 
 <p>
 Nowadays, most Go programmers use a tool,
-<a href="https://godoc.org/golang.org/x/tools/cmd/goimports">goimports</a>,
+<a href="https://pkg.go.dev/golang.org/x/tools/cmd/goimports">goimports</a>,
 which automatically rewrites a Go source file to have the correct imports,
 eliminating the unused imports issue in practice.
 This program is easily connected to most editors to run automatically when a Go source file is written.

--- a/doc/install.html
+++ b/doc/install.html
@@ -274,7 +274,7 @@ go version go1.10.7 linux/amd64
 
 <p>
 All Go versions available via this method are listed on
-<a href="https://godoc.org/golang.org/dl#pkg-subdirectories">the download page</a>.
+<a href="https://pkg.go.dev/golang.org/dl">the download page</a>.
 You can find where each of these extra Go versions is installed by looking
 at its <code>GOROOT</code>; for example, <code>go1.10.7 env GOROOT</code>.
 To uninstall a downloaded version, just remove its <code>GOROOT</code> directory

--- a/doc/modules.md
+++ b/doc/modules.md
@@ -273,7 +273,7 @@ example, [`go get`](#go-get) can upgrade or downgrade specific dependencies.
 Commands that load the module graph will [automatically update](#go.mod-updates)
 `go.mod` when needed. [`go mod edit`](#go-mod-tidy) can perform low-level edits.
 The
-[`golang.org/x/mod/modfile`](https://pkg.go.dev/golang.org/x/mod/modfile?tab=doc)
+[`golang.org/x/mod/modfile`](https://pkg.go.dev/golang.org/x/mod/modfile)
 package can be used by Go programs to make the same changes programmatically.
 
 <a id="go.mod-lexical"></a>

--- a/src/bufio/bufio_test.go
+++ b/src/bufio/bufio_test.go
@@ -1494,7 +1494,7 @@ func (r *eofReader) Read(p []byte) (int, error) {
 	case 0, len(r.buf):
 		// As allowed in the documentation, this will return io.EOF
 		// in the same call that consumes the last of the data.
-		// https://godoc.org/io#Reader
+		// https://pkg.go.dev/io#Reader
 		return read, io.EOF
 	}
 

--- a/src/cmd/vendor/golang.org/x/sys/unix/README.md
+++ b/src/cmd/vendor/golang.org/x/sys/unix/README.md
@@ -1,7 +1,7 @@
 # Building `sys/unix`
 
 The sys/unix package provides access to the raw system call interface of the
-underlying operating system. See: https://godoc.org/golang.org/x/sys/unix
+underlying operating system. See: https://pkg.go.dev/golang.org/x/sys/unix
 
 Porting Go to a new architecture/OS combination or adding syscalls, types, or
 constants to an existing architecture/OS pair requires some manual effort;

--- a/src/log/syslog/doc.go
+++ b/src/log/syslog/doc.go
@@ -13,7 +13,7 @@
 // The syslog package is frozen and is not accepting new features.
 // Some external packages provide more functionality. See:
 //
-//   https://godoc.org/?q=syslog
+//   https://pkg.go.dev/search?q=syslog
 package syslog
 
 // BUG(brainman): This package is not implemented on Windows. As the

--- a/src/net/rpc/jsonrpc/client.go
+++ b/src/net/rpc/jsonrpc/client.go
@@ -4,7 +4,7 @@
 
 // Package jsonrpc implements a JSON-RPC 1.0 ClientCodec and ServerCodec
 // for the rpc package.
-// For JSON-RPC 2.0 support, see https://godoc.org/?q=json-rpc+2.0
+// For JSON-RPC 2.0 support, see https://pkg.go.dev/search?q=json-rpc%202.0
 package jsonrpc
 
 import (

--- a/src/net/smtp/smtp.go
+++ b/src/net/smtp/smtp.go
@@ -12,7 +12,7 @@
 // The smtp package is frozen and is not accepting new features.
 // Some external packages provide more functionality. See:
 //
-//   https://godoc.org/?q=smtp
+//   https://pkg.go.dev/search?q=smtp
 package smtp
 
 import (


### PR DESCRIPTION
> Pkg.go.dev is a new destination for Go discovery & docs