### PR TITLE
cmd/go: delay os/arch pair check for better error message

### DIFF
--- a/src/cmd/go/internal/work/action.go
+++ b/src/cmd/go/internal/work/action.go
@@ -290,12 +290,6 @@ func (b *Builder) Init() {
 		}
 	}
 
-	if err := CheckGOOSARCHPair(cfg.Goos, cfg.Goarch); err != nil {
-		fmt.Fprintf(os.Stderr, "cmd/go: %v\n", err)
-		base.SetExitStatus(2)
-		base.Exit()
-	}
-
 	for _, tag := range cfg.BuildContext.BuildTags {
 		if strings.Contains(tag, ",") {
 			fmt.Fprintf(os.Stderr, "cmd/go: -tags space-separated list contains comma\n")
@@ -303,13 +297,6 @@ func (b *Builder) Init() {
 			base.Exit()
 		}
 	}
-}
-
-func CheckGOOSARCHPair(goos, goarch string) error {
-	if _, ok := cfg.OSArchSupportsCgo[goos+"/"+goarch]; !ok && cfg.BuildContext.Compiler == "gc" {
-		return fmt.Errorf("unsupported GOOS/GOARCH pair %s/%s", goos, goarch)
-	}
-	return nil
 }
 
 // NewObjdir returns the name of a fresh object directory under b.WorkDir.

--- a/src/cmd/go/internal/work/init.go
+++ b/src/cmd/go/internal/work/init.go
@@ -25,6 +25,12 @@ func BuildInit() {
 	instrumentInit()
 	buildModeInit()
 
+	if err := CheckGOOSARCHPair(cfg.Goos, cfg.Goarch); err != nil {
+		fmt.Fprintf(os.Stderr, "cmd/go: %v\n", err)
+		base.SetExitStatus(2)
+		base.Exit()
+	}
+
 	// Make sure -pkgdir is absolute, because we run commands
 	// in different directories.
 	if cfg.BuildPkgdir != "" && !filepath.IsAbs(cfg.BuildPkgdir) {
@@ -284,4 +290,11 @@ func inGOFLAGS(flag string) bool {
 		}
 	}
 	return false
+}
+
+func CheckGOOSARCHPair(goos, goarch string) error {
+	if _, ok := cfg.OSArchSupportsCgo[goos+"/"+goarch]; !ok && cfg.BuildContext.Compiler == "gc" {
+		return fmt.Errorf("unsupported GOOS/GOARCH pair %s/%s", goos, goarch)
+	}
+	return nil
 }

--- a/src/cmd/go/testdata/script/build_issue24398.txt
+++ b/src/cmd/go/testdata/script/build_issue24398.txt
@@ -1,0 +1,11 @@
+env GOARCH=xtensa
+env GOOS=linux
+! go build -compiler=gccgo issue24398/main.go
+stderr 'executable file not found in'
+
+
+-- issue24398/main.go --
+package main
+
+func main() {
+}

--- a/src/cmd/go/testdata/script/build_issue24398.txt
+++ b/src/cmd/go/testdata/script/build_issue24398.txt
@@ -1,3 +1,6 @@
+# "GOARCH=xtensa GOOS=darwin go build -compiler=gccgo" should build successful because gccgo support this GOARCH/GOOS pair although gc does not. But in the previous version of go command, we checked the GOARCH/GOOS pair before parse and set the compiler from flags, and lead to misleading error message to users.
+
+[gccgo] skip
 env GOARCH=xtensa
 env GOOS=linux
 ! go build -compiler=gccgo issue24398/main.go


### PR DESCRIPTION
Check GOOS/GOARCH pair after compiler binary exists check.

Fixes #24398 