### PR TITLE
cmd/go/internal/get: expose error when git ls-remote failed

### DIFF
--- a/src/cmd/go/internal/modfetch/codehost/git.go
+++ b/src/cmd/go/internal/modfetch/codehost/git.go
@@ -296,6 +296,10 @@ func (r *gitRepo) stat(rev string) (*RevInfo, error) {
 	// Or maybe it's the prefix of a hash of a named ref.
 	// Try to resolve to both a ref (git name) and full (40-hex-digit) commit hash.
 	r.refsOnce.Do(r.loadRefs)
+	if r.refsErr != nil {
+		return nil, r.refsErr
+	}
+
 	var ref, hash string
 	if r.refs["refs/tags/"+rev] != "" {
 		ref = "refs/tags/" + rev


### PR DESCRIPTION
When I use Git 1.7.1, I execute go get failed, because load refs failed

https://github.com/golang/go/blob/1c4e9b2edaa741860944edef83b7ce8eac00079e/src/cmd/go/internal/modfetch/codehost/git.go#L178


```
> go get k8s.io/kubernetes
go: k8s.io/kubernetes upgrade => v1.18.2
go get: k8s.io/kubernetes@v1.18.2 requires
	k8s.io/api@v0.0.0: reading k8s.io/api/go.mod at revision v0.0.0: unknown revision v0.0.0
```

But I don't understand why I got `unknown revision`, so add a simple check after `loadRefs`.