### PR TITLE
container/list: check the list state before mutation

### DIFF
--- a/src/container/list/list_test.go
+++ b/src/container/list/list_test.go
@@ -341,3 +341,20 @@ func TestMoveUnknownMark(t *testing.T) {
 	checkList(t, &l1, []interface{}{1})
 	checkList(t, &l2, []interface{}{2})
 }
+
+// Test that a list l is not modified when calling Remove after list was reset to zero value.
+func TestRemoveAfterReset(t *testing.T) {
+	var l List
+	el1 := l.PushBack(1)
+
+	l = List{}
+
+	l.Remove(el1)
+	checkListPointers(t, &l, []*Element{})
+
+	el2 := l.PushBack(2)
+	checkListPointers(t, &l, []*Element{el2})
+
+	l.Remove(el1)
+	checkListPointers(t, &l, []*Element{el2})
+}


### PR DESCRIPTION
It is not enough to check if the Element's list pointer is equal to some
particular List pointer to answer whether an Element belongs to that List.
List might be zeroed and then mutated, which makes it completely different,
so that previous elements must not be connected with the new generation of
the list.

Fixes #39014
