### PR TITLE
net/http/httputil: improve compatibility with server sent events

### DIFF
--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -371,7 +371,7 @@ func (p *ReverseProxy) flushInterval(req *http.Request, res *http.Response) time
 
 	// For Server-Sent Events responses, flush immediately.
 	// The MIME type is defined in https://www.w3.org/TR/eventsource/#text-event-stream
-	if resCT == "text/event-stream" {
+	if strings.HasPrefix(resCT, "text/event-stream") {
 		return -1 // negative means immediately
 	}
 


### PR DESCRIPTION
According to https://html.spec.whatwg.org/multipage/server-sent-events.html#sse-processing-model
MIME type parameters should be ignored when Content-Type` header value is `text/event-stream`.

Related https://github.com/spring-projects/spring-framework/pull/24632