### PR TITLE
cmd/go: escape $WORK in ccompile when -n is set

### DIFF
--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -2129,9 +2129,8 @@ func (b *Builder) gfortran(a *Action, p *load.Package, workdir, out string, flag
 func (b *Builder) ccompile(a *Action, p *load.Package, outfile string, flags []string, file string, compiler []string) error {
 	file = mkAbs(p.Dir, file)
 	desc := p.ImportPath
-	if !filepath.IsAbs(outfile) {
-		outfile = filepath.Join(p.Dir, outfile)
-	}
+	outfile = mkAbs(p.Dir, outfile)
+
 	output, err := b.runOut(a, filepath.Dir(file), b.cCompilerEnv(), compiler, flags, "-o", outfile, "-c", filepath.Base(file))
 	if len(output) > 0 {
 		// On FreeBSD 11, when we pass -g to clang 3.8 it

--- a/src/cmd/go/testdata/script/build_n_cgo.txt
+++ b/src/cmd/go/testdata/script/build_n_cgo.txt
@@ -1,0 +1,13 @@
+[!cgo] skip
+
+# Test that nothing is prepended to $WORK path prefix.
+# See issue golang.org/issue/37012.
+go build -n
+! stderr '[/\\]\$WORK'
+
+-- main.go --
+package main
+
+import "C"
+
+var _ C.int


### PR DESCRIPTION
Fixes #37012