### PR TITLE
sort: Fixes IntSlice Less function if duplicate values

### DIFF
--- a/src/sort/sort.go
+++ b/src/sort/sort.go
@@ -269,7 +269,7 @@ func IsSorted(data Interface) bool {
 type IntSlice []int
 
 func (p IntSlice) Len() int           { return len(p) }
-func (p IntSlice) Less(i, j int) bool { return p[i] < p[j] }
+func (p IntSlice) Less(i, j int) bool { return p[i] <= p[j] }
 func (p IntSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 // Sort is a convenience method.


### PR DESCRIPTION
This PR fixes IntSlice less function to contain a smaller than or equal to. This should be the case in case an array contains duplicate values, currently an array with duplicate values is never considered sorted.

I am not 100% certain this change will work due to how sorting functions work. If `Less` is used to sort it may be caught in an endless loop.