### PR TITLE
context: remove redundant parent context check

### DIFF
--- a/src/context/context.go
+++ b/src/context/context.go
@@ -263,15 +263,10 @@ func propagateCancel(parent Context, child canceler) {
 
 	if p, ok := parentCancelCtx(parent); ok {
 		p.mu.Lock()
-		if p.err != nil {
-			// parent has already been canceled
-			child.cancel(false, p.err)
-		} else {
-			if p.children == nil {
-				p.children = make(map[canceler]struct{})
-			}
-			p.children[child] = struct{}{}
+		if p.children == nil {
+			p.children = make(map[canceler]struct{})
 		}
+		p.children[child] = struct{}{}
 		p.mu.Unlock()
 	} else {
 		atomic.AddInt32(&goroutines, +1)


### PR DESCRIPTION
We already checked whether parent context has been canceled.