### PR TITLE
runtime: remove tracebackinit and unused skipPC

### DIFF
--- a/src/runtime/asm.s
+++ b/src/runtime/asm.s
@@ -11,24 +11,3 @@
 DATA runtime·no_pointers_stackmap+0x00(SB)/4, $2
 DATA runtime·no_pointers_stackmap+0x04(SB)/4, $0
 GLOBL runtime·no_pointers_stackmap(SB),RODATA, $8
-
-// NaCl requires that these skips be verifiable machine code.
-#ifdef GOARCH_amd64
-#define SKIP4 BYTE $0x90; BYTE $0x90; BYTE $0x90; BYTE $0x90
-#endif
-#ifdef GOARCH_386
-#define SKIP4 BYTE $0x90; BYTE $0x90; BYTE $0x90; BYTE $0x90
-#endif
-#ifdef GOARCH_wasm
-#define SKIP4 UNDEF; UNDEF; UNDEF; UNDEF
-#endif
-#ifndef SKIP4
-#define SKIP4 WORD $0
-#endif
-
-#define SKIP16 SKIP4; SKIP4; SKIP4; SKIP4
-#define SKIP64 SKIP16; SKIP16; SKIP16; SKIP16
-
-// This function must be sizeofSkipFunction bytes.
-TEXT runtime·skipPleaseUseCallersFrames(SB),NOSPLIT,$0-0
-	SKIP64; SKIP64; SKIP64; SKIP64

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -557,7 +557,6 @@ func schedinit() {
 
 	sched.maxmcount = 10000
 
-	tracebackinit()
 	moduledataverify()
 	stackinit()
 	mallocinit()

--- a/src/runtime/traceback.go
+++ b/src/runtime/traceback.go
@@ -35,16 +35,6 @@ import (
 
 const usesLR = sys.MinFrameSize > 0
 
-var skipPC uintptr
-
-func tracebackinit() {
-	// Go variable initialization happens late during runtime startup.
-	// Instead of initializing the variables above in the declarations,
-	// schedinit calls this function so that the variables are
-	// initialized and available earlier in the startup sequence.
-	skipPC = funcPC(skipPleaseUseCallersFrames)
-}
-
 // Traceback over the deferred function calls.
 // Report them like calls that have been invoked but not started executing yet.
 func tracebackdefers(gp *g, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer) {
@@ -81,9 +71,6 @@ func tracebackdefers(gp *g, callback func(*stkframe, unsafe.Pointer) bool, v uns
 }
 
 const sizeofSkipFunction = 256
-
-// This function is defined in asm.s to be sizeofSkipFunction bytes long.
-func skipPleaseUseCallersFrames()
 
 // Generic traceback. Handles runtime stack prints (pcbuf == nil),
 // the runtime.Callers function (pcbuf != nil), as well as the garbage


### PR DESCRIPTION
CL [152537](https://go-review.googlesource.com/c/go/+/152537/) changed the way inlined frames are represented in tracebacks to no longer use skipPC