### PR TITLE
net/http: add defer Unlock after Lock in transport_test

### DIFF
--- a/src/net/http/transport_test.go
+++ b/src/net/http/transport_test.go
@@ -3623,6 +3623,7 @@ func TestTransportDialTLS(t *testing.T) {
 	}
 	res.Body.Close()
 	mu.Lock()
+	defer mu.Unlock()
 	if !gotReq {
 		t.Error("didn't get request")
 	}
@@ -3663,6 +3664,7 @@ func TestTransportDialContext(t *testing.T) {
 	}
 	res.Body.Close()
 	mu.Lock()
+	defer mu.Unlock()
 	if !gotReq {
 		t.Error("didn't get request")
 	}
@@ -3707,6 +3709,7 @@ func TestTransportDialTLSContext(t *testing.T) {
 	}
 	res.Body.Close()
 	mu.Lock()
+	defer mu.Unlock()
 	if !gotReq {
 		t.Error("didn't get request")
 	}


### PR DESCRIPTION
In net/http/transport_test.go,
there are three places in test functions that forget Unlock before `t.Error()`.
The first one is in `TestTransportDialTLS`:
https://github.com/golang/go/blob/876c1feb7d5e10a6ff831de9db19b9ff0ea92fa8/src/net/http/transport_test.go#L3625-L3631
The second one is in `TestTransportDialContext`:
https://github.com/golang/go/blob/876c1feb7d5e10a6ff831de9db19b9ff0ea92fa8/src/net/http/transport_test.go#L3665-L3671
The third one is in `TestTransportDialTLSContext`:
https://github.com/golang/go/blob/876c1feb7d5e10a6ff831de9db19b9ff0ea92fa8/src/net/http/transport_test.go#L3709-L3715
The fix is to add `defer mu.Unlock()` after each `mu.Lock()`
