### PR TITLE
os/user: add solaris getgroups support

### DIFF
--- a/src/os/user/listgroups_solaris.go
+++ b/src/os/user/listgroups_solaris.go
@@ -4,14 +4,44 @@
 
 // +build cgo,!osusergo
 
-// Even though this file requires no C, it is used to provide a
-// listGroup stub because all the other Solaris calls work.  Otherwise,
-// this stub will conflict with the lookup_stubs.go fallback.
-
 package user
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"unsafe"
+)
+
+// #include <grp.h>
+import "C"
+
+var listGroupsLock sync.Mutex
 
 func listGroups(u *User) ([]string, error) {
-	return nil, fmt.Errorf("user: list groups for %s: not supported on Solaris", u.Username)
+	listGroupsLock.Lock()
+	defer listGroupsLock.Unlock()
+
+	ug, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		return nil, fmt.Errorf("user: list groups for %s: invalid gid %q", u.Username, u.Gid)
+	}
+
+	gids := []string{u.Gid}
+
+	C.setgrent()
+	for grp := C.getgrent(); grp != nil; grp = C.getgrent() {
+		if int(grp.gr_gid) != ug && grp.gr_mem != nil {
+			mem := (*[1<<30 - 1]*C.char)(unsafe.Pointer(grp.gr_mem))
+			for i := 0; mem[i] != nil; i++ {
+				if C.GoString(mem[i]) == u.Username {
+					gids = append(gids, strconv.Itoa(int(grp.gr_gid)))
+					break
+				}
+			}
+		}
+	}
+	C.endgrent()
+
+	return gids, nil
 }

--- a/src/os/user/user_test.go
+++ b/src/os/user/user_test.go
@@ -132,9 +132,6 @@ func TestGroupIds(t *testing.T) {
 	if runtime.GOOS == "aix" {
 		t.Skip("skipping GroupIds, see golang.org/issue/30563")
 	}
-	if runtime.GOOS == "solaris" || runtime.GOOS == "illumos" {
-		t.Skip("skipping GroupIds, see golang.org/issue/14709")
-	}
 	user, err := Current()
 	if err != nil {
 		t.Fatalf("Current(): %v", err)


### PR DESCRIPTION
This adds support for User.GroupIds on Solaris.  Before folks ask why I didn't just use getgrent_r:
1. it was simpler and
2. the thread-safeness of getgrent_r is questionable as it still depends on setgrent setting the internal pointer to the right place, which could be moved if someone else calls getgrent.