### PR TITLE
src/runtime/testdata/testprogcgo: fix goroutine leak on panic

### DIFF
--- a/src/runtime/testdata/testprogcgo/callback.go
+++ b/src/runtime/testdata/testprogcgo/callback.go
@@ -72,6 +72,12 @@ func CgoCallbackGC() {
 	// allocate a bunch of stack frames and spray them with pointers
 	for i := 0; i < P; i++ {
 		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					done <- true
+					return
+				}
+			}()
 			grow()
 			done <- true
 		}()


### PR DESCRIPTION
When fn grow() calls panic on Line 53, done<-true on Line 76 in child thread will not run. Thus <-done on Line 80 blocks forever, leading to goroutine leak of parent thread. The fix is to add a defer func to call done<-true on panic.