### PR TITLE
A+C: add Kush Patel (corporate CLA for Hootsuite Inc)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -563,6 +563,7 @@ Hitoshi Mitake <mitake.hitoshi@gmail.com>
 Holden Huang <ttyh061@gmail.com>
 Hong Ruiqi <hongruiqi@gmail.com>
 Hongfei Tan <feilengcui008@gmail.com>
+Hootsuite Inc.
 Hsin-Ho Yeh <yhh92u@gmail.com>
 Hu Keping <hukeping@huawei.com>
 Hugues Bruant <hugues.bruant@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1303,6 +1303,7 @@ Kshitij Saraogi <kshitijsaraogi@gmail.com>
 Kun Li <likunarmstrong@gmail.com>
 Kunpei Sakai <namusyaka@gmail.com>
 Kuntal Majumder <hellozee@disroot.org>
+Kush Patel <kush.patel@hootsuite.com>
 Kyle Consalus <consalus@gmail.com>
 Kyle Isom <kyle@gokyle.net>
 Kyle Jones <kyle@kyledj.com>


### PR DESCRIPTION
I'm from Hootsuite. We're a Canadian tech company who provides products
and services to businesses, organizations and individuals to really help
them succeed on social. We have leveraged Go in our stack for the past
4+ years. I am super happy to give back to Go on behalf of Hootsuite
through a small contribution to pkgsite (with a few more in the works).
We love this project and we love open source :)

Hopefully we can give back more in the future!
Kush