### PR TITLE
net/http: add SameSiteUnsetMode const

### DIFF
--- a/src/net/http/cookie.go
+++ b/src/net/http/cookie.go
@@ -46,7 +46,8 @@ type Cookie struct {
 type SameSite int
 
 const (
-	SameSiteDefaultMode SameSite = iota + 1
+	SameSiteUnsetMode SameSite = iota
+	SameSiteDefaultMode
 	SameSiteLaxMode
 	SameSiteStrictMode
 	SameSiteNoneMode
@@ -219,6 +220,7 @@ func (c *Cookie) String() string {
 		b.WriteString("; Secure")
 	}
 	switch c.SameSite {
+	case SameSiteUnsetMode:
 	case SameSiteDefaultMode:
 		b.WriteString("; SameSite")
 	case SameSiteNoneMode:

--- a/src/net/http/cookie_test.go
+++ b/src/net/http/cookie_test.go
@@ -81,6 +81,10 @@ var writeSetCookiesTests = []struct {
 		&Cookie{Name: "cookie-15", Value: "samesite-none", SameSite: SameSiteNoneMode},
 		"cookie-15=samesite-none; SameSite=None",
 	},
+	{
+		&Cookie{Name: "cookie-16", Value: "samesite-unset", SameSite: SameSiteUnsetMode},
+		"cookie-16=samesite-unset",
+	},
 	// The "special" cookies have values containing commas or spaces which
 	// are disallowed by RFC 6265 but are common in the wild.
 	{


### PR DESCRIPTION
The existing implementation does not have a const for SameSite
mode that would output cookies without any SameSite attribute set.

This commit adds SameSiteUnsetMode to explicitly name such behavior.

Fixes #39609


