### PR TITLE
reflect: add parentheses to properly bind <- in ChanOf’s string

### DIFF
--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -74,6 +74,10 @@ var typeTests = []pair{
 	{struct{ x ([]int8) }{}, "[]int8"},
 	{struct{ x (map[string]int32) }{}, "map[string]int32"},
 	{struct{ x (chan<- string) }{}, "chan<- string"},
+	{struct{ x (chan<- chan string) }{}, "chan<- chan string"},
+	{struct{ x (chan<- <-chan string) }{}, "chan<- <-chan string"},
+	{struct{ x (<-chan <-chan string) }{}, "<-chan <-chan string"},
+	{struct{ x (chan (<-chan string)) }{}, "chan (<-chan string)"},
 	{struct {
 		x struct {
 			c chan *int32

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -5491,6 +5491,18 @@ func TestChanOf(t *testing.T) {
 	// check that type already in binary is found
 	type T1 int
 	checkSameType(t, ChanOf(BothDir, TypeOf(T1(1))), (chan T1)(nil))
+
+	// Check arrow token association in undefined chan types.
+	var left chan<- chan T
+	var right chan (<-chan T)
+	tLeft := ChanOf(SendDir, ChanOf(BothDir, TypeOf(T(""))))
+	tRight := ChanOf(BothDir, ChanOf(RecvDir, TypeOf(T(""))))
+	if tLeft != TypeOf(left) {
+		t.Errorf("chan<-chan: have %s, want %T", tLeft, left)
+	}
+	if tRight != TypeOf(right) {
+		t.Errorf("chan<-chan: have %s, want %T", tRight, right)
+	}
 }
 
 func TestChanOfDir(t *testing.T) {

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -1789,7 +1789,6 @@ func ChanOf(dir ChanDir, t Type) Type {
 	}
 
 	// Look in known types.
-	// TODO: Precedence when constructing string.
 	var s string
 	switch dir {
 	default:
@@ -1799,7 +1798,14 @@ func ChanOf(dir ChanDir, t Type) Type {
 	case RecvDir:
 		s = "<-chan " + typ.String()
 	case BothDir:
-		s = "chan " + typ.String()
+		typstr := typ.String()
+		if typstr[0] == '<' {
+			// typ is recv chan, need parentheses as "<-" associates with leftmost
+			// chan possible, see https://golang.org/ref/spec#Channel_types.
+			s = "chan (" + typstr + ")"
+		} else {
+			s = "chan " + typstr
+		}
 	}
 	for _, tt := range typesByString(s) {
 		ch := (*chanType)(unsafe.Pointer(tt))

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -1798,13 +1798,13 @@ func ChanOf(dir ChanDir, t Type) Type {
 	case RecvDir:
 		s = "<-chan " + typ.String()
 	case BothDir:
-		typstr := typ.String()
-		if typstr[0] == '<' {
+		typeStr := typ.String()
+		if typeStr[0] == '<' {
 			// typ is recv chan, need parentheses as "<-" associates with leftmost
 			// chan possible, see https://golang.org/ref/spec#Channel_types.
-			s = "chan (" + typstr + ")"
+			s = "chan (" + typeStr + ")"
 		} else {
-			s = "chan " + typstr
+			s = "chan " + typeStr
 		}
 	}
 	for _, tt := range typesByString(s) {

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -1801,7 +1801,9 @@ func ChanOf(dir ChanDir, t Type) Type {
 		typeStr := typ.String()
 		if typeStr[0] == '<' {
 			// typ is recv chan, need parentheses as "<-" associates with leftmost
-			// chan possible, see https://golang.org/ref/spec#Channel_types.
+			// chan possible, see:
+			// * https://golang.org/ref/spec#Channel_types
+			// * https://github.com/golang/go/issues/39897
 			s = "chan (" + typeStr + ")"
 		} else {
 			s = "chan " + typeStr


### PR DESCRIPTION
Adds parentheses so as to properly bind <- to the right most
channel.
This meant that previously given:

   ChanOf(<-chan T)

it would mistakenly try to look up the type as

    chan <-chan T

instead of

    chan (<-chan T)

Fixes #39897