### PR TITLE
regexp: link to the regexp syntax documentation from go doc regexp

### DIFF
--- a/src/regexp/regexp.go
+++ b/src/regexp/regexp.go
@@ -4,12 +4,12 @@
 
 // Package regexp implements regular expression search.
 //
-// The syntax of the regular expressions accepted is the same
-// general syntax used by Perl, Python, and other languages.
-// More precisely, it is the syntax accepted by RE2 and described at
-// https://golang.org/s/re2syntax, except for \C.
-// For an overview of the syntax, run
-//   go doc regexp/syntax
+// This package uses RE2 syntax for regular expressions. Users of regular
+// expressions in Perl, Python, and other languages and tools will find it
+// familiar. For an overview of the syntax, see
+//     https://golang.org/pkg/regexp/syntax/
+// Or run
+//     go doc regexp/syntax
 //
 // The regexp implementation provided by this package is
 // guaranteed to run in time linear in the size of the input.


### PR DESCRIPTION
The current documentation links outside of the Go project to give
users the reference specification used by Go. Later it links to
the actual Go regexp syntax documentation. This change eliminates
the first link and makes the wording a bit more to the point.
Fixes #39405.