### PR TITLE
crypto/x509: add directory name constraints

### DIFF
--- a/src/crypto/x509/verify_test.go
+++ b/src/crypto/x509/verify_test.go
@@ -368,6 +368,220 @@ var verifyTests = []verifyTest{
 			{"Leaf", "Root B"},
 		},
 	},
+	{
+		// Test if permitted dirname constraint works.
+		name:          "DirnameParse",
+		leaf:          dirNameConstraintLeafCA_permitted_ok,
+		intermediates: []string{dirNameConstraintSubCA_permitted_ok},
+		roots:         []string{dirNameConstraintRootCA_permitted_ok},
+		currentTime:   1600000000,
+		systemSkip:    true,
+
+		expectedChains: [][]string{
+			{"Leaf", "SubCA", "RootCA"},
+		},
+	},
+	{
+		// Test if permitted RDN match dirname constraint.
+		name:          "DirnamePermit",
+		leaf:          dirNameConstraintLeafCA_permitted_dirname_multirdn,
+		intermediates: []string{dirNameConstraintSubCA_permitted_dirname_multirdn},
+		roots:         []string{dirNameConstraintRootCA_permitted_dirname_multirdn},
+		currentTime:   1600000000,
+		systemSkip:    true,
+
+		expectedChains: [][]string{
+			{"Leaf", "SubCA", "RootCA"},
+		},
+	},
+	{
+		// Test if RootCA dirname constraint violation is ignored.
+		name:          "DirnamePermitNotValidateRoot",
+		leaf:          dirNameConstraintLeafCA_notpermitted_rootca,
+		intermediates: []string{dirNameConstraintSubCA_notpermitted_rootca},
+		roots:         []string{dirNameConstraintRootCA_notpermitted_rootca},
+		currentTime:   1600000000,
+		systemSkip:    true,
+
+		expectedChains: [][]string{
+			{"Leaf", "SubCA", "RootCA"},
+		},
+	},
+	{
+		// Test if SubCA dirname constraint violation (ST missing) fails.
+		name:          "DirNamePermitSubCAViolationMissing",
+		leaf:          dirNameConstraintLeafCA_notpermitted_subca_missing,
+		intermediates: []string{dirNameConstraintSubCA_notpermitted_subca_missing},
+		roots:         []string{dirNameConstraintRootCA_notpermitted_subca_missing},
+		currentTime:   1600000000,
+		systemSkip:    true,
+
+		errorCallback: expectNameConstraintsError,
+	},
+	{
+		// Test if SubCA dirname constraint violation (ST changed) fails.
+		name:          "DirNamePermitSubCAViolationDiffer",
+		leaf:          dirNameConstraintLeafCA_notpermitted_subca_changed,
+		intermediates: []string{dirNameConstraintSubCA_notpermitted_subca_changed},
+		roots:         []string{dirNameConstraintRootCA_notpermitted_subca_changed},
+		currentTime:   1600000000,
+		systemSkip:    true,
+
+		errorCallback: expectNameConstraintsError,
+	},
+	{
+		// Test if leaf dirname constraint violation (ST missing) fails.
+		name:          "DirNamePermitCertViolationMissing",
+		leaf:          dirNameConstraintLeafCA_notpermitted_leaf_missing,
+		intermediates: []string{dirNameConstraintSubCA_notpermitted_leaf_missing},
+		roots:         []string{dirNameConstraintRootCA_notpermitted_leaf_missing},
+		currentTime:   1600000000,
+		systemSkip:    true,
+
+		errorCallback: expectNameConstraintsError,
+	},
+	{
+		// Test if leaf dirname constraint violation (ST changed) fails.
+		name:          "DirNamePermitCertViolationDiffer",
+		leaf:          dirNameConstraintLeafCA_notpermitted_leaf_changed,
+		intermediates: []string{dirNameConstraintSubCA_notpermitted_leaf_changed},
+		roots:         []string{dirNameConstraintRootCA_notpermitted_leaf_changed},
+		currentTime:   1600000000,
+		systemSkip:    true,
+
+		errorCallback: expectNameConstraintsError,
+	},
+	{
+		// Test if excluded dirname works.
+		name:          "DirnameExclude",
+		leaf:          dirNameConstraintLeafCA_excluded_ok,
+		intermediates: []string{dirNameConstraintSubCA_excluded_ok},
+		roots:         []string{dirNameConstraintRootCA_excluded_ok},
+		currentTime:   1600000000,
+		systemSkip:    true,
+
+		expectedChains: [][]string{
+			{"Leaf", "SubCA", "RootCA"},
+		},
+	},
+	{
+		// Test if RootCA using excluded dirname is ignored.
+		name:          "DirnameExcludeNotValidateRoot",
+		leaf:          dirNameConstraintLeafCA_excluded_rootca,
+		intermediates: []string{dirNameConstraintSubCA_excluded_rootca},
+		roots:         []string{dirNameConstraintRootCA_excluded_rootca},
+		currentTime:   1600000000,
+		systemSkip:    true,
+
+		expectedChains: [][]string{
+			{"Leaf", "SubCA", "RootCA"},
+		},
+	},
+	{
+		// Test if SubCA using excluded dirname fails.
+		name:          "DirnameExcludeSubCA",
+		leaf:          dirNameConstraintLeafCA_excluded_subca,
+		intermediates: []string{dirNameConstraintSubCA_excluded_subca},
+		roots:         []string{dirNameConstraintRootCA_excluded_subca},
+		currentTime:   1600000000,
+		systemSkip:    true,
+
+		errorCallback: expectNameConstraintsError,
+	},
+	{
+		// Test if leaf using excluded dirname fails.
+		name:          "DirnameExcludeCert",
+		leaf:          dirNameConstraintLeafCA_excluded_leaf,
+		intermediates: []string{dirNameConstraintSubCA_excluded_leaf},
+		roots:         []string{dirNameConstraintRootCA_excluded_leaf},
+		currentTime:   1600000000,
+		systemSkip:    true,
+
+		errorCallback: expectNameConstraintsError,
+	},
+	{
+		// Test if permitted and excluded dirname works together.
+		name:          "DirnamePermitExclude",
+		leaf:          dirNameConstraintLeafCA_permitted_excluded_OK,
+		intermediates: []string{dirNameConstraintSubCA_permitted_excluded_OK},
+		roots:         []string{dirNameConstraintRootCA_permitted_excluded_OK},
+		currentTime:   1600000000,
+		systemSkip:    true,
+
+		expectedChains: [][]string{
+			{"Leaf", "SubCA", "RootCA"},
+		},
+	},
+	{
+		// Test if RootCA using dirname both in excluded and permitted works.
+		name:          "DirnamePermitExcludeRoot",
+		leaf:          dirNameConstraintLeafCA_permitted_excluded_rootca,
+		intermediates: []string{dirNameConstraintSubCA_permitted_excluded_rootca},
+		roots:         []string{dirNameConstraintRootCA_permitted_excluded_rootca},
+		currentTime:   1600000000,
+		systemSkip:    true,
+
+		expectedChains: [][]string{
+			{"Leaf", "SubCA", "RootCA"},
+		},
+	},
+	{
+		// Test if SubCA using dirname both in excluded and permitted fails.
+		name:          "DirnamePermitExcludeSubCA",
+		leaf:          dirNameConstraintLeafCA_permitted_excluded_subca,
+		intermediates: []string{dirNameConstraintSubCA_permitted_excluded_subca},
+		roots:         []string{dirNameConstraintRootCA_permitted_excluded_subca},
+		currentTime:   1600000000,
+		systemSkip:    true,
+
+		errorCallback: expectNameConstraintsError,
+	},
+	{
+		// Test if leaf using dirname both in excluded and permitted fails.
+		name:          "DirnamePermitExcludeCert",
+		leaf:          dirNameConstraintLeafCA_permitted_excluded_leaf,
+		intermediates: []string{dirNameConstraintSubCA_permitted_excluded_leaf},
+		roots:         []string{dirNameConstraintRootCA_permitted_excluded_leaf},
+		currentTime:   1600000000,
+		systemSkip:    true,
+
+		errorCallback: expectNameConstraintsError,
+	},
+	{
+		// Test if SubCA can restrict a constraint.
+		name:          "DirnamePermitRootExcludeSubCAOK",
+		leaf:          dirNameConstraintLeafCA_subca_restr_ok,
+		intermediates: []string{dirNameConstraintSubCA_subca_restr_ok},
+		roots:         []string{dirNameConstraintRootCA_subca_restr_ok},
+		currentTime:   1600000000,
+		systemSkip:    true,
+
+		expectedChains: [][]string{
+			{"Leaf", "SubCA", "RootCA"},
+		},
+	},
+	{
+		// Test if SubCA can restrict a constraint.
+		name:          "DirnamePermitRootExcludeSubCAFail",
+		leaf:          dirNameConstraintLeafCA_subca_restr_fail,
+		intermediates: []string{dirNameConstraintSubCA_subca_restr_fail},
+		roots:         []string{dirNameConstraintRootCA_subca_restr_fail},
+		currentTime:   1600000000,
+		systemSkip:    true,
+
+		errorCallback: expectNameConstraintsError,
+	},
+	{
+		// Test if SubCA can relax a constraint.
+		name:          "DirnameExcludeRootPermitSubCA",
+		leaf:          dirNameConstraintLeafCA_subca_relax_fail,
+		intermediates: []string{dirNameConstraintSubCA_subca_relax_fail},
+		roots:         []string{dirNameConstraintRootCA_subca_relax_fail},
+		currentTime:   1600000000,
+		systemSkip:    true,
+
+		errorCallback: expectNameConstraintsError,
+	},
 }
 
 func expectHostnameError(msg string) func(*testing.T, error) {
@@ -963,6 +1177,1132 @@ qCPorxi0xoRogj8kqkS2xyzYLElhx9X7jIzfZ8dC4mgOeoCtVvwM9xvmef3n6Vyb
 7/hl3w/zWwKxWyKJNaF7tScD5nvtLUzyBpr++aztiyJ1WliWcS6W+V2gKg9rxEC/
 rc2yJS70DvfkPiEnBJ2x2AHZV3yKTALUqurkV705JledqUT9I5frAwYNXZ8pNzde
 n+DIcSIo7yKy6MX9czbFWQ==
+-----END CERTIFICATE-----`
+
+const dirNameConstraintRootCA_permitted_ok = `-----BEGIN CERTIFICATE-----
+MIIDvjCCAqagAwIBAgIUCf6ZyZVyoojtih3/xWDxu9ThBcQwDQYJKoZIhvcNAQEL
+BQAwQDELMAkGA1UEBhMCRk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwD
+T3JnMQ8wDQYDVQQDDAZSb290Q0EwHhcNMjAwNjE3MjM0NDQ3WhcNNDAwNjEyMjM0
+NDQ3WjBAMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQK
+DANPcmcxDzANBgNVBAMMBlJvb3RDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBAOiv42C7m4dqfMrONXUkc1qJ4b35ecKB50QGHf/G33QGTvX3ZPgJcsbY
+DEHZ3avrvPoIVntktNYFJ8OrDZ2HWNdECMuPELLZsFkWCRoXSg/924pO35M9GsbQ
+8k0JLrQYQ00Wpl8X/CYeUJ/Y+M6Op9Y8U8zSp6qpTV/hfuSixeiVE6NsuIjLY+DW
+H+7UlgapR5fO3UuLEowaCaY6YC9FCljYrQ9z8LfFXL8g8g1s/7kzJJMfqtrag/op
+Km2IB9cRCBQoAnsxyq0DmSiq5nKmD1A+f0OI5v+xbCtzBiwpX8aBN0vEl3wt9WAU
+JwzfZGjc9/7CCAt1cLLgSbMm8XIT4l0CAwEAAaOBrzCBrDCBlQYDVR0eAQH/BIGK
+MIGHoIGEMDOkMTAvMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQww
+CgYDVQQKDANPcmcwTaRLMEkxEzARBgoJkiaJk/IsZAEZFgNjb20xFzAVBgoJkiaJ
+k/IsZAEZFgdleGFtcGxlMRkwFwYKCZImiZPyLGQBGRYJcGVybWl0dGVkMBIGA1Ud
+EwEB/wQIMAYBAf8CAQEwDQYJKoZIhvcNAQELBQADggEBAHvkDdR6ktMaz2/I8bOo
+o0e0TPgEdt3u4SxUhK48Kunm3Rg93Z6/Off57hv/M4X3UkCsQeUhQ556EbNLrwpG
+sUfMAdtfpZAIgPK75Mr/aDRvGf9grdt7s0jzO96rboFKpUFKpP3TFgaVDDuse92I
+3KEh6N5aryTumz8W/qddbw/CcetXnucKQw4Hq3o+uPD8Neu8sWJjWeUXPYs2r5Lu
+VCjkeTG/iMovWwHTHqSdLSs+SQP7RB35W573qDP02u1iwiS+hUXc7uO2/dujF4pS
+NI4IEgWvKtPKPIUdFwPaNn4ycOvgFdYZTrWDMdq4cpgAD2Z945VA5K6KtUSW3xNn
+2VA=
+-----END CERTIFICATE-----`
+const dirNameConstraintSubCA_permitted_ok = `-----BEGIN CERTIFICATE-----
+MIIDDTCCAfWgAwIBAgIBATANBgkqhkiG9w0BAQ0FADBAMQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAMMBlJvb3RD
+QTAeFw0yMDA2MTcyMzQ0NDdaFw00MDAzMDQyMzQ0NDdaMD8xCzAJBgNVBAYTAkZP
+MRIwEAYDVQQIDAlQZXJtaXR0ZWQxDDAKBgNVBAoMA09yZzEOMAwGA1UEAwwFU3Vi
+Q0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7oC2drjJaDbo7QnCy
+8tbyVZm6QeKZ/V/i7RSbdnf0RHNDM85J2i2qBrT5n2uRoV3D0/Ln8z/VgO/AqFhI
+B3PNcyrTn2Cjf9ZLQJFuo8MQlouQgwRgai8tRWNS0IUJFjQeG49+JEm5tPIHLEoC
+Hu6WfOnWTQ5otS/crdxEiMZ40UBAL/INw2XnlttY+H+2eyHrmzP0OvPASVkekZgs
+7CtMer11GIAAS9zfKq67fpXTUuAZoMFYjEYRr+/qfY0rMwnC63YhfpOx3ob2KLPl
+IMntwc95rHuXPYA1Fwss0YfWM2pPsjRtegYWpslhS1XZLWRQlr0uGj1qyiT3Ltcv
+W1elAgMBAAGjEzARMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQENBQADggEB
+AJkTjOcfHRnS9sjVu4MjUrKAR5g6QLwr0ae46hEjLBNR0GYdl6E3hv0UwCKHBG7Z
+XnF69GH5NOpIcaJqeInpCabOi2tMDoX9IjcvLBIYLtEzltrR/hjM7N6kNYRLhY6U
+voqQIUx0pSMIiCyg5ic8nfD04NR27dwxgu2aqx23oZw22FM1rRfvcfGWlRCK/gRv
+Y/VE0jmGSRb3luBd9AEca0M9jSZ1pYo80Sq7tx3Dh0oNuxYQuOeUhwSb54tuR7xE
+tD6UJw2/yzpUDIkFtnlohEC2IdxiOq8RHJkzzjnpBMsKeTgERIh8Vtwt7eNZ+uJ4
+Ac5kF0XcLUKZljv7MoFWPIs=
+-----END CERTIFICATE-----`
+const dirNameConstraintLeafCA_permitted_ok = `-----BEGIN CERTIFICATE-----
+MIIDFzCCAf+gAwIBAgIBATANBgkqhkiG9w0BAQ0FADA/MQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDjAMBgNVBAMMBVN1YkNB
+MB4XDTIwMDYxNzIzNDQ0N1oXDTM5MTEyNTIzNDQ0N1owPjELMAkGA1UEBhMCRk8x
+EjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwDT3JnMQ0wCwYDVQQDDARMZWFm
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsUWA857XFQVL7tASKR8y
+iUVy8eXPjk/Zl5D3Vb/5BeIoQ5zqLimyjkxjLaKTWnEl64byTKyVvACwzaCQaBs9
+2SobUDCFYhw6iPfND32jmuONSdtLvJYuxVDpp+wr9bArEx4+b9C7n+rrFszgrcns
+wMOVNZeZXomekLqO+WL9CLt4HHmXQcmUStl2/VqN4XwKMHWivECyUL5Y4RRAxkfb
+rjmJoNtqiiswNzhalHod5UUvJADul5xCbY7NPn4q1/SzLwX/2WaOVfSuYzQdNabc
+NgXc8AFfxNfRMJvmLPOcPMocFRMItUMBqpxyWRFDLKxnIe+ymgsvAWQLe9ixGz0O
+mwIDAQABox8wHTAbBgNVHREEFDASghBsZWFmLmV4YW1wbGUuY29tMA0GCSqGSIb3
+DQEBDQUAA4IBAQBML4KdOb+vZt9Xemb+i2fOZjiAlZLPa3zz7HHt7b/zSB9MDiRo
+XNLT/zf+xD76rMGo6wCDDs9lqUyveBun5siXYAObsG/pOB/AJ+w4GTCm/rCngbOG
+PhRWhLumCdGt4NQ2uZweNbDnGKUtjlFbG1KUabrV2X2eM0SnZnh8hq1qFr7SE/pF
+Ro8HCf1ctqe0RG7mmqGWx5ilH9oMSG6Pc60iEkRB7hnBkTft7r2XIDCR4mVGJamj
+JYn+C43+lBSFyAIkCHRbAOoxZo0WZC49Mahm8aNwsKtXlCCP6u/ESpGEGvMMsnIJ
+MLp5X4M72jmFYuRgCMNfCGiVEJqvJmeismjX
+-----END CERTIFICATE-----`
+
+const dirNameConstraintRootCA_permitted_dirname_multirdn = `-----BEGIN CERTIFICATE-----
+MIIDvjCCAqagAwIBAgIUOjzggjKgLVBb637t75xq0PhCUXUwDQYJKoZIhvcNAQEL
+BQAwQDELMAkGA1UEBhMCRk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwD
+T3JnMQ8wDQYDVQQDDAZSb290Q0EwHhcNMjAwNjE3MjM0NDQ4WhcNNDAwNjEyMjM0
+NDQ4WjBAMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQK
+DANPcmcxDzANBgNVBAMMBlJvb3RDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBALqeJ5JPi92OJZw3omUnJw6IGrAK8KwfrCeDVsxII5Jg1AATmeEVd/KY
+2vSTdU8eEx1odC7icatEKfN5TnSR4MFGPfQ74zIenD9IuZi8OjdiRGMS65ZvSZhR
+gD88aKELIvwZzwBCgNd9i8RvzRodHhnmmDJ8MQW5yTnwu261jqODCDuXJidllVPB
+pZy9O2rQ8bQ1hyl/1ZZxTHgKTsFj4fdpjW8oq2QgEBIiaVpdhl8iMnAMmiAlF9s4
+x/i5cGdqui4wpUYBQfCvTY2a+hG0PQaBDX3fGNe0kTHTJQwI1GsvMc1Rpnyzs+6P
+BlD5oBffhngAIvyTrfDhAAfF0bouQD0CAwEAAaOBrzCBrDCBlQYDVR0eAQH/BIGK
+MIGHoIGEMDOkMTAvMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQww
+CgYDVQQKDANPcmcwTaRLMEkxEzARBgoJkiaJk/IsZAEZFgNjb20xFzAVBgoJkiaJ
+k/IsZAEZFgdleGFtcGxlMRkwFwYKCZImiZPyLGQBGRYJcGVybWl0dGVkMBIGA1Ud
+EwEB/wQIMAYBAf8CAQEwDQYJKoZIhvcNAQELBQADggEBAJiBUa1P4ccHeAtdYkqw
+ZeogyfSydfR9P0aSsuhVfZBU65gcsaNfhxGtQ2WW+BXFNK8YH3vp2rif+A0j9RG1
+KhvEUEOjDAQEkRa4uuUnYMC/vjeV7QDeEsHOZF01Bp5HkkBDgu5GANkW0ea/h4m6
+GnGQ9UW/RudJVAu00Swr1TBAk6wyAQmRxUwqpEA26EXzt2yfKTHlrDIzqjoB5hWG
+Jh7FqhYSWF4dlnj4uBGrtklbfKrUAVzYcRe1rW1lMivOFHGMO07WYDfSrGE17KTt
+QsDsLN28WZhx1u9YoluR5iLGF+fyBMsZCoIu/E7i0WIIR0O9T6rFpsZjzMyokTZ+
+1y8=
+-----END CERTIFICATE-----`
+const dirNameConstraintSubCA_permitted_dirname_multirdn = `-----BEGIN CERTIFICATE-----
+MIIDDTCCAfWgAwIBAgIBATANBgkqhkiG9w0BAQ0FADBAMQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAMMBlJvb3RD
+QTAeFw0yMDA2MTcyMzQ0NDhaFw00MDAzMDQyMzQ0NDhaMD8xCzAJBgNVBAYTAkZP
+MRIwEAYDVQQIDAlQZXJtaXR0ZWQxDDAKBgNVBAoMA09yZzEOMAwGA1UEAwwFU3Vi
+Q0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDK4DcFqHSbi+eMsEPC
+OZgA0WiwStLMFw3MwZ9mp1gJDo6BAVav3osAomOoxB1A8ffAX0UOQZfeGdlXP2GN
+S+0EYFOSNxzL5nwszygDbSnHOkwlSBlFNLvDi8qQ9YesSFTGt0LBeoz0k/VYP3y0
+sMGolcZB2quVn/F2GXGMmNsZCKyEbEmHoAp6a15lXvBLVEVVSbpBKEdi4jy6840q
+8Y75sBCD3N4q3uUukCdAFdlgD5zidn3d3+YJu/j/OJ7d5/Pk/R5O+qVVzwFn4SAO
+hZZDTa6eG4dIDkkcdbaE9Ys6ep1oP/lRgBe9QD3TzkrQb/RIDXRJziBp2akd+LFf
+xYwrAgMBAAGjEzARMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQENBQADggEB
+ALFbPzdbzNuCI/qs34rV5K1nR7X/Lq85Gt0DbSKbcJV1DC/d9HTFl9Mi1G2AU1To
+YIuG52QZm7534heGvllsn4W1yDEwZCfcEwFJqNZGp6PNM+8+G5+7JKyvuKLeWtWF
+I5/oBeX/qzudIHvx97p/LRQ56E2fp11lExmMRIkYWVUPQTdylnOXZQ61A7Xyn3xv
+bgXaf/nBC/zBnQ1atsVYtHpyt8JnidYxnsldVXoOqe3sVFq19zIrLamEJErA4xYS
+b/dTNMuHrCUNHnqsRaiPgvMFLF+wr+O7R95tJRLFZReb9xUU/BaYjabLN3ViOw9N
+7SKwkY3laFzYiSc0Dr4EhWE=
+-----END CERTIFICATE-----`
+const dirNameConstraintLeafCA_permitted_dirname_multirdn = `-----BEGIN CERTIFICATE-----
+MIIDMTCCAhmgAwIBAgIBATANBgkqhkiG9w0BAQ0FADA/MQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDjAMBgNVBAMMBVN1YkNB
+MB4XDTIwMDYxNzIzNDQ0OFoXDTM5MTEyNTIzNDQ0OFowWDETMBEGCgmSJomT8ixk
+ARkWA2NvbTEXMBUGCgmSJomT8ixkARkWB2V4YW1wbGUxGTAXBgoJkiaJk/IsZAEZ
+FglwZXJtaXR0ZWQxDTALBgNVBAMMBExlYWYwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+DwAwggEKAoIBAQC+d487XDxy19YHRhebr6vwACM/quLTIht/WdoKcrXUAwWOlrXP
+6cK6ekr8JWJsBXeI4GpFHv+ZLmxadYCWdZmSf5r2glUNETGoRLrFwyW1riGJigDK
+L0Yuv25avRD+7VkDfs/pkHStaWRQ0CNbLEsypNujSen8GMqw3JSIdehNTDlErDpl
+OY1MNTpYOOe65GC481FuxdpwVfoUShSEXC5FCF0bImBdKgbkU5cBeRUOgzIp/ANe
+t/cCOeP6x9GqH0xbt9pnNfv1hHndIGITuzmzZZ8KX+gzRVly6bQ4K2HDlzgL8cNv
+0pw0MIMUH9x5UtRhyvDtY2qir6fjukYQVlEpAgMBAAGjHzAdMBsGA1UdEQQUMBKC
+EGxlYWYuZXhhbXBsZS5jb20wDQYJKoZIhvcNAQENBQADggEBAIBpybozqH+AtD0a
+v89pZrnOIKSekdRBqgL2uwMuak99aNa4tqx1X4qMej9cbiQjYBBCCNitIuAmQTyd
+a0MCvcoiCCVaiygqduLyLJV9FKPhOIh7/dUAKamPSdnGxNdg2Pb/B8EyZaIyz/RK
+4i1i0fNFQdstYrcT/sGr8UR7k7q7xsYiT5aIGUAQZFunq9HrjuzUVarm24xDXMG7
+9fcW79lhxK9OhFQZHLdaSzcwvkNc4j2aB/b8Yhoth955wROXF/2QGLfDjgvtgOsA
+OiJOtt3RIoQtV08UClUfOdUTQjOJr9140qtvd1WkeKeftYeHtHpDfQx+oyFTexn8
+RKfy9P8=
+-----END CERTIFICATE-----`
+
+const dirNameConstraintRootCA_notpermitted_rootca = `-----BEGIN CERTIFICATE-----
+MIIDsjCCApqgAwIBAgIUcczaknDNG0WPrt+RCoq8UxE1KU0wDQYJKoZIhvcNAQEL
+BQAwOjELMAkGA1UEBhMCRk8xDDAKBgNVBAgMA0FueTEMMAoGA1UECgwDT3JnMQ8w
+DQYDVQQDDAZSb290Q0EwHhcNMjAwNjE3MjM0NDQ4WhcNNDAwNjEyMjM0NDQ4WjA6
+MQswCQYDVQQGEwJGTzEMMAoGA1UECAwDQW55MQwwCgYDVQQKDANPcmcxDzANBgNV
+BAMMBlJvb3RDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMIVw3Am
+qybiYS6ejJG9+Cte6DvlSXJeq4mYQk0LH3sg7kMCQXSPjMyZ7v6sshrd+GjYKnGm
+87NpzFUp0EK1nJmuslVW5ETtRxHL3GpCQo0qtoEXpumJCmSI8agnqluFY4YqxVyp
+K8vx2BA72YcQNCe7wQGHMgqKolGjKjUTAEHFVzixaJgjvHSSdh9yHpUOBFoWvWt/
+10nZabzr0IQX9o2DGhBuqo2WPji7HOZYfU21g8EXRNybCf6KPnKH7uCiqPOFu+oJ
+xA26L8VygGIvniWUsZdFH8ymuxRnsPXymZMoeHy4bIflU8HlmbCS4WbjmEYBxWj0
+5v2T0oFqEVxCIEECAwEAAaOBrzCBrDCBlQYDVR0eAQH/BIGKMIGHoIGEMDOkMTAv
+MQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcw
+TaRLMEkxEzARBgoJkiaJk/IsZAEZFgNjb20xFzAVBgoJkiaJk/IsZAEZFgdleGFt
+cGxlMRkwFwYKCZImiZPyLGQBGRYJcGVybWl0dGVkMBIGA1UdEwEB/wQIMAYBAf8C
+AQEwDQYJKoZIhvcNAQELBQADggEBAB970E+C4RQKUd2G388Hqs2WelqQHUNpVvFC
+DAD3T9+pfnndW9pALYF8naS41+lYHN3HN73JCZo2N54MUakNRGNZtSIhGuWMdM3p
+Ndz5CYw0z1rXEcWcvhqChF21eXn2MbJeC6hT2W8TS8KK2pnG89DGwQmfDBRp3nn3
+Rj2RGX6O81e11v81oEGWHhJF5d5LUsDQEr7V55oB9JMjJ8+XsQpWe029q1p17HMR
+86JqgEqGqxhp9h1mhtL2/8skvTV+s+hyHOxvYFQGS3dr6MVLYZjZj1TcA6k2xCW8
+yYFxpQAy/orCUWbGXSUew2y7c+3tUpkvnbLupZeiiqyKqw53RvQ=
+-----END CERTIFICATE-----`
+const dirNameConstraintSubCA_notpermitted_rootca = `-----BEGIN CERTIFICATE-----
+MIIDBzCCAe+gAwIBAgIBATANBgkqhkiG9w0BAQ0FADA6MQswCQYDVQQGEwJGTzEM
+MAoGA1UECAwDQW55MQwwCgYDVQQKDANPcmcxDzANBgNVBAMMBlJvb3RDQTAeFw0y
+MDA2MTcyMzQ0NDhaFw00MDAzMDQyMzQ0NDhaMD8xCzAJBgNVBAYTAkZPMRIwEAYD
+VQQIDAlQZXJtaXR0ZWQxDDAKBgNVBAoMA09yZzEOMAwGA1UEAwwFU3ViQ0EwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC0Q8r0nlb5uB4FdUCy8ywl27dM
+6vhK9hyjibiD4MPrmd8z7HVadVEqRNrmVYCEwh/2yLE7fXS66I0vd9qJNkZlaBYt
+o/kkVJ4FCgNWAq5D/tR8/N03mYqYmdo38sCfFbbfH4TH6NWSClYl2lm1MjgdwLmy
+z5CmRBIbTPR4VsK/G5Hl6uh8kboQPqR9L3JsEqRPlxB0AOpjVPDS7AjLpE8rfEDf
+bfMVe1j1CdSmYan3/oYvSsg2HX6JZ4//Ka2dhw5shrkLhTvKsi7ZKMWyZKn5he+F
+yFx2s/DhdrEGo1mC4cMiS0iIGIkFsP/0DrT7V6QKnn1bpuPoQ/59jQrPKDADAgMB
+AAGjEzARMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQENBQADggEBAEvP+l3T
+aoy9i+1OpXTFD2OJSZp4qbuLZsyz8OWJfh7OR72SmQmuujCRmaZiAUhnCm+Hye2J
+enTsgOg+ivJ1s2LmLheo/lP49uRIXQXD7EAnTlC7DUxlHmaqaD4zoIXv50bjpK95
+nUHnChXtG8ohjbLNU9Vpoau1knDjRt6I8HISvhyZK4xl+RUZ3yGdA/fHEJoy/01e
++eXfnO/6DS43okpQVYK5fSc7pLesPGvekGLHaLdyAwPvAzC+bhzjL5g1gaSdYbD8
+AzLdi8PHLbxHJIBZPxYMhwUjdz6lRH0SCsTWFrWJERwPphNHxI//Y3Gxm5M+8kVS
+D0H3uSJwOfS8JD0=
+-----END CERTIFICATE-----`
+const dirNameConstraintLeafCA_notpermitted_rootca = `-----BEGIN CERTIFICATE-----
+MIIDFzCCAf+gAwIBAgIBATANBgkqhkiG9w0BAQ0FADA/MQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDjAMBgNVBAMMBVN1YkNB
+MB4XDTIwMDYxNzIzNDQ0OFoXDTM5MTEyNTIzNDQ0OFowPjELMAkGA1UEBhMCRk8x
+EjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwDT3JnMQ0wCwYDVQQDDARMZWFm
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzjY4bMjA/7wPMoHMQv6Z
+tUKa9t/WXAm1LJMHSQshcsJqWYKjxNE+zUVVX2tJKxL1fp0KYjhbGmFafAcsZi/w
+Mjj43W6jO1weLk66c1cXfnqflIemb/y73pJNnOOp+l3qdP98SsxnFthCdouSMNS1
+H2jdOCf0vPEdVw5M8rOypzo+dzUQtJycF60Iq08/mRZSE4OOUsp05CavIDWSe1jL
+r8d2ELWt5oI6P4yYOyec9zZ+QdgtaZI24besam9OemHjmlY1n4OQD5gXbur819Zb
+CCdQ3GtY7iQbq0ehAyJwFbov++Om2RbnDe5+ZLnrYcSAs+Ev5X+94pzWNXk9VtvE
+2QIDAQABox8wHTAbBgNVHREEFDASghBsZWFmLmV4YW1wbGUuY29tMA0GCSqGSIb3
+DQEBDQUAA4IBAQB1XZX7ZXRJM4YUUXUZE5yx3ej3tV8/4SF7oXFZuhZ1QKz+To3t
+yCPkqA0eNwUcxl+LQ4uWjVm/gT8HxXKL5arK7bjlD+sACh1d/Kpbz0JkfSNa55Da
+gn42Z5HZLnIzSxA3FyQDjwZxoMquH6Hl21JO8RlHKSDzacEwzv5SPD8eKhv2IhyD
+O/dTsn9gVLZ9bCoBVEXFlg9L5H+rmw3TY29ZofrP8VOrm3xT2dl1wQCjIJNkQDsy
+DSGd1959IulS0/VHFR3AD3zLurzDqjqREYZ5oGwZYFEpUtA/PCuIykLR9kYEK6t8
+nkCrY2/fNGhFGB3Vk9UD01u3u/fRQfCsFyf5
+-----END CERTIFICATE-----`
+
+const dirNameConstraintRootCA_notpermitted_subca_missing = `-----BEGIN CERTIFICATE-----
+MIIDvjCCAqagAwIBAgIUOZnUJpd1fjyoR4/IO5WCiAi+PvowDQYJKoZIhvcNAQEL
+BQAwQDELMAkGA1UEBhMCRk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwD
+T3JnMQ8wDQYDVQQDDAZSb290Q0EwHhcNMjAwNjE3MjM0NDQ4WhcNNDAwNjEyMjM0
+NDQ4WjBAMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQK
+DANPcmcxDzANBgNVBAMMBlJvb3RDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBAMDFX/Pn3LdxQxA7BNsnRFyO3o5WEyxyaDEIhbGoFm5aRnBe3jXaJNNg
+KT9SoNHUXVqfm0y0d3jzZVmM5IjP56ZyL5N9Jo7Qev6TB4WbxO4od7AmIgG8e+wv
+awLV223Yop0P/rhPG8cU4UYm4gWGHCi9gkyCGzKrNkz6csA5TTWOZ90VNn6MQzt4
+IdENCVrREfr7kMyzF1tZV3CO+xdMyV/5JKrkIVUEGQzIyYsdp0PYE3RsdRiBGY0n
+dWvqiyjhEc/IiChv0PP+rZltlHhXgFlyTdV0mVKIMPVk3376kpwLYcMU/Vk2MZ2Y
+PQzThsvIZGtmRg6i6tr8l5WzfbgK2EsCAwEAAaOBrzCBrDCBlQYDVR0eAQH/BIGK
+MIGHoIGEMDOkMTAvMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQww
+CgYDVQQKDANPcmcwTaRLMEkxEzARBgoJkiaJk/IsZAEZFgNjb20xFzAVBgoJkiaJ
+k/IsZAEZFgdleGFtcGxlMRkwFwYKCZImiZPyLGQBGRYJcGVybWl0dGVkMBIGA1Ud
+EwEB/wQIMAYBAf8CAQEwDQYJKoZIhvcNAQELBQADggEBAFFyzGvkIC4DBbQMCPbc
+H46MlrLUxkN6B5cautRtDEHQ8ArCHQtGvUNNGKVRkr6dgdpJ1JJ+YPISFFGg0Hkm
+Q1ampZLBW2SmzQM3eU0fdUIzNtCdLz5Uxqhz7/gpHOUXyEqpKJ3KezsbGp2USGXN
+Anw1ZK0dwtDDYo/CLBQB/aRpT4CewoAVI+g2fti8HgZjaw+Bu9hB7FW1+BAliMSB
+nS1qHGyMwTwWAh9F4eJNvDoBsvklrIgQYmAKtbAqbYxnIscp3vSHIMyj4k1+AJR3
+XeJ5XxDbEO0ukwpWyRfwZnXvYRlETgeK5V2Qm974U3wO8sZtjOiYjR4Sc7uo7de7
+QHI=
+-----END CERTIFICATE-----`
+const dirNameConstraintSubCA_notpermitted_subca_missing = `-----BEGIN CERTIFICATE-----
+MIIC/zCCAeegAwIBAgIBATANBgkqhkiG9w0BAQ0FADBAMQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAMMBlJvb3RD
+QTAeFw0yMDA2MTcyMzQ0NDlaFw00MDAzMDQyMzQ0NDlaMDExCzAJBgNVBAYTAkZP
+MRIwEAYDVQQIDAlQZXJtaXR0ZWQxDjAMBgNVBAMMBVN1YkNBMIIBIjANBgkqhkiG
+9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzv5q7cB8jpa1WAziOzX8MCWZ4L95gwpdB8Vq
+7Rg/JXoALy0BWRPf+vwqXhsytXfTevLhsHNNkIu7ZWC5EZNkWJfShAlUXyy0aa/T
+Qn3ALQ7uqwZvKTxmXXle6dLI55npcvV3+26TmzYwdSVaxO9oAY0RVl5xbQWHvLf0
+dhSWvYllyiDEkJ4brrE9Los7eTPM6SaMU8OLqLJH3bxicfgWzZ9I6mfKSRgF6MCs
+BwS5u3BRbJ7L33m+OxkGKnKoFJh4LsSoxEBfYdGkavkhSuluTnavbN9FJGqt+4W1
+9c10wHABSAKXsPfIARVin3IRWIukyTFJt5nXJP8KMPliiQL7KQIDAQABoxMwETAP
+BgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBDQUAA4IBAQAIK4/rwCYokHaEG2fM
+oYUfIMS/jFnpU7AT0Q+9Fgm4EazAdvC39car42jjHJbw1YF2AqQXFFG3kpRG1Lvl
+q0po31/WHtOMGRcDilt8Qr3etMa2j7wKeUY38WvoeV2xa8KuVmNCSTYrFXr8MFmY
+cfA3GSydibasgpd6jEn4jooj6J0kABLHk5j2F14CcRvuMQ4QFoi7vDOAK5sm0Ff+
+zd1o00Rs3IGvlWUnNIa2vmij6y/8iHbCWCKw0vC01ZqD8RDD6520mUqPx/LLhaIn
+H0koBpvbZ1SuPoN7pKpiKl40SY92vb2ESLozm4Ew/tmFiIcOgwia8MU9HXq8pXiD
+MO+Y
+-----END CERTIFICATE-----`
+const dirNameConstraintLeafCA_notpermitted_subca_missing = `-----BEGIN CERTIFICATE-----
+MIIDCTCCAfGgAwIBAgIBATANBgkqhkiG9w0BAQ0FADAxMQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQ4wDAYDVQQDDAVTdWJDQTAeFw0yMDA2MTcyMzQ0
+NDlaFw0zOTExMjUyMzQ0NDlaMD4xCzAJBgNVBAYTAkZPMRIwEAYDVQQIDAlQZXJt
+aXR0ZWQxDDAKBgNVBAoMA09yZzENMAsGA1UEAwwETGVhZjCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBANcDUQdUZPpfHo2MJNmI/wQ//tuAlcEjqrAIJJa4
+b0KcYmE68QxaN7imErm/03WPSY3wUmjtA0BJXMhidtDKy2TETXAvRSKjXovrXcft
+rmt0sFl6fud1saSraZHp4x7OmFPYwjV5fTIM+a3eF+ncrp/mhsXonAEXq8AB0Tx+
+tqZUYxQcXeeRgQWt9HF/ZZQ7UTjXqmDaumhPaaeWANlvjm30uy8HCVrMOAn93fgN
+dTEHGjVPuIB/UyMz9KfTpr7WN3fyHIxlmuFEUwZo2InRK3XVMAZODJ3RDmIx/2jM
+4BFs7rcYCV+wQsvCPQrxOqK5rS2gkZuAdeK/5fCiAEBM9UUCAwEAAaMfMB0wGwYD
+VR0RBBQwEoIQbGVhZi5leGFtcGxlLmNvbTANBgkqhkiG9w0BAQ0FAAOCAQEAStJA
+zg4RBCHex5AX10P+fqAF1P1cSgtOOrpviFR4FXTrM46wuJZiSlbt3E/p+zEivnoW
+SeVulXG0he3umVn2rO/9cBhczGCbQCkxZygVujKzkW8zqy4GN2lZQOZc3NWNGK03
+IMuwij/zE8JSK3xMELfW5BEKPut87lSWOD4ezCnrsFlGGOmlKG8NhLHB3P+l9vmi
+FND4NmH2766rTB2Q1fGaDK6vWfB4S/QmotR1NMdRusfgu/kjSr0ImJWbXHqtfTxg
+0rFJdsil+AFy0AiW/4/f4EdDESd4pbKdwGONGNEeZiHVbKCICDewlQAR5sH0aHou
+PCo5OTfZrymZRtEKzA==
+-----END CERTIFICATE-----`
+
+const dirNameConstraintRootCA_notpermitted_subca_changed = `-----BEGIN CERTIFICATE-----
+MIIDvjCCAqagAwIBAgIUe3SmR56/ASYLO6+vXN9pwIwj7w0wDQYJKoZIhvcNAQEL
+BQAwQDELMAkGA1UEBhMCRk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwD
+T3JnMQ8wDQYDVQQDDAZSb290Q0EwHhcNMjAwNjE3MjM0NDQ5WhcNNDAwNjEyMjM0
+NDQ5WjBAMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQK
+DANPcmcxDzANBgNVBAMMBlJvb3RDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBAK9U8xt1FHV1W8Q2cD4ewmmoAtHTmNeH76sqN5X/5OaE9iM0NXePTzNx
+OuIo0tFQ0L5e3PTPMEf9ayIA1i+gULKjhbYAw8NI55/olGGPRMpeJpE5PSJFg/DQ
+eX4QwAIPTmH6xiSPVsc89VqCDbtunCtbWwQRtJ1Nws1tLJCpeCtcFVEiBg0bAze6
+9QFqrmoc7Vb94JWHgxQEHFafdZI+EJQZ9KFIn0aypgX1aVp7h248OvmxAt0jm7al
+2Pg7wHLQhdXxZWfETrV3IFhFPoy6dBin90ZB98Aw+gss1JWJYvdkodmkZMoIxCoE
+6axLDhyogOMYiYp9NOO6uvA67JcV3aUCAwEAAaOBrzCBrDCBlQYDVR0eAQH/BIGK
+MIGHoIGEMDOkMTAvMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQww
+CgYDVQQKDANPcmcwTaRLMEkxEzARBgoJkiaJk/IsZAEZFgNjb20xFzAVBgoJkiaJ
+k/IsZAEZFgdleGFtcGxlMRkwFwYKCZImiZPyLGQBGRYJcGVybWl0dGVkMBIGA1Ud
+EwEB/wQIMAYBAf8CAQEwDQYJKoZIhvcNAQELBQADggEBAJAYXOz00pd5rX3eJGdm
+/OQclUUoAibHJZ2KUEBpqOJ1Noha3t7ei9TIl1ZR88KkYJtoVFi/2sOvhHE1+TJ/
+lpSjcqCcLEMELtGvcNyOq4dVS5Eo3IOLrFxUYTBxIAFZZrZj7gWtAXZeQur5i94r
+SoJmUqB4Ry0wNvImEEkhr9nA+wsYxDG1zgWtmPxKZs0rHkZWOZpXpZYaXQ5U9aQp
+/g3Q1eJJ9OFn/vavd7ek26/Embo3TB//FdPJKCNsBCGUCSDUj/ZsgCpHZKOlOsB+
+z3wvPaMeSBlWViG0IXEout+ePmHUDdJFyA3wzR2cb11Oi7IlzL07H2uqosmcZ0nj
+DIk=
+-----END CERTIFICATE-----`
+const dirNameConstraintSubCA_notpermitted_subca_changed = `-----BEGIN CERTIFICATE-----
+MIIDBzCCAe+gAwIBAgIBATANBgkqhkiG9w0BAQ0FADBAMQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAMMBlJvb3RD
+QTAeFw0yMDA2MTcyMzQ0NDlaFw00MDAzMDQyMzQ0NDlaMDkxCzAJBgNVBAYTAkZP
+MQwwCgYDVQQIDANBbnkxDDAKBgNVBAoMA09yZzEOMAwGA1UEAwwFU3ViQ0EwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDUxe+fE/HMM6A/cxvPl6/cckCv
+ky/DLaY8rGkoo/cwZDwEq3hBvcNmhr0cVWyGcGNvK3aiXxDoopFm9Xn/A2ntE6ks
+A3crk7q2TgzD0BGsojQ0qXtjg2a+aDH+Cjj8Tay2U1r9E8+Ey7xharaDgI9XpnIw
+VPHn2aD2l7zAALEl87hqt3DNskeVktPYHPRS+/HcitblC7sLRILJV4JlJ1UIZ3Xl
+4u8+loyCqYXe4VgYBKixxB5Pp5loqiNO52IL4vL2RcZ97KTliaIVF6VolcRqSkmF
+CZMJci0UPV/i52Ft2RLCPz4EKNOAUHbuCyNj4aJ4Z1hlmO1o7FaqoQG8yY7RAgMB
+AAGjEzARMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQENBQADggEBAFOQV5H+
+YKpPSwNMe58CihZ4tjfO7NeIC/gt3LPBdrPkRiELuMuBODSAOxEYK+jrKm/Ohtrz
+DqGBx0rFDwmrc7wvDKji3ATvUj76Tx3c3yak5ePEXvnYUUKBZfsnTrcgQbVMb640
+K4ESolprjjVeHDEgVa8nKWk/mk8JGxGGYD06jUaoGSf2M2nGzdR69SVf7FG+fAJd
+QR5YpIN5Mp1Vy1L7hevOVUMwR84ldG171Xsaj+toVL4YraTXhzJTfdXg5ABIdOKr
+kAFCjNJfU4VuaRJqN+4gWOmSEuGbLJTmMkT1UR6I9addCYiSQsIHqfycgiZHkASf
+sIgrpXtSzaoe4pc=
+-----END CERTIFICATE-----`
+const dirNameConstraintLeafCA_notpermitted_subca_changed = `-----BEGIN CERTIFICATE-----
+MIIDETCCAfmgAwIBAgIBATANBgkqhkiG9w0BAQ0FADA5MQswCQYDVQQGEwJGTzEM
+MAoGA1UECAwDQW55MQwwCgYDVQQKDANPcmcxDjAMBgNVBAMMBVN1YkNBMB4XDTIw
+MDYxNzIzNDQ0OVoXDTM5MTEyNTIzNDQ0OVowPjELMAkGA1UEBhMCRk8xEjAQBgNV
+BAgMCVBlcm1pdHRlZDEMMAoGA1UECgwDT3JnMQ0wCwYDVQQDDARMZWFmMIIBIjAN
+BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1Zm8kWAEpVojRFlPuJzFqX789YLv
+5xLbS1D8/jz4WOKRixFQk4AuE8sv6VxTlMSv8G9XX9iGLcoPF0CnTBKaCsOGXSV9
+qxcW+6Qiof29mapgo0KKgaNN7qHLK5TGhpjcxrZnbSYELl/irUMInNYpeInss6cB
+h64eEOiunCF3hTDt+ySAfajky2tFRNu6AZw9f71MFIud5lSNGraqSeve1Uh+KE84
+QY1EbOTTeZmCXkweBFYYSaCUFfM1Ro0K5wVrKSndInDtGNbvPhtchKxhQC7So30J
+5IORjjOxpfzNXDz/F/ITL9h+Ge7zK006wT1W4R1jZVl+2QdNBUTqBoRpOQIDAQAB
+ox8wHTAbBgNVHREEFDASghBsZWFmLmV4YW1wbGUuY29tMA0GCSqGSIb3DQEBDQUA
+A4IBAQDNuKbGKcn5n++1DAzkelygR/jGf9s0JksNNUxIBFkPlpcOM9nCJhuEVftm
+vL+xtLbIAfFc6NsTxZPuYReMoqmYbZljxKRvNKCYSIp1SpZ0expFpE7lGcEiNH/b
+52nzryhE9MGvEiCVSM3k6Xn2ClDgInaIqpYa3+NBAcoITjy4AfX52XLmEJD2SE88
+x0yGuGWN+kH0hp+lLbMHD9nkNZ9vnup4GlQDPjocCRCyW1Yqr/x4808hYuWh4vR5
+gNthif+VowJxbv6o8+eeQFM/MoYcJS29Fv17MMQ44tv07vW4FD5GCPOwPdQPJ6qC
+Hr2KWB6mW0pVQZq9hjxa1PZjq/AR
+-----END CERTIFICATE-----`
+
+const dirNameConstraintRootCA_notpermitted_leaf_missing = `-----BEGIN CERTIFICATE-----
+MIIDvjCCAqagAwIBAgIUBCnFa8P+O6piDTKh6BPes9iE7vAwDQYJKoZIhvcNAQEL
+BQAwQDELMAkGA1UEBhMCRk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwD
+T3JnMQ8wDQYDVQQDDAZSb290Q0EwHhcNMjAwNjE3MjM0NDQ5WhcNNDAwNjEyMjM0
+NDQ5WjBAMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQK
+DANPcmcxDzANBgNVBAMMBlJvb3RDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBALWTGlyJkZ/3qR1O+FviuVNzRO/II0qwTqIbS58MK6/UqHKR9lBT2Zlz
+aAj4yGeEtZppGbvO8Pw+yWZMMk/mPa97tbdzkUC/elBbUg7UyBcPoMDT6pHngl7l
+ar3ubde+K/RFWu1aqcZlKr/jmaKvUhEAgsqMT73MV8XRbDaUr9DhldHQe7gi2Hu2
+rW5FoYwdiwZmmF+jmWNmcc/ZoZa0A+Pdusr+XeC+k3P5Jrn37iCQRJ/Q4BJxrv0y
+V8Q7X/eExPdhdFJPZTh9gemK2ZNeUmqxrxrVIy/Vt58SECVpS67MPb6u4I5Wr+We
+J1H3ND7cgz4dHi+WWRE2QUubZwirwU8CAwEAAaOBrzCBrDCBlQYDVR0eAQH/BIGK
+MIGHoIGEMDOkMTAvMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQww
+CgYDVQQKDANPcmcwTaRLMEkxEzARBgoJkiaJk/IsZAEZFgNjb20xFzAVBgoJkiaJ
+k/IsZAEZFgdleGFtcGxlMRkwFwYKCZImiZPyLGQBGRYJcGVybWl0dGVkMBIGA1Ud
+EwEB/wQIMAYBAf8CAQEwDQYJKoZIhvcNAQELBQADggEBAGs2ToR8fiUXW6Ud7aNP
+z9fEO8eNSgV9yCZpT0/NGuHp+hcjaXY56xo3NIwVEq/LerGnDLWBokXkfFAInjSi
+5GrIBmZR7rVqxfqOg50odUgD52vpVyjqsVEIdP8qjp6XtgPMp0QAaaOIjj/L6V7k
+Rpp9v312sUvch5wCWSfyW5k5WRQV/SmUCthIuyGhw6REc+ZOxxm8m9Ahw6J3OViY
+1GWZUrG1Qh6iWqrGQZOtFd5iqXrRqCSIyY7UBT2/cE7jrzoTjKTxNcimUawC3Ix0
+iRuOlCYUBqao80167vIJcWqu1oms+A9u6D49Ja6XrYxysf7NaK5axOFqRmFHAYEQ
+otc=
+-----END CERTIFICATE-----`
+const dirNameConstraintSubCA_notpermitted_leaf_missing = `-----BEGIN CERTIFICATE-----
+MIIDDTCCAfWgAwIBAgIBATANBgkqhkiG9w0BAQ0FADBAMQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAMMBlJvb3RD
+QTAeFw0yMDA2MTcyMzQ0NDlaFw00MDAzMDQyMzQ0NDlaMD8xCzAJBgNVBAYTAkZP
+MRIwEAYDVQQIDAlQZXJtaXR0ZWQxDDAKBgNVBAoMA09yZzEOMAwGA1UEAwwFU3Vi
+Q0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCo6wfyS4TIHXcBkclL
+yv/YHbVacWYWj7apY+G25l4DGyro0YTAF7goQfSLFHKFnWK+q52dIbsIZ7MnAi2C
+Jfd25bGttHsz8dhT7DcMJlIDLoWOcd4e4KYzVF+CiVpsznVzH44jBwHjBm2qV2KR
+u/u2qir161zKunsCZd/AgGpHxNcJ5EHhQwW/jynr4qA9+fweuw6qa1S/b/mxxd8G
+8c1SzGK3pM06M+CR/pOjnzObFtsv77TPGTu89/901gdBLax7rId4wCIYLwIr0/DB
+TIrJvqBTBkrqxIn3rfDfQ3WKUa2iZFw/laCCMC6bF7yR2Aq9lwoDf07xYzHDeJ1S
+Wke9AgMBAAGjEzARMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQENBQADggEB
+AB8rIgpfLED9OAyK0hYjPe4BC7wvXFB/KFV0lMaKgwJOsKFahOYroyw1m93nXGux
+vd8LMhBsAbLoDJAR8FAW8yhgrOCdI0Klv9F7F96OJAZ67J0wn85HS4jwGolZRgvT
+VDfglwp1sqH7U+h4EuK4mEFrCB/cXb4AUJpB62zBcR8lDZQpQBZeURhAmwBR5nRO
+gajZxBMhXvjjEmc1k3aPqTCFq7sAmhLpS4DWSOIoAwkeo85EHi3dPZ0kJopVxESE
+nVQJtIM1vfa0up0dsK8c286orsaN+r7XFqngCY1q52xL27LiexZp0wiGqW9oi1Zd
+oOncdhkvpHousxdP9DT340w=
+-----END CERTIFICATE-----`
+const dirNameConstraintLeafCA_notpermitted_leaf_missing = `-----BEGIN CERTIFICATE-----
+MIIDCTCCAfGgAwIBAgIBATANBgkqhkiG9w0BAQ0FADA/MQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDjAMBgNVBAMMBVN1YkNB
+MB4XDTIwMDYxNzIzNDQ1MFoXDTM5MTEyNTIzNDQ1MFowMDELMAkGA1UEBhMCRk8x
+EjAQBgNVBAgMCVBlcm1pdHRlZDENMAsGA1UEAwwETGVhZjCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBAKt5B4e2kjEKi70Fxqkv+g2KBvIiVE9Fg1D4sdpv
+F/OOEIQ/yCNAl5GCinl24TGu/9pjMJSXmHRKYNXtPhjTCAWOhh7MRPXOcVQ9Sa1N
+4uTQFQooz3gHtIWVeUzRAvl5SRDy9IN0claHdS7VOWUPrkV658/eV7BbMjPlQxrx
+m/meUtj26B0BFQYOCGpRk/YAyS3aKlMICz0RrZqDmJH2zll60gm5t9hnzgI9+AXG
+sTcSAFZLWadYnSEeLWT/HFgI+F9/RSQRb3NL2eGIf96EF//ab6Bwkkf7IxT0n2am
+yxj+oRseQCkGU9Hn8KDVM4eDcZHKANAbLyZj08vj88N73UkCAwEAAaMfMB0wGwYD
+VR0RBBQwEoIQbGVhZi5leGFtcGxlLmNvbTANBgkqhkiG9w0BAQ0FAAOCAQEAmMm8
+LSdEa+8HR0/tOuevc/bp8PfepiME20MBzkp9/CJeqBiryu4vSzuzd6i6rLGw3VrE
+JWox9Ju4VcaptcXwv05CINrvrzFbi93UMmUGGTz634AeLOAQSk8nWwmo84qjbvAh
+sXB2Bi2aZVSooh9h2+d6Zm916uWfkZR2iHwNHXzpWPfq4BZM48YQh6mY1SCNHiL7
+IMaeHUrp6CLli7xjHYRSjYldiYDIeycN3SkbfVvMp4bWCBZ4qdR4RtcXIul6I4wQ
+N7TANKK0oa2RMS4nEKPQeRogDf5Vt9L9R+OpUV8deyb1KPywFRJ78nlzGfdsiL13
+jVrfHBkSphYjljc/1Q==
+-----END CERTIFICATE-----`
+
+const dirNameConstraintRootCA_notpermitted_leaf_changed = `-----BEGIN CERTIFICATE-----
+MIIDvjCCAqagAwIBAgIUeir4p8XxdPWLdvbhVDafSTVBzD4wDQYJKoZIhvcNAQEL
+BQAwQDELMAkGA1UEBhMCRk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwD
+T3JnMQ8wDQYDVQQDDAZSb290Q0EwHhcNMjAwNjE3MjM0NDUwWhcNNDAwNjEyMjM0
+NDUwWjBAMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQK
+DANPcmcxDzANBgNVBAMMBlJvb3RDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBAKh2BrO04S0u3JUh+yCsYkgU8M+6sCx8L7UYUVjyzcWqcAi6hWm1NaJv
+zbvZdHopY1BoPbktqaP03Il1CySV4TV8V8RudKBnNYeOLXlc8OUlHd5FH+me0Y9I
+wH5Jv2adh1MO5IVssUVDIqDkX4p7Gs2UzAU32G9V+iH6+1QFqOj/F/uICbSQNY6y
+SE/tOf9inW5x2nxdOEJ5YmiSqQ+nUGRgq0+5kSWooXFzHhfVSYmiuuO7aPZOnmW2
+Rk0iskheHnLwL3F8LGSx96ToRFl6hk/EJI2CE0UR31PdTGYmqBKV3C76TSibawMh
+/DNxQ+BPwm91xDVo5fW88/zUsUGODQUCAwEAAaOBrzCBrDCBlQYDVR0eAQH/BIGK
+MIGHoIGEMDOkMTAvMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQww
+CgYDVQQKDANPcmcwTaRLMEkxEzARBgoJkiaJk/IsZAEZFgNjb20xFzAVBgoJkiaJ
+k/IsZAEZFgdleGFtcGxlMRkwFwYKCZImiZPyLGQBGRYJcGVybWl0dGVkMBIGA1Ud
+EwEB/wQIMAYBAf8CAQEwDQYJKoZIhvcNAQELBQADggEBAEdtnkb9IftTDxSqxulq
+EmnRS8MVya1zt+HNwNiMU8jvoS07M7ccoIi3GR+8VToWTRYtlhsLY31iiM65ZD+t
+zTa2SAO74BAub1pgRH9s9mITlAJGSTCBPZunW2/bCul3vau+MKZLB1r0mSLAObS6
+5Ydj1bSQWCs//OCunNAvQH7SoSLsttTYKRdzaOMhjzLGLJTyIHDB2HwWHZzCifDt
+naZTFds9VaoDxXBsnFNZiSY2I042DZp4ftQom3JAlu2IdnpMVWLGqCZouzpCI4EP
+qw3Su6ekSUz6KbZJbzlsrO6xCWmQ3RIiL1Lul2sCMznnyMh3UATKfKS2xRh+sLMn
+DQs=
+-----END CERTIFICATE-----`
+const dirNameConstraintSubCA_notpermitted_leaf_changed = `-----BEGIN CERTIFICATE-----
+MIIDDTCCAfWgAwIBAgIBATANBgkqhkiG9w0BAQ0FADBAMQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAMMBlJvb3RD
+QTAeFw0yMDA2MTcyMzQ0NTBaFw00MDAzMDQyMzQ0NTBaMD8xCzAJBgNVBAYTAkZP
+MRIwEAYDVQQIDAlQZXJtaXR0ZWQxDDAKBgNVBAoMA09yZzEOMAwGA1UEAwwFU3Vi
+Q0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCmQdQG2xqxMOOmtdF7
+hZrmFADZRi0dmEGf+ggNVkTRnEwMbvYn/Yux7DcFYamUP/ULddff/ij1P/N6iJEm
+o9mR4IntBmSUpSKhTYCQFxlMR5HcEkTTVOC+BaNi/tOxkVC4aWvrEIM0Hp+EiYt/
+a6ZnwpLGI9Jwel6IAf+vMFQaPdoDYJrAv1OUhxeysfPWT6UuZiNLW0/uYnyKBfWE
+d8cHjUqJs+6gQkGK/HVan7L9MgpzGj7uhRunVFjS8H7QBUIDH9a24zHZYt4ST0r0
+rcJ7iDHTL2EXavjBEXKNDCSW2WRS6hPVJdFU/3P7EGp5xUZF2QsBztOq5wgPvSNL
+e7wZAgMBAAGjEzARMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQENBQADggEB
+AIxpJeku+FuklM4wh7hpyMLJCgeoOHKtVSSV3vRGG0Y9PI/p+gnnz/IBA0pnCYiq
+XHtqVp9hk6/DoKbWRq7/lXiYUdsHClhaXMKjZoXMdLPuhYSh4mbEgL6zkdtgvEVs
+RQhgmYWhb5ddkiXTOfEdhscjSC+pSizzTqUq7S/donMI04drVe3ePRW1WLEqsXDq
+GK5vLiXNAMcZfO7LF0cwRtAv8ZHwJSW137MFJumZV3MqSYF/6kBrvi69Yc60xwdN
+x0qqkHPFKVful9kdk0tAsQb+q0pBWSSQ6g0IkwSnfvONWyNWwuY6QULryJDPrljq
+Y7Xbi8UDMMLE91YWZsh2Bj0=
+-----END CERTIFICATE-----`
+const dirNameConstraintLeafCA_notpermitted_leaf_changed = `-----BEGIN CERTIFICATE-----
+MIIDETCCAfmgAwIBAgIBATANBgkqhkiG9w0BAQ0FADA/MQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDjAMBgNVBAMMBVN1YkNB
+MB4XDTIwMDYxNzIzNDQ1MFoXDTM5MTEyNTIzNDQ1MFowODELMAkGA1UEBhMCRk8x
+DDAKBgNVBAgMA0FueTEMMAoGA1UECgwDT3JnMQ0wCwYDVQQDDARMZWFmMIIBIjAN
+BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnax+6OUje5TLEe56CnceXS2Y4tav
+EJbvTSpunOMYQlytHXvSR6P/fDc5sWL3AYeI1218aFJRHaHbCSg/Bu60RRmpZTuC
+oHfat3dxygRwI4kAuDEege0ACWYQ/iFNqSug5QYdghAhuevO1nT5AcwhTVA88665
+tjZhzTslIszlsgmol3Tc1bUH/SwXCWsUghjzLv0G914JwFQNQddrf1+/wOfVB6l8
+O+9SpO/Y6hxQ/QOlAFn5/alZe9QSX4YQHIOZuedSEkLvLDiLOx05oi5FHmzVlIsd
+nzFz+dID9fUWFwdy+B9aBzpXzKe+3bo5aN6kBzNLG0mGwH7aKEUOKM0S4QIDAQAB
+ox8wHTAbBgNVHREEFDASghBsZWFmLmV4YW1wbGUuY29tMA0GCSqGSIb3DQEBDQUA
+A4IBAQAh6LZx+VMHMlrvTzE33v9kaq9RpWIgyRGb8otk3kziyg10gRAqtHSkXaan
+01sY71+jt6HVgv/um4qaaYsVyO2FWx/FTQf5xaCMpKZE7xVeck7QSKebq2u9jnBx
+tzRF4SL5mcb6bX9FeCQTjWxZBj5/3HkWRnEOc/Wva0c257zQK0jEjla4EHesyoh0
+kmLZzjqoEy7RyEDrXfirH8Ej+wUTSr6wheaMolRp3WAxkeK7bot4o8m7hD/dRxci
+hL0up/65eS71M8VWIp4l99YdMtT3DkPXO4JARETrCIKq0BCESxRgoREWAYyQ19YV
+x6P2q0VOe8PnGyy5ufPbbvWroK6+
+-----END CERTIFICATE-----`
+
+const dirNameConstraintRootCA_excluded_ok = `-----BEGIN CERTIFICATE-----
+MIIDtzCCAp+gAwIBAgIUKmG31+ydG9YyJMivYp9ABzmIe9gwDQYJKoZIhvcNAQEL
+BQAwQDELMAkGA1UEBhMCRk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwD
+T3JnMQ8wDQYDVQQDDAZSb290Q0EwHhcNMjAwNjE3MjM0NDUwWhcNNDAwNjEyMjM0
+NDUwWjBAMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQK
+DANPcmcxDzANBgNVBAMMBlJvb3RDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBALLjJ9XNAfJpuRDGAA0u0KNkQ++wZywbPH/EL9zDvjXPlTGTE7JqESv8
+A9QMGtkfELsvoVMsP8npuICdEmSLzkgWmS+Dypng2Pj29/3fnxE0cII9WCh6pRg/
+WUtfEjF4IShHWuPIlvSg+ucF8peSCm0CenVDWqd+uJ5msXdE0XyyuVUAfycMGzsX
+fkiw6q91pEb5Lle+tmBXL8zT+JPvbLDPeHrkU/0+jPwX/xC+ziDHrfh9Hetddcd+
+6xJRr72PX5cuQ9lcQvxnSQUTc6PJHascWBkklQxdOvy2blIFTKk8fSZqa6sJP5Qd
+cnp1mcvinlpjZ3lgzMtu7TYkX0AnSP8CAwEAAaOBqDCBpTCBjgYDVR0eAQH/BIGD
+MIGAoX4wMKQuMCwxCzAJBgNVBAYTAkZPMQ8wDQYDVQQIDAZEZW5pZWQxDDAKBgNV
+BAoMA09yZzBKpEgwRjETMBEGCgmSJomT8ixkARkWA2NvbTEXMBUGCgmSJomT8ixk
+ARkWB2V4YW1wbGUxFjAUBgoJkiaJk/IsZAEZFgZkZW5pZWQwEgYDVR0TAQH/BAgw
+BgEB/wIBATANBgkqhkiG9w0BAQsFAAOCAQEAOtJkL4GXHbzJsOeLduGb8m99G14+
+7ldlQ7zN8/MlkLx1q29ZF3xIWqgRug/mdIdPDkM+E7kmMESwXg832Zbmn4T2DrW1
+ZWiAot3TPsI9P3uzHz21gFU+exruc+uNNwoD0rbvV5KEqKg/O6KU/n/1i0wybir1
+Hp2HvEUZYKFWfHqbqbfyN+kEUUp0NNWPqoARAcuEr4p5YiFRMSrIu37NfWM2AHWd
+fR6it0pc5ynH1UN49J6qwaCEut6pyY/fdzLgHiILdAYcR8fWTLViN+iiSQccUkUR
+AeOkf65mEY6s4ul1VUyH+lD+ignUoRs/uIV073pZYxKnD/nAlQZj6o6abA==
+-----END CERTIFICATE-----`
+const dirNameConstraintSubCA_excluded_ok = `-----BEGIN CERTIFICATE-----
+MIIDDTCCAfWgAwIBAgIBATANBgkqhkiG9w0BAQ0FADBAMQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAMMBlJvb3RD
+QTAeFw0yMDA2MTcyMzQ0NTBaFw00MDAzMDQyMzQ0NTBaMD8xCzAJBgNVBAYTAkZP
+MRIwEAYDVQQIDAlQZXJtaXR0ZWQxDDAKBgNVBAoMA09yZzEOMAwGA1UEAwwFU3Vi
+Q0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDC1wndgO+pMuo9f/a9
+xO1yLvJjrq6GWAumFUDP7bV8n2njsSlPjQ/1fNS4LC3V5UCBcwC1a+CgWHd9SrpK
+nw0iWRdxQekrbKelwzTihTo2eXgj5wJbEbE7QzrR3jFig0KTgavc5c+jWKLEDG1i
+cmCNGC7MTwtwNgt2SmyxAeNa+EDOs1KY/mXCsh/tXLXbhehhtQxCITRfftrAje2q
+EVjHyhI0WnMt4q2rf3buRoC087ufyk7G2rDzcghjSn6E0zrFn3HMOm+/7VL0OROr
+9g5mDKTAbIOUjiqRYPkeYIjU+M/jyIw9Wn5xSvbcVIgqg3224VES9knrUnZT/EHC
+Cg5BAgMBAAGjEzARMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQENBQADggEB
+AKeSM3cbWwPyH09xlKBUrJDdLlVVJIKSchwx9IJk9/2DL3K5/ku8q0GJMIIY8YqS
+4Bzi92yiEf/jizZeIrfK/rBIN3jxmx9cGdt0fVq3ZudOEW62ZdK3UsqnINGgv9UE
+eCcAySWRZi9qkXDTui/7q7V2FCEJseqwgOI8N9TKxTnwTVyyCi/lyUYz7jOWU/JZ
+QUG5HmMBe99z+yaF3JTa0AbeaTcj5urdklL6aOeTcaHEBoUPsTsLQlAYjI/I1XIm
+KJlrxfY0DddCLr+CyJVCthLDxNdI70yDz9VNk38amJBoDaCMmQEeYwCZ6jk1d1Cl
+bZ1UyIZnvOxXQQQB6+jRcfY=
+-----END CERTIFICATE-----`
+const dirNameConstraintLeafCA_excluded_ok = `-----BEGIN CERTIFICATE-----
+MIIDFzCCAf+gAwIBAgIBATANBgkqhkiG9w0BAQ0FADA/MQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDjAMBgNVBAMMBVN1YkNB
+MB4XDTIwMDYxNzIzNDQ1MVoXDTM5MTEyNTIzNDQ1MVowPjELMAkGA1UEBhMCRk8x
+EjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwDT3JnMQ0wCwYDVQQDDARMZWFm
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAva5lDCQyJbOmhGswkMw0
+P2GJ9AFxE50BysndmYtslER78rM61UYdVeFKpq/j2oreriCZLbrbrOuMRubGo4Sh
+8uoUvxRahVE9aFhKIGtXirV/LNnKjGjvZ0M4XuDfnvheCP+SZsVU36l4LvJ7Dz98
+UznLZvx1gUTZsgU69rxd03X/MOh5dTzDzmu01U4U3bhYd8LtCLELfxQVJfh43Rd6
+nj1Y3sFmib0J6WI+V0cHKenx+fYjetO5TiJ9Qw3O1hLzDt7EUd1gPgle9jzwD+8n
+MpxBdGTyzChAXoBVDgfBV8bxFVzDGyV40+dism8gXdmq3T9GHw/kt1vemWMfnUxZ
+gQIDAQABox8wHTAbBgNVHREEFDASghBsZWFmLmV4YW1wbGUuY29tMA0GCSqGSIb3
+DQEBDQUAA4IBAQCwu0rnwQkDndNxQcjgsShz9QDvnDur8H2zy3m9aJLNaFQCnTDx
+ZeBEQNeanU7vM53MtdreWQXk9fRZ3kLCP/HxLBcBzu5KDUX55Au3Gtk5/MREXGyV
+JksApOfU9sPxaDuhjeBHETkumM1T2CfMO/bzaA1D1zcwjJE9hrVmSmySm6WalcFx
+QxCSAIZvWgQIZS8zYf9xTs6oKNFoZLWZZikASUpzRhqx87iLQztOiqO5yVLyNUuf
+a59aVQbF7j2plSFoiODXoOF+QKmvD6ATx2OmmnCrM0N2aM8dVm0dLyxsxwUcw9mC
+/5ZIq3EF09A56PdGEoaNU0J2bgj/nxQkosIv
+-----END CERTIFICATE-----`
+
+const dirNameConstraintRootCA_excluded_rootca = `-----BEGIN CERTIFICATE-----
+MIIDsTCCApmgAwIBAgIUciX5Nbh7s6Idfc5QHaSHAKvFqDYwDQYJKoZIhvcNAQEL
+BQAwPTELMAkGA1UEBhMCRk8xDzANBgNVBAgMBkRlbmllZDEMMAoGA1UECgwDT3Jn
+MQ8wDQYDVQQDDAZSb290Q0EwHhcNMjAwNjE3MjM0NDUxWhcNNDAwNjEyMjM0NDUx
+WjA9MQswCQYDVQQGEwJGTzEPMA0GA1UECAwGRGVuaWVkMQwwCgYDVQQKDANPcmcx
+DzANBgNVBAMMBlJvb3RDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+AMZvcJrRcSl9BxPt4VpAZuXv9AyTWqqbED952LGjng/dKKf3Pjc+v1ySX2/62iiy
+TUWuXWOesVZ5tECooT7JZyD0P/67QDgYqjtDYDiJ1SBmaiQ87/w+6hq9B9loyaiK
+KniXov0IFHme/yvlUbpa458kXGriV5/oCMlBvnYb1TEZyMcBqyXEluw6CCAJ2FJx
+izQubA2nGtg80meLiYoI9OAtDe6ERyb/HRJP0qVlEXQCrDDCC+PK7hMbgNgquFnm
+UpLusoNEuacZMQW7gB/Fr0ZWK1HS10pnsf9GYdfR0xU/p6tqBGabcK7HrH7C0pb8
+OZLvxdW+HW5L/M34YkutZCkCAwEAAaOBqDCBpTCBjgYDVR0eAQH/BIGDMIGAoX4w
+MKQuMCwxCzAJBgNVBAYTAkZPMQ8wDQYDVQQIDAZEZW5pZWQxDDAKBgNVBAoMA09y
+ZzBKpEgwRjETMBEGCgmSJomT8ixkARkWA2NvbTEXMBUGCgmSJomT8ixkARkWB2V4
+YW1wbGUxFjAUBgoJkiaJk/IsZAEZFgZkZW5pZWQwEgYDVR0TAQH/BAgwBgEB/wIB
+ATANBgkqhkiG9w0BAQsFAAOCAQEAgL7XZUy5U7fzDz3O9bTQcbAxNJ56ky01jJvy
+Kj8Wuo+Ot04qO1V7kWF8jB39cwlw9RP2bptUTH6KGS6hJ2LOoYP8WMhOTkHAq/Np
+ttNcjWce4KFNs8512URo/8FtQZ4fiFyhKfxLuWS3EX1I8B1OlJVZBsqtCH8rglQM
+E0r4HWs5rhBvmD3vgxrFQsdGAN8Tconc769FxaHynySgK6bpsOHe8YWtnO8yCaha
+Q68/4dmE3FcafVJT896d9N3w61GvQqsa8jbP2uUMWi3dg6YBqsRU1bh3CvBrYpYl
+K0KZZLQ9bTbqH1ksZ9Iod1YeyhCpTd1kf3bkAHDNylqPus2vbw==
+-----END CERTIFICATE-----`
+const dirNameConstraintSubCA_excluded_rootca = `-----BEGIN CERTIFICATE-----
+MIIDCjCCAfKgAwIBAgIBATANBgkqhkiG9w0BAQ0FADA9MQswCQYDVQQGEwJGTzEP
+MA0GA1UECAwGRGVuaWVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAMMBlJvb3RDQTAe
+Fw0yMDA2MTcyMzQ0NTFaFw00MDAzMDQyMzQ0NTFaMD8xCzAJBgNVBAYTAkZPMRIw
+EAYDVQQIDAlQZXJtaXR0ZWQxDDAKBgNVBAoMA09yZzEOMAwGA1UEAwwFU3ViQ0Ew
+ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQClm2QGf5fZf3Ky+iXjaghW
+qJp6L6tDMbMg9yAvA9M60xD6A+ND/1jSlKzPC+95m5oqdvCUXoM7riGCknzuUx77
+CE8Usk2bojmEz06mpH46upuLjpQ1tK9sIYODupaT0wx1gj+HRn1p5OuGLFn08MRy
+TORY0TdrcGTH5rSlmKrqxjD0fTBUJZh35u5FN6tOTMf3M8/ggOOkksQWW2FdK5eQ
+2JcfUxFipyldsqIl9QdFGvybGzaD3MbqTJz0tKX9AA/PWqqC5yP30aS+c6Nt9wBw
+bCBu86L6t8nyxGGzY+DwfVUOi6he0Nv48XF647ozDGzO7iyRHulWvfxIQv9P+8Xd
+AgMBAAGjEzARMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQENBQADggEBAHgw
+O4aO2+WfJWOnOKTTEE7Z4hQkVcrR9Aw30eX8CmNXrCtRzNEvJhhooGl7HX+DzHFZ
+BZiUpCG2J5rT4qM3eiNYU15EXZcK7jr2hJeUo6GwR97QXJDqrtVz3ijc1yj3/bFX
+kgZ+poFTmK8uktXa940pwuMrVUyyc1UVsSRDyujbogAGJIf6WQDFB14BghDMYvup
+TM4PoJcj1AC9wClecTPOSRFX98Ld+Q6LI7sSYS7NwYl9DBZfzvjvoJ7Y81j/uSyY
+brVMI3izH0/oOxVDcv/J8T66hfXjxKhaawnWJgz/4Vt95mn0tpSOOuV0nw9dGrIQ
+8VfPrcqVUWGjuXmdylI=
+-----END CERTIFICATE-----`
+const dirNameConstraintLeafCA_excluded_rootca = `-----BEGIN CERTIFICATE-----
+MIIDFzCCAf+gAwIBAgIBATANBgkqhkiG9w0BAQ0FADA/MQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDjAMBgNVBAMMBVN1YkNB
+MB4XDTIwMDYxNzIzNDQ1MVoXDTM5MTEyNTIzNDQ1MVowPjELMAkGA1UEBhMCRk8x
+EjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwDT3JnMQ0wCwYDVQQDDARMZWFm
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyfIZLyzQT+alQzukkpIX
+p2E7wBLQ+ss91sKjZ6OWj+NbWLkaUNyAN76kyPxPgint9p49xjqZY9GCUnGtvWYb
+cYZQ1fj3crxt3Rn3qXMDPHUUE3HXJYXBl6wE8paIivqdqoqLdHHgNmfyXURxHuOM
+NKcHpBbR7eZPmXVMikz2rD5jesRDZJUYCyRxD0OfeVYaUOX5mNZX10MvNs4WcVoC
+TB3/WDPk+PjJKAserOIAi5xJNFaxpILo+iQ+s2+T+ewJA20rro0oLykNKKhvzVnJ
+Mrn6gnHavxIoPsFkLUoRxF5vyQ/UJ2+DWsaKKqBDE01LCVjvpd4Z0OVTyU1f42zS
+6QIDAQABox8wHTAbBgNVHREEFDASghBsZWFmLmV4YW1wbGUuY29tMA0GCSqGSIb3
+DQEBDQUAA4IBAQAzKKVdTpFjgEmpZy43PFErJVIhLn8iz/a6jAKz80wlVsXhdjtC
+4GXPP01KIfzJws1odZ0S/nKVuYZhFCbAudyTcZ+hfG7DOMHXEVjF49QmLh6Rl57z
+KZaopWWlkNHtB3jQhdX6I+JeS3hQ9h3ZHg/lp1kxA5FIJx4iUdfEEcHP+VPprsax
+NNkJhyMPXhEmzZkhBVwAriAsmaoPAhw0i8p706GoyPEXTTMkozckX846Zo1VKJpG
+ko3gpLlcY/eyBDBN6wdoRWatA5hOaMrsArlOPwFnoIhWs5PI+drUiBTGEpoFgRAT
+HCBEKADPXWJ3oEDPlvIN+Q6VsTHMskcjFWVe
+-----END CERTIFICATE-----`
+
+const dirNameConstraintRootCA_excluded_subca = `-----BEGIN CERTIFICATE-----
+MIIDtzCCAp+gAwIBAgIUFsSJpy7YvFGg4UPXR5J7xRF5ur8wDQYJKoZIhvcNAQEL
+BQAwQDELMAkGA1UEBhMCRk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwD
+T3JnMQ8wDQYDVQQDDAZSb290Q0EwHhcNMjAwNjE3MjM0NDUxWhcNNDAwNjEyMjM0
+NDUxWjBAMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQK
+DANPcmcxDzANBgNVBAMMBlJvb3RDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBAMNsQN73YR/WaK4LNvwHZ4saV602YIRW86DObnWz52OtxO+jnoysFN1H
+T7YuyZziDGgN8Cbo4n3ERb3QuhAbaPUdeMZGeikLp9eb6043O6Bs9WDwspXlsUXx
+/ngyBbeNB4DOqKyEwU5QAqWjpUbylpMXjNAaEQOU02BIFkIxCD/O0s4oZN6DFskc
+3rwy8IYZduCeVNXVswdim2afo0tuhU0FNyrDBgAcCwNeyUKurCnVD4QF+XP8q1aC
+LyoieXHjTOg7l4Ksa+VOyTMH0d9qzRrOcOQm78DPHefsAtBLfVaNWHMsUYWz0S0z
+8BOFDzew2dGQa/d4DbjG75S9DkbvwC0CAwEAAaOBqDCBpTCBjgYDVR0eAQH/BIGD
+MIGAoX4wMKQuMCwxCzAJBgNVBAYTAkZPMQ8wDQYDVQQIDAZEZW5pZWQxDDAKBgNV
+BAoMA09yZzBKpEgwRjETMBEGCgmSJomT8ixkARkWA2NvbTEXMBUGCgmSJomT8ixk
+ARkWB2V4YW1wbGUxFjAUBgoJkiaJk/IsZAEZFgZkZW5pZWQwEgYDVR0TAQH/BAgw
+BgEB/wIBATANBgkqhkiG9w0BAQsFAAOCAQEAcUxARhOit2At4mUA5hrKmljssLwP
+995QU6+645W0J7gxv487aawalithORk7zE8wm4BAB7mz4S6R8UdfNNY39pLEfh7h
+JiTH5HUYqfolmT0GUTzvUtBCE8fkIf+IX5bVxPgNrEIAT6euJScpJkXlqr5ZuYts
+EHSlKvgxBDbddgjs6N6OyXQSG6Po/4PpcgzhxKy8w2qfO3S4j1G5YEWwQBRFa5VJ
+c4DNSz7ydRtkga4VDsIV0mbK0mjZeJDu+nb0V/rsyryvkZj9qSiH3M9y/3gfvFWD
+GnifjahHwYe/xN4eNSgSxgqYx20TH4nthaFQgcDzIpqSmJfOHHCMNcg2JA==
+-----END CERTIFICATE-----`
+const dirNameConstraintSubCA_excluded_subca = `-----BEGIN CERTIFICATE-----
+MIIDCjCCAfKgAwIBAgIBATANBgkqhkiG9w0BAQ0FADBAMQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAMMBlJvb3RD
+QTAeFw0yMDA2MTcyMzQ0NTFaFw00MDAzMDQyMzQ0NTFaMDwxCzAJBgNVBAYTAkZP
+MQ8wDQYDVQQIDAZEZW5pZWQxDDAKBgNVBAoMA09yZzEOMAwGA1UEAwwFU3ViQ0Ew
+ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDUc2Muxik2k7dasG1BBksQ
+5M5EPCc101nS6RZgD+LfpQl9/DD4qHZF8iMdGcaDg531wVfchlpejpsE9ghHsHrS
+YHi4sfw2Puc1sMoJ19WDdOmAA3uWzfLUGp0T0jx9vifcElKgmczvUucAaHPLSK/O
+MUafIABY0zOatVOBdB7XzfctQQQ2y5VgegLCDSPP5YXbzxernczSlF32q6pDPO83
+Z8AfQmosRLsFL6w0iMtfcdeXzUuEh0n+mv32Gbg7zNORTzQK5PtO58LSyJoNO3Gn
+gopjYInUYRd6dnI6QXfaS7vE0cVgnzXVRgtKoroIEbVs+XNrtqX3X0bg7pXSsCIn
+AgMBAAGjEzARMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQENBQADggEBAB9E
+GDcUX7KxUsIYfJQYnNIQIcFp9lcYIv8H5Xt1o5ZhNRYAOaRLTsdjQaB/nhiygwZS
+eij+V935kAmcl0V0UWhb+W0a18kmPSWH+AHXElMfLXKzYabb5YA3EgiiuGV4uxBD
+b3Wch++73P4m6AjApDaYG2MOFvoZuvmPNi5jGA+fGsxMe1gBoKmg1Z9QnGPQF1yB
+/M9YJAL/qafrbHY7IyliCLMXgfMXRjXVCHSYwLuPfkXH5QIx4Ihks7NVVziNH/Kd
+AqXUU8j8kU654PNggTJ23aar3JuRK0r1XOchG7z3YvUFK2O5Eov/Y7Z6FEjs4oK3
+IwfESSS3nPVZijufvbU=
+-----END CERTIFICATE-----`
+const dirNameConstraintLeafCA_excluded_subca = `-----BEGIN CERTIFICATE-----
+MIIDFDCCAfygAwIBAgIBATANBgkqhkiG9w0BAQ0FADA8MQswCQYDVQQGEwJGTzEP
+MA0GA1UECAwGRGVuaWVkMQwwCgYDVQQKDANPcmcxDjAMBgNVBAMMBVN1YkNBMB4X
+DTIwMDYxNzIzNDQ1MVoXDTM5MTEyNTIzNDQ1MVowPjELMAkGA1UEBhMCRk8xEjAQ
+BgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwDT3JnMQ0wCwYDVQQDDARMZWFmMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0jyOWMwIUsUif4UqnIkA4JJF
+mN781Pn1cnOMTmXuBmmxb1CUJEmj45ZgaAWuYH5fokrH4CB7hNYQN6yDfhnZDfjJ
+dFo/6d359qRYaUxnj8OuHx1HtqVDVeF/BiOXbBCBUwEhkpPg9yEBensgY12peeCU
+ESOEjOffQDMsJXK7Ewavdbz1Zggy5hkL3fS1ToLd+QSsYCWNNdUSIhYhtwt+ebVO
+BdwANOPPpFjtd4+TWf/4Hr/hXy6hv+XUFRrAxUiiKcwPQW/hcHQY6P/91gyRYPOv
+9rREex3hjP9+czq/dDO6gwpGrBIeG0N+ubi1j7Qm2VGxpxGOQ90bpUqv7SsJ1QID
+AQABox8wHTAbBgNVHREEFDASghBsZWFmLmV4YW1wbGUuY29tMA0GCSqGSIb3DQEB
+DQUAA4IBAQB7njnf8EvV6Ks5jr8Jp2rLkKnKkiVHy0jo3tb2zlpqBHSoE0AjB7BO
+Y9u0gN41YTSBDDEt4XYNB8zdgcykF7CjtkyjA5XZFrd746mtV4B14obUI9flUOGD
+LQSvzsfQ8ZQXI3pODwKw5h4c4Oamd0PWxDH9cdOJ6gYQSYLvGTJ3Lw7mtLA8/FHz
+iud7q4A7IzWqc4ddz1fgidA84PdEQuueIxe+f+dIEg0xbmx1WDE1M+DODNoJv1lO
+0WJmtih1vXrMXZmRYrX+C6hpwe8eEUZ8I+ji166BE77c8WuVOVv8Xt9/VgbbfcV5
+Yks9b1uKfoT2OFIZpWz2Koelx2QY3hXV
+-----END CERTIFICATE-----`
+
+const dirNameConstraintRootCA_excluded_leaf = `-----BEGIN CERTIFICATE-----
+MIIDtzCCAp+gAwIBAgIUER/ZnG2p8SujBgP67sNKnIsmpIMwDQYJKoZIhvcNAQEL
+BQAwQDELMAkGA1UEBhMCRk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwD
+T3JnMQ8wDQYDVQQDDAZSb290Q0EwHhcNMjAwNjE3MjM0NDUxWhcNNDAwNjEyMjM0
+NDUxWjBAMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQK
+DANPcmcxDzANBgNVBAMMBlJvb3RDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBAMouJboGH9bOAMsx/PX4D2tCay0+eWFrsN16XIoXy7E2ARjFzzEmKZPD
+WaaMhFlNKP2qO/6pD5g2PY8I27nnyqmzXoz26NJ7e8H7fT7wmbrEcLHT4ish+X3E
+NKxKkTG3SFNoAlCaTZvf6QhSMDcAsG5tEV1MotVo0xwrhITzbrOwejnn018OZJ21
+CPK7mFPqCx6MF4gfzzGG2gTbNU9K4AjL0ykUAKRBs0oZ/Q/Qe9Iid6VW8A1+qUZT
+lJ5WjxYgHyaeW0dlNAHhrnpo8bY0nZpvIoMisGJKSbyvp/HO1Om3mX3PfUjfi51u
+pS5GUKQ/a/rvCu6kKeK3UU6U9eI1TfsCAwEAAaOBqDCBpTCBjgYDVR0eAQH/BIGD
+MIGAoX4wMKQuMCwxCzAJBgNVBAYTAkZPMQ8wDQYDVQQIDAZEZW5pZWQxDDAKBgNV
+BAoMA09yZzBKpEgwRjETMBEGCgmSJomT8ixkARkWA2NvbTEXMBUGCgmSJomT8ixk
+ARkWB2V4YW1wbGUxFjAUBgoJkiaJk/IsZAEZFgZkZW5pZWQwEgYDVR0TAQH/BAgw
+BgEB/wIBATANBgkqhkiG9w0BAQsFAAOCAQEASdeIWexo2e4JTIwEpa+Eq2LZL1+M
+MO14ddKsVs4xXi/t0W2XCf3CA9OCSeLXQmPipS7y3VJ9XGjUwMIKJyuwpXTFQ4g8
+D7t0eNfBlROIFSqDGhit0W0A6h8sTUKG+xfBhLCDmp3Y77Ma8ZzdTStCRyuP9Phf
+5J7qXnQR3mJYxcU3rZ5aI5pJ90K7pQTHzvqqgKdLdvPxXuo6hATXxrO7LQGbZY6m
+4LD0bZc/PnAYkz1XKL8qwDy+/J+00DaaAqCkKeaT/DwikI8YKCN8V6VsXLmiXFO+
+y4ms6r+xEIRrWn6Bu9qdXN+R93uuIupzGVn5MorKpXOIIpg5FnfJmhREfw==
+-----END CERTIFICATE-----`
+const dirNameConstraintSubCA_excluded_leaf = `-----BEGIN CERTIFICATE-----
+MIIDDTCCAfWgAwIBAgIBATANBgkqhkiG9w0BAQ0FADBAMQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAMMBlJvb3RD
+QTAeFw0yMDA2MTcyMzQ0NTJaFw00MDAzMDQyMzQ0NTJaMD8xCzAJBgNVBAYTAkZP
+MRIwEAYDVQQIDAlQZXJtaXR0ZWQxDDAKBgNVBAoMA09yZzEOMAwGA1UEAwwFU3Vi
+Q0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCkt+0vVGmZja1qEIPG
+38tPtiKup2eZPRBwj6gwyZQgBrLn+/U5UcDiO1sfoNpCE9KHGxl2eiUZGirsahSA
+gkS9Qs+zawQ9GPqh0btZ0KfzIzMYOjiD18rPSlqq/LJ5PILLt8Z3uYaeJYM9YOXI
+biiGaAN7dPaht2iW92l+VIbHgEjEWpHU2ds2kEJmm848w35hoPsHuWxRYaLPr2va
+XGAoiUSbuxNclXRTIm30xIosmGTPeBxrdJ5YH/uiVgfvaNFiQkbjNrEWt4b1DVwJ
+mjB6o4XyX5mWI6Nu3ik05FXe7gYAfekjV+UeH0JcI/CW9q69gsHfx4suphA6KRSp
+vidPAgMBAAGjEzARMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQENBQADggEB
+AKEgKNLBlpbRGbIV9e6e3ma9lEn6x7QpHfFLXGajDznH6Yl/p4NKjqlQu0eQECzZ
+em6cHze6sI2UNXPbHnfvDHSytdR5HPJB5NlWQ+ChTHw9aTGiscdYpQx8FmGQNLh/
+ksdP5xaopCNcqEI1MdhjDzfy2yTjIpxe228nZPpJ6uufWhXogyOLRiES/flztuHQ
+qn7HXTMRf8PL5L/XLK/W+g51j8lToIphAts1wWACBag+LVBexFBf9yWIm25A0V7C
+Dzpqf3WexKIUoPeE+Aopuxp+GyCEBWOV4XNyTtQFuQRGPBm9yb9FoV1YRHJ9EQoM
+7nnDEO5bB3baJR44wI7Y9ZI=
+-----END CERTIFICATE-----`
+const dirNameConstraintLeafCA_excluded_leaf = `-----BEGIN CERTIFICATE-----
+MIIDFDCCAfygAwIBAgIBATANBgkqhkiG9w0BAQ0FADA/MQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDjAMBgNVBAMMBVN1YkNB
+MB4XDTIwMDYxNzIzNDQ1MloXDTM5MTEyNTIzNDQ1MlowOzELMAkGA1UEBhMCRk8x
+DzANBgNVBAgMBkRlbmllZDEMMAoGA1UECgwDT3JnMQ0wCwYDVQQDDARMZWFmMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwU4n8x5VIRYEoAvc6aUtNMLZ
+RLCScHDt6xrh0irM9jeMCKZeIlm2rfwj9NMMy6amHYXcIFfPWnFKQVMIvDicNS3Y
+4bTW4JeaXqyIRcTexwXP3tTJriHCwwPx/pCtBXplMEB+3xQ2kWJMLmrQ5+nSGo72
+EbnSZPb69AhYFW9R0MqqsP5jNEfJDkTHubiEY1ceZSXujRkntCsw203e75I066Rr
+quA5a/OW8kPHXqwBJOr0UopE6bxisFdbbSSQB3FOtB+qlxXnt78ruE8bJA3shrAQ
+70hcWvo03xh0UKSRjtnd+dXntY0ayOLBkG3eKXIUT+bUVXgx7RAm0FERFJBNAQID
+AQABox8wHTAbBgNVHREEFDASghBsZWFmLmV4YW1wbGUuY29tMA0GCSqGSIb3DQEB
+DQUAA4IBAQBMm5kHxsfwI5u3QoPdrYgbkUtejeJqrU3FpWGyn/covE82DabM8znR
+ZFXCol+vDKPFUQM0E4b9Z08cJyCnj88GokhanBWio4hkkRMN5KoolsrfPCRy2CSw
+cnbocsytyUj9sGVKedZCjwS7X4M+I+eTm+U2xTjF57BzsHqPBegX+Ofrj1SjxRLH
+xBHNPCbcUJ+cvOOrRAf55p2mqrC7Q6fgClKC+fXAOtoqz/ZxZaD0PKbZlQCNWAkv
+O9ec3/SAIOo6VB2dq99ipEeLOMDzFgIMAzqMcoLWJzyoeLk+QiMSfX0QyUP/6J2F
+vYRU3G452BEcPAgk1NW0pvVP5aJDh3Ep
+-----END CERTIFICATE-----`
+
+const dirNameConstraintRootCA_permitted_excluded_OK = `-----BEGIN CERTIFICATE-----
+MIIEBjCCAu6gAwIBAgIUHHkAQg5TrY3k+UsAX2bN+Tmcn9QwDQYJKoZIhvcNAQEL
+BQAwQDELMAkGA1UEBhMCRk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwD
+T3JnMQ8wDQYDVQQDDAZSb290Q0EwHhcNMjAwNjE3MjM0NDUyWhcNNDAwNjEyMjM0
+NDUyWjBAMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQK
+DANPcmcxDzANBgNVBAMMBlJvb3RDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBAPD++dF1edxTqT0NoB33VdRMJBvl2MNvs1dDpxN1GDzGmqyHIrOZZbjo
+k7xQhGoWBsqFS9Erz1o8li70l4ZC2yG7oQPTVqMGWMGza07GVK/jN4fT+qwTCT3+
+P7X7i/D8UahwvnELlt6GxnNIpSY/vdQ4A8Cm9Xj5WpZ7hbsR6Bo5S8Zh7zzl0SAR
+pkZ0ImtC//9+VbYh4LjHndQhGtyKBmL42J1yl4Adll2NvbNTVS3GU1CL8d3DVay3
+IQ9T9adR8MMH6JcwZqrMoqOTRYarMxe+PyhRHAQJ+bWjunidInrKDpMltWSIbB56
+LIXf0bYghMm8l5K1anG4LnLT7bnpLB8CAwEAAaOB9zCB9DCB3QYDVR0eAQH/BIHS
+MIHPoIGEMDOkMTAvMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQww
+CgYDVQQKDANPcmcwTaRLMEkxEzARBgoJkiaJk/IsZAEZFgNjb20xFzAVBgoJkiaJ
+k/IsZAEZFgdleGFtcGxlMRkwFwYKCZImiZPyLGQBGRYJcGVybWl0dGVkoUYwRKRC
+MEAxCzAJBgNVBAYTAkZPMRIwEAYDVQQIDAlQZXJtaXR0ZWQxDDAKBgNVBAoMA09y
+ZzEPMA0GA1UECwwGRGVuaWVkMBIGA1UdEwEB/wQIMAYBAf8CAQEwDQYJKoZIhvcN
+AQELBQADggEBACBb5Z5bO8kRXwBZ5X45CCibEzXFIlCGT/ltx4pwYwjizu22zHOS
+bh90opvy22DYS3CPdh5ymw399MW6w9eBGEKMF9vMAaO4ilM+Q2M1LpLtXfQ/42Pl
+I++5UAQX30NdbO8yipt0gX4Iu+GkbTnrw5yk/+t8i0z69BEMhfazj7m/u4sv0ut/
+HGHX2fwQvOiBRkj49MlBlIWV0DZL5ElpvQHj7RdQSvn4NW47jr33sOkRaupCpI5b
+tflSTzc2EAMFuZdCGAoXFOMUqij3YiHWSU6UYPkQBli8uD1vYPSViap+WT8AeiFv
+OeTzR443icXmzlf4wxl9jsTHGfRADhvLciY=
+-----END CERTIFICATE-----`
+const dirNameConstraintSubCA_permitted_excluded_OK = `-----BEGIN CERTIFICATE-----
+MIIDDTCCAfWgAwIBAgIBATANBgkqhkiG9w0BAQ0FADBAMQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAMMBlJvb3RD
+QTAeFw0yMDA2MTcyMzQ0NTJaFw00MDAzMDQyMzQ0NTJaMD8xCzAJBgNVBAYTAkZP
+MRIwEAYDVQQIDAlQZXJtaXR0ZWQxDDAKBgNVBAoMA09yZzEOMAwGA1UEAwwFU3Vi
+Q0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCY5bIR8o7qsn4csuqR
+7aeg266455zodK93EMNRUA5MMVa2dSTJYigNvkgrxJZtcftG6Wee6Ggnvd6AO8wC
+pigLog7VEsH4eMU65BEZ4qafTKoRZm/N4I2JcApaL6DswSdvTjyPS6BNzFYvgnoc
+cd/ohhqpIDTxlMQRC5tLWY3JDdN7M3azAdVW3wdaS7ED9jzgBCoM/r95VXSlsBss
+4N2lLQ0Kiws1znbRsIv1YbMMTwcSAoGuCyQ7oRHvXicx3Uvuqmmkqvvx4XNfHyKd
+C3MkxSynxeYBMnEOqVgsHd0UfxY/eiWUvpNQAUJErp3kQ8a7JWve8/R7OMJnr78u
+mwITAgMBAAGjEzARMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQENBQADggEB
+AHuotykffPrlv2U5tRH3ld+05d4Hg+O9hehwRpIFl/8bbCE1ODLMM59RilDgvp5m
+hdsS5R/Ml3PyuuLvYG3X97MjWs7GgKrg/ujBFYR+NboiAgdmwxmJ8VofoHwnkoJH
+Hkdz7BLuP/fxZ1by11I+VqIYzcGhGq2RvUwLv2njF4+hllPuZ2omHbbIFI6poDfS
+ra0KukiyYcxxZkusKvURYnHwA1v7hTbGwnK9nSQnLdpd0PXvGj5L5x+OHTExywzf
+hZ5Vr0ypm3R7sRWY//+CdfHYrRzlyGV8noM+O1ChM+WVTW/GN/TFfirH2HP40Npr
+AGqLZQf2YoJszdfGQx13tX4=
+-----END CERTIFICATE-----`
+const dirNameConstraintLeafCA_permitted_excluded_OK = `-----BEGIN CERTIFICATE-----
+MIIDFzCCAf+gAwIBAgIBATANBgkqhkiG9w0BAQ0FADA/MQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDjAMBgNVBAMMBVN1YkNB
+MB4XDTIwMDYxNzIzNDQ1MloXDTM5MTEyNTIzNDQ1MlowPjELMAkGA1UEBhMCRk8x
+EjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwDT3JnMQ0wCwYDVQQDDARMZWFm
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxvij2deQVA9eQoL7ub3M
+KVMOyeab9ykDgwwGv8QUaEbhd7ceWRK2JTl52G/H2Fvjs5dL3Qs2xQg+A6J/cYdF
+FwmJAcueD9UBXf6FjLmMVpkWHnRWb88lNCaiTkICxgBClCL1gXjdJmADc8JYMYMU
+Oe6wRryR7hU9pAfvv/b5Af+PX9yZCVU0W+sV33E4RLsxXh00WwvSATAZrKJAyNH8
+d3mAisKLPxiGoe8ScRM79QXseCmN2DyU+haH0gJQ53/P7E8bjyE93V1uzcTZ1Y4g
+qZJn2U8OddcfXlaQrtXKaTK7M7ew7IK/0BDtEKVHuq00Rw06MAlJC3ZtFkVz7b7J
+uQIDAQABox8wHTAbBgNVHREEFDASghBsZWFmLmV4YW1wbGUuY29tMA0GCSqGSIb3
+DQEBDQUAA4IBAQBECiF98p9q6xsjb7tVFm3M7o2CcZz41rfI5uqNygL0NhJ/UAKL
+uMRJAX8uZryAY43eDyENV8pG6E9eD1igicfOhHM6OOfYpVsKp4mGqolsJ+4LY+Xf
+OBK6YCb7E0XxKm3Jd+BwbTZzAQREHAszs2DExtRnKSqVadK5iibuBiTqj7z2uQs2
+IagL8eosXur1YlAofPsOcYY2F3pGLuUOarrGhG6pG3Zk4hIrRMSityydRUtPP5s0
+BrkIuCAbQfUNNvZTTZHe3lGx0NS6dKZEifv0sNa9r7LE3P//3/ygMrdySnJdIWmQ
+Fos0rNtOdCQiGF9A0GEe8+x8XvSQIduzO/bP
+-----END CERTIFICATE-----`
+
+const dirNameConstraintRootCA_permitted_excluded_rootca = `-----BEGIN CERTIFICATE-----
+MIIEKDCCAxCgAwIBAgIUN/OCI30gBFPmRoocQis4QA5OEpkwDQYJKoZIhvcNAQEL
+BQAwUTELMAkGA1UEBhMCRk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwD
+T3JnMQ8wDQYDVQQLDAZEZW5pZWQxDzANBgNVBAMMBlJvb3RDQTAeFw0yMDA2MTcy
+MzQ0NTJaFw00MDA2MTIyMzQ0NTJaMFExCzAJBgNVBAYTAkZPMRIwEAYDVQQIDAlQ
+ZXJtaXR0ZWQxDDAKBgNVBAoMA09yZzEPMA0GA1UECwwGRGVuaWVkMQ8wDQYDVQQD
+DAZSb290Q0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDJalqWEi1E
+6bWCCprS19c9IFSnlJdap0XAf1tMATraZ+PA9Tln59hXgCeerfOj5juSK7cVmBF2
+WADibScC8gAa//QxOsrUzIR9HEmxDU0dk2Ky6+5dsGureyH6KN0ODJb0igXjo24V
+t6pLyWugb/VHUhe3bSPO9tp41UiUe27RDuTKQs43DstM/i5HpAcZ6C7UGKE4JWNR
+5/09qQdVWyDPllVC1kHP8lmFJMiHFpJQLu97jFKimIlsJRi0FzhEZ4bstSdhvv9g
+JbR6Lf6vCl4KZx0SbAb4fgwoPMhxhshiIbwQg1R76kQCkH8n8k26+p4piN7Mk/yk
+WWuZv+T9l6YxAgMBAAGjgfcwgfQwgd0GA1UdHgEB/wSB0jCBz6CBhDAzpDEwLzEL
+MAkGA1UEBhMCRk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwDT3JnME2k
+SzBJMRMwEQYKCZImiZPyLGQBGRYDY29tMRcwFQYKCZImiZPyLGQBGRYHZXhhbXBs
+ZTEZMBcGCgmSJomT8ixkARkWCXBlcm1pdHRlZKFGMESkQjBAMQswCQYDVQQGEwJG
+TzESMBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAsMBkRl
+bmllZDASBgNVHRMBAf8ECDAGAQH/AgEBMA0GCSqGSIb3DQEBCwUAA4IBAQClCGBJ
+fpzdwvHOA6J7g0AI9Dfd2pgVKlnlpg5el+atQsBobOgP4qLbvMku6xV9pDpGqh9d
+tVhTyOzlEU3VKU3CRXA3m7VYlJsQ/KSjaAgxrw/d5xMlTVE8nH9LXGFvysCaZPMN
+X3vW3NLGpagZF7NOLsq0QdlUsBcebLLN8ylpBprhdzu8gJimsfi2kqK62bLfd/fn
+z7T02A6mz5+Wsc94SkYaGlxRkzUeOzTa9OobWRPgwWOY0vxLcmuEOtXDAQEU8FKa
+oMeBUF7ioKlpFwWgDBcvqACu4NypB21fal/udhPDf54s0UMk6SDgAVSHCtA+fkYO
+yvfJQWyYi1FqKLYa
+-----END CERTIFICATE-----`
+const dirNameConstraintSubCA_permitted_excluded_rootca = `-----BEGIN CERTIFICATE-----
+MIIDHjCCAgagAwIBAgIBATANBgkqhkiG9w0BAQ0FADBRMQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAsMBkRlbmll
+ZDEPMA0GA1UEAwwGUm9vdENBMB4XDTIwMDYxNzIzNDQ1MloXDTQwMDMwNDIzNDQ1
+MlowPzELMAkGA1UEBhMCRk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwD
+T3JnMQ4wDAYDVQQDDAVTdWJDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+ggEBAMsVBEbP1/GskjZsqqLA8gh3e3EOTK//OiATz41UNK3VI1e5Rkc8AO8M5ZMj
+SmRdxp04eXPP6MDOjKKOj4rQNH2UdGXi/nsMeYguvaQNamiUoipcsxrkNiYaiAR4
+W7CpilV3g0O3X8nvTnN7FjVZ0JAoJeG/I/yEjRIZpbLZK6H52dsV0lic5MPNvEYu
+Ev0TWQms4cqzDnzKg0/XKwjFvAX7kv6z1uvvip4JvDdlmYr6UKP2wZ7HBbMnOzyj
+ZViF/gCePufpkkFmKYC7rNtqVnVVt+xqVPX6uq5jyGueEybZCuCgPlnbmKPqVWOW
+clkMVl/3B4qLM4icdFEt+L3E6PsCAwEAAaMTMBEwDwYDVR0TAQH/BAUwAwEB/zAN
+BgkqhkiG9w0BAQ0FAAOCAQEASDjFeGGAGFvvSgGjUzWfSURoqqKc1NzokXYBcvKs
+XWLKXufRPeZWgEb87+QlSIQsd+punSEpPIlCWxGz/5iXS99YDU4enWgpZBB9mKnb
+Y1MZWOTEYRAptuQ11Aw74do991unNyxFhUNBmNP2Vd8VP9ezLiKSoSxsRKStcVlv
+OERLF9MILFmTQh/F2mV0nm4EbTsPhdkmdP7fG9hKKiVKyVQ+7VNo02APfibz2Bdb
+zANfoW8iBqSqOEfaiQ87ZlNYgR9HX+0wQRotEEo2nRaj8zWc7q4cf2CrpSpnwMzf
+vTEH4jCyq1Grw731lAAjvC6dLgdu4StYXMm5VX58GJq3Ng==
+-----END CERTIFICATE-----`
+const dirNameConstraintLeafCA_permitted_excluded_rootca = `-----BEGIN CERTIFICATE-----
+MIIDFzCCAf+gAwIBAgIBATANBgkqhkiG9w0BAQ0FADA/MQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDjAMBgNVBAMMBVN1YkNB
+MB4XDTIwMDYxNzIzNDQ1M1oXDTM5MTEyNTIzNDQ1M1owPjELMAkGA1UEBhMCRk8x
+EjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwDT3JnMQ0wCwYDVQQDDARMZWFm
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu5OyPa7p78CQX2ZwiT01
+fhIgQGqTBfmQWQSQKBvYySCNTFnVBeeNxdYcHJRPlemYTJwva0S/z4zsJx2snpXW
+ukB2CARUQxWrvT4soJ6f0R9UKFj21vefanvZn9P3zERzFji1QpuvYelqzNtalS/d
+7rQmaNkqH4vgLFe2rl+mZeQBjHsFd4wlMU0PBNTEO+RScpY2jjcbBTBq1YMRLeFd
+6FplGeWlSQCmYZD4HCBzzn/BEE0xRHNYB4ez39byPR7p0+AszRSdz0K7+OF/aTha
+XChq7fMCk8Zh+4plKRvOh3LCCsc+cjHxK8CPHAU9XArM9r4QG4qmXamsLeYmZPxk
+5QIDAQABox8wHTAbBgNVHREEFDASghBsZWFmLmV4YW1wbGUuY29tMA0GCSqGSIb3
+DQEBDQUAA4IBAQBNiY3fPOBhrO5sB6m2Nd+UvbZjHnnSF5Jr3J5a8+/vIvFk/VVa
+SsKVMxVgeQCcFsl8XSdJ0tGAlUKDpHUysUxsORCeqGMERlMTVBOEYnxf/zSo11Ib
+MSRoRg61HdFLrXOW7w+DC5gvml8sp5qtD6C49WuppkcMk9eG7MwquwPyy00RR+Rh
+d8gZeAg9/S3pHJIlD9knOsJdjXSnSsI9Y/f4l6/DWix45LZSsgNTOY6kNShiymq6
+r0LNUsrf4EXHfT09ue0G7wM+jFNKce9/jVODd32RlauwoELCmZDn/NNE1fmgM94B
+x3TmGdDmchE4ohuAxsd3QS/eP3fzCjSVUxWz
+-----END CERTIFICATE-----`
+
+const dirNameConstraintRootCA_permitted_excluded_subca = `-----BEGIN CERTIFICATE-----
+MIIEBjCCAu6gAwIBAgIUZoGLxoJB/t62La/s4Lz3rPlJeqUwDQYJKoZIhvcNAQEL
+BQAwQDELMAkGA1UEBhMCRk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwD
+T3JnMQ8wDQYDVQQDDAZSb290Q0EwHhcNMjAwNjE3MjM0NDUzWhcNNDAwNjEyMjM0
+NDUzWjBAMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQK
+DANPcmcxDzANBgNVBAMMBlJvb3RDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBANe1PwY2H1aiQ/I4x895MemeNJ6FSesXTwuVXAnfs1bq+bKnqQD7CLzO
+edaBtmMZA7YRG/GFzUKcsBQpaHoGUqLOQ89Uz+JtjVzeE5ytqoUUfd7YxEphmNZV
+Jh/yNqyoOoLQWs5ip5rNKPZgENTt2EiPZUrUFsuBs/drbla8ZJoF8w17wLhneanF
+TlydJvnzUtqhtXV/qclMIbqi+CjGyIHtaQORR41nXu8JIEjzlZEUgarLZ4nAqU2q
+3NhBJ03AaklcibAAXEy5OxYF9jV2+1gkkA0xFMB0Rt0JyhiC3E6QH/m+PjkCrKhM
+tnw/mtrLAAsAaIP4t4a7HvXViWrckK8CAwEAAaOB9zCB9DCB3QYDVR0eAQH/BIHS
+MIHPoIGEMDOkMTAvMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQww
+CgYDVQQKDANPcmcwTaRLMEkxEzARBgoJkiaJk/IsZAEZFgNjb20xFzAVBgoJkiaJ
+k/IsZAEZFgdleGFtcGxlMRkwFwYKCZImiZPyLGQBGRYJcGVybWl0dGVkoUYwRKRC
+MEAxCzAJBgNVBAYTAkZPMRIwEAYDVQQIDAlQZXJtaXR0ZWQxDDAKBgNVBAoMA09y
+ZzEPMA0GA1UECwwGRGVuaWVkMBIGA1UdEwEB/wQIMAYBAf8CAQEwDQYJKoZIhvcN
+AQELBQADggEBAE6Qfh/vmiCdpYXtQe9IlFZeH4429HPgGJ2rEo42kBt7BlDffH2+
+8hfMW8TDMrIhnQqNLfOCr1wY5xybnXdURcoB4apjN1weFxsvAqJCAOXKHD/z1EHB
+gyxwfNsUbzTfsMgX4ofa7OAKxhFDy3MVFnFQZsh2AWOwwr0t/abmw8fbeQzzyu+/
+r0yFyPEc3nnX7SYVVoWyHf+yZg4OSDcHe7kazuHoGfbPEjLFsAdIORRVSzt3dSta
+6/uhtKinfChOPdyk8yQB2uD2sE/UW1NLwQjm1r87eea38M31+UCAEhRqJXy3Gijj
++ntI1SF2rRUD0AKt08pKnhbcoPtC4ghZFw8=
+-----END CERTIFICATE-----`
+const dirNameConstraintSubCA_permitted_excluded_subca = `-----BEGIN CERTIFICATE-----
+MIIDHjCCAgagAwIBAgIBATANBgkqhkiG9w0BAQ0FADBAMQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAMMBlJvb3RD
+QTAeFw0yMDA2MTcyMzQ0NTNaFw00MDAzMDQyMzQ0NTNaMFAxCzAJBgNVBAYTAkZP
+MRIwEAYDVQQIDAlQZXJtaXR0ZWQxDDAKBgNVBAoMA09yZzEPMA0GA1UECwwGRGVu
+aWVkMQ4wDAYDVQQDDAVTdWJDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+ggEBAM3MbMOK0Hg6jMpQInol99Qo81sG4zTkDbLUwusvpurLLLCrzOsidf2Pxrv+
+nrCw+mLfCKE1h953FQnE25C84ZGIInLDhVhOYWApzPxft+qOEBYA9UQm36gRrg+I
++1vERD0MPVzEGo4X1XkcWahlYoNLE9yvIGLNM2wTi+tcaFOnqclFWlVMpHlpaOO5
+9UGsPZcqBO3EDP4pFGBc/c8NPvIayqnWt3xVie0CweYR9R42TR6wa5zBYbXN6QBX
+qdJSVz6CyBT9dLQpAMAVGErEKLI09FtdAkjfkrIpJLOovzmOmXKgGW23B1shPc69
+GQ/amkJ7rSv9xf8Fexe+hx08risCAwEAAaMTMBEwDwYDVR0TAQH/BAUwAwEB/zAN
+BgkqhkiG9w0BAQ0FAAOCAQEAYpQNA3tDt8wjI01RaJuJD2qj+mGY3Awm6rhGEuPD
+FbrR6Tx0BmuVXBFgBc0HkKvx2VL0MIzJ40sekl/4RPtHm1x7TIR0U/doqG1npEPk
+V+YIQE2lwjhsJNH+yxYqQKhPd0aHrI2JMbeURuJURMlqXJ2P0wM/no9z4+7r2fmk
+Voe4Yek22geOiyBo2Y1Gl7CyvPMuVJOBuzjssu8vciVYLaoEaQO49w++nfcq/8mr
+ToDTThwne5AESDXi7ioyIMM7N+8SLlAB0xu0ElpgEqAvTZzYWDDu1rNKnGFghYgA
++GVcVI2E9k/eYD+wMR/5aCn+311HRUh7HorJhpr82JFElg==
+-----END CERTIFICATE-----`
+const dirNameConstraintLeafCA_permitted_excluded_subca = `-----BEGIN CERTIFICATE-----
+MIIDKDCCAhCgAwIBAgIBATANBgkqhkiG9w0BAQ0FADBQMQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAsMBkRlbmll
+ZDEOMAwGA1UEAwwFU3ViQ0EwHhcNMjAwNjE3MjM0NDUzWhcNMzkxMTI1MjM0NDUz
+WjA+MQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANP
+cmcxDTALBgNVBAMMBExlYWYwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
+AQDTMfU76XQ0fRzY2vuNEcB8FMO4Z1el2DoQHpp8FmvrCzd22PDU7KmnrPI9GJbD
+oNZi644yKGS0MsoAyPvXwz+DxvxeI8vEz+VMSHWYR3bCyBcnTXurjDQpjXvlmmCK
+nljgYrg8JAw1kirpGYbAV+QEOU+mdxdS/99Ux/Gn8WT2XwkGdhbZq53R6v4t9t2e
+4lO45sS+uVadhOfKyKERtQj9n87gxjHw0E4LmxkxMAkWllYWPIVFpcVM9XwvkM+1
+QLm+5alXt9h7UG0WcsC7fuP2eoBmZ9f9isT1cj7+S8cckZ3NsY2AoEMm3Gueza5l
+HxEJY0VB9rJNGww6bILt1fcvAgMBAAGjHzAdMBsGA1UdEQQUMBKCEGxlYWYuZXhh
+bXBsZS5jb20wDQYJKoZIhvcNAQENBQADggEBAESBbtTpdEbrJPPKrc+FVCcC+nPD
+EMT6FQgnlZvplz0AuMlZvQ8LeSaS2onDy6BwOrFiZF2tLOz3X14WS/L9p0fMZn9H
+Xxei1iR1rOlZaV+wUaLlpKFjbdrs2Y/6+586ikymnCLETnev66JVrcDth67Q7cqO
+588kio1lWkbhaaIzkB8U/vEEzXWZX/b5OmZtp+F407DPK67Ubu37v9FZ5h/8M7t2
+MRKP0OEWOOCk25WCMWpQrWj4WSjcukUykuG8H/B1XN9fij4vE48UGORxY+DpzR81
+u82w8+dHO2+vc5bazKvO4kIK1l5bApcpEZdx+7G27dN3fN1IFEHh7q3Vu94=
+-----END CERTIFICATE-----`
+
+const dirNameConstraintRootCA_permitted_excluded_leaf = `-----BEGIN CERTIFICATE-----
+MIIEBjCCAu6gAwIBAgIUZ/AwWIImSJMUCRlk+v3NcAx9wpIwDQYJKoZIhvcNAQEL
+BQAwQDELMAkGA1UEBhMCRk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwD
+T3JnMQ8wDQYDVQQDDAZSb290Q0EwHhcNMjAwNjE3MjM0NDUzWhcNNDAwNjEyMjM0
+NDUzWjBAMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQK
+DANPcmcxDzANBgNVBAMMBlJvb3RDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBAL6ZyXjgtDCmhyY+Bylm+hwfcR6Mmh1xZUV/zv/3pmejlPuqktdIjFKg
+Ja3w9bTrgct+U/ugD014b4zNHiwQlWGzDL/zynB1/STJFWzNKwtYBclQhTqZX3fs
+e4c6d2bnbe6BXghRQ/qxiknmAIJIfI4DhcLZTcQ3nQe09P1oxJQM4+MMWR9c8tnN
+3jeqrVUUDpatVL2VLuaoYDStvxyeiKcJ9psZ5aFv5hALbx414PGKkiyOnZnHqmuB
+92wzHv6PGihdViPmV3RbnQEqpcYNKA/uuLZr11rfxRfvwu5HsTDaps7BTTUseT/1
+jucBG86Y7qZWHAUGLXhgXGj8W+oDHOECAwEAAaOB9zCB9DCB3QYDVR0eAQH/BIHS
+MIHPoIGEMDOkMTAvMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQww
+CgYDVQQKDANPcmcwTaRLMEkxEzARBgoJkiaJk/IsZAEZFgNjb20xFzAVBgoJkiaJ
+k/IsZAEZFgdleGFtcGxlMRkwFwYKCZImiZPyLGQBGRYJcGVybWl0dGVkoUYwRKRC
+MEAxCzAJBgNVBAYTAkZPMRIwEAYDVQQIDAlQZXJtaXR0ZWQxDDAKBgNVBAoMA09y
+ZzEPMA0GA1UECwwGRGVuaWVkMBIGA1UdEwEB/wQIMAYBAf8CAQEwDQYJKoZIhvcN
+AQELBQADggEBAIvfjB5gfRUo1IXnzQwbYCkONLZUHT4hlQTtuEYZbRlt0JKdgmmg
+TGqyzdtfsp2I2ph0DfVEaLRT86zRsl/w7oXx42JSWiAfcF+vE+2pVVT7mjMKEm4k
+A3GAt5h5Ob+5mMj1rBgAxIPa74K2qVWVQGReIJkmkLUYiMwRHgvdSIgE/1ysuu7d
+2GrE94s98AGRmLtHVVAYC3+aMf2Pg3/0gcPBG+LKw9ZPbjKFTxPOJy5Uoc+r/UFl
+61rhY9wqsjfiaGA7nPzZPeFcwlBWL1DRW5MMOp2xl3epDkluo6MW5aNFunAsF7IG
+48G6IU60NnEUfhVD15f34sIjmYu57vQU6j4=
+-----END CERTIFICATE-----`
+const dirNameConstraintSubCA_permitted_excluded_leaf = `-----BEGIN CERTIFICATE-----
+MIIDDTCCAfWgAwIBAgIBATANBgkqhkiG9w0BAQ0FADBAMQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAMMBlJvb3RD
+QTAeFw0yMDA2MTcyMzQ0NTNaFw00MDAzMDQyMzQ0NTNaMD8xCzAJBgNVBAYTAkZP
+MRIwEAYDVQQIDAlQZXJtaXR0ZWQxDDAKBgNVBAoMA09yZzEOMAwGA1UEAwwFU3Vi
+Q0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCk66g519/o7Z1ZqIz8
+3ZC5794Vhe3pP2LgixfaFslNnSaL+8Jw0mQzVPNS7KWjK2wuc3a4dKWfAEff++Bj
+BKCfNiZhRo4B7F1cycSS2h0H2Hs/CiB2FjECdVGwE8vaPJ3I+IllyHD0pNu2W3kZ
+Dq24HHeIiPaViSaGAYRwXm3AamZxaWrUyfmf1TQcNZaU3BgyFerE2Oq2yMN5FifG
+NDd63kjXA3tLHiihBOFHnZ+SsOvldeGO4HgGYrHh05qomBX2t4zkoJu25lMN5KSX
+6y8k7yuRpYA95LYcj7+rOEdtcxugBX+2xDVH+to9SmV1Tbksc6AlKuULKMaQs731
+8NhnAgMBAAGjEzARMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQENBQADggEB
+AGbNb6n7zNuV59aQlg2h6/BxfEakRqRCIuZugjmTGpJyQrGs0srZW+TZ26pTm50J
+8jpTje0IeKiR5tm9TiHLjb/vCP70Ax4gyl5GxxsWL68uURhdr11E5FtUEz53VJGD
+qJAzUlIS03Dxt2iri3UmpwHmOJ+2fQeoyUOYxCLXxNHOcYKC5M+c0KpHyve/sPp4
+hqv3Bbh7hOVMyO7Pp1VdxUUdXRI1uCIC5SvME9+/PCYRcPhURNIp220IyMhGQAsj
+t6hPoqywJJMtdvEEJF2U/cnQkcEfG6K4vMo9UNXSSsSsVf5LkvMUOApNj5Ix6QdH
+6vMbY3mqAKmbZIG69Xn88VQ=
+-----END CERTIFICATE-----`
+const dirNameConstraintLeafCA_permitted_excluded_leaf = `-----BEGIN CERTIFICATE-----
+MIIDKDCCAhCgAwIBAgIBATANBgkqhkiG9w0BAQ0FADA/MQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDjAMBgNVBAMMBVN1YkNB
+MB4XDTIwMDYxNzIzNDQ1NFoXDTM5MTEyNTIzNDQ1NFowTzELMAkGA1UEBhMCRk8x
+EjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwDT3JnMQ8wDQYDVQQLDAZEZW5p
+ZWQxDTALBgNVBAMMBExlYWYwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
+AQC/8TMEC7sZFol4Mq3lGOfrSsn0wKJ2pXfCSOH9fddBtbyev+SDMRO1kpgvUIbF
+i76hFhh0TGxWv3gqHf4ducn2SaY6txFJ2KnkRsFh3a3OjJQolh3cM2tgH4dLKr3b
+Ig9AkicN2cnE25LMA1k5cUOgioDUSF1slvj5vKPZLEPSJROYjkcqYjQoz40OOPcg
+gzhX6gdnDJIIQ0fuhPxTB4XqUDLQaAAJAFXJlEqbppJ4UUIEAcScRjohl5ev+xNE
+5oGoJAgf2t5fnRnDJ4Xc9Gf4UdntgO3L6+9Lb7UR3xqfYVrqb5uxXkNSJTLaHsSo
+Sigzs5Z2yjNTf3C6jUbvpGtnAgMBAAGjHzAdMBsGA1UdEQQUMBKCEGxlYWYuZXhh
+bXBsZS5jb20wDQYJKoZIhvcNAQENBQADggEBAAKx/WzBwH+Ct+OFLfhubUCBN7+8
+LSJykUzzhxwHsvz1Wznl8HtnaveZfsT4Jy2TVSYtq9Uw//QSkbE7T5GNgUVgJX8F
+wy4N/r3oe5FhHM9+3Gt/Y2emk57TGwYKNH3CkLLV49HU9ZAVs4zduTnIh5GEq5ME
+fe/nED3uMLG8hjoJcbkFrPM93tDAUvECFj3CT6T3Tkkgayl5ne6ze6SpkptLnDz9
+QqNkHVN1AabOnotzBLhoQ377aY+IulXI5nTPLCqOsoc/25sseQ3MUcz8gPGDdad5
+LTr5PR1yDHhapT53uuEphwmgx5/LGSRpS17xVBcN49dBcRDH+7Y9jaJx4UI=
+-----END CERTIFICATE-----`
+
+const dirNameConstraintRootCA_subca_restr_ok = `-----BEGIN CERTIFICATE-----
+MIIDvjCCAqagAwIBAgIUdgdVSerl539uQkUf2PkVF8xeZY8wDQYJKoZIhvcNAQEL
+BQAwQDELMAkGA1UEBhMCRk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwD
+T3JnMQ8wDQYDVQQDDAZSb290Q0EwHhcNMjAwNjE4MDEyODIzWhcNNDAwNjEzMDEy
+ODIzWjBAMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQK
+DANPcmcxDzANBgNVBAMMBlJvb3RDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBAOr1t17VOPHNQOZ1Cz9WGmryTmqP0DFOYpEapxoJ0mZtAfZ286Y649vb
+Fu9TKaGy8cPkwOfDfFlyh68kfMi2SiJxU7b0ETyBdkI01fRlbUgzq043etDkPh+L
+5Q3EGwd9nhQHwzPUKZFgk8x56wYW7lWcRV6wEiqpUegZYXdvuCzKaCMy8v3lFP1V
+hPDWjTS/eudfUbsFgjZjtwy/DjzeMT7EmbmNafTRV0xJuc1+sjr5omSXLafH5zkZ
+BqAbqbBpUEPuHncgAKUpjIpwkzJZlJ/WjzZIBCH0mQMoMUiOMEs2FqGvSpOCcYHd
+sEtSBeJvy96j+dNsJkiB0V8ns4rEO6cCAwEAAaOBrzCBrDCBlQYDVR0eAQH/BIGK
+MIGHoIGEMDOkMTAvMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQww
+CgYDVQQKDANPcmcwTaRLMEkxEzARBgoJkiaJk/IsZAEZFgNjb20xFzAVBgoJkiaJ
+k/IsZAEZFgdleGFtcGxlMRkwFwYKCZImiZPyLGQBGRYJcGVybWl0dGVkMBIGA1Ud
+EwEB/wQIMAYBAf8CAQEwDQYJKoZIhvcNAQELBQADggEBAJi4InxaMxsNPnj9z+GI
+1O3W6oofqQTm44+jYiwS6IGAw9fSp44HHbRigT1g2hGgz1T1FHJ1X2GbjakxQ25W
+IGr0QDDMA5zYFjnX6NsNEpGcbg4HxAyaoC8HVhgI9xLNkHGZ2Qy/TJw0zcY2BlDZ
+h42tTHc4pWzxyzx3o+nSxddqfJG0+xrOA9Y5NmSLOg2sRsdEETlOC8Zng+wZW8Ei
+M/muDwyV0KB62lyPzPjxBEno7dmlMr69lHmVPAvArM89vqA2jpB3v8YugLjuQ/Pg
+KlS8Rxg8FH00vlrWObdwWIc7p8cQIf5H8QRHCqURdbtkZ4XtG79I7Qk5wauzmZfN
+f+s=
+-----END CERTIFICATE-----`
+const dirNameConstraintSubCA_subca_restr_ok = `-----BEGIN CERTIFICATE-----
+MIIDmTCCAoGgAwIBAgIBATANBgkqhkiG9w0BAQ0FADBAMQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAMMBlJvb3RD
+QTAeFw0yMDA2MTgwMTI4MjNaFw00MDAzMDUwMTI4MjNaMD8xCzAJBgNVBAYTAkZP
+MRIwEAYDVQQIDAlQZXJtaXR0ZWQxDDAKBgNVBAoMA09yZzEOMAwGA1UEAwwFU3Vi
+Q0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyG4FreI0nED+bgVY6
+piX7DborHXEM77PNpdjLriZIyTYVWCgUmj0F72KRHWbkVtYrxVhy0JjfbJztvWoJ
+RoXvvqi7RcEGa2ak0HPIPvV3iePqvsn8PTWC5tyrI46gMsIMJ0vbqjiTE4JgdipN
+F/E4S89N5NudvrStA7Gob4z6AeIvmoHr3Gypy87i+in0xiHmIO99T3A1vb+SOwOy
+IzTPXRbF4tp07DO3q9u8JpPys1CPlgxs9pnrBA2unXNv0grM98HXW/OulgVO/T2H
+NHvkFt6GjhZOTyiFK6ROnmn82iveP2BqPTzZLVi0Pwwk8sC7YMipkc5iQ/u8FT4d
+6hvhAgMBAAGjgZ4wgZswgYcGA1UdHgEB/wR9MHugeTBBpD8wPTELMAkGA1UEBhMC
+Rk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwDT3JnMQwwCgYDVQQLDANP
+dVgwNKQyMDAxCzAJBgNVBAYTAkZPMRIwEAYDVQQIDAlQZXJtaXR0ZWQxDTALBgNV
+BAoMBE9yZzIwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQ0FAAOCAQEAQC4m
+/2AhJb6C2RzWtaOjk9OF+Y6rCgJq6zswwXy17apmNxG2c7ib6TU5SOf2A+IFAhaN
+ZxhWXzVqq9H+qOT0HuhKdBcTf4SUncvQ4mlgo3fKZfgcVDZ4NC01/JfD8G768lVT
+R1PJQhpR0SqrhUPhMTw7+3Dm0kHIO819t31AwAoFWH+QLOB6/w0bswaTMdOgVHGc
+/2d9X4ZJfE5ufyOrf9EFxCQCFCSKOUzpzHxIDRgd2pBvvAS/+KO65tYsHO84Hc3v
+cIWtYq48e2jFA7kWzKmosKTlLqwBOYqNQ0A5yrkQRhFzl4i1BwfQ4OMEJ3Rf/JIW
+R2b9G1qpy36jqZQzxQ==
+-----END CERTIFICATE-----`
+const dirNameConstraintLeafCA_subca_restr_ok = `-----BEGIN CERTIFICATE-----
+MIIDJTCCAg2gAwIBAgIBATANBgkqhkiG9w0BAQ0FADA/MQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDjAMBgNVBAMMBVN1YkNB
+MB4XDTIwMDYxODAxMjgyM1oXDTM5MTEyNjAxMjgyM1owTDELMAkGA1UEBhMCRk8x
+EjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwDT3JnMQwwCgYDVQQLDANPdVgx
+DTALBgNVBAMMBExlYWYwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDh
+w6nC02HVa2rOD/66Nzv7e+JNNePz7WkDUD9sA8Czjgly9gB94XCAmW38tovgAkcx
+WQNaYermjaFVefWmicyjJDpdEsjrKbL83c8shp9a7a4LFlVSroZwjO7W8ioclPVH
+dsb6OUq2t/l+roKa70TjSJv7ZdZI3//pWlnvhgCCFpXh4eIGxRTRw7xIMaj8Naw5
+e5kdeT5hZ1BmLxwhZE0yFMaxVMfCAYqbT/MNmD7a3UFknRkafMfpGU/FXs44F723
+jTywu8aattRiq/9NO0+NfrrSP0ALGQBXzsJMsGXFl0JBvNgXysbBGdMuvNwOSCa/
+iBHoBXn7wKEWWDdruDHLAgMBAAGjHzAdMBsGA1UdEQQUMBKCEGxlYWYuZXhhbXBs
+ZS5jb20wDQYJKoZIhvcNAQENBQADggEBADkGGgwWLTMQ+P7wMMTE32AC940rBHGM
+yxckjRKCN0w2O+eu5vx7MjAMKb/dLT+KSKliPeRaU3vLaetXuIsuCnqKkdAW0V8e
+hMjPuj1ud40Un5bdRmWhLjr+bok+Grcqb1HwRX82kzqkxY2wQRNrYwplJ2NBsr9W
++yBHxe0mcsKCMOuz52lXBwZ+dmOBzotcxRCQqB2WXPkvHPxVdbywLcT5lyC3DBMB
+z6ITKAjZl9Zv/pM720649GpqW4nJJzCvnPGA6nhKmLhbr/QaXq/cwJ5C1IObNVW/
+U+IxRmdHsRiGIDgL4rt37u5VA9QucSsfHeboePYjMU4nM4f6g7ixtGQ=
+-----END CERTIFICATE-----`
+
+const dirNameConstraintRootCA_subca_restr_fail = `-----BEGIN CERTIFICATE-----
+MIIDvjCCAqagAwIBAgIUY49WkHoq+tF4DzsOBI/lYhJjFDgwDQYJKoZIhvcNAQEL
+BQAwQDELMAkGA1UEBhMCRk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwD
+T3JnMQ8wDQYDVQQDDAZSb290Q0EwHhcNMjAwNjE4MDEyODIzWhcNNDAwNjEzMDEy
+ODIzWjBAMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQK
+DANPcmcxDzANBgNVBAMMBlJvb3RDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBAM5I3sr7WI+CdKd0KpTH8PsIdt+SX0dtl5hoojYtaUdn7HMAwRDZbvVH
+jy+/pvehrRN2FTtUngy+4qJaQsnFT1mBlKXhabLnU0vXHfkjVSmCYsC01KNjMeeN
+Ilskp4jXkp38HK9tGH8VpWLiaICmhxsqQCeEDGBMKfjTm2WKrK3GbDwQ8ump7fQx
+JSSpt5t8H1D01oXjvsZpefWjuhl2u18cNJ1irvmTmRw4aTEI8c5R4cFK+BNmbab6
+fkRsvZNmdBQw1Q8G4zXGqrSx2xN7BmY58hZqrAQA+dVxNSitc8dElCZ6D1r/et0v
+S8qZ+GbSAB2Fy8aF8dULy1HU2ZHy4tUCAwEAAaOBrzCBrDCBlQYDVR0eAQH/BIGK
+MIGHoIGEMDOkMTAvMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQww
+CgYDVQQKDANPcmcwTaRLMEkxEzARBgoJkiaJk/IsZAEZFgNjb20xFzAVBgoJkiaJ
+k/IsZAEZFgdleGFtcGxlMRkwFwYKCZImiZPyLGQBGRYJcGVybWl0dGVkMBIGA1Ud
+EwEB/wQIMAYBAf8CAQEwDQYJKoZIhvcNAQELBQADggEBAMtx9Ky+BRDma0CfMaSE
+sN/Dac0F1qZj02FXKrgVRC/ifoKVYOjAuH1RveSjpDMnUYQ6qEnWhiXDuZ87C0a7
+KTQuckGZfTo97hozkS6HHSVAwZi3P6G4DoQsqd+BXTYngYON2xGPgigKD71zdZG0
+04QJEr3BAyOCft8kIzF3bsP3saxW/IdEQGYSR7WwbuP2XZvg3ZYIgUNpOxZH/Pi0
+8MeQjm9PNLFeuzSAKLnioMhO41csEPdkB6ExS0DYfrbswwe16IT1wIPkRaMJRZN8
+zGKlqTKP9Ft3jkSD5Q0H1noKAmZceIPUQEBoypCRKS5GYgjli3vPMpfneBSoQjf3
+3Y8=
+-----END CERTIFICATE-----`
+const dirNameConstraintSubCA_subca_restr_fail = `-----BEGIN CERTIFICATE-----
+MIIDmTCCAoGgAwIBAgIBATANBgkqhkiG9w0BAQ0FADBAMQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAMMBlJvb3RD
+QTAeFw0yMDA2MTgwMTI4MjNaFw00MDAzMDUwMTI4MjNaMD8xCzAJBgNVBAYTAkZP
+MRIwEAYDVQQIDAlQZXJtaXR0ZWQxDDAKBgNVBAoMA09yZzEOMAwGA1UEAwwFU3Vi
+Q0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDsKBQgO6RZ1N//V+59
++xhsPPO57gdzwlb0p4ifA6MNpg2p74XjNSoYm/TTQ2xs4Gyxj0Gp+ml2XUTMp6Oo
+x7e9Z6MIJD1j6KFf2kapfH9mi6Tg79sa8pHSTEDKRFyNc8uNTwi4KwrQgT7cJLcp
+hB/jfv2BKRVap8x/IkOI+Wk4lruVQhUAeRVEXElYlrQms8E93v/XHBkLbh1v07ah
+Syf5gGtJ1YaC9eSkbGLXHCmUw4AlzyK4nH6lOPEfQme5EkhUOtWjsghkvCUmkMl3
+yuk52/O1XK6D78eWA2MqjwFZ9oOKlSzSJiB56fpNqT2FYRQdgatBRYLNLLaIDpul
+N1EbAgMBAAGjgZ4wgZswgYcGA1UdHgEB/wR9MHugeTBBpD8wPTELMAkGA1UEBhMC
+Rk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwDT3JnMQwwCgYDVQQLDANP
+dVgwNKQyMDAxCzAJBgNVBAYTAkZPMRIwEAYDVQQIDAlQZXJtaXR0ZWQxDTALBgNV
+BAoMBE9yZzIwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQ0FAAOCAQEAtS9k
+V7Yv/c858v8kBdaGWSd3r14iMOuQznCOE3XTPrS1C0hinvKjWcx5iWIEJtgpJDy6
+nX7YtR1RPtdyKkWG9dvY4AtDRN4zEOXdLR3UthDPlLSaZ3QIXUKw61SBtcHJfa+J
+HcEC+ICjxxwsCcTFBcY576tE/OcM7e4kqgLkbz6Hzd0l9N5UYWNfQT7e6EbfSDhn
+4WmPxIAKsE1Csn95hVymC7NGqFM+GOUu8KW3XCiMMcj091a4x+BA8Ks1+rQqoMyU
+T6H2DccsggD+frCgtKgxOStRaVh/mOYGQjbbQyfg7/57bMTE312Q4D737P+6kMsm
+7lqOF86/aYqAoBLGIg==
+-----END CERTIFICATE-----`
+const dirNameConstraintLeafCA_subca_restr_fail = `-----BEGIN CERTIFICATE-----
+MIIDFzCCAf+gAwIBAgIBATANBgkqhkiG9w0BAQ0FADA/MQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDjAMBgNVBAMMBVN1YkNB
+MB4XDTIwMDYxODAxMjgyM1oXDTM5MTEyNjAxMjgyM1owPjELMAkGA1UEBhMCRk8x
+EjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwDT3JnMQ0wCwYDVQQDDARMZWFm
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyQkri+DYu7Oc9jOp9yTb
+enYM7jtJoWOJd41H7ExriVqAwMaPaFvIIzGdoi/iOEp1mRjLLmeypCjvcsmz2G8b
+ocsskkHzKrLSvQ6qEY85i0QNz4mnWKrpeYcLVWfdcMkm5I+YC0ex7RoouLULiSb/
++c3CKEwPHkFCXxLOimzIcfirjWmqTxxmeW3IM6Yi/cToptXG8nCUVQ3re0oMWmxp
+rt7r8BYbZskA93s2EFMBbQBAzhwBBFxIQwfikhoA5J1khIWndqiLTkW0aizHdzOm
+ez4MoLzWApyXV666CYWdsDNXOFHdnp7ok7VF+D+OvXSODd6g8M7YlEuhLuPPlQPS
+HQIDAQABox8wHTAbBgNVHREEFDASghBsZWFmLmV4YW1wbGUuY29tMA0GCSqGSIb3
+DQEBDQUAA4IBAQCbMXhx+QLNsYhq/xXo2TzSdlRTW64oYNmgBtPAwqW0qY5cyDnz
+/X/LLQFGae2mFFgtO21/uYLs3pbuThJj4kVBSwG7fm9cEib4GLpO9Gf+DJyNel1J
+SQL80YYAa8yW9lQThTptFxB98piBwIxIO8sW+P60+zh/QNORXBoDfLXvgwGs7P77
+Xv9FXWKOpdUUn2MIdCX25XdTP2W/avztwrAhoo3izC8uhK+mqVEixQGIdKx1o2Vq
+v0IJQk/MARF9wXWtkX6UghGSii6OA95pEyv940JHYAZ6uZvvg97pN8pGJfO89m6h
+TJExl0p1rxT7TbGrrRClMg9dXSXh6F6uew9U
+-----END CERTIFICATE-----`
+
+const dirNameConstraintRootCA_subca_relax_fail = `-----BEGIN CERTIFICATE-----
+MIIDvjCCAqagAwIBAgIUVJsYgTK/J+ER7U2Qpo20qAokMzswDQYJKoZIhvcNAQEL
+BQAwQDELMAkGA1UEBhMCRk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwD
+T3JnMQ8wDQYDVQQDDAZSb290Q0EwHhcNMjAwNjE4MDEyODI0WhcNNDAwNjEzMDEy
+ODI0WjBAMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQK
+DANPcmcxDzANBgNVBAMMBlJvb3RDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBAMJDPxG4LHZnM4fK8hSgFxVFplpkwbyqDIoYJPi1GgJ+PCCvjGvFqSQw
+FRu0bRXOim5x78kx2/abg7kKVU7P0izBNR3axFsfUPdcSDR8kwAwaC80inmAibMP
+z62OrM/rpSykRct1tVFwScYWfX8TT0LlWr21bkO3TekEle3DhW2Aj9eRSG4oOqrs
+D8i7cMlLMSTq+2VwRiXXhchax3H7T23O33wKs/8aDFiuhwqHAa6YTFDBkOFmL60Y
+i55a8sTV7hgQfnvsuExOIYQKvUu06iBcMywTTpE/ZrX2X53L8U5UoUvXogSNi4Nf
+k/vGWhYiYl6Gby2FlC4uw1hOT4hRU18CAwEAAaOBrzCBrDCBlQYDVR0eAQH/BIGK
+MIGHoIGEMDOkMTAvMQswCQYDVQQGEwJGTzESMBAGA1UECAwJUGVybWl0dGVkMQww
+CgYDVQQKDANPcmcwTaRLMEkxEzARBgoJkiaJk/IsZAEZFgNjb20xFzAVBgoJkiaJ
+k/IsZAEZFgdleGFtcGxlMRkwFwYKCZImiZPyLGQBGRYJcGVybWl0dGVkMBIGA1Ud
+EwEB/wQIMAYBAf8CAQEwDQYJKoZIhvcNAQELBQADggEBAFsmKPJMhx7CQ8rhtRO1
+sV4ybRu4Ghe2kE3HH84Q9RonZ5oDIAo7xNBWBgiGTjNK3jdtalNsmuErmGHLSPHh
+u+nHmJWcyN+ebq9AGXwZ02YHeql0EXbgt7mp6+yYd8kPRr4mtzeWhU/qeR1nXo8W
+rxRdtEt7jgeEXiD4vnGQgbCtokn2563RVMRaHW4jL8OuSIQvk8kirUBFi1nTsx33
+sGs64n9SFFl8xBFSbt0UPuJKM0twV7b2P1bZgp9NoBO7TaInmk3Kp8+F/x+O3ee+
+c5LdSWd1i4gT+71mRmuGLZ0GQ9ZRVS+8tNlMRQ09Sl3pjF4gPWtjRtTGBB5ZWqjR
+YKY=
+-----END CERTIFICATE-----`
+const dirNameConstraintSubCA_subca_relax_fail = `-----BEGIN CERTIFICATE-----
+MIIDmTCCAoGgAwIBAgIBATANBgkqhkiG9w0BAQ0FADBAMQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDzANBgNVBAMMBlJvb3RD
+QTAeFw0yMDA2MTgwMTI4MjRaFw00MDAzMDUwMTI4MjRaMD8xCzAJBgNVBAYTAkZP
+MRIwEAYDVQQIDAlQZXJtaXR0ZWQxDDAKBgNVBAoMA09yZzEOMAwGA1UEAwwFU3Vi
+Q0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCxlKpMxkI/BCGHzinE
+JhFp91Me94aNmhLNL5ollDc+S4AYEDhpHGPP5ilqt5+RL906lQtD0bG6qIJ7PiKd
+ipya+428BbPDSDJIYQx14NBZ/IU5ZIudH2NGY3J4WW27/wn2v0busWt6ZS1+IYuB
+B3mRrDyZjYB2hQlmkAEQdi9+cU5u8T7jb5RAbu6cK0b9zfPGy5lP1MGmowDRgsQE
+jIuS6LXK2BXjyd9RatJjv9woCZuQ1qR+YZY5OsQLCm5JFQZZ5/QHezthokaePBAN
+0kTHLEm80l1SJKk/x6AuhM2E2xsfqorSu3Vxx81uio9lLkx5PRZrGjEdN2660i0q
+wUjpAgMBAAGjgZ4wgZswgYcGA1UdHgEB/wR9MHugeTBBpD8wPTELMAkGA1UEBhMC
+Rk8xEjAQBgNVBAgMCVBlcm1pdHRlZDEMMAoGA1UECgwDT3JnMQwwCgYDVQQLDANP
+dVgwNKQyMDAxCzAJBgNVBAYTAkZPMRIwEAYDVQQIDAlQZXJtaXR0ZWQxDTALBgNV
+BAoMBE9yZzIwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQ0FAAOCAQEAjrsR
+rdwDO99BnpAIWseZR1B+W7QX4PrM9Eoh9G9YuUVzILXTBAoq2X0YSXp1+etkWMd8
+3Al9PiGoEfhCIPToczfAmgQtIJowfFI0wnwB5GLce1wDQEgihRkM9ful4DZQ+gdW
+ToJrJD2v7gMJAX8Y3ByOm3NKoHzlyiyVgo7pJhNjIZStpqbRXKw8rS9FXAM5M6zG
+ht+e6bmFTKuRTxyK1W51r0vdsV6O0R+1VH8mj5XXFmTZ9EU0ExNjXl3LOU+mjrKM
+uxjzuJT6t2dGwOYEzZH3mVV/CfpIlXDbmVSsJRkh0s+ssXY3ZFN4o1yBYWx9Z/Nq
+PN0V1hB67ZfEK3OOyA==
+-----END CERTIFICATE-----`
+const dirNameConstraintLeafCA_subca_relax_fail = `-----BEGIN CERTIFICATE-----
+MIIDGDCCAgCgAwIBAgIBATANBgkqhkiG9w0BAQ0FADA/MQswCQYDVQQGEwJGTzES
+MBAGA1UECAwJUGVybWl0dGVkMQwwCgYDVQQKDANPcmcxDjAMBgNVBAMMBVN1YkNB
+MB4XDTIwMDYxODAxMjgyNFoXDTM5MTEyNjAxMjgyNFowPzELMAkGA1UEBhMCRk8x
+EjAQBgNVBAgMCVBlcm1pdHRlZDENMAsGA1UECgwET3JnMjENMAsGA1UEAwwETGVh
+ZjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAM+0S7NZaxtLZIrg6s8N
+a2JzHBYHizdqlaL0oowf6Er7c483/VzYwKJ2AB61R3Sxr3/6SQSmyjiXZW5rVWJp
+WJH5MKka+LKi/fWvDWPHFc4bM0xGZ7F0wowewvvnbOGmRr9HFTqXs6O4p1MWe5Qy
+5jah/HEHaRCP1QMxa2GVgMdNijMDdmvicF149yB7FY1mqbBXA0OED8fTvW/oP4ns
+aX5HiY38sM0gXtx2t+HiThIB5utVhefAnNCKFmjLIpiMpAxa+JQcgdVz2PkLBAVk
+473idSFVsbTL0A0Ney1kyoCI0yU7eK/I5TgCBbNnGMbJy7xdzwexepzrJQGd3PQi
+6KUCAwEAAaMfMB0wGwYDVR0RBBQwEoIQbGVhZi5leGFtcGxlLmNvbTANBgkqhkiG
+9w0BAQ0FAAOCAQEATYyFhjlHa+EdWdVyE4hRYEJUeoSL1CLWSNsnRqlSRUj6f47B
+Z6ppHFCIaOKS1HWTRmxlR8ZZacGesdrISec21CJkfMjQe8ha4Og9mwTxYBvfkAz0
+n7czYC97N7b4+wTwwGREclO4QphcgUwW1FOU5yPHAGLmKNvJpXEKN+TDya08Gmam
+OQMzV3zvbJlDICnYjwgIbdlTjDvdOhGmiSF/MU5F2FXXN9kotcRQdJQL6lPIB84/
+ixyGmqlNXtjKU9ADJIrNIFajvXTl4ln2Jrfu42hKCpDsvT07GLYSTfinHQjeTiUR
+G1IZnzmYGDbyUgD74HsLWxQoS2zIEuwb/R2mKQ==
 -----END CERTIFICATE-----`
 
 var globalSignRoot = `-----BEGIN CERTIFICATE-----


### PR DESCRIPTION
Adam Langley implemented the optional part of name constraints
(9e76ce70701ceef8fbccfb953b33a2ae7fe0367c) left the directory name
validation, which is a mandatory part of RFC5280, section 4.2.1.10.

Fixes #15196 