### PR TITLE
time: add widely used time.Duration Day

### DIFF
--- a/src/time/time.go
+++ b/src/time/time.go
@@ -605,6 +605,7 @@ const (
 	Second               = 1000 * Millisecond
 	Minute               = 60 * Second
 	Hour                 = 60 * Minute
+	Day                  = 24 * Hour
 )
 
 // String returns a string representing the duration in the form "72h3m0.5s".


### PR DESCRIPTION
This PR add new time constant `time.Day`, which is `time.Duration`. Duration `Day` is widely used like pre-defined `Hour`/`Minute`/`Second`/`Millisecond` etc, but is not pre-defined in `time` package. So I add it.