### PR TITLE
runtime/trace: fix file name in example

### DIFF
--- a/src/runtime/trace/trace.go
+++ b/src/runtime/trace/trace.go
@@ -19,7 +19,7 @@
 // command runs the test in the current directory and writes the trace
 // file (trace.out).
 //
-//    go test -trace=test.out
+//    go test -trace=trace.out
 //
 // This runtime/trace package provides APIs to add equivalent tracing
 // support to a standalone program. See the Example that demonstrates


### PR DESCRIPTION
The preceding paragraph suggests the test run will produce a file called trace.out.
The same name, trace.out, is used in the output from go help testflag, thus we change the go test line instead of changing the preceding paragraph.