### PR TITLE
net/http: remove redundant numeric StatusCode from Status message

### DIFF
--- a/src/net/http/response.go
+++ b/src/net/http/response.go
@@ -174,6 +174,7 @@ func ReadResponse(r *bufio.Reader, req *Request) (*Response, error) {
 	statusCode := resp.Status
 	if i := strings.IndexByte(resp.Status, ' '); i != -1 {
 		statusCode = resp.Status[:i]
+		resp.Status = resp.Status[i:]
 	}
 	if len(statusCode) != 3 {
 		return nil, badStringError("malformed HTTP status code", statusCode)


### PR DESCRIPTION
In the case of parsing HTTP status with a message, eg: `HTTP/1.1 200 OK`,  `StatusCode` is correctly set to `200` but `Status` is parsed to `200 OK` when it should only be `OK`. This leads to inconsistency with `http.StatusText` which only returns `OK` instead of `200 OK`.

In the case `Status` includes a space, it includes a numeric status code we can trim out the numeral and move it to `StatusCode`

Fixes #38996 
