### PR TITLE
container/ring: modify the Prev() function

### DIFF
--- a/src/container/ring/ring.go
+++ b/src/container/ring/ring.go
@@ -32,7 +32,7 @@ func (r *Ring) Next() *Ring {
 
 // Prev returns the previous ring element. r must not be empty.
 func (r *Ring) Prev() *Ring {
-	if r.next == nil {
+	if r.prev == nil {
 		return r.init()
 	}
 	return r.prev


### PR DESCRIPTION
func (r *Ring) Prev() *Ring {
	if r.next == nil {
		return r.init()
	}
	return r.prev
}
should be 
func (r *Ring) Prev() *Ring {
	if r.prev == nil {
		return r.init()
	}
	return r.prev
}