### PR TITLE
crypto/rand: use BCryptGenRandom instead of CryptGenRandom on Windows

### DIFF
--- a/src/crypto/rand/rand.go
+++ b/src/crypto/rand/rand.go
@@ -14,7 +14,7 @@ import "io"
 // On Linux and FreeBSD, Reader uses getrandom(2) if available, /dev/urandom otherwise.
 // On OpenBSD, Reader uses getentropy(2).
 // On other Unix-like systems, Reader reads from /dev/urandom.
-// On Windows systems, Reader uses the CryptGenRandom API.
+// On Windows systems, Reader uses the BCryptGenRandom API with provider BCRYPT_RNG_ALGORITHM.
 // On Wasm, Reader uses the Web Crypto API.
 var Reader io.Reader
 

--- a/src/internal/syscall/windows/syscall_windows.go
+++ b/src/internal/syscall/windows/syscall_windows.go
@@ -145,6 +145,13 @@ const (
 //sys	GetComputerNameEx(nameformat uint32, buf *uint16, n *uint32) (err error) = GetComputerNameExW
 //sys	MoveFileEx(from *uint16, to *uint16, flags uint32) (err error) = MoveFileExW
 //sys	GetModuleFileName(module syscall.Handle, fn *uint16, len uint32) (n uint32, err error) = kernel32.GetModuleFileNameW
+//sys	BCryptOpenAlgorithmProvider(algHandle *syscall.Handle, algID *uint16, impl *uint16, flags uint32) (status int32) = bcrypt.BCryptOpenAlgorithmProvider
+//sys	BCryptGenRandom(algHandle syscall.Handle, buf *byte, buflen uint32, flags uint32) (status int32) = bcrypt.BCryptGenRandom
+
+const (
+	// bcrypt.h
+	BCRYPT_RNG_ALGORITHM = "RNG"
+)
 
 const (
 	WSA_FLAG_OVERLAPPED        = 0x01

--- a/src/internal/syscall/windows/zsyscall_windows.go
+++ b/src/internal/syscall/windows/zsyscall_windows.go
@@ -38,6 +38,7 @@ func errnoErr(e syscall.Errno) error {
 var (
 	modiphlpapi = syscall.NewLazyDLL(sysdll.Add("iphlpapi.dll"))
 	modkernel32 = syscall.NewLazyDLL(sysdll.Add("kernel32.dll"))
+	modbcrypt   = syscall.NewLazyDLL(sysdll.Add("bcrypt.dll"))
 	modws2_32   = syscall.NewLazyDLL(sysdll.Add("ws2_32.dll"))
 	modnetapi32 = syscall.NewLazyDLL(sysdll.Add("netapi32.dll"))
 	modadvapi32 = syscall.NewLazyDLL(sysdll.Add("advapi32.dll"))
@@ -48,6 +49,8 @@ var (
 	procGetComputerNameExW           = modkernel32.NewProc("GetComputerNameExW")
 	procMoveFileExW                  = modkernel32.NewProc("MoveFileExW")
 	procGetModuleFileNameW           = modkernel32.NewProc("GetModuleFileNameW")
+	procBCryptOpenAlgorithmProvider  = modbcrypt.NewProc("BCryptOpenAlgorithmProvider")
+	procBCryptGenRandom              = modbcrypt.NewProc("BCryptGenRandom")
 	procWSASocketW                   = modws2_32.NewProc("WSASocketW")
 	procLockFileEx                   = modkernel32.NewProc("LockFileEx")
 	procUnlockFileEx                 = modkernel32.NewProc("UnlockFileEx")
@@ -115,6 +118,18 @@ func GetModuleFileName(module syscall.Handle, fn *uint16, len uint32) (n uint32,
 			err = syscall.EINVAL
 		}
 	}
+	return
+}
+
+func BCryptOpenAlgorithmProvider(algHandle *syscall.Handle, algID *uint16, impl *uint16, flags uint32) (status int32) {
+	r0, _, _ := syscall.Syscall6(procBCryptOpenAlgorithmProvider.Addr(), 4, uintptr(unsafe.Pointer(algHandle)), uintptr(unsafe.Pointer(algID)), uintptr(unsafe.Pointer(impl)), uintptr(flags), 0, 0)
+	status = int32(r0)
+	return
+}
+
+func BCryptGenRandom(algHandle syscall.Handle, buf *byte, buflen uint32, flags uint32) (status int32) {
+	r0, _, _ := syscall.Syscall6(procBCryptGenRandom.Addr(), 4, uintptr(algHandle), uintptr(unsafe.Pointer(buf)), uintptr(buflen), uintptr(flags), 0, 0)
+	status = int32(r0)
 	return
 }
 


### PR DESCRIPTION
The existing function that is used is CryptGenRandom. This function
and the whole underling API is deprecated.

Use the function BCryptGenRandom from the new recommended
API called "Cryptography API: Next Generation (CNG)".

Fixes #33542
