### PR TITLE
encoding/csv: allow for interpretation of empty lines

### DIFF
--- a/src/encoding/csv/reader.go
+++ b/src/encoding/csv/reader.go
@@ -16,8 +16,8 @@
 //
 // Carriage returns before newline characters are silently removed.
 //
-// Blank lines are ignored. A line with only whitespace characters (excluding
-// the ending newline character) is not considered a blank line.
+// Blank lines are ignored by default. A line with only whitespace characters
+// (excluding the ending newline character) is not considered a blank line.
 //
 // Fields which start and stop with the quote character " are called
 // quoted-fields. The beginning and ending quote are not part of the
@@ -141,6 +141,10 @@ type Reader struct {
 	// the backing array of the previous call's returned slice for performance.
 	// By default, each call to Read returns newly allocated memory owned by the caller.
 	ReuseRecord bool
+
+	// If InterpretBlankLines is true, blank lines are interpreted as a single empty field,
+	// the default is to skip these lines.
+	InterpretBlankLines bool
 
 	TrailingComma bool // Deprecated: No longer used.
 
@@ -268,7 +272,7 @@ func (r *Reader) readRecord(dst []string) ([]string, error) {
 			line = nil
 			continue // Skip comment lines
 		}
-		if errRead == nil && len(line) == lengthNL(line) {
+		if !r.InterpretBlankLines && errRead == nil && len(line) == lengthNL(line) {
 			line = nil
 			continue // Skip empty lines
 		}

--- a/src/encoding/csv/reader_test.go
+++ b/src/encoding/csv/reader_test.go
@@ -20,13 +20,14 @@ func TestRead(t *testing.T) {
 		Error  error
 
 		// These fields are copied into the Reader
-		Comma              rune
-		Comment            rune
-		UseFieldsPerRecord bool // false (default) means FieldsPerRecord is -1
-		FieldsPerRecord    int
-		LazyQuotes         bool
-		TrimLeadingSpace   bool
-		ReuseRecord        bool
+		Comma               rune
+		Comment             rune
+		UseFieldsPerRecord  bool // false (default) means FieldsPerRecord is -1
+		FieldsPerRecord     int
+		LazyQuotes          bool
+		TrimLeadingSpace    bool
+		ReuseRecord         bool
+		InterpretBlankLines bool
 	}{{
 		Name:   "Simple",
 		Input:  "a,b,c\n",
@@ -78,6 +79,25 @@ field"`,
 			{"a", "b", "c"},
 			{"d", "e", "f"},
 		},
+	}, {
+		Name:  "BlankLineInterpreted",
+		Input: "a,b,c\n\nd,e,f\n\n",
+		Output: [][]string{
+			{"a", "b", "c"},
+			{""},
+			{"d", "e", "f"},
+			{""},
+		},
+		InterpretBlankLines: true,
+	}, {
+		Name:   "BlankLineSingleColumn",
+		Input:  "a\nb\n\nd",
+		Output: [][]string{{"a"}, {"b"}, {"d"}},
+	}, {
+		Name:                "BlankLineInterpretedSingleColumn",
+		Input:               "a\nb\n\nd",
+		Output:              [][]string{{"a"}, {"b"}, {""}, {"d"}},
+		InterpretBlankLines: true,
 	}, {
 		Name:  "BlankLineFieldCount",
 		Input: "a,b,c\n\nd,e,f\n\n",
@@ -400,6 +420,7 @@ x,,,
 			r.LazyQuotes = tt.LazyQuotes
 			r.TrimLeadingSpace = tt.TrimLeadingSpace
 			r.ReuseRecord = tt.ReuseRecord
+			r.InterpretBlankLines = tt.InterpretBlankLines
 
 			out, err := r.ReadAll()
 			if !reflect.DeepEqual(err, tt.Error) {


### PR DESCRIPTION
Empty lines are ignored by default, this change introduces a switch that
changes this behaviour - empty line is then interpreted as a single empty
field. This is especially important when dealing with single-column CSVs,
where an empty line is actually data (an empty field).

Fixes #39119.