### PR TITLE
cmd/go, flag: make undefined flag msg less ambiguous. Fixes #36364

### DIFF
--- a/src/cmd/go/internal/cmdflag/flag.go
+++ b/src/cmd/go/internal/cmdflag/flag.go
@@ -31,7 +31,7 @@ type FlagNotDefinedError struct {
 }
 
 func (e FlagNotDefinedError) Error() string {
-	return fmt.Sprintf("flag provided but not defined: -%s", e.Name)
+	return fmt.Sprintf("The flag '-%s' is an unknown flag.", e.Name)
 }
 
 // A NonFlagError indicates an argument that is not a syntactically-valid flag.

--- a/src/cmd/go/testdata/script/mod_getmode_vendor.txt
+++ b/src/cmd/go/testdata/script/mod_getmode_vendor.txt
@@ -13,7 +13,7 @@ stdout '^golang.org/x/text v0.0.0.* .*vendor[\\/]golang.org[\\/]x[\\/]text[\\/]l
 ! go list -mod=vendor -m rsc.io/quote@latest
 stderr 'go list -m: rsc.io/quote@latest: cannot query module due to -mod=vendor'
 ! go get -mod=vendor -u
-stderr 'flag provided but not defined: -mod'
+stderr 'The flag ''-mod'' is an unknown flag.'
 
 # Since we don't have a complete module graph, 'go list -m' queries
 # that require the complete graph should fail with a useful error.

--- a/src/flag/flag.go
+++ b/src/flag/flag.go
@@ -926,7 +926,7 @@ func (f *FlagSet) parseOne() (bool, error) {
 			f.usage()
 			return false, ErrHelp
 		}
-		return false, f.failf("flag provided but not defined: -%s", name)
+		return false, f.failf("The flag '-%s' is an unknown flag.", name)
 	}
 
 	if fv, ok := flag.Value.(boolFlag); ok && fv.IsBoolFlag() { // special case: doesn't need an arg

--- a/src/flag/flag_test.go
+++ b/src/flag/flag_test.go
@@ -454,7 +454,7 @@ func TestUsageOutput(t *testing.T) {
 	defer func(old []string) { os.Args = old }(os.Args)
 	os.Args = []string{"app", "-i=1", "-unknown"}
 	Parse()
-	const want = "flag provided but not defined: -i\nUsage of app:\n"
+	const want = "The flag '-i' is an unknown flag.\nUsage of app:\n"
 	if got := buf.String(); got != want {
 		t.Errorf("output = %q; want %q", got, want)
 	}


### PR DESCRIPTION
This fix tries to improve the error message from an undefined flag as discussed in issue #36364 Changing this error message unfortunately has a high impact on 3rd party tools and editors that monitor the go command stderr output for the error message that is changed here. Any tool that imports the flag package will be affected. Vscode-go plugin and likely other editors and tools will be affected.   I have also completed the matching changes neeeded for golang/tools, golang/dep, golang/gofrontend and microsoft/vscode-go. I'll link them in here after I create the corresponding PR's for them all 

https://github.com/golang/gofrontend/pull/2
https://github.com/golang/dep/pull/2238
https://github.com/golang/tools/pull/216
https://github.com/microsoft/vscode-go/pull/3113