### PR TITLE
misc/wasm: fix the empty global fs check

### DIFF
--- a/misc/wasm/wasm_exec.js
+++ b/misc/wasm/wasm_exec.js
@@ -28,7 +28,7 @@
 
 	if (!global.fs && global.require) {
 		const fs = require("fs");
-		if (Object.keys(fs) !== 0) {
+		if (Object.keys(fs).length !== 0) {
 			global.fs = fs;
 		}
 	}

--- a/misc/wasm/wasm_exec.js
+++ b/misc/wasm/wasm_exec.js
@@ -11,6 +11,7 @@
 	// - Node.js
 	// - Electron
 	// - Parcel
+	// - Webpack
 
 	if (typeof global !== "undefined") {
 		// global already exists


### PR DESCRIPTION
`Object.keys` returns an array so can never equal zero. I believe this check is
looking for a stubbed `fs` object with no keys. I'm using vuepress and a stub
object like this is being added to the `window` object.
