### PR TITLE
net/http: fix infinite 301 redirects of http.FileServe

### DIFF
--- a/src/net/http/fs.go
+++ b/src/net/http/fs.go
@@ -579,7 +579,7 @@ func serveFile(w ResponseWriter, r *Request, fs FileSystem, name string, redirec
 				return
 			}
 		} else {
-			if url[len(url)-1] == '/' {
+			if url[len(url)-1] == '/' && url !="/" {
 				localRedirect(w, r, "../"+path.Base(url))
 				return
 			}


### PR DESCRIPTION
This change modifies If the url is already root "/", don't cause additional redirect. Fixes:  #13996