### PR TITLE
internal/xcoff: fix wrong bit masking comparisons

### DIFF
--- a/src/internal/xcoff/file.go
+++ b/src/internal/xcoff/file.go
@@ -412,10 +412,10 @@ func NewFile(r io.ReaderAt) (*File, error) {
 				sect.Relocs[i].Type = rel.Rtype
 				sect.Relocs[i].Length = rel.Rsize&0x3F + 1
 
-				if rel.Rsize&0x80 == 1 {
+				if rel.Rsize&0x80 != 0 {
 					sect.Relocs[i].Signed = true
 				}
-				if rel.Rsize&0x40 == 1 {
+				if rel.Rsize&0x40 != 0 {
 					sect.Relocs[i].InstructionFixed = true
 				}
 
@@ -428,10 +428,10 @@ func NewFile(r io.ReaderAt) (*File, error) {
 				sect.Relocs[i].Symbol = idxToSym[int(rel.Rsymndx)]
 				sect.Relocs[i].Type = rel.Rtype
 				sect.Relocs[i].Length = rel.Rsize&0x3F + 1
-				if rel.Rsize&0x80 == 1 {
+				if rel.Rsize&0x80 != 0 {
 					sect.Relocs[i].Signed = true
 				}
-				if rel.Rsize&0x40 == 1 {
+				if rel.Rsize&0x40 != 0 {
 					sect.Relocs[i].InstructionFixed = true
 				}
 			}


### PR DESCRIPTION
I do not know much about xcoff, but this was probably the intended
behavior. (The comparison is tautologically false, as is.)

Also note: does any other code even depend on the changed code existing?
Maybe it should just be removed, as I did not find any uses of fields
that are written to if the branch condition tests true.