### PR TITLE
errors: add new function Temporary(error) bool

### DIFF
--- a/src/errors/errors.go
+++ b/src/errors/errors.go
@@ -67,3 +67,11 @@ type errorString struct {
 func (e *errorString) Error() string {
 	return e.s
 }
+
+// Temporary returns true if it makes sense to retry the call that returned the error.
+func Temporary(err error) bool {
+	if err, ok := err.(interface{ Temporary() bool }); ok {
+		return err.Temporary()
+	}
+	return false
+}


### PR DESCRIPTION
This is proposal to add the Temporary function into errors package. I tend to rewrite it over and over again in every project.

Mainly, this function will be used in conjunction with the net package. 
Nevertheless, I think Temporary function belongs to the erros package, in this case user code and other packages may follow the same convention.