### PR TITLE
context: prevent creation of invalid contexts

### DIFF
--- a/src/context/context.go
+++ b/src/context/context.go
@@ -230,6 +230,9 @@ type CancelFunc func()
 // Canceling this context releases resources associated with it, so code should
 // call cancel as soon as the operations running in this Context complete.
 func WithCancel(parent Context) (ctx Context, cancel CancelFunc) {
+	if parent == nil {
+		panic("cannot create context from nil parent.")
+	}
 	c := newCancelCtx(parent)
 	propagateCancel(parent, &c)
 	return &c, func() { c.cancel(true, Canceled) }
@@ -425,6 +428,9 @@ func (c *cancelCtx) cancel(removeFromParent bool, err error) {
 // Canceling this context releases resources associated with it, so code should
 // call cancel as soon as the operations running in this Context complete.
 func WithDeadline(parent Context, d time.Time) (Context, CancelFunc) {
+	if parent == nil {
+		panic("cannot create context from nil parent.")
+	}
 	if cur, ok := parent.Deadline(); ok && cur.Before(d) {
 		// The current deadline is already sooner than the new one.
 		return WithCancel(parent)
@@ -511,6 +517,9 @@ func WithTimeout(parent Context, timeout time.Duration) (Context, CancelFunc) {
 // struct{}. Alternatively, exported context key variables' static
 // type should be a pointer or interface.
 func WithValue(parent Context, key, val interface{}) Context {
+	if parent == nil {
+		panic("cannot create context from nil parent.")
+	}
 	if key == nil {
 		panic("nil key")
 	}

--- a/src/context/context.go
+++ b/src/context/context.go
@@ -231,7 +231,7 @@ type CancelFunc func()
 // call cancel as soon as the operations running in this Context complete.
 func WithCancel(parent Context) (ctx Context, cancel CancelFunc) {
 	if parent == nil {
-		panic("cannot create context from nil parent.")
+		panic("cannot create context from nil parent")
 	}
 	c := newCancelCtx(parent)
 	propagateCancel(parent, &c)
@@ -429,7 +429,7 @@ func (c *cancelCtx) cancel(removeFromParent bool, err error) {
 // call cancel as soon as the operations running in this Context complete.
 func WithDeadline(parent Context, d time.Time) (Context, CancelFunc) {
 	if parent == nil {
-		panic("cannot create context from nil parent.")
+		panic("cannot create context from nil parent")
 	}
 	if cur, ok := parent.Deadline(); ok && cur.Before(d) {
 		// The current deadline is already sooner than the new one.
@@ -518,7 +518,7 @@ func WithTimeout(parent Context, timeout time.Duration) (Context, CancelFunc) {
 // type should be a pointer or interface.
 func WithValue(parent Context, key, val interface{}) Context {
 	if parent == nil {
-		panic("cannot create context from nil parent.")
+		panic("cannot create context from nil parent")
 	}
 	if key == nil {
 		panic("nil key")

--- a/src/context/context_test.go
+++ b/src/context/context_test.go
@@ -667,7 +667,7 @@ func XTestWithValueChecksKey(t testingT) {
 	}
 }
 
-func TestInvalidDerivedFail(t testingT) {
+func XTestInvalidDerivedFail(t testingT) {
 	panicVal := recoveredValue(func() { WithCancel(nil) })
 	if panicVal == nil {
 		t.Error("expected panic")

--- a/src/context/context_test.go
+++ b/src/context/context_test.go
@@ -667,6 +667,21 @@ func XTestWithValueChecksKey(t testingT) {
 	}
 }
 
+func TestInvalidDerivedFail(t testingT) {
+	panicVal := recoveredValue(func() { WithCancel(nil) })
+	if panicVal == nil {
+		t.Error("expected panic")
+	}
+	panicVal := recoveredValue(func() { WithDeadline(nil, time.Second) })
+	if panicVal == nil {
+		t.Error("expected panic")
+	}
+	panicVal := recoveredValue(func() { WithValue(nil, "foo", "bar") })
+	if panicVal == nil {
+		t.Error("expected panic")
+	}
+}
+
 func recoveredValue(fn func()) (v interface{}) {
 	defer func() { v = recover() }()
 	fn()

--- a/src/context/context_test.go
+++ b/src/context/context_test.go
@@ -672,11 +672,11 @@ func XTestInvalidDerivedFail(t testingT) {
 	if panicVal == nil {
 		t.Error("expected panic")
 	}
-	panicVal := recoveredValue(func() { WithDeadline(nil, time.Second) })
+	panicVal = recoveredValue(func() { WithDeadline(nil, time.Now().Add(shortDuration)) })
 	if panicVal == nil {
 		t.Error("expected panic")
 	}
-	panicVal := recoveredValue(func() { WithValue(nil, "foo", "bar") })
+	panicVal = recoveredValue(func() { WithValue(nil, "foo", "bar") })
 	if panicVal == nil {
 		t.Error("expected panic")
 	}

--- a/src/context/x_test.go
+++ b/src/context/x_test.go
@@ -26,5 +26,6 @@ func TestLayersTimeout(t *testing.T)                   { XTestLayersTimeout(t) }
 func TestCancelRemoves(t *testing.T)                   { XTestCancelRemoves(t) }
 func TestWithCancelCanceledParent(t *testing.T)        { XTestWithCancelCanceledParent(t) }
 func TestWithValueChecksKey(t *testing.T)              { XTestWithValueChecksKey(t) }
+func TestInvalidDerivedFail(t *testing.T)              { XTestInvalidDerivedFail(t) }
 func TestDeadlineExceededSupportsTimeout(t *testing.T) { XTestDeadlineExceededSupportsTimeout(t) }
 func TestCustomContextGoroutines(t *testing.T)         { XTestCustomContextGoroutines(t) }


### PR DESCRIPTION
This commit makes it impossible to create derived contexts with nil parents.
Previously it was possible to create derived contexts with nil parents, and
invalid contexts could propogate through the program. Eventually this can
cause a panic downstream, which is difficult to trace back to the source
of the error.

Although `WithCancel` and `WithDeadline` already panic if `parent` is `nil`, this adds explicit checks to give a useful message in the panic.

Fixes #37908