### PR TITLE
cmd/go/internal/modfetch: add Unlock before return in checkModSum

### DIFF
--- a/src/cmd/go/internal/modfetch/fetch.go
+++ b/src/cmd/go/internal/modfetch/fetch.go
@@ -514,6 +514,7 @@ func checkModSum(mod module.Version, h string) error {
 	goSum.mu.Lock()
 	inited, err := initGoSum()
 	if err != nil {
+		goSum.mu.Unlock()
 		return err
 	}
 	done := inited && haveModSumLocked(mod, h)


### PR DESCRIPTION
In cmd/go/internal/modfetch/fetch.go,
`checkModSum()` forgets Unlock before return, which may lead to deadlock.
https://github.com/golang/go/blob/876c1feb7d5e10a6ff831de9db19b9ff0ea92fa8/src/cmd/go/internal/modfetch/fetch.go#L514-L520
The fix is to add `goSum.mu.Unlock()` before return.