### PR TITLE
path/filepath: return the correct extensions when using filepath.Ext(path)

### DIFF
--- a/src/path/filepath/path.go
+++ b/src/path/filepath/path.go
@@ -217,8 +217,11 @@ func Join(elem ...string) string {
 // in the final element of path; it is empty if there is
 // no dot.
 func Ext(path string) string {
-	for i := len(path) - 1; i >= 0 && !os.IsPathSeparator(path[i]); i-- {
+	for i := len(path) - 1; i > 0 && !os.IsPathSeparator(path[i]); i-- {
 		if path[i] == '.' {
+			if os.IsPathSeparator(path[i-1]) {
+				return ""
+			}
 			return path[i:]
 		}
 	}

--- a/src/path/filepath/path_test.go
+++ b/src/path/filepath/path_test.go
@@ -315,6 +315,9 @@ var exttests = []ExtTest{
 	{"a.dir/b", ""},
 	{"a.dir/b.go", ".go"},
 	{"a.dir/", ""},
+	{"path/.config", ""},
+	{"./.config", ""},
+	{".gitignore", ""},
 }
 
 func TestExt(t *testing.T) {


### PR DESCRIPTION
Previously filepath.Ext(path) would return incorrect values for paths such as _path/.config_ and files such as _.gitignore_ as both of them do not have an extension.

This PR addresses this issue.