### PR TITLE
strings: improve performance of ToUpper and ToLower

### DIFF
--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -11,6 +11,7 @@ import (
 	"internal/bytealg"
 	"unicode"
 	"unicode/utf8"
+	"unsafe"
 )
 
 // explode splits s into a slice of UTF-8 strings,
@@ -562,16 +563,15 @@ func ToUpper(s string) string {
 		if !hasLower {
 			return s
 		}
-		var b Builder
-		b.Grow(len(s))
+		b := make([]byte, len(s))
 		for i := 0; i < len(s); i++ {
 			c := s[i]
 			if 'a' <= c && c <= 'z' {
 				c -= 'a' - 'A'
 			}
-			b.WriteByte(c)
+			b[i] = c
 		}
-		return b.String()
+		return *(*string)(unsafe.Pointer(&b))
 	}
 	return Map(unicode.ToUpper, s)
 }
@@ -592,16 +592,15 @@ func ToLower(s string) string {
 		if !hasUpper {
 			return s
 		}
-		var b Builder
-		b.Grow(len(s))
+		b := make([]byte, len(s))
 		for i := 0; i < len(s); i++ {
 			c := s[i]
 			if 'A' <= c && c <= 'Z' {
 				c += 'a' - 'A'
 			}
-			b.WriteByte(c)
+			b[i] = c
 		}
-		return b.String()
+		return *(*string)(unsafe.Pointer(&b))
 	}
 	return Map(unicode.ToLower, s)
 }

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -544,7 +544,7 @@ var upperTests = []StringTest{
 	{"abc", "ABC"},
 	{"AbC123", "ABC123"},
 	{"azAZ09_", "AZAZ09_"},
-	{"longStrinGwitHmixofsmaLLandcAps", "LONGSTRINGWITHMIXOFSMALLANDCAPS"},
+	{"alongerStrinGwitHmixofsmaLLandcApsLeTTers", "ALONGERSTRINGWITHMIXOFSMALLANDCAPSLETTERS"},
 	{"long\u0250string\u0250with\u0250nonascii\u2C6Fchars", "LONG\u2C6FSTRING\u2C6FWITH\u2C6FNONASCII\u2C6FCHARS"},
 	{"\u0250\u0250\u0250\u0250\u0250", "\u2C6F\u2C6F\u2C6F\u2C6F\u2C6F"}, // grows one byte per char
 	{"a\u0080\U0010FFFF", "A\u0080\U0010FFFF"},                           // test utf8.RuneSelf and utf8.MaxRune
@@ -555,7 +555,7 @@ var lowerTests = []StringTest{
 	{"abc", "abc"},
 	{"AbC123", "abc123"},
 	{"azAZ09_", "azaz09_"},
-	{"longStrinGwitHmixofsmaLLandcAps", "longstringwithmixofsmallandcaps"},
+	{"alongerStrinGwitHmixofsmaLLandcApsLeTTers", "alongerstringwithmixofsmallandcapsletters"},
 	{"LONG\u2C6FSTRING\u2C6FWITH\u2C6FNONASCII\u2C6FCHARS", "long\u0250string\u0250with\u0250nonascii\u0250chars"},
 	{"\u2C6D\u2C6D\u2C6D\u2C6D\u2C6D", "\u0251\u0251\u0251\u0251\u0251"}, // shrinks one byte per char
 	{"A\u0080\U0010FFFF", "a\u0080\U0010FFFF"},                           // test utf8.RuneSelf and utf8.MaxRune


### PR DESCRIPTION
ASCII-only strings are treated separately in these two functions,
instead of using a pre-allocated strings.Builder we might just as well
use a byte slice.

In the benchmarks I run on my environment, using []byte directly is
generally faster than using a strings.Builder.

