### PR TITLE
encoding/base64: add examples for Encode/Decode, fixes #37595

### DIFF
--- a/src/encoding/base64/example_test.go
+++ b/src/encoding/base64/example_test.go
@@ -27,6 +27,15 @@ func Example() {
 	// Hello, 世界
 }
 
+func ExampleEncoding_Encode() {
+	data := []byte("hello gophers!")
+	dst := make([]byte, base64.StdEncoding.EncodedLen(len(data)))
+	base64.StdEncoding.Encode(dst, data)
+	fmt.Printf("%q\n", dst)
+	// Output:
+	// "aGVsbG8gZ29waGVycyE="
+}
+
 func ExampleEncoding_EncodeToString() {
 	data := []byte("any + old & data")
 	str := base64.StdEncoding.EncodeToString(data)

--- a/src/encoding/base64/example_test.go
+++ b/src/encoding/base64/example_test.go
@@ -35,6 +35,19 @@ func ExampleEncoding_EncodeToString() {
 	// YW55ICsgb2xkICYgZGF0YQ==
 }
 
+func ExampleEncoding_Decode() {
+	data := []byte("aGVsbG8gZ29waGVycywgeW91IGFsbCByaWdodD8K")
+	dst := make([]byte, base64.StdEncoding.DecodedLen(len(data)))
+	n, err := base64.StdEncoding.Decode(dst, data)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Printf("%q: %d\n", dst, n)
+	// Output:
+	// "hello gophers, you all right?\n": 30
+}
+
 func ExampleEncoding_DecodeString() {
 	str := "c29tZSBkYXRhIHdpdGggACBhbmQg77u/"
 	data, err := base64.StdEncoding.DecodeString(str)


### PR DESCRIPTION
Create examples for Encode and Decode methods in encoding/base64.

Fixes #37595