### PR TITLE
Add TryLock method to Mutex

### DIFF
--- a/src/sync/mutex.go
+++ b/src/sync/mutex.go
@@ -170,6 +170,18 @@ func (m *Mutex) lockSlow() {
 	}
 }
 
+// Tries to lock m without blocking.
+// Returns if it locked the mutex or not
+func (m *Mutex) TryLock() bool {
+	if atomic.CompareAndSwapInt32(&m.state, 0, mutexLocked) {
+		if race.Enabled {
+			race.Acquire(unsafe.Pointer(m))
+		}
+		return true
+	}
+	return false
+}
+
 // Unlock unlocks m.
 // It is a run-time error if m is not locked on entry to Unlock.
 //


### PR DESCRIPTION
TryLock is a really useful primitive.  A very common pattern for example is something like:

```
func cleanup() {
   mutex.Lock()
   defer mutex.Unlock();


    // thread unsafe cleanup code
}
```

But it suffers from a pretty typical issue where a bunch of them could queue up. A try lock would allow someone to write the code to abort immediately if the code isn't in progress