### PR TITLE
net/http: prevent incorrect redirections when the path contains %2F%2F

### DIFF
--- a/src/net/http/serve_test.go
+++ b/src/net/http/serve_test.go
@@ -553,6 +553,7 @@ func TestServeWithSlashRedirectForHostPatterns(t *testing.T) {
 	mux.Handle("example.com:3000/pkg/connect/", stringHandler("example.com:3000/pkg/connect/"))
 	mux.Handle("example.com:9000/", stringHandler("example.com:9000/"))
 	mux.Handle("/pkg/baz/", stringHandler("/pkg/baz/"))
+	mux.Handle("example.com/r/", stringHandler("example.com/r/https%3A%2F%2Fgoogle.com"))
 
 	tests := []struct {
 		method string
@@ -562,11 +563,13 @@ func TestServeWithSlashRedirectForHostPatterns(t *testing.T) {
 		want   string
 	}{
 		{"GET", "http://example.com/", 404, "", ""},
+		{"GET", "http://example.com//", 301, "http://example.com/", ""},
 		{"GET", "http://example.com/pkg/foo", 301, "/pkg/foo/", ""},
 		{"GET", "http://example.com/pkg/bar", 200, "", "example.com/pkg/bar"},
 		{"GET", "http://example.com/pkg/bar/", 200, "", "example.com/pkg/bar/"},
 		{"GET", "http://example.com/pkg/baz", 301, "/pkg/baz/", ""},
 		{"GET", "http://example.com:3000/pkg/foo", 301, "/pkg/foo/", ""},
+		{"GET", "http://example.com/r/https%3A%2F%2Fgoogle.com", 200, "", "example.com/r/https%3A%2F%2Fgoogle.com"},
 		{"CONNECT", "http://example.com/", 404, "", ""},
 		{"CONNECT", "http://example.com:3000/", 404, "", ""},
 		{"CONNECT", "http://example.com:9000/", 200, "", "example.com:9000/"},

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -2334,10 +2334,15 @@ func (mux *ServeMux) Handler(r *Request) (h Handler, pattern string) {
 		return mux.handler(r.Host, r.URL.Path)
 	}
 
+	rawPath := r.URL.RawPath
+	if rawPath == "" {
+		rawPath = r.URL.Path
+	}
+
 	// All other requests have any port stripped and path cleaned
 	// before passing to mux.handler.
 	host := stripHostPort(r.Host)
-	path := cleanPath(r.URL.Path)
+	path := cleanPath(rawPath)
 
 	// If the given path is /tree and its handler is not registered,
 	// redirect for /tree/.
@@ -2345,7 +2350,7 @@ func (mux *ServeMux) Handler(r *Request) (h Handler, pattern string) {
 		return RedirectHandler(u.String(), StatusMovedPermanently), u.Path
 	}
 
-	if path != r.URL.Path {
+	if path != rawPath {
 		_, pattern = mux.handler(host, path)
 		url := *r.URL
 		url.Path = path


### PR DESCRIPTION
The current implementation of ServeMux incorrectly returns a 301 status
code when the path contains URL-encoded data, and especially URL-encoded
URLs.

Fixes #21955

Before this change, an URL such as "/r/https%3A%2F%2Fgoogle.com" where always triggering a 301, which is a bug preventing to pass escaped URLs as path parameters (common for redirection services for instance).

Unlike the patch proposed (and never merged) in #21955, this implementation relies on URL.RawPath which looks designed for this kind of use case, and is less intrusive.
