### PR TITLE
docs: Add missing import in tutorial

### DIFF
--- a/doc/articles/wiki/index.html
+++ b/doc/articles/wiki/index.html
@@ -257,6 +257,7 @@ To use the <code>net/http</code> package, it must be imported:
 import (
 	"fmt"
 	"io/ioutil"
+	<b>"log"</b>
 	<b>"net/http"</b>
 )
 </pre>

--- a/doc/articles/wiki/index.html
+++ b/doc/articles/wiki/index.html
@@ -373,6 +373,7 @@ also won't be using <code>fmt</code> anymore, so we have to remove that.
 import (
 	<b>"html/template"</b>
 	"io/ioutil"
+	"log"
 	"net/http"
 )
 </pre>
@@ -581,7 +582,7 @@ this, we can write a function to validate the title with a regular expression.
 </p>
 
 <p>
-First, add <code>"regexp"</code> to the <code>import</code> list.
+First, add <code>"regexp"</code> and <code>"errors"</code> to the <code>import</code> list.
 Then we can create a global variable to store our validation
 expression:
 </p>


### PR DESCRIPTION
We also need to import `log`, as shown in https://golang.org/doc/articles/wiki/part2.go.

Used for `log.Fatal(http.ListenAndServe(":8080", nil))`.