### PR TITLE
cmd/go2go: standardize help flag with other tools

### DIFF
--- a/src/cmd/go2go/main.go
+++ b/src/cmd/go2go/main.go
@@ -27,6 +27,7 @@ var cmds = map[string]bool{
 }
 
 func main() {
+	flag.Usage = usage
 	flag.Parse()
 
 	args := flag.Args()
@@ -174,7 +175,7 @@ The commands are:
 	test       translate and test packages
 	translate  translate .go2 files into .go files
 `)
-	os.Exit(1)
+	os.Exit(2)
 }
 
 // die reports an error and exits.


### PR DESCRIPTION
A very small change because the `--help` flag printing nothing was bugging me.