### PR TITLE
net/textproto, sync: unlock mutexes appropriately before panics

### DIFF
--- a/src/net/textproto/pipeline.go
+++ b/src/net/textproto/pipeline.go
@@ -99,6 +99,7 @@ func (s *sequencer) Start(id uint) {
 func (s *sequencer) End(id uint) {
 	s.mu.Lock()
 	if s.id != id {
+		s.mu.Unlock()
 		panic("out of sync")
 	}
 	id++

--- a/src/sync/rwmutex_test.go
+++ b/src/sync/rwmutex_test.go
@@ -59,6 +59,7 @@ func reader(rwm *RWMutex, num_iterations int, activity *int32, cdone chan bool) 
 		rwm.RLock()
 		n := atomic.AddInt32(activity, 1)
 		if n < 1 || n >= 10000 {
+			rwm.RUnlock()
 			panic(fmt.Sprintf("wlock(%d)\n", n))
 		}
 		for i := 0; i < 100; i++ {
@@ -74,6 +75,7 @@ func writer(rwm *RWMutex, num_iterations int, activity *int32, cdone chan bool) 
 		rwm.Lock()
 		n := atomic.AddInt32(activity, 10000)
 		if n != 10000 {
+			rwm.Unlock()
 			panic(fmt.Sprintf("wlock(%d)\n", n))
 		}
 		for i := 0; i < 100; i++ {


### PR DESCRIPTION
Ensure mutexes are unlocked right before panics, where defers aren’t easily usable.