### PR TITLE
mime: look up mime types on Arch Linux

### DIFF
--- a/src/mime/type_unix.go
+++ b/src/mime/type_unix.go
@@ -20,6 +20,7 @@ var typeFiles = []string{
 	"/etc/mime.types",
 	"/etc/apache2/mime.types",
 	"/etc/apache/mime.types",
+	"/etc/httpd/conf/mime.types",
 }
 
 func loadMimeFile(filename string) {


### PR DESCRIPTION
Some systems use "httpd" directory structure instead of "apache"
