### PR TITLE
cmd/cgo: updated exported function parameter names

### DIFF
--- a/src/cmd/cgo/out.go
+++ b/src/cmd/cgo/out.go
@@ -916,12 +916,14 @@ func (p *Package) writeExports(fgo2, fm, fgcc, fgcch io.Writer) {
 				if i > 0 || fn.Recv != nil {
 					s += ", "
 				}
+				pname := aname
 				for j := 0; j < len(aname); j++ {
 					if aname[j] > unicode.MaxASCII {
-						fatalf("error: invalid non ASCII character found in cgo exported function parameter: %s", aname)
+						pname = fmt.Sprintf("p%d", i)
+						break
 					}
 				}
-				s += fmt.Sprintf("%s %s", p.cgoType(atype).C, aname)
+				s += fmt.Sprintf("%s %s", p.cgoType(atype).C, pname)
 			})
 		s += ")"
 
@@ -947,7 +949,14 @@ func (p *Package) writeExports(fgo2, fm, fgcc, fgcch io.Writer) {
 		}
 		forFieldList(fntype.Params,
 			func(i int, aname string, atype ast.Expr) {
-				fmt.Fprintf(fgcc, "\ta.p%d = %s;\n", i, aname)
+				pname := aname
+				for j := 0; j < len(aname); j++ {
+					if aname[j] > unicode.MaxASCII {
+						pname = fmt.Sprintf("p%d", i)
+						break
+					}
+				}
+				fmt.Fprintf(fgcc, "\ta.p%d = %s;\n", i, pname)
 			})
 		fmt.Fprintf(fgcc, "\t_cgo_tsan_release();\n")
 		fmt.Fprintf(fgcc, "\tcrosscall2(_cgoexp%s_%s, &a, %d, _cgo_ctxt);\n", cPrefix, exp.ExpName, off)

--- a/src/cmd/cgo/out.go
+++ b/src/cmd/cgo/out.go
@@ -951,28 +951,28 @@ func (p *Package) writeExports(fgo2, fm, fgcc, fgcch io.Writer) {
 		fmt.Fprintf(fgcc, "\n%s\n", s)
 		fmt.Fprintf(fgcc, "{\n")
 		fmt.Fprintf(fgcc, "\t__SIZE_TYPE__ _cgo_ctxt = _cgo_wait_runtime_init_done();\n")
-		fmt.Fprintf(fgcc, "\t%s %v a;\n", ctype, p.packedAttribute())
+		fmt.Fprintf(fgcc, "\t%s %v _cgo_a;\n", ctype, p.packedAttribute())
 		if gccResult != "void" && (len(fntype.Results.List) > 1 || len(fntype.Results.List[0].Names) > 1) {
 			fmt.Fprintf(fgcc, "\t%s r;\n", gccResult)
 		}
 		if fn.Recv != nil {
-			fmt.Fprintf(fgcc, "\ta.recv = recv;\n")
+			fmt.Fprintf(fgcc, "\t_cgo_a.recv = recv;\n")
 		}
 		forFieldList(fntype.Params,
 			func(i int, aname string, atype ast.Expr) {
-				fmt.Fprintf(fgcc, "\ta.p%d = %s;\n", i, exportParamName(aname, i))
+				fmt.Fprintf(fgcc, "\t_cgo_a.p%d = %s;\n", i, exportParamName(aname, i))
 			})
 		fmt.Fprintf(fgcc, "\t_cgo_tsan_release();\n")
-		fmt.Fprintf(fgcc, "\tcrosscall2(_cgoexp%s_%s, &a, %d, _cgo_ctxt);\n", cPrefix, exp.ExpName, off)
+		fmt.Fprintf(fgcc, "\tcrosscall2(_cgoexp%s_%s, &_cgo_a, %d, _cgo_ctxt);\n", cPrefix, exp.ExpName, off)
 		fmt.Fprintf(fgcc, "\t_cgo_tsan_acquire();\n")
 		fmt.Fprintf(fgcc, "\t_cgo_release_context(_cgo_ctxt);\n")
 		if gccResult != "void" {
 			if len(fntype.Results.List) == 1 && len(fntype.Results.List[0].Names) <= 1 {
-				fmt.Fprintf(fgcc, "\treturn a.r0;\n")
+				fmt.Fprintf(fgcc, "\treturn _cgo_a.r0;\n")
 			} else {
 				forFieldList(fntype.Results,
 					func(i int, aname string, atype ast.Expr) {
-						fmt.Fprintf(fgcc, "\tr.r%d = a.r%d;\n", i, i)
+						fmt.Fprintf(fgcc, "\tr.r%d = _cgo_a.r%d;\n", i, i)
 					})
 				fmt.Fprintf(fgcc, "\treturn r;\n")
 			}

--- a/src/cmd/cgo/out.go
+++ b/src/cmd/cgo/out.go
@@ -803,12 +803,12 @@ func (p *Package) packedAttribute() string {
 	return s + "))"
 }
 
-// filterParamName returns the value of param as it should be
-// displayed in a c header file. if param contains any non-ASCII
+// exportParamName returns the value of param as it should be
+// displayed in a c header file. If param contains any non-ASCII
 // characters, this function will return the character p followed by
 // the value of position; otherwise, this function will return the
 // value of param.
-func filterParamName(param string, position int) string {
+func exportParamName(param string, position int) string {
 	pname := param
 
 	for i := 0; i < len(param); i++ {
@@ -934,7 +934,7 @@ func (p *Package) writeExports(fgo2, fm, fgcc, fgcch io.Writer) {
 				if i > 0 || fn.Recv != nil {
 					s += ", "
 				}
-				s += fmt.Sprintf("%s %s", p.cgoType(atype).C, filterParamName(aname, i))
+				s += fmt.Sprintf("%s %s", p.cgoType(atype).C, exportParamName(aname, i))
 			})
 		s += ")"
 
@@ -960,7 +960,7 @@ func (p *Package) writeExports(fgo2, fm, fgcc, fgcch io.Writer) {
 		}
 		forFieldList(fntype.Params,
 			func(i int, aname string, atype ast.Expr) {
-				fmt.Fprintf(fgcc, "\ta.p%d = %s;\n", i, filterParamName(aname, i))
+				fmt.Fprintf(fgcc, "\ta.p%d = %s;\n", i, exportParamName(aname, i))
 			})
 		fmt.Fprintf(fgcc, "\t_cgo_tsan_release();\n")
 		fmt.Fprintf(fgcc, "\tcrosscall2(_cgoexp%s_%s, &a, %d, _cgo_ctxt);\n", cPrefix, exp.ExpName, off)


### PR DESCRIPTION
Functions that are exported through cgo will now retain their
parameter names provided that their parameter names use only
ASCII characters.

Fixes #37746