### PR TITLE
net/http: fixes off-by-one error in http2getDataBufferChunk

### DIFF
--- a/src/net/http/h2_bundle.go
+++ b/src/net/http/h2_bundle.go
@@ -982,7 +982,7 @@ var (
 
 func http2getDataBufferChunk(size int64) []byte {
 	i := 0
-	for ; i < len(http2dataChunkSizeClasses)-1; i++ {
+	for ; i < len(http2dataChunkSizeClasses); i++ {
 		if size <= int64(http2dataChunkSizeClasses[i]) {
 			break
 		}


### PR DESCRIPTION
Previously it was doing `i < len(...)-1`, because it is a 'less than' instead of a 'less than or equal to' the -1 ends up being redundant. This in turn causes the largest buffer size to not be reused.