### PR TITLE
net/mail: improve date parsing

### DIFF
--- a/src/net/mail/message.go
+++ b/src/net/mail/message.go
@@ -117,6 +117,9 @@ func ParseDate(date string) (time.Time, error) {
 		// If T is misplaced, the date to parse is garbage.
 		date = p.s[:ind+1]
 		p.s = p.s[ind+1:]
+		if strings.HasSuffix(date, " UT") {
+			date += "C"
+		}
 	}
 	if !p.skipCFWS() {
 		return time.Time{}, errors.New("mail: misformatted parenthetical comment")

--- a/src/net/mail/message.go
+++ b/src/net/mail/message.go
@@ -112,7 +112,7 @@ func ParseDate(date string) (time.Time, error) {
 	if ind := strings.IndexAny(p.s, "+-"); ind != -1 && len(p.s) >= ind+5 {
 		date = p.s[:ind+5]
 		p.s = p.s[ind+5:]
-	} else if ind := strings.Index(p.s, "T"); ind != -1 {
+	} else if ind := index(p.s, "T", 1); ind != -1 {
 		// The last letter T of the obsolete time zone is checked when no standard time zone is found.
 		// If T is misplaced, the date to parse is garbage.
 		date = p.s[:ind+1]
@@ -128,6 +128,17 @@ func ParseDate(date string) (time.Time, error) {
 		}
 	}
 	return time.Time{}, errors.New("mail: header could not be parsed")
+}
+
+func index(s, substr string, start int) int {
+	if len(s) < start {
+		return -1
+	}
+	i := strings.Index(s[start:], substr)
+	if i == -1 {
+		return i
+	}
+	return i + start
 }
 
 // A Header represents the key-value pairs in a mail message header.

--- a/src/net/mail/message.go
+++ b/src/net/mail/message.go
@@ -112,7 +112,7 @@ func ParseDate(date string) (time.Time, error) {
 	if ind := strings.IndexAny(p.s, "+-"); ind != -1 && len(p.s) >= ind+5 {
 		date = p.s[:ind+5]
 		p.s = p.s[ind+5:]
-	} else if ind := strings.Index(p.s, "T"); ind != -1 && len(p.s) >= ind+1 {
+	} else if ind := strings.Index(p.s, "T"); ind != -1 {
 		// The last letter T of the obsolete time zone is checked when no standard time zone is found.
 		// If T is misplaced, the date to parse is garbage.
 		date = p.s[:ind+1]

--- a/src/net/mail/message_test.go
+++ b/src/net/mail/message_test.go
@@ -102,6 +102,10 @@ func TestDateParsing(t *testing.T) {
 			"Thu, 20 Nov 97 09:55:06 GMT",
 			time.Date(1997, 11, 20, 9, 55, 6, 0, time.FixedZone("GMT", 0)),
 		},
+		{
+			"Fri, 21 Nov 97 09:55:06 UT",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("UTC", 0)),
+		},
 		// Commonly found format not specified by RFC 5322.
 		{
 			"Fri, 21 Nov 1997 09:55:06 -0600 (MDT)",

--- a/src/net/mail/message_test.go
+++ b/src/net/mail/message_test.go
@@ -98,6 +98,10 @@ func TestDateParsing(t *testing.T) {
 			"21 Nov 97 09:55:06 GMT",
 			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("GMT", 0)),
 		},
+		{
+			"Thu, 20 Nov 97 09:55:06 GMT",
+			time.Date(1997, 11, 20, 9, 55, 6, 0, time.FixedZone("GMT", 0)),
+		},
 		// Commonly found format not specified by RFC 5322.
 		{
 			"Fri, 21 Nov 1997 09:55:06 -0600 (MDT)",


### PR DESCRIPTION
This improves the package's date parsing for better compatibility with RFC 5322.

According to section 3.3, a full date and time specification can begin with a day of week and end with a time containing an obsolete time zone. This makes "Tue, ... GMT" a legal value. The package would trim the input string after the first "T" causing it to fail this format when the date is a Tuesday or a Thursday.

Section 4.3 recognizes "UT" as universal time. The built-in time parser does not so we need to append "C" before handing it off.