### PR TITLE
encoding/json: consolidate the isSpace function

### DIFF
--- a/src/encoding/json/scanner.go
+++ b/src/encoding/json/scanner.go
@@ -186,12 +186,12 @@ func (s *scanner) popParseState() {
 }
 
 func isSpace(c byte) bool {
-	return c == ' ' || c == '\t' || c == '\r' || c == '\n'
+	return c <= ' ' && (c == ' ' || c == '\t' || c == '\r' || c == '\n')
 }
 
 // stateBeginValueOrEmpty is the state after reading `[`.
 func stateBeginValueOrEmpty(s *scanner, c byte) int {
-	if c <= ' ' && isSpace(c) {
+	if isSpace(c) {
 		return scanSkipSpace
 	}
 	if c == ']' {
@@ -202,7 +202,7 @@ func stateBeginValueOrEmpty(s *scanner, c byte) int {
 
 // stateBeginValue is the state at the beginning of the input.
 func stateBeginValue(s *scanner, c byte) int {
-	if c <= ' ' && isSpace(c) {
+	if isSpace(c) {
 		return scanSkipSpace
 	}
 	switch c {
@@ -242,7 +242,7 @@ func stateBeginValue(s *scanner, c byte) int {
 
 // stateBeginStringOrEmpty is the state after reading `{`.
 func stateBeginStringOrEmpty(s *scanner, c byte) int {
-	if c <= ' ' && isSpace(c) {
+	if isSpace(c) {
 		return scanSkipSpace
 	}
 	if c == '}' {
@@ -255,7 +255,7 @@ func stateBeginStringOrEmpty(s *scanner, c byte) int {
 
 // stateBeginString is the state after reading `{"key": value,`.
 func stateBeginString(s *scanner, c byte) int {
-	if c <= ' ' && isSpace(c) {
+	if isSpace(c) {
 		return scanSkipSpace
 	}
 	if c == '"' {
@@ -275,7 +275,7 @@ func stateEndValue(s *scanner, c byte) int {
 		s.endTop = true
 		return stateEndTop(s, c)
 	}
-	if c <= ' ' && isSpace(c) {
+	if isSpace(c) {
 		s.step = stateEndValue
 		return scanSkipSpace
 	}


### PR DESCRIPTION
The new code is easier to read, and practically equivalent in terms of
performance.

	name                  old time/op    new time/op    delta
	CodeUnmarshal-2          166ms ± 1%     166ms ± 1%    ~     (p=0.863 n=11+10)
	CodeUnmarshalReuse-2     139ms ± 1%     139ms ± 1%    ~     (p=0.050 n=10+12)
	UnmarshalString-2       1.08µs ± 1%    1.07µs ± 1%  -0.64%  (p=0.001 n=10+11)
	UnmarshalFloat64-2      1.01µs ± 1%    1.01µs ± 1%    ~     (p=0.280 n=12+11)
	UnmarshalInt64-2         850ns ± 0%     851ns ± 0%    ~     (p=0.455 n=11+12)

	name                  old speed      new speed      delta
	CodeUnmarshal-2       11.7MB/s ± 1%  11.7MB/s ± 1%    ~     (p=0.904 n=11+10)
	CodeUnmarshalReuse-2  14.0MB/s ± 1%  14.0MB/s ± 1%  +0.40%  (p=0.041 n=10+12)

	name                  old alloc/op   new alloc/op   delta
	CodeUnmarshal-2         3.28MB ± 0%    3.28MB ± 0%    ~     (p=0.907 n=10+11)
	CodeUnmarshalReuse-2    2.19MB ± 0%    2.19MB ± 0%    ~     (p=0.306 n=12+12)
	UnmarshalString-2         192B ± 0%      192B ± 0%    ~     (all equal)
	UnmarshalFloat64-2        180B ± 0%      180B ± 0%    ~     (all equal)
	UnmarshalInt64-2          176B ± 0%      176B ± 0%    ~     (all equal)

	name                  old allocs/op  new allocs/op  delta
	CodeUnmarshal-2          92.7k ± 0%     92.7k ± 0%    ~     (all equal)
	CodeUnmarshalReuse-2     80.4k ± 0%     80.4k ± 0%    ~     (all equal)
	UnmarshalString-2         2.00 ± 0%      2.00 ± 0%    ~     (all equal)
	UnmarshalFloat64-2        2.00 ± 0%      2.00 ± 0%    ~     (all equal)
	UnmarshalInt64-2          1.00 ± 0%      1.00 ± 0%    ~     (all equal)