### PR TITLE
doc/faq: update the MITM reference to "machine-in-the-middle" 

### DIFF
--- a/doc/go_faq.html
+++ b/doc/go_faq.html
@@ -1285,7 +1285,7 @@ Companies often permit outgoing traffic only on the standard TCP ports 80 (HTTP)
 and 443 (HTTPS), blocking outgoing traffic on other ports, including TCP port 9418
 (git) and TCP port 22 (SSH).
 When using HTTPS instead of HTTP, <code>git</code> enforces certificate validation by
-default, providing protection against man-in-the-middle, eavesdropping and tampering attacks.
+default, providing protection against machine-in-the-middle, eavesdropping and tampering attacks.
 The <code>go get</code> command therefore uses HTTPS for safety.
 </p>
 


### PR DESCRIPTION
Changing "man-in-the-middle" to "machine-in-the-middle" as it's a more inclusive term and still aligns with the MITM acronym.