### PR TITLE
net: prefer /etc/hosts over DNS when no /etc/nsswitch.conf is present

### DIFF
--- a/src/net/conf.go
+++ b/src/net/conf.go
@@ -202,11 +202,6 @@ func (c *conf) hostLookupOrder(r *Resolver, hostname string) (ret hostLookupOrde
 			// illumos defaults to "nis [NOTFOUND=return] files"
 			return fallbackOrder
 		}
-		if c.goos == "linux" {
-			// glibc says the default is "dns [!UNAVAIL=return] files"
-			// https://www.gnu.org/software/libc/manual/html_node/Notes-on-NSS-Configuration-File.html.
-			return hostLookupDNSFiles
-		}
 		return hostLookupFilesDNS
 	}
 	if nss.err != nil {

--- a/src/net/conf_test.go
+++ b/src/net/conf_test.go
@@ -170,8 +170,6 @@ func TestConfHostLookupOrder(t *testing.T) {
 			},
 			hostTests: []nssHostTest{{"google.com", "myhostname", hostLookupDNSFiles}},
 		},
-		// glibc lacking an nsswitch.conf, per
-		// https://www.gnu.org/software/libc/manual/html_node/Notes-on-NSS-Configuration-File.html
 		{
 			name: "linux_no_nsswitch.conf",
 			c: &conf{
@@ -179,7 +177,7 @@ func TestConfHostLookupOrder(t *testing.T) {
 				nss:    &nssConf{err: os.ErrNotExist},
 				resolv: defaultResolvConf,
 			},
-			hostTests: []nssHostTest{{"google.com", "myhostname", hostLookupDNSFiles}},
+			hostTests: []nssHostTest{{"google.com", "myhostname", hostLookupFilesDNS}},
 		},
 		{
 			name: "files_mdns_dns",

--- a/src/net/conf_test.go
+++ b/src/net/conf_test.go
@@ -180,6 +180,15 @@ func TestConfHostLookupOrder(t *testing.T) {
 			hostTests: []nssHostTest{{"google.com", "myhostname", hostLookupFilesDNS}},
 		},
 		{
+			name: "linux_empty_nsswitch.conf",
+			c: &conf{
+				goos:   "linux",
+				nss:    nssStr(""),
+				resolv: defaultResolvConf,
+			},
+			hostTests: []nssHostTest{{"google.com", "myhostname", hostLookupFilesDNS}},
+		},
+		{
 			name: "files_mdns_dns",
 			c: &conf{
 				nss:    nssStr("hosts: files mdns dns"),


### PR DESCRIPTION
Do not mimic glibc behavior if /etc/nsswitch.conf is missing. This will
will likely be missing on musl libc systems and glibc systems will likely
always have it, resulting in localhost lookup being done over DNS rather
than from /etc/hosts.

Do what makes most sense rather than making any assumption about the
libc.

Fixes #35305

