### PR TITLE
encoding/asn1: only accept minimally encoded base 128 integers

### DIFF
--- a/src/encoding/asn1/asn1.go
+++ b/src/encoding/asn1/asn1.go
@@ -283,7 +283,6 @@ func parseObjectIdentifier(bytes []byte) (s ObjectIdentifier, err error) {
 		if err != nil {
 			return
 		}
-		fmt.Println(v, offset)
 		s[i] = v
 	}
 	s = s[0:i]

--- a/src/encoding/asn1/asn1.go
+++ b/src/encoding/asn1/asn1.go
@@ -283,6 +283,7 @@ func parseObjectIdentifier(bytes []byte) (s ObjectIdentifier, err error) {
 		if err != nil {
 			return
 		}
+		fmt.Println(v, offset)
 		s[i] = v
 	}
 	s = s[0:i]
@@ -313,6 +314,12 @@ func parseBase128Int(bytes []byte, initOffset int) (ret, offset int, err error) 
 		}
 		ret64 <<= 7
 		b := bytes[offset]
+		// integers should be minimally encoded, so the leading octet should
+		// never be 0x80
+		if shifted == 0 && b == 0x80 {
+			err = SyntaxError{"integer is not minimally encoded"}
+			return
+		}
 		ret64 |= int64(b & 0x7f)
 		offset++
 		if b&0x80 == 0 {

--- a/src/encoding/asn1/asn1_test.go
+++ b/src/encoding/asn1/asn1_test.go
@@ -1129,3 +1129,15 @@ func TestBMPString(t *testing.T) {
 		}
 	}
 }
+
+func TestNonMinimalEncodedOID(t *testing.T) {
+	h, err := hex.DecodeString("060a2a80864886f70d01010b")
+	if err != nil {
+		t.Fatalf("failed to decode from hex string: %s", err)
+	}
+	var oid ObjectIdentifier
+	_, err = Unmarshal(h, &oid)
+	if err == nil {
+		t.Fatalf("accepted non-minimally encoded oid")
+	}
+}


### PR DESCRIPTION
Reject base 128 encoded integers that aren't using minimal encoding,
specifically if the leading octet of an encoded integer is 0x80. This
only affects parsing of tags and OIDs, both of which expect this
encoding (see X.690 8.1.2.4.2 and 8.19.2).

Fixes #36881