### PR TITLE
sync: fix goroutine leak for when TestMutexFairness times out

### DIFF
--- a/src/sync/mutex_test.go
+++ b/src/sync/mutex_test.go
@@ -194,7 +194,7 @@ func TestMutexFairness(t *testing.T) {
 			}
 		}
 	}()
-	done := make(chan bool)
+	done := make(chan bool, 1)
 	go func() {
 		for i := 0; i < 10; i++ {
 			time.Sleep(100 * time.Microsecond)


### PR DESCRIPTION
If the timeout triggers before writing to the done channel, the
goroutine will be blocked waiting for a corresponding read that’s
no longer existent, thus a goroutine leak. This change fixes that by
using a buffered channel instead.