### PR TITLE
fmt: explain how Formatter interface affects verbs and flags

### DIFF
--- a/src/fmt/doc.go
+++ b/src/fmt/doc.go
@@ -150,7 +150,8 @@
 	concrete value that it holds, and printing continues with the next rule.
 
 	2. If an operand implements the Formatter interface, it will
-	be invoked. Formatter provides fine control of formatting.
+	be invoked. In this case the meaning of verbs and flags is entirely
+	up to that implementation.
 
 	3. If the %v verb is used with the # flag (%#v) and the operand
 	implements the GoStringer interface, that will be invoked.

--- a/src/fmt/doc.go
+++ b/src/fmt/doc.go
@@ -150,8 +150,8 @@
 	concrete value that it holds, and printing continues with the next rule.
 
 	2. If an operand implements the Formatter interface, it will
-	be invoked. In this case the meaning of verbs and flags is entirely
-	up to that implementation.
+	be invoked. In this case the interpretation of verbs and flags is
+	controlled by that implementation.
 
 	3. If the %v verb is used with the # flag (%#v) and the operand
 	implements the GoStringer interface, that will be invoked.

--- a/src/fmt/print.go
+++ b/src/fmt/print.go
@@ -47,7 +47,10 @@ type State interface {
 	Flag(c int) bool
 }
 
-// Formatter is the interface implemented by values with a custom formatter.
+// Formatter is implemented by any value that has a Format method.
+// The rune argument contains the verb and the State argument contains information
+// about the flags of the format specifier, but how they are interpreted is entirely
+// up to the implementation of Format.
 // The implementation of Format may call Sprint(f) or Fprint(f) etc.
 // to generate its output.
 type Formatter interface {

--- a/src/fmt/print.go
+++ b/src/fmt/print.go
@@ -48,13 +48,13 @@ type State interface {
 }
 
 // Formatter is implemented by any value that has a Format method.
-// The rune argument contains the verb and the State argument contains information
-// about the flags of the format specifier, but how they are interpreted is entirely
+// The State argument contains information about the flags of the format
+// specifier, but how they and the verb are interpreted is entirely
 // up to the implementation of Format.
 // The implementation of Format may call Sprint(f) or Fprint(f) etc.
 // to generate its output.
 type Formatter interface {
-	Format(f State, c rune)
+	Format(f State, verb rune)
 }
 
 // Stringer is implemented by any value that has a String method,

--- a/src/fmt/print.go
+++ b/src/fmt/print.go
@@ -48,11 +48,8 @@ type State interface {
 }
 
 // Formatter is implemented by any value that has a Format method.
-// The State argument contains information about the flags of the format
-// specifier, but how they and the verb are interpreted is entirely
-// up to the implementation of Format.
-// The implementation of Format may call Sprint(f) or Fprint(f) etc.
-// to generate its output.
+// The implementation controls how State and rune are interpreted,
+// and may call Sprint(f) or Fprint(f) etc. to generate its output.
 type Formatter interface {
 	Format(f State, verb rune)
 }


### PR DESCRIPTION
Formatter is mentioned further down, but it's helpful
to add it amongst the verbs and flags.

Background: I spent a while puzzling how "%+v" prints
a stack trace for github.com/pkg/errors when this isn't
documented under 'flags'.
