### PR TITLE
Fix filepath.EvalSymlinks when symlink is at filesystem root

### DIFF
--- a/src/path/filepath/symlink.go
+++ b/src/path/filepath/symlink.go
@@ -136,6 +136,8 @@ func walkSymlinks(path string) (string, error) {
 			}
 			if r < volLen {
 				dest = vol
+			} else if r == 0 && os.IsPathSeparator(dest[0]) {
+				dest = dest[:1]
 			} else {
 				dest = dest[:r]
 			}


### PR DESCRIPTION
When a symlink is at filesystem root (such can be the case on OSTree systems where /root points to /var/roothome and /home points to /var/home) EvalSymlinks fails to follow it correctly. Instead of following it in the context of the root directory, it tries to follow it in the context of the current directory.

This is because when the last traversed directory is removed to concatenate the symlink target, "/home" contract to the empty string, and "var/home" is thus evaluated in the context of the current directory.

This commit fixes that by detecting if the last removed directory was a root directory, and does not remove the trailing path separator in that case.