### PR TITLE
os/exec: escape percent literal for Windows PATH

### DIFF
--- a/src/os/exec/lp_windows.go
+++ b/src/os/exec/lp_windows.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ErrNotFound is the error resulting if a path search failed to find an executable file.
-var ErrNotFound = errors.New("executable file not found in %PATH%")
+var ErrNotFound = errors.New("executable file not found in %%PATH%%")
 
 func chkStat(file string) error {
 	d, err := os.Stat(file)


### PR DESCRIPTION
Fix #38994
