### PR TITLE
whence does not mean from

### DIFF
--- a/src/io/io.go
+++ b/src/io/io.go
@@ -16,7 +16,7 @@ import (
 	"errors"
 )
 
-// Seek whence values.
+// Seek from values.
 const (
 	SeekStart   = 0 // seek relative to the origin of the file
 	SeekCurrent = 1 // seek relative to the current offset


### PR DESCRIPTION
in the english dictionary, whence means "from where"
https://www.google.com/search?q=whence&oq=whence&aqs=chrome..69i57&sourceid=chrome&ie=UTF-8

the sentence "seek whence (from where) values" doesn't make much sense. normally it wouldn't matter, but in documentation where each word is worth a 1000 words, it would be helpful to have the correct form so the reader can understand the author's intent while trying to gather information to understand the code.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
