### PR TITLE
doc/go1.14: document that unparsable URL in net/url.Error is now quoted

### DIFF
--- a/doc/go1.14.html
+++ b/doc/go1.14.html
@@ -759,6 +759,19 @@ Do not send CLs removing the interior tags from such phrases.
   </dd>
 </dl><!-- net/textproto -->
 
+<dl id="net/url"><dt><a href="/pkg/net/url/">net/url</a></dt>
+  <dd>
+    <p><!-- CL 185117 -->
+      When parsing of an URL fails 
+      (e.g. by <a href="/pkg/net/url/#Parse"><code>Parse</code></a> 
+      or <a href="/pkg/net/url/#ParseRequestURI"><code>ParseRequestURI</code></a>),
+      the resulting <a href="/pkg/net/url/#Error.Error"><code>Error</code></a> message 
+      will now quote the unparsable URL
+      for clearer structure and consistency with other parsing errors.
+    </p>
+  </dd>
+</dl><!-- net/url -->
+
 <dl id="os/signal"><dt><a href="/pkg/os/signal/">os/signal</a></dt>
   <dd>
     <p><!-- CL 187739 -->

--- a/doc/go1.14.html
+++ b/doc/go1.14.html
@@ -762,10 +762,10 @@ Do not send CLs removing the interior tags from such phrases.
 <dl id="net/url"><dt><a href="/pkg/net/url/">net/url</a></dt>
   <dd>
     <p><!-- CL 185117 -->
-      When parsing of an URL fails 
-      (e.g. by <a href="/pkg/net/url/#Parse"><code>Parse</code></a> 
+      When parsing of an URL fails
+      (e.g. by <a href="/pkg/net/url/#Parse"><code>Parse</code></a>
       or <a href="/pkg/net/url/#ParseRequestURI"><code>ParseRequestURI</code></a>),
-      the resulting <a href="/pkg/net/url/#Error.Error"><code>Error</code></a> message 
+      the resulting <a href="/pkg/net/url/#Error.Error"><code>Error</code></a> message
       will now quote the unparsable URL
       for clearer structure and consistency with other parsing errors.
     </p>

--- a/doc/go1.14.html
+++ b/doc/go1.14.html
@@ -762,12 +762,12 @@ Do not send CLs removing the interior tags from such phrases.
 <dl id="net/url"><dt><a href="/pkg/net/url/">net/url</a></dt>
   <dd>
     <p><!-- CL 185117 -->
-      When parsing of an URL fails
+      When parsing of a URL fails
       (e.g. by <a href="/pkg/net/url/#Parse"><code>Parse</code></a>
       or <a href="/pkg/net/url/#ParseRequestURI"><code>ParseRequestURI</code></a>),
       the resulting <a href="/pkg/net/url/#Error.Error"><code>Error</code></a> message
-      will now quote the unparsable URL
-      for clearer structure and consistency with other parsing errors.
+      will now quote the unparsable URL.
+      This provides clearer structure and consistency with other parsing errors.
     </p>
   </dd>
 </dl><!-- net/url -->

--- a/doc/go1.14.html
+++ b/doc/go1.14.html
@@ -763,7 +763,7 @@ Do not send CLs removing the interior tags from such phrases.
   <dd>
     <p><!-- CL 185117 -->
       When parsing of a URL fails
-      (e.g. by <a href="/pkg/net/url/#Parse"><code>Parse</code></a>
+      (for example by <a href="/pkg/net/url/#Parse"><code>Parse</code></a>
       or <a href="/pkg/net/url/#ParseRequestURI"><code>ParseRequestURI</code></a>),
       the resulting <a href="/pkg/net/url/#Error.Error"><code>Error</code></a> message
       will now quote the unparsable URL.


### PR DESCRIPTION
Fixes #37614
Updates #36878 
Updates #29384
Updates #37630