### PR TITLE
database/sql: fix variable name in example

### DIFF
--- a/src/database/sql/example_test.go
+++ b/src/database/sql/example_test.go
@@ -41,7 +41,7 @@ func ExampleDB_QueryContext() {
 	// encounter an auto-commit error and be forced to rollback changes.
 	rerr := rows.Close()
 	if rerr != nil {
-		log.Fatal(err)
+		log.Fatal(rerr)
 	}
 
 	// Rows.Err will report the last error encountered by Rows.Scan.


### PR DESCRIPTION
It's a very minor error, but it's a bad copy/paste example.