### PR TITLE
all: change x&(1<<i)==(1<<i) to x&(1<<i)!=0

### DIFF
--- a/src/crypto/elliptic/elliptic.go
+++ b/src/crypto/elliptic/elliptic.go
@@ -256,7 +256,7 @@ func (curve *CurveParams) ScalarMult(Bx, By *big.Int, k []byte) (*big.Int, *big.
 	for _, byte := range k {
 		for bitNum := 0; bitNum < 8; bitNum++ {
 			x, y, z = curve.doubleJacobian(x, y, z)
-			if byte&0x80 == 0x80 {
+			if byte&0x80 != 0 {
 				x, y, z = curve.addJacobian(Bx, By, Bz, x, y, z)
 			}
 			byte <<= 1

--- a/src/encoding/asn1/asn1.go
+++ b/src/encoding/asn1/asn1.go
@@ -82,7 +82,7 @@ func checkInteger(bytes []byte) error {
 	if len(bytes) == 1 {
 		return nil
 	}
-	if (bytes[0] == 0 && bytes[1]&0x80 == 0) || (bytes[0] == 0xff && bytes[1]&0x80 == 0x80) {
+	if (bytes[0] == 0 && bytes[1]&0x80 == 0) || (bytes[0] == 0xff && bytes[1]&0x80 != 0) {
 		return StructuralError{"integer not minimally-encoded"}
 	}
 	return nil
@@ -136,7 +136,7 @@ func parseBigInt(bytes []byte) (*big.Int, error) {
 		return nil, err
 	}
 	ret := new(big.Int)
-	if len(bytes) > 0 && bytes[0]&0x80 == 0x80 {
+	if len(bytes) > 0 && bytes[0]&0x80 != 0 {
 		// This is a negative number.
 		notBytes := make([]byte, len(bytes))
 		for i := range notBytes {
@@ -529,7 +529,7 @@ func parseTagAndLength(bytes []byte, initOffset int) (ret tagAndLength, offset i
 	b := bytes[offset]
 	offset++
 	ret.class = int(b >> 6)
-	ret.isCompound = b&0x20 == 0x20
+	ret.isCompound = b&0x20 != 0
 	ret.tag = int(b & 0x1f)
 
 	// If the bottom five bits are set, then the tag number is actually base 128

--- a/src/syscall/syscall_aix.go
+++ b/src/syscall/syscall_aix.go
@@ -494,7 +494,7 @@ func (w WaitStatus) Signal() Signal {
 
 func (w WaitStatus) Continued() bool { return w&0x01000000 != 0 }
 
-func (w WaitStatus) CoreDump() bool { return w&0x80 == 0x80 }
+func (w WaitStatus) CoreDump() bool { return w&0x80 != 0 }
 
 func (w WaitStatus) TrapCause() int { return -1 }
 


### PR DESCRIPTION
Minor bit mask comparison optimization.

Changes some expressions of the form x&y==y, where popcnt(y) is one, to
x&y!=0.

What was not touched: vendored directories, test directories, and
comparisons of the form x&1==1 and x&2==2 (because it did not cause a
significant change in the generated code in the case of math.tan).

In the case of AMD64 and asn1, this results in the emission of a single
'test' instruction instead of a 'and' and a 'cmp'.