### PR TITLE
crypto/tls: update the MITM reference to "machine-in-the-middle"

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -549,7 +549,7 @@ type Config struct {
 	// server's certificate chain and host name.
 	// If InsecureSkipVerify is true, TLS accepts any certificate
 	// presented by the server and any host name in that certificate.
-	// In this mode, TLS is susceptible to man-in-the-middle attacks.
+	// In this mode, TLS is susceptible to machine-in-the-middle attacks.
 	// This should be used only for testing.
 	InsecureSkipVerify bool
 


### PR DESCRIPTION
Changing "man-in-the-middle" references to "machine-in-the-middle",
it's a more inclusive term and still aligns with the MITM acronym.

