### PR TITLE
net/http: add defer Unlock after Lock in clientserver_test

### DIFF
--- a/src/net/http/clientserver_test.go
+++ b/src/net/http/clientserver_test.go
@@ -141,7 +141,8 @@ func TestNewClientServerTest(t *testing.T) {
 		}
 		cst.close()
 	}
-	got.Lock() // no need to unlock
+	got.Lock()
+	defer got.Unlock()
 	if want := []string{"HTTP/1.1", "HTTP/2.0"}; !reflect.DeepEqual(got.log, want) {
 		t.Errorf("got %q; want %q", got.log, want)
 	}


### PR DESCRIPTION
In net/http/clientserver_test.go,
There is no Unlock for `got.Lock()` in `TestNewClientServerTest`.
The fix is to add `defer got.Unlock()` after `got.Lock()` to make the code look better.