### PR TITLE
net/route: fixed a typo in RIBType's comment

### DIFF
--- a/src/vendor/golang.org/x/net/route/route.go
+++ b/src/vendor/golang.org/x/net/route/route.go
@@ -88,7 +88,7 @@ func (m *RouteMessage) Marshal() ([]byte, error) {
 	return m.marshal()
 }
 
-// A RIBType reprensents a type of routing information base.
+// A RIBType represents a type of routing information base.
 type RIBType int
 
 const (


### PR DESCRIPTION
Fixed a typo in `RIBType`'s comment.
