### PR TITLE
database/sql: fix incorrect function name in example_test

### DIFF
--- a/src/database/sql/example_test.go
+++ b/src/database/sql/example_test.go
@@ -220,7 +220,7 @@ func ExampleTx_Prepare() {
 	}
 }
 
-func ExampleConn_BeginTx() {
+func ExampleDB_BeginTx() {
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
fixes incorrect function name prefix in `example_test.go`