### PR TITLE
runtime/race: fix comment in select_test.TestNoRaceSelect1

### DIFF
--- a/src/runtime/race/testdata/select_test.go
+++ b/src/runtime/race/testdata/select_test.go
@@ -20,7 +20,7 @@ func TestNoRaceSelect1(t *testing.T) {
 		x = 1
 		// At least two channels are needed because
 		// otherwise the compiler optimizes select out.
-		// See comment in runtime/select.go:^func selectgoImpl.
+		// See comment in runtime/select.go:^func selectgo.
 		select {
 		case c <- true:
 		case c1 <- true:


### PR DESCRIPTION
selectGoImpl was merged into selectGo in https://golang.org/cl/37860.
