### PR TITLE
crypto/tls: add r.Lock to protect r.flows in WriteTo

### DIFF
--- a/src/crypto/tls/handshake_test.go
+++ b/src/crypto/tls/handshake_test.go
@@ -148,6 +148,10 @@ func (r *recordingConn) WriteTo(w io.Writer) (int64, error) {
 	// TLS always starts with a client to server flow.
 	clientToServer := true
 	var written int64
+
+	r.Lock()
+	defer r.Unlock()
+
 	for i, flow := range r.flows {
 		source, dest := "client", "server"
 		if !clientToServer {


### PR DESCRIPTION
In src/crypto/tls/handshake_test.go,
`r.flows` is not protected by `r.Lock()` in func `WriteTo()`. 
For all the other six places, it is protected by `r.Lock()`.
The callers of `WriteTo()` do not protect it with `r.Lock()` either.
This may cause data race.

The patch adds `r.Lock()` to protect `r.flows` in `WriteTo()`.