### PR TITLE
crypto/ecdsa: fix dead reference link

### DIFF
--- a/src/crypto/ecdsa/ecdsa.go
+++ b/src/crypto/ecdsa/ecdsa.go
@@ -17,7 +17,7 @@
 //   [Coron]
 //     https://cs.nyu.edu/~dodis/ps/merkle.pdf
 //   [Larsson]
-//     https://www.nada.kth.se/kurser/kth/2D1441/semteo03/lecturenotes/assump.pdf
+//     https://web.archive.org/web/20040719170906/https://www.nada.kth.se/kurser/kth/2D1441/semteo03/lecturenotes/assump.pdf
 package ecdsa
 
 // Further references:


### PR DESCRIPTION
The previous link broke, but it's available on the internet archive.

Fixes #39808