### PR TITLE
plugin: add OpenFile to allow loading of Plugins from file descriptors

### DIFF
--- a/src/plugin/plugin.go
+++ b/src/plugin/plugin.go
@@ -17,6 +17,10 @@
 // Please report any issues.
 package plugin
 
+import (
+	"os"
+)
+
 // Plugin is a loaded Go plugin.
 type Plugin struct {
 	pluginpath string
@@ -30,6 +34,13 @@ type Plugin struct {
 // It is safe for concurrent use by multiple goroutines.
 func Open(path string) (*Plugin, error) {
 	return open(path)
+}
+
+// Open opens a Go plugin from a File over its file descriptor.
+// If a path has already been opened, then the existing *Plugin is returned.
+// It is safe for concurrent use by multiple goroutines.
+func OpenFile(file *os.File) (*Plugin, error) {
+	return openFile(file)
 }
 
 // Lookup searches for a symbol named symName in plugin p.

--- a/src/plugin/plugin_dlopen.go
+++ b/src/plugin/plugin_dlopen.go
@@ -43,6 +43,7 @@ func open(name string) (*Plugin, error) {
 	cPath := make([]byte, C.PATH_MAX+1)
 	cRelName := make([]byte, len(name)+1)
 	copy(cRelName, name)
+
 	if C.realpath(
 		(*C.char)(unsafe.Pointer(&cRelName[0])),
 		(*C.char)(unsafe.Pointer(&cPath[0]))) == nil {
@@ -51,6 +52,10 @@ func open(name string) (*Plugin, error) {
 
 	filepath := C.GoString((*C.char)(unsafe.Pointer(&cPath[0])))
 
+	return openPath(name, filepath, cPath)
+}
+
+func openPath(name, filepath string, cPath []byte) (*Plugin, error) {
 	pluginsMu.Lock()
 	if p := plugins[filepath]; p != nil {
 		pluginsMu.Unlock()

--- a/src/plugin/plugin_linux.go
+++ b/src/plugin/plugin_linux.go
@@ -1,0 +1,20 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux,cgo
+
+package plugin
+
+import (
+	"fmt"
+	"os"
+)
+
+func openFile(f *os.File) (*Plugin, error) {
+	name := fmt.Sprintf("/proc/self/fd/%d", f.Fd())
+	cPath := make([]byte, len(name)+1)
+	copy(cPath, name)
+
+	return openPath(name, name, cPath)
+}

--- a/src/plugin/plugin_other.go
+++ b/src/plugin/plugin_other.go
@@ -1,0 +1,15 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin,cgo freebsd,cgo
+
+package plugin
+
+import (
+	"os"
+)
+
+func openFile(f *os.File) (*Plugin, error) {
+	return open(f.Name())
+}

--- a/src/plugin/plugin_stubs.go
+++ b/src/plugin/plugin_stubs.go
@@ -6,12 +6,19 @@
 
 package plugin
 
-import "errors"
+import (
+	"errors"
+	"os"
+)
 
 func lookup(p *Plugin, symName string) (Symbol, error) {
 	return nil, errors.New("plugin: not implemented")
 }
 
 func open(name string) (*Plugin, error) {
+	return nil, errors.New("plugin: not implemented")
+}
+
+func openFile(f *os.File) (*Plugin, error) {
 	return nil, errors.New("plugin: not implemented")
 }


### PR DESCRIPTION
This allows loading of plugins that are stored in a memfd. Thanks to @terorie for the initial testing.
