### PR TITLE
go/doc: make formatting comments more flexible using an interface

### DIFF
--- a/src/crypto/x509/verify.go
+++ b/src/crypto/x509/verify.go
@@ -578,13 +578,13 @@ func (c *Certificate) isValid(certType int, currentChain []*Certificate, opts *V
 	}
 	if now.Before(c.NotBefore) {
 		return CertificateInvalidError{
-			Cert: c,
+			Cert:   c,
 			Reason: Expired,
 			Detail: fmt.Sprintf("current time %s is before %s", now.Format(time.RFC3339), c.NotBefore.Format(time.RFC3339)),
 		}
 	} else if now.After(c.NotAfter) {
 		return CertificateInvalidError{
-			Cert: c,
+			Cert:   c,
 			Reason: Expired,
 			Detail: fmt.Sprintf("current time %s is after %s", now.Format(time.RFC3339), c.NotAfter.Format(time.RFC3339)),
 		}

--- a/src/crypto/x509/verify.go
+++ b/src/crypto/x509/verify.go
@@ -578,13 +578,13 @@ func (c *Certificate) isValid(certType int, currentChain []*Certificate, opts *V
 	}
 	if now.Before(c.NotBefore) {
 		return CertificateInvalidError{
-			Cert:   c,
+			Cert: c,
 			Reason: Expired,
 			Detail: fmt.Sprintf("current time %s is before %s", now.Format(time.RFC3339), c.NotBefore.Format(time.RFC3339)),
 		}
 	} else if now.After(c.NotAfter) {
 		return CertificateInvalidError{
-			Cert:   c,
+			Cert: c,
 			Reason: Expired,
 			Detail: fmt.Sprintf("current time %s is after %s", now.Format(time.RFC3339), c.NotAfter.Format(time.RFC3339)),
 		}

--- a/src/go/doc/comment.go
+++ b/src/go/doc/comment.go
@@ -385,6 +385,9 @@ func (f *markdownFormatter) EndRaw()                 {}
 // in the words map, the link is taken from the map (if the corresponding map
 // value is the empty string, the URL is not converted into a link).
 //
+// A pair of (consecutive) backticks (`) is converted to a unicode left quote (“), and a pair of (consecutive)
+// single quotes (') is converted to a unicode right quote (”).
+//
 // Go identifiers that appear in the words map are italicized; if the corresponding
 // map value is not the empty string, it is considered a URL and the word is converted
 // into a link.
@@ -399,6 +402,9 @@ func ToHTML(w io.Writer, text string, words map[string]string) {
 // It wraps paragraphs of text to width or fewer Unicode code points
 // and then prefixes each line with the indent. In preformatted sections
 // (such as program text), it prefixes each non-blank line with preIndent.
+//
+// A pair of (consecutive) backticks (`) is converted to a unicode left quote (“), and a pair of (consecutive)
+// single quotes (') is converted to a unicode right quote (”).
 func ToText(w io.Writer, text string, indent, preIndent string, width int) {
 	f := &textFormatter{
 		out:       w,

--- a/src/go/doc/comment_test.go
+++ b/src/go/doc/comment_test.go
@@ -20,10 +20,10 @@ type testFormatter struct {
 	headID string
 }
 
-// Escape escapes text for HTML. If nice is set,
+// Put escapes text for HTML. If pretty is set,
 // also turn `` and '' into appropirate quotes.
-func (f *testFormatter) Escape(text string, nice bool) {
-	if nice {
+func (f *testFormatter) Put(text string, pretty bool) {
+	if pretty {
 		// In the first pass, we convert `` and '' into their unicode equivalents.
 		// This prevents them from being escaped in HTMLEscape.
 		text = convertQuotes(text)
@@ -38,16 +38,16 @@ func (f *testFormatter) Escape(text string, nice bool) {
 	template.HTMLEscape(f.out, []byte(text))
 }
 
-func (f *testFormatter) WriteURL(url, match string, italics, nice bool) {
+func (f *testFormatter) WriteURL(url, match string, italics, pretty bool) {
 	if len(url) > 0 {
 		f.out.Write(htmlPreLink)
-		f.Escape(url, false)
+		f.Put(url, false)
 		f.out.Write(htmlPostLink)
 	}
 	if italics {
 		f.out.Write(htmlStartI)
 	}
-	f.Escape(match, nice)
+	f.Put(match, pretty)
 	if italics {
 		f.out.Write(htmlEndI)
 	}
@@ -320,7 +320,7 @@ func TestHtmlEscape(t *testing.T) {
 	for i, tt := range commentTests {
 		var buf strings.Builder
 		html.out = &buf
-		html.Escape(tt.in, true)
+		html.Put(tt.in, true)
 		out := buf.String()
 		if out != tt.out {
 			t.Errorf("#%d: mismatch\nhave: %q\nwant: %q", i, out, tt.out)


### PR DESCRIPTION
Tools, like gopls, have to basically copy-paste go/doc/comment.go and replace certain aspects using for their own format. This means having to keeping it up-to-date with go/doc and thus a maintenance  burden.

This change removes that burden for developers.

Fixes #34875