### PR TITLE
doc/go_spec: fix underlying types example

### DIFF
--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -825,7 +825,7 @@ type (
 <p>
 The underlying type of <code>string</code>, <code>A1</code>, <code>A2</code>, <code>B1</code>,
 and <code>B2</code> is <code>string</code>.
-The underlying type of <code>[]B1</code>, <code>B3</code>, and <code>B4</code> is <code>[]B1</code>.
+The underlying type of <code>B3</code>, and <code>B4</code> is <code>[]B1</code>.
 </p>
 
 <h3 id="Method_sets">Method sets</h3>


### PR DESCRIPTION
I believe that if there is an underlying type for []T1, it should be rather []string, not []T1.