### PR TITLE
math/cmplx: fix typo in code comment

### DIFF
--- a/src/math/cmplx/sqrt.go
+++ b/src/math/cmplx/sqrt.go
@@ -40,7 +40,7 @@ import "math"
 //                       1/2
 // Im w  =  [ (r - x)/2 ]   .
 //
-// Cancelation error in r-x or r+x is avoided by using the
+// Cancellation error in r-x or r+x is avoided by using the
 // identity  2 Re w Im w  =  y.
 //
 // Note that -w is also a square root of z. The root chosen


### PR DESCRIPTION
Everywhere else is using "cancellation" as of 2019

The reasoning is mentioned in 170060.

> Though there is variation in the spelling of canceled,
> cancellation is always spelled with a double l.
>
> Reference: https://www.grammarly.com/blog/canceled-vs-cancelled/
