### PR TITLE
net/http/httputil: fix typo in unit test name

### DIFF
--- a/src/net/http/httputil/reverseproxy_test.go
+++ b/src/net/http/httputil/reverseproxy_test.go
@@ -386,7 +386,7 @@ func TestReverseProxyFlushIntervalHeaders(t *testing.T) {
 	}
 }
 
-func TestReverseProxyCancelation(t *testing.T) {
+func TestReverseProxyCancellation(t *testing.T) {
 	const backendResponse = "I am the backend"
 
 	reqInFlight := make(chan struct{})


### PR DESCRIPTION
Everywhere else is using "cancellation"

The reasoning is mentioned in 170060

> Though there is variation in the spelling of canceled,
> cancellation is always spelled with a double l.
>
> Reference: https://www.grammarly.com/blog/canceled-vs-cancelled/
