### PR TITLE
cmd/link/internal/ld/lib.go: use lld on Android

### DIFF
--- a/src/cmd/link/internal/ld/lib.go
+++ b/src/cmd/link/internal/ld/lib.go
@@ -1478,6 +1478,11 @@ func (ctxt *Link) hostlink() {
 		// from the beginning of the section (like sym.STYPE).
 		argv = append(argv, "-Wl,-znocopyreloc")
 
+		if objabi.GOOS == "android" {
+			// Use lld to avoid errors from default linker (issue #38838)
+			altLinker = "lld"
+		}
+
 		if ctxt.Arch.InFamily(sys.ARM, sys.ARM64) && objabi.GOOS == "linux" {
 			// On ARM, the GNU linker will generate COPY relocations
 			// even with -znocopyreloc set.


### PR DESCRIPTION
Set linker explicitly to lld because the default does not work on NDK 
versions r19c, r20, r20b and r21. NDK 18b (or earlier) based builds 
will need to specify -fuse-ld=gold.

Fixes #38838