### PR TITLE
io: simplify Examples

### DIFF
--- a/src/io/example_test.go
+++ b/src/io/example_test.go
@@ -48,7 +48,7 @@ func ExampleCopyBuffer() {
 func ExampleCopyN() {
 	r := strings.NewReader("some io.Reader stream to be read")
 
-	if _, err := io.CopyN(os.Stdout, r, 5); err != nil {
+	if _, err := io.CopyN(os.Stdout, r, 4); err != nil {
 		log.Fatal(err)
 	}
 
@@ -136,24 +136,15 @@ func ExampleMultiReader() {
 }
 
 func ExampleTeeReader() {
-	r := strings.NewReader("some io.Reader stream to be read\n")
-	var buf bytes.Buffer
-	tee := io.TeeReader(r, &buf)
+	var r io.Reader = strings.NewReader("some io.Reader stream to be read\n")
 
-	printall := func(r io.Reader) {
-		b, err := ioutil.ReadAll(r)
-		if err != nil {
-			log.Fatal(err)
-		}
+	// every byte read from 'r' will also be written to 'os.Stdout' before
+	r = io.TeeReader(r, os.Stdout)
 
-		fmt.Printf("%s", b)
-	}
-
-	printall(tee)
-	printall(&buf)
+	// reading from it will also print to stdout now!
+	ioutil.ReadAll(r)
 
 	// Output:
-	// some io.Reader stream to be read
 	// some io.Reader stream to be read
 }
 
@@ -171,7 +162,7 @@ func ExampleSectionReader() {
 
 func ExampleSectionReader_ReadAt() {
 	r := strings.NewReader("some io.Reader stream to be read\n")
-	s := io.NewSectionReader(r, 5, 16)
+	s := io.NewSectionReader(r, 5, 17)
 
 	buf := make([]byte, 6)
 	if _, err := s.ReadAt(buf, 10); err != nil {
@@ -186,18 +177,15 @@ func ExampleSectionReader_ReadAt() {
 
 func ExampleSectionReader_Seek() {
 	r := strings.NewReader("some io.Reader stream to be read\n")
-	s := io.NewSectionReader(r, 5, 16)
+	s := io.NewSectionReader(r, 5, 17)
 
 	if _, err := s.Seek(10, io.SeekStart); err != nil {
 		log.Fatal(err)
 	}
 
-	buf := make([]byte, 6)
-	if _, err := s.Read(buf); err != nil {
+	if _, err := io.Copy(os.Stdout, s); err != nil {
 		log.Fatal(err)
 	}
-
-	fmt.Printf("%s\n", buf)
 
 	// Output:
 	// stream
@@ -205,11 +193,8 @@ func ExampleSectionReader_Seek() {
 
 func ExampleSeeker_Seek() {
 	r := strings.NewReader("some io.Reader stream to be read\n")
-	if _, err := io.Copy(os.Stdout, r); err != nil {
-		log.Fatal(err)
-	}
 
-	r.Seek(15, io.SeekStart)
+	r.Seek(5, io.SeekStart) // move to the 5th char from the start
 	if _, err := io.Copy(os.Stdout, r); err != nil {
 		log.Fatal(err)
 	}
@@ -220,8 +205,7 @@ func ExampleSeeker_Seek() {
 	}
 
 	// Output:
-	// some io.Reader stream to be read
-	// stream to be read
+	// io.Reader stream to be read
 	// read
 }
 
@@ -247,14 +231,15 @@ func ExamplePipe() {
 	r, w := io.Pipe()
 
 	go func() {
-		fmt.Fprint(w, "some text to be read\n")
+		// Pipe is a synchronous so we need to write in a goroutine
+		fmt.Fprint(w, "some io.Reader stream to be read\n")
 		w.Close()
 	}()
 
-	buf := new(bytes.Buffer)
-	buf.ReadFrom(r)
-	fmt.Print(buf.String())
+	if _, err := io.Copy(os.Stdout, r); err != nil {
+		log.Fatal(err)
+	}
 
 	// Output:
-	// some text to be read
+	// some io.Reader stream to be read
 }

--- a/src/io/example_test.go
+++ b/src/io/example_test.go
@@ -138,7 +138,6 @@ func ExampleMultiReader() {
 func ExampleTeeReader() {
 	var r io.Reader = strings.NewReader("some io.Reader stream to be read\n")
 
-	// every byte read from 'r' will also be written to 'os.Stdout' before
 	r = io.TeeReader(r, os.Stdout)
 
 	// reading from it will also print to stdout now!

--- a/src/io/example_test.go
+++ b/src/io/example_test.go
@@ -140,7 +140,7 @@ func ExampleTeeReader() {
 
 	r = io.TeeReader(r, os.Stdout)
 
-	// reading from it will also print to stdout now!
+	// Everything read from r will be copied to stdout.
 	ioutil.ReadAll(r)
 
 	// Output:
@@ -230,7 +230,6 @@ func ExamplePipe() {
 	r, w := io.Pipe()
 
 	go func() {
-		// Pipe is a synchronous so we need to write in a goroutine
 		fmt.Fprint(w, "some io.Reader stream to be read\n")
 		w.Close()
 	}()


### PR DESCRIPTION
- CopyN: 5 creates ambiguity with respect to whitespace and upperbound
- TeeReader less boilerplate and displays a common usage of it
- SectionReader_* all sections unified to 5:17 for clarity
- SectionReader_Seek uses io.Copy to stdout like other examples
- Seeker_Seek remove useless prints
- Pipe print reader like other examples

Updates #36417