### PR TITLE
cmd/go: use the correct linker config in the buildID hash

### DIFF
--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -1178,8 +1178,13 @@ func (b *Builder) printLinkerConfig(h io.Writer, p *load.Package) {
 		key, val := cfg.GetArchEnv()
 		fmt.Fprintf(h, "%s=%s\n", key, val)
 
-		// The linker writes source file paths that say GOROOT_FINAL.
-		fmt.Fprintf(h, "GOROOT=%s\n", cfg.GOROOT_FINAL)
+		// The linker writes source file paths that say GOROOT_FINAL, but
+		// only if -trimpath is not specified (see ld() in gc.go).
+		gorootFinal := cfg.GOROOT_FINAL
+		if cfg.BuildTrimpath {
+			gorootFinal = trimPathGoRootFinal
+		}
+		fmt.Fprintf(h, "GOROOT=%s\n", gorootFinal)
 
 		// GO_EXTLINK_ENABLED controls whether the external linker is used.
 		fmt.Fprintf(h, "GO_EXTLINK_ENABLED=%s\n", cfg.Getenv("GO_EXTLINK_ENABLED"))

--- a/src/cmd/go/internal/work/gc.go
+++ b/src/cmd/go/internal/work/gc.go
@@ -25,6 +25,9 @@ import (
 	"crypto/sha1"
 )
 
+// The 'path' used for GOROOT_FINAL when -trimpath is specified
+const trimPathGoRootFinal = "go"
+
 // The Go toolchain.
 
 type gcToolchain struct{}
@@ -569,7 +572,7 @@ func (gcToolchain) ld(b *Builder, root *Action, out, importcfg, mainpkg string) 
 
 	env := []string{}
 	if cfg.BuildTrimpath {
-		env = append(env, "GOROOT_FINAL=go")
+		env = append(env, "GOROOT_FINAL="+trimPathGoRootFinal)
 	}
 	return b.run(root, dir, root.Package.ImportPath, env, cfg.BuildToolexec, base.Tool("link"), "-o", out, "-importcfg", importcfg, ldflags, mainpkg)
 }

--- a/src/cmd/go/testdata/script/link_matching_actionid.txt
+++ b/src/cmd/go/testdata/script/link_matching_actionid.txt
@@ -1,0 +1,34 @@
+env GO111MODULE=off
+[short] skip
+
+# Symlink the compiler to a local path
+env GOROOT=$WORK/goroot1
+symlink $GOROOT -> $TESTGO_GOROOT
+
+# Set up fresh GOCACHE
+env GOCACHE=$WORK/gocache1
+mkdir $GOCACHE
+
+# Build a simple binary
+go build -o binary1 -trimpath -x main.go
+
+# Now repeat the same process with the compiler at a different local path
+env GOROOT=$WORK/goroot2
+symlink $GOROOT -> $TESTGO_GOROOT
+
+env GOCACHE=$WORK/gocache2
+mkdir $GOCACHE
+
+go build -o binary2 -trimpath -x main.go
+
+# Check that the binaries match exactly
+go tool buildid binary1
+cp stdout buildid1
+go tool buildid binary2
+cp stdout buildid2
+cmp buildid1 buildid2
+
+
+-- main.go --
+package main
+func main() {}

--- a/src/cmd/go/testdata/script/link_matching_actionid.txt
+++ b/src/cmd/go/testdata/script/link_matching_actionid.txt
@@ -1,5 +1,6 @@
 env GO111MODULE=off
 [short] skip
+[!symlink] skip
 
 # Symlink the compiler to a local path
 env GOROOT=$WORK/goroot1

--- a/src/cmd/go/testdata/script/link_matching_actionid.txt
+++ b/src/cmd/go/testdata/script/link_matching_actionid.txt
@@ -1,4 +1,3 @@
-env GO111MODULE=off
 [short] skip
 [!symlink] skip
 

--- a/src/cmd/go/testdata/script/link_matching_actionid.txt
+++ b/src/cmd/go/testdata/script/link_matching_actionid.txt
@@ -1,3 +1,7 @@
+# Checks that an identical binary is built with -trimpath from the same
+# source files, with GOROOT in two different locations.
+# Verifies golang.org/issue/38989
+
 [short] skip
 [!symlink] skip
 


### PR DESCRIPTION
The linker config is hashed into the buildID; however,
the GOROOT_FINAL environment variable that is
actually used when -trimpath is specified was not
reflected in that hash. This change fixes that.

Fixes #38989