### PR TITLE
encoding/json: remove comment about performance of scanner.step

### DIFF
--- a/src/encoding/json/scanner.go
+++ b/src/encoding/json/scanner.go
@@ -63,9 +63,8 @@ func (e *SyntaxError) Error() string { return e.msg }
 // the beginning of 12345e+6?).
 type scanner struct {
 	// The step is a func to be called to execute the next transition.
-	// Also tried using an integer constant and a single func
-	// with a switch, but using the func directly was 10% faster
-	// on a 64-bit Mac Mini, and it's nicer to read.
+	// Also tried using an integer constant and a single func with a
+	// switch, but this is nicer to read.
 	step func(*scanner, byte) int
 
 	// Reached end of top-level value.


### PR DESCRIPTION
In an experiment I could not reproduce the 10% performance loss when
using an integer constant for scanner.step. Instead the performance
seemed to be about the same.

The experiment can be seen here: https://github.com/codesoap/go/commit/c7b685b5640282fd625d93d295eb772b98262504

Less allocations are made in my experimental version, but the difference
is probably insignificant and depends on the used hardware. I'd be
interested to see the results on other systems.

I tested on a ThinkPad T450:
- CPU: Intel(R) Core(TM) i5-5300U CPU @ 2.30GHz
- 12GiB Ram DDR3
- OS: OpenBSD 6.6 (amd64)

I know this PR is somewhat pedantic, but I think the comment could
potentially keep people from trying to optimize this piece of code and
thus hinder development.