### PR TITLE
internal/poll: correct the comment dupCloseOnExecUnixOld to dupCloseOnExecOld

### DIFF
--- a/src/internal/poll/fd_unix.go
+++ b/src/internal/poll/fd_unix.go
@@ -479,7 +479,7 @@ func DupCloseOnExec(fd int) (int, string, error) {
 	return dupCloseOnExecOld(fd)
 }
 
-// dupCloseOnExecUnixOld is the traditional way to dup an fd and
+// dupCloseOnExecOld is the traditional way to dup an fd and
 // set its O_CLOEXEC bit, using two system calls.
 func dupCloseOnExecOld(fd int) (int, string, error) {
 	syscall.ForkLock.RLock()


### PR DESCRIPTION
Correct the comment dupCloseOnExecUnixOld to dupCloseOnExecOld in function dupCloseOnExecOld