### PR TITLE
math/big: fix typo in documentation for Int.Exp

### DIFF
--- a/src/math/big/int.go
+++ b/src/math/big/int.go
@@ -466,7 +466,7 @@ func (x *Int) TrailingZeroBits() uint {
 
 // Exp sets z = x**y mod |m| (i.e. the sign of m is ignored), and returns z.
 // If m == nil or m == 0, z = x**y unless y <= 0 then z = 1. If m > 0, y < 0,
-// and x and n are not relatively prime, z is unchanged and nil is returned.
+// and x and m are not relatively prime, z is unchanged and nil is returned.
 //
 // Modular exponentiation of inputs of a particular size is not a
 // cryptographically constant-time operation.


### PR DESCRIPTION
Fixes #38304 