### PR TITLE
README.go2go: add a note about GO2PATH

### DIFF
--- a/README.go2go.md
+++ b/README.go2go.md
@@ -9,10 +9,13 @@ usual](https://golang.org/doc/install/source).
 You can then use the new `go2go` tool.
 Write your generic code in a file with the extension `.go2` instead of
 `.go`.
+
 Run it using `go tool go2go run x.go2`.
 There are some sample packages in `cmd/go2go/testdata/go2path/src`.
 You can see the full documentation for the tool by running `go doc
 cmd/go2go`.
+
+The `go2go` tool requires `GO2PATH`, for example to run the sample packages, `export GO2PATH="$(go env GOROOT)/src/cmd/go2go/testdata/go2path`.
 
 If you find bugs in the updated type checker or in the translation
 tool, they should be filed in the [standard Go issue

--- a/README.go2go.md
+++ b/README.go2go.md
@@ -9,13 +9,14 @@ usual](https://golang.org/doc/install/source).
 You can then use the new `go2go` tool.
 Write your generic code in a file with the extension `.go2` instead of
 `.go`.
-
 Run it using `go tool go2go run x.go2`.
 There are some sample packages in `cmd/go2go/testdata/go2path/src`.
 You can see the full documentation for the tool by running `go doc
 cmd/go2go`.
 
-The `go2go` tool requires `GO2PATH`, for example to run the sample packages, `export GO2PATH="$(go env GOROOT)/src/cmd/go2go/testdata/go2path`.
+The `go2go` tool will look for `.go2` files using the environment variable `GO2PATH`.
+You can find some useful packages that you might want to experiment with by
+setting `GO2PATH=$GOROOT/src/cmd/go2go/testdata/go2path`.
 
 If you find bugs in the updated type checker or in the translation
 tool, they should be filed in the [standard Go issue


### PR DESCRIPTION
Adds a little note about `GO2PATH` and that it is required for the `go2go` tool.

Updates #39617 