### PR TITLE
cmd/go/internal/get: add GOINSECURE support

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -2172,7 +2172,10 @@
 // before resolving dependencies or building the code.
 //
 // The -insecure flag permits fetching from repositories and resolving
-// custom domains using insecure schemes such as HTTP. Use with caution.
+// custom domains using insecure schemes such as HTTP. Use with caution. The
+// GOINSECURE environment variable is usually a better alternative, since it
+// provides control over which modules may be retrieved using an insecure scheme.
+// See 'go help environment' for details.
 //
 // The -t flag instructs get to also download the packages required to build
 // the tests for the specified packages.

--- a/src/cmd/go/internal/get/get.go
+++ b/src/cmd/go/internal/get/get.go
@@ -20,6 +20,8 @@ import (
 	"cmd/go/internal/str"
 	"cmd/go/internal/web"
 	"cmd/go/internal/work"
+
+	"golang.org/x/mod/module"
 )
 
 var CmdGet = &base.Command{
@@ -429,7 +431,7 @@ func downloadPackage(p *load.Package) error {
 		return fmt.Errorf("%s: invalid import path: %v", p.ImportPath, err)
 	}
 	security := web.SecureOnly
-	if Insecure || str.GlobsMatchPath(cfg.GOINSECURE, importPrefix) {
+	if Insecure || module.MatchPrefixPatterns(cfg.GOINSECURE, importPrefix) {
 		security = web.Insecure
 	}
 

--- a/src/cmd/go/internal/get/get.go
+++ b/src/cmd/go/internal/get/get.go
@@ -41,7 +41,10 @@ The -fix flag instructs get to run the fix tool on the downloaded packages
 before resolving dependencies or building the code.
 
 The -insecure flag permits fetching from repositories and resolving
-custom domains using insecure schemes such as HTTP. Use with caution.
+custom domains using insecure schemes such as HTTP. Use with caution. The
+GOINSECURE environment variable is usually a better alternative, since it
+provides control over which modules may be retrieved using an insecure scheme.
+See 'go help environment' for details.
 
 The -t flag instructs get to also download the packages required to build
 the tests for the specified packages.
@@ -409,11 +412,6 @@ func downloadPackage(p *load.Package) error {
 		blindRepo      bool // set if the repo has unusual configuration
 	)
 
-	security := web.SecureOnly
-	if Insecure {
-		security = web.Insecure
-	}
-
 	// p can be either a real package, or a pseudo-package whose “import path” is
 	// actually a wildcard pattern.
 	// Trim the path at the element containing the first wildcard,
@@ -429,6 +427,10 @@ func downloadPackage(p *load.Package) error {
 	}
 	if err := CheckImportPath(importPrefix); err != nil {
 		return fmt.Errorf("%s: invalid import path: %v", p.ImportPath, err)
+	}
+	security := web.SecureOnly
+	if Insecure || str.GlobsMatchPath(cfg.GOINSECURE, importPrefix) {
+		security = web.Insecure
 	}
 
 	if p.Internal.Build.SrcRoot != "" {
@@ -473,7 +475,7 @@ func downloadPackage(p *load.Package) error {
 		}
 		vcs, repo, rootPath = rr.vcs, rr.Repo, rr.Root
 	}
-	if !blindRepo && !vcs.isSecure(repo) && !Insecure {
+	if !blindRepo && !vcs.isSecure(repo) && security == web.SecureOnly {
 		return fmt.Errorf("cannot download, %v uses insecure protocol", repo)
 	}
 

--- a/src/cmd/go/internal/get/get.go
+++ b/src/cmd/go/internal/get/get.go
@@ -475,7 +475,7 @@ func downloadPackage(p *load.Package) error {
 		}
 		vcs, repo, rootPath = rr.vcs, rr.Repo, rr.Root
 	}
-	if !blindRepo && !vcs.isSecure(repo) && security == web.SecureOnly {
+	if !blindRepo && !vcs.isSecure(repo) && security != web.Insecure {
 		return fmt.Errorf("cannot download, %v uses insecure protocol", repo)
 	}
 

--- a/src/cmd/go/testdata/script/get_insecure_env.txt
+++ b/src/cmd/go/testdata/script/get_insecure_env.txt
@@ -20,7 +20,7 @@ env GOINSECURE=
 ! go get -d -u -f insecure.go-get-issue-15410.appspot.com/pkg/p
 
 # GOPATH: Try updating with GOINSECURE glob (should succeed).
-env GOINSECURE=insecure.go-get-*
+env GOINSECURE=*.go-get-*.appspot.com
 go get -d -u -f insecure.go-get-issue-15410.appspot.com/pkg/p
 
 # GOPATH: Try updating with GOINSECURE base URL (should succeed).

--- a/src/cmd/go/testdata/script/get_insecure_env.txt
+++ b/src/cmd/go/testdata/script/get_insecure_env.txt
@@ -1,0 +1,29 @@
+[!net] skip
+[!exec:git] skip
+
+# GOPATH: Set up
+env GO111MODULE=off
+
+# GOPATH: Try go get -d of HTTP-only repo (should fail).
+! go get -d insecure.go-get-issue-15410.appspot.com/pkg/p
+
+# GOPATH: Try again with invalid GOINSECURE (should fail).
+env GOINSECURE=insecure.go-get-issue-15410.appspot.com/pkg/q
+! go get -d insecure.go-get-issue-15410.appspot.com/pkg/p
+
+# GOPATH: Try with correct GOINSECURE (should succeed).
+env GOINSECURE=insecure.go-get-issue-15410.appspot.com/pkg/p
+go get -d insecure.go-get-issue-15410.appspot.com/pkg/p
+
+# GOPATH: Try updating without GOINSECURE (should fail).
+env GOINSECURE=
+! go get -d -u -f insecure.go-get-issue-15410.appspot.com/pkg/p
+
+# GOPATH: Try updating with GOINSECURE glob (should succeed).
+env GOINSECURE=insecure.go-get-*
+go get -d -u -f insecure.go-get-issue-15410.appspot.com/pkg/p
+
+# GOPATH: Try updating with GOINSECURE base URL (should succeed).
+env GOINSECURE=insecure.go-get-issue-15410.appspot.com
+go get -d -u -f insecure.go-get-issue-15410.appspot.com/pkg/p
+


### PR DESCRIPTION
Adds support for the GOINSECURE environment variable to GOPATH mode.

Updates #37519.