### PR TITLE
cmd/internal/objabi: enable frame-pointer for iOS arm64

### DIFF
--- a/src/cmd/internal/objabi/util.go
+++ b/src/cmd/internal/objabi/util.go
@@ -134,7 +134,7 @@ func init() {
 }
 
 func Framepointer_enabled(goos, goarch string) bool {
-	return framepointer_enabled != 0 && (goarch == "amd64" || goarch == "arm64" && goos == "linux")
+	return framepointer_enabled != 0 && (goarch == "amd64" || goarch == "arm64" && (goos == "linux" || goos == "darwin"))
 }
 
 func addexp(s string) {


### PR DESCRIPTION
This improves stack unwinding of Go code running on iOS arm64.