### PR TITLE
cmd/go/internal/cache: fix typing error in errVerifyMode

### DIFF
--- a/src/cmd/go/internal/cache/cache.go
+++ b/src/cmd/go/internal/cache/cache.go
@@ -108,7 +108,7 @@ const (
 // GODEBUG=gocacheverify=1.
 var verify = false
 
-var errVerifyMode = errors.New("gocachverify=1")
+var errVerifyMode = errors.New("gocacheverify=1")
 
 // DebugTest is set when GODEBUG=gocachetest=1 is in the environment.
 var DebugTest = false


### PR DESCRIPTION
This change fixes the typing mistake in errVerifyMode error message in cache.