### PR TITLE
cmd: fail go mod vendor on case-insensitive import collisions

### DIFF
--- a/src/cmd/go/internal/modcmd/vendor.go
+++ b/src/cmd/go/internal/modcmd/vendor.go
@@ -65,7 +65,7 @@ func runVendor(ctx context.Context, cmd *base.Command, args []string) {
 	}
 	_, pkgs := modload.LoadPackages(ctx, loadOpts, "all")
 
-	checkCaseInsensitivePathsDuplications(modload.LoadBuildList())
+	checkCaseInsensitivePathsDuplications(modload.LoadedModules())
 
 	vdir := filepath.Join(modload.ModRoot(), "vendor")
 	if err := os.RemoveAll(vdir); err != nil {

--- a/src/cmd/go/internal/str/str.go
+++ b/src/cmd/go/internal/str/str.go
@@ -30,7 +30,7 @@ func StringList(args ...interface{}) []string {
 }
 
 // ToFold returns a string with the property that
-//	strings.EqualFold(s, t) iff ToFold(s) == ToFold(t)
+// strings.EqualFold(s, t) if ToFold(s) == ToFold(t)
 // This lets us test a large set of strings for fold-equivalent
 // duplicates without making a quadratic number of calls
 // to EqualFold. Note that strings.ToUpper and strings.ToLower

--- a/src/cmd/go/testdata/script/mod_vendor_case_insensitive.txt
+++ b/src/cmd/go/testdata/script/mod_vendor_case_insensitive.txt
@@ -1,0 +1,33 @@
+# Tests issue #38571
+# Tests that go mod vendor fails on case-insensitive import collision.
+
+env GO111MODULE=on
+
+! go mod vendor
+stderr 'case-insensitive module path collision'
+
+-- go.mod --
+module m
+
+go 1.14
+
+require (
+	example.com/foo v0.1.0
+	example.com/Foo v0.1.0
+)
+
+replace (
+	example.com/foo => ./foo
+	example.com/Foo => ./!foo
+)
+-- foo/go.mod --
+module example.com/foo
+
+-- foo/foo.go --
+package foo
+
+-- !foo/go.mod --
+module example.com/Foo
+
+-- !foo/foo.go --
+package Foo


### PR DESCRIPTION
The existing implementation of go mod vendor allows having
case-insensitive imports, which will anyway fail during go build.
This improvement validates such collisions during any mod pkg
loads ('tidy', 'why', 'vendor').

Fixes #38571