### PR TITLE
cmd/cover: change coverage precision to .2f

### DIFF
--- a/src/cmd/cover/func.go
+++ b/src/cmd/cover/func.go
@@ -78,12 +78,12 @@ func funcOutput(profile, outputFile string) error {
 		// Now match up functions and profile blocks.
 		for _, f := range funcs {
 			c, t := f.coverage(profile)
-			fmt.Fprintf(tabber, "%s:%d:\t%s\t%.1f%%\n", fn, f.startLine, f.name, percent(c, t))
+			fmt.Fprintf(tabber, "%s:%d:\t%s\t%.2f%%\n", fn, f.startLine, f.name, percent(c, t))
 			total += t
 			covered += c
 		}
 	}
-	fmt.Fprintf(tabber, "total:\t(statements)\t%.1f%%\n", percent(covered, total))
+	fmt.Fprintf(tabber, "total:\t(statements)\t%.2f%%\n", percent(covered, total))
 
 	return nil
 }

--- a/src/cmd/cover/html.go
+++ b/src/cmd/cover/html.go
@@ -223,7 +223,7 @@ const tmplHTML = `
 			<div id="nav">
 				<select id="files">
 				{{range $i, $f := .Files}}
-				<option value="file{{$i}}">{{$f.Name}} ({{printf "%.1f" $f.Coverage}}%)</option>
+				<option value="file{{$i}}">{{$f.Name}} ({{printf "%.2f" $f.Coverage}}%)</option>
 				{{end}}
 				</select>
 			</div>


### PR DESCRIPTION
This CL increases coverage precision to .2f in cover tool. 

Fixes #38175 