### PR TITLE
net/http:Fix 308 jump and lose authorization header

### DIFF
--- a/src/net/http/client.go
+++ b/src/net/http/client.go
@@ -989,6 +989,16 @@ func shouldCopyHeaderOnRedirect(headerKey string, initial, dest *url.URL) bool {
 //
 // Both domains must already be in canonical form.
 func isDomainOrSubdomain(sub, parent string) bool {
+	// domain.com:443 --> domain.com
+	if pos := strings.LastIndex(sub, ":"); pos != -1 {
+		sub = sub[:pos]
+	}
+
+	// domain.com:80 --> domain.com
+	if pos := strings.LastIndex(parent, ":"); pos != -1 {
+		parent = parent[:pos]
+	}
+
 	if sub == parent {
 		return true
 	}


### PR DESCRIPTION
I found that if the HTTP request is sent, the server returns a 308 jump, and the value of the Authorization header is lost.
The following is a simplified code for the actual situation.

```go
package main

import (
	"fmt"
	"io"
	"net/http"
	"os"
	"time"

	"github.com/gin-gonic/gin"
)

// Port 443 service for the same domain name
func mockServer443Port() {
	r := gin.New()
	r.GET("/test", func(c *gin.Context) {
		fmt.Printf("443--------->authorization:(%s)\n", c.Request.Header.Get("Authorization"))
//=================== got:
//output:
//443--------->authorization:()
//==================need:
//output:
//443--------->authorization:(***value***)
	})

	r.Run(":443")
}

// Port 80 service for the same domain name
func mockServer80Port() {
	r := gin.New()
	r.GET("/test", func(c *gin.Context) {
		fmt.Printf("80--------->authorization:(%s)\n", c.Request.Header.Get("Authorization"))
		c.Redirect(308, "http://127.0.0.1:443/test")
//output:
//80--------->authorization:(***value***)
	})

	r.Run(":80")
}

func main() {

	go mockServer443Port()
	go mockServer80Port()
	time.Sleep(time.Second * 1)

	httpURL := "http://127.0.0.1:80/test"
	req, err := http.NewRequest("GET", httpURL, nil)
	if err != nil {
		panic(err.Error())
	}

	req.Header.Add("Authorization", "***value***")

	resp, err := http.DefaultClient.Do(req)
	if err != nil {
		panic(err.Error())
	}

	defer resp.Body.Close()
	io.Copy(os.Stdout, resp.Body)

}

```