### PR TITLE
encoding/asn1: clarify use of SET suffix

### DIFF
--- a/src/encoding/asn1/asn1.go
+++ b/src/encoding/asn1/asn1.go
@@ -1073,7 +1073,7 @@ func setDefaultValue(v reflect.Value, params fieldParameters) (ok bool) {
 // If the type of the first field of a structure is RawContent then the raw
 // ASN1 contents of the struct will be stored in it.
 //
-// If the type name of a slice type ends with "SET" then it's treated as if
+// If the name of a slice type ends with "SET" then it's treated as if
 // the "set" tag was set on it. This results in interpreting the type as a
 // SET OF x rather than a SEQUENCE OF x. This can be used with nested slices
 // where a struct tag cannot be given.

--- a/src/encoding/asn1/asn1.go
+++ b/src/encoding/asn1/asn1.go
@@ -1073,9 +1073,10 @@ func setDefaultValue(v reflect.Value, params fieldParameters) (ok bool) {
 // If the type of the first field of a structure is RawContent then the raw
 // ASN1 contents of the struct will be stored in it.
 //
-// If the type name of a slice element ends with "SET" then it's treated as if
-// the "set" tag was set on it. This can be used with nested slices where a
-// struct tag cannot be given.
+// If the type name of a slice type ends with "SET" then it's treated as if
+// the "set" tag was set on it. This results in interpreting the type as a
+// SET OF x rather than a SEQUENCE OF x. This can be used with nested slices
+// where a struct tag cannot be given.
 //
 // Other ASN.1 types are not supported; if it encounters them,
 // Unmarshal returns a parse error.


### PR DESCRIPTION
This change clarifies the usage of the SET type name suffix. Previously
the documentation was somewhat confusing about where the suffix should
be used, and when used what it applied to. For instance the previous
language could be interpreted such that []exampleSET would be parsed as
a SEQUENCE OF SET, which is incorrect as the SET suffix only applies to
slice types, such as type exampleSET []struct{} which is parsed as a
SET OF SEQUENCE.