### PR TITLE
container/list: Add elementPool for alloc new element

### DIFF
--- a/src/container/list/list.go
+++ b/src/container/list/list.go
@@ -11,6 +11,10 @@
 //
 package list
 
+import(
+	"sync"
+)
+
 // Element is an element of a linked list.
 type Element struct {
 	// Next and previous pointers in the doubly-linked list of elements.
@@ -41,6 +45,12 @@ func (e *Element) Prev() *Element {
 		return p
 	}
 	return nil
+}
+
+var elementPool = sync.Pool{
+	New: func() interface{} {
+		return new(Element)
+	},
 }
 
 // List represents a doubly linked list.
@@ -101,7 +111,9 @@ func (l *List) insert(e, at *Element) *Element {
 
 // insertValue is a convenience wrapper for insert(&Element{Value: v}, at).
 func (l *List) insertValue(v interface{}, at *Element) *Element {
-	return l.insert(&Element{Value: v}, at)
+	e := elementPool.Get().(*Element)
+	e.Value = v
+	return l.insert(e, at)
 }
 
 // remove removes e from its list, decrements l.len, and returns e.
@@ -112,6 +124,7 @@ func (l *List) remove(e *Element) *Element {
 	e.prev = nil // avoid memory leaks
 	e.list = nil
 	l.len--
+	elementPool.Put(e)
 	return e
 }
 

--- a/src/container/list/list_test.go
+++ b/src/container/list/list_test.go
@@ -341,3 +341,12 @@ func TestMoveUnknownMark(t *testing.T) {
 	checkList(t, &l1, []interface{}{1})
 	checkList(t, &l2, []interface{}{2})
 }
+
+func BenchmarkPool(b *testing.B) {
+	b.ReportAllocs()
+	l := New()
+	for i := 0; i < b.N; i++ {
+		e := l.PushBack(i)
+		l.Remove(e)
+	}
+}


### PR DESCRIPTION
Use sync.Pool to buffer element to reduce alloc, Comparison as below:

BenchmarkNoPool-4   	16685536	        73.8 ns/op	      56 B/op	       2 allocs/op
BenchmarkPool-4   	18580586	        55.3 ns/op	       8 B/op	       1 allocs/op

No changes to the API or documented semantics.