### PR TITLE
[elf] Fix range iterator issue

### DIFF
--- a/src/cmd/link/internal/ld/elf2.go
+++ b/src/cmd/link/internal/ld/elf2.go
@@ -54,7 +54,7 @@ func elfrelocsect2(ctxt *Link, sect *sym.Section, syms []*sym.Symbol) {
 			break
 		}
 		for ri := range s.R {
-			r := &syms[i].R[ri]
+			r := &syms[i].s.R[ri]
 			if r.Done {
 				continue
 			}

--- a/src/cmd/link/internal/ld/elf2.go
+++ b/src/cmd/link/internal/ld/elf2.go
@@ -46,7 +46,7 @@ func elfrelocsect2(ctxt *Link, sect *sym.Section, syms []*sym.Symbol) {
 	}
 
 	eaddr := int32(sect.Vaddr + sect.Length)
-	for _, s := range syms {
+	for i, s := range syms {
 		if !s.Attr.Reachable() {
 			continue
 		}
@@ -54,7 +54,7 @@ func elfrelocsect2(ctxt *Link, sect *sym.Section, syms []*sym.Symbol) {
 			break
 		}
 		for ri := range s.R {
-			r := &s.R[ri]
+			r := &syms[i].R[ri]
 			if r.Done {
 				continue
 			}

--- a/src/cmd/oldlink/internal/ld/elf.go
+++ b/src/cmd/oldlink/internal/ld/elf.go
@@ -1368,7 +1368,7 @@ func elfrelocsect(ctxt *Link, sect *sym.Section, syms []*sym.Symbol) {
 			break
 		}
 		for ri := range s.R {
-			r := &syms[i].R[ri]
+			r := &syms[i].s.R[ri]
 			if r.Done {
 				continue
 			}

--- a/src/cmd/oldlink/internal/ld/elf.go
+++ b/src/cmd/oldlink/internal/ld/elf.go
@@ -1360,7 +1360,7 @@ func elfrelocsect(ctxt *Link, sect *sym.Section, syms []*sym.Symbol) {
 	}
 
 	eaddr := int32(sect.Vaddr + sect.Length)
-	for _, s := range syms {
+	for i, s := range syms {
 		if !s.Attr.Reachable() {
 			continue
 		}
@@ -1368,7 +1368,7 @@ func elfrelocsect(ctxt *Link, sect *sym.Section, syms []*sym.Symbol) {
 			break
 		}
 		for ri := range s.R {
-			r := &s.R[ri]
+			r := &syms[i].R[ri]
 			if r.Done {
 				continue
 			}


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

Go uses the same address variable while iterating in a range, so use a copy when using its address, otherwise we end up using the last value for all iterations.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
