### PR TITLE
src/runtime/testdata/testprogcgo: fix goroutine leak on timeout

### DIFF
--- a/src/runtime/testdata/testprogcgo/cgo.go
+++ b/src/runtime/testdata/testprogcgo/cgo.go
@@ -71,6 +71,7 @@ func CgoSignalDeadlock() {
 		case <-ping:
 			times = append(times, time.Since(start))
 		case <-time.After(time.Second):
+			<-ping
 			fmt.Printf("HANG 1 %v\n", times)
 			return
 		}
@@ -79,6 +80,7 @@ func CgoSignalDeadlock() {
 	select {
 	case <-ping:
 	case <-time.After(time.Second):
+		<-ping
 		fmt.Printf("HANG 2 %v\n", times)
 		return
 	}


### PR DESCRIPTION
ping <- false on Line 69 is definitely executed. If channel recvs from time.After on Line 73 earlier than from ping, it leaves from the select statement. No other goroutines can pull messages from ping. Therefore, the goroutine is blocked forever, leading to goroutine leak. The fix is to add <-ping after time.After. Same is true for Line 78 and Line 81.