### PR TITLE
image/gif: treat NUL byte between sections or before trailer as trailer

### DIFF
--- a/src/image/gif/reader.go
+++ b/src/image/gif/reader.go
@@ -53,6 +53,7 @@ const (
 	sExtension       = 0x21
 	sImageDescriptor = 0x2C
 	sTrailer         = 0x3B
+	sEmpty           = 0x00
 )
 
 // Extensions.
@@ -255,6 +256,9 @@ func (d *decoder) decode(r io.Reader, configOnly, keepAllFrames bool) error {
 				return fmt.Errorf("gif: missing image data")
 			}
 			return nil
+
+		case sEmpty:
+			// Empty bytes are ignored between blocks or before the trailer
 
 		default:
 			return fmt.Errorf("gif: unknown block type: 0x%.2x", c)

--- a/src/image/gif/reader.go
+++ b/src/image/gif/reader.go
@@ -53,7 +53,7 @@ const (
 	sExtension       = 0x21
 	sImageDescriptor = 0x2C
 	sTrailer         = 0x3B
-	sEmpty           = 0x00
+	sNul             = 0x00
 )
 
 // Extensions.
@@ -251,14 +251,16 @@ func (d *decoder) decode(r io.Reader, configOnly, keepAllFrames bool) error {
 				return err
 			}
 
+		case sNul:
+			// This is off spec but we handle a NUL byte here as if it were
+			// a trailer byte like Chromium and Mozilla.
+			fallthrough
+
 		case sTrailer:
 			if len(d.image) == 0 {
 				return fmt.Errorf("gif: missing image data")
 			}
 			return nil
-
-		case sEmpty:
-			// Empty bytes are ignored between blocks or before the trailer
 
 		default:
 			return fmt.Errorf("gif: unknown block type: 0x%.2x", c)

--- a/src/image/gif/reader_test.go
+++ b/src/image/gif/reader_test.go
@@ -423,6 +423,29 @@ func TestDecodeMemoryConsumption(t *testing.T) {
 	}
 }
 
+func TestTrailingByte(t *testing.T) {
+
+	extra := []byte{
+		0x00, // extraneous empty byte
+		0x3b, // trailer
+	}
+
+	// Remove the trailer byte so we can append new data
+	testGIFLen := len(testGIF) - 1
+
+	// Make a copy of the GIF
+	gif := make([]byte, testGIFLen+len(extra))
+	copy(gif, testGIF)
+
+	// Add trailing extra bytes
+	for i:=0; i<len(extra); i++ {
+		gif[testGIFLen+i] = extra[i]
+	}
+
+	try(t, gif, "")
+}
+
+
 func BenchmarkDecode(b *testing.B) {
 	data, err := ioutil.ReadFile("../testdata/video-001.gif")
 	if err != nil {


### PR DESCRIPTION
Some real-world GIF files have extraneous `0x00` bytes between sections and before the trailer.  This PR treats a NUL (`0x00`) byte between sections or before a trailer byte as a trailer byte.

Previously, both of these cases would result in the error `gif: unknown block type: 0x00`. After this change, `image/gif` will stop decoding the image in both of these cases and successfully return the frames that were decoded.  This is treated exactly the same as encountering a trailer byte, so if no frames have been decoded yet an error will be returned.

This behavior tracks Chromium and Mozilla/Firefox.

Fixes #38853.