### PR TITLE
cmd/cover: add <title> tag to <head> for coverage report HTML template

### DIFF
--- a/src/cmd/cover/html.go
+++ b/src/cmd/cover/html.go
@@ -183,6 +183,7 @@ const tmplHTML = `
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+		<title>Go Coverage Report</title>
 		<style>
 			body {
 				background: black;


### PR DESCRIPTION
Adds a missing <title> tag to the HTML template to make it
more compliant as <title> tags are generally required for valid
HTML documents.