### PR TITLE
cmd/go: support non .go named files in go build

### DIFF
--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2166,7 +2166,8 @@ func validateSourceFile(name string) error {
 	}
 
 	// We need to test whether the path is an actual Go file and not a
-	// package path or pattern ending in '.go' (see golang.org/issue/34653).
+	// package path or pattern ending in one of the valid extensions.
+	// (see golang.org/issue/34653).
 	fi, err := os.Stat(name)
 	if err != nil {
 		return err

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2286,7 +2286,6 @@ func GoFilesPackage(gofiles []string) *Package {
 
 	// This is a list of valid file exensions that can be accepted in
 	// the named files passed to the `go build` command.
-	extensionIsValid := false
 	validFileTypes := []string{
 		".go", ".c", ".s", ".S", ".sx", ".cc", ".cpp", ".cxx", ".f",
 		".F", ".for", ".f90"

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2291,11 +2291,17 @@ func GoFilesPackage(gofiles []string) *Package {
 		".F", ".for", ".f90",
 	}
 
-	for _, f := range gofiles {
+    for _, f := range gofiles {
+        fileExtensionValid := false
 		for _, ext := range validFileTypes {
-			if strings.HasSuffix(f, ext) {
-				break
+            if strings.HasSuffix(f, ext) {
+                fileExtensionValid = true
+                break
             }
+        }
+
+        if fileExtensionValid {
+            continue
         }
         
         pkg := new(Package)

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2165,8 +2165,8 @@ func validateSourceFile(name string) error {
 		return fmt.Errorf("invalid file type: %s", name)
 	}
 
-	// We need to test whether the path is an actual Go file and not a
-	// package path or pattern ending in one of the valid extensions.
+	// We need to test whether the path is an actual Source file and
+	// not a package path or pattern ending in one of the valid extensions.
 	// (see golang.org/issue/34653).
 	fi, err := os.Stat(name)
 	if err != nil {

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2284,16 +2284,26 @@ func PackagesForBuild(ctx context.Context, args []string) []*Package {
 func GoFilesPackage(gofiles []string) *Package {
 	ModInit()
 
+	// This is a list of valid file exensions that can be accepted in
+	// the named files passed to the `go build` command.
+	extensionIsValid := false
+	validFileTypes := []string{
+		".go", ".c", ".s", ".S", ".sx", ".cc", ".cpp", ".cxx", ".f",
+		".F", ".for", ".f90"
+	}
+
 	for _, f := range gofiles {
-		if !strings.HasSuffix(f, ".go") {
-			pkg := new(Package)
-			pkg.Internal.Local = true
-			pkg.Internal.CmdlineFiles = true
-			pkg.Name = f
-			pkg.Error = &PackageError{
-				Err: fmt.Errorf("named files must be .go files: %s", pkg.Name),
+		for _, ext := range validFileTypes {
+			if !strings.HasSuffix(f, ext) {
+				pkg := new(Package)
+				pkg.Internal.Local = true
+				pkg.Internal.CmdlineFiles = true
+				pkg.Name = f
+				pkg.Error = &PackageError{
+					Err: fmt.Errorf("invalid named file: %s", pkg.Name),
+				}
+				return pkg
 			}
-			return pkg
 		}
 	}
 

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2140,20 +2140,20 @@ func Packages(ctx context.Context, args []string) []*Package {
 // fileHasValidSourceExtension will determine if the specified file
 // ends in one of the valid source file extensions.
 func fileHasValidSourceExtension(name string) bool {
-    // This is a list of valid file exensions that can be accepted in
+	// This is a list of valid file exensions that can be accepted in
 	// the named files passed to the `go build` command.
 	validFileTypes := []string{
 		".go", ".c", ".s", ".S", ".sx", ".cc", ".cpp", ".cxx", ".f",
 		".F", ".for", ".f90",
-    }
-    
-    for _,ext := range validFileTypes {
-        if strings.HasSuffix(name, ext) {
-            return true
-        }
-    }
+	}
 
-    return false
+	for _, ext := range validFileTypes {
+		if strings.HasSuffix(name, ext) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // validateSourceFile will determine if the provided file name exists
@@ -2161,22 +2161,22 @@ func fileHasValidSourceExtension(name string) bool {
 // exensions, and is not a directory. It will return a corresponding
 // error, or nil if the specified name is valid.
 func validateSourceFile(name string) error {
-    if !fileHasValidSourceExtension(name) {
-        return fmt.Errorf("invalid file type: %s", name)
-    }
+	if !fileHasValidSourceExtension(name) {
+		return fmt.Errorf("invalid file type: %s", name)
+	}
 
 	// We need to test whether the path is an actual Go file and not a
-    // package path or pattern ending in '.go' (see golang.org/issue/34653).
-    fi, err := os.Stat(name)
-    if err != nil {
-        return err
-    }
+	// package path or pattern ending in '.go' (see golang.org/issue/34653).
+	fi, err := os.Stat(name)
+	if err != nil {
+		return err
+	}
 
-    if fi.IsDir() {
-        return fmt.Errorf("invalid directory listed as source file: %s", name)
-    }
+	if fi.IsDir() {
+		return fmt.Errorf("invalid directory listed as source file: %s", name)
+	}
 
-    return nil
+	return nil
 }
 
 // PackagesAndErrors is like 'packages' but returns a
@@ -2188,10 +2188,10 @@ func PackagesAndErrors(ctx context.Context, patterns []string) []*Package {
 	defer span.Done()
 
 	for _, p := range patterns {
-        err := validateSourceFile(p)
-        if err == nil {
-            return []*Package{GoFilesPackage(patterns)}
-        }
+		err := validateSourceFile(p)
+		if err == nil {
+			return []*Package{GoFilesPackage(patterns)}
+		}
 	}
 
 	matches := ImportPaths(patterns)
@@ -2321,17 +2321,17 @@ func GoFilesPackage(gofiles []string) *Package {
 	ModInit()
 
 	for _, f := range gofiles {
-        err := validateSourceFile(f)
+		err := validateSourceFile(f)
 		if err != nil {
-            pkg := new(Package)
-    		pkg.Internal.Local = true
-    		pkg.Internal.CmdlineFiles = true
-    		pkg.Name = f
-    		pkg.Error = &PackageError{
-    			Err: err,
-    		}
-    		return pkg
-        }
+			pkg := new(Package)
+			pkg.Internal.Local = true
+			pkg.Internal.CmdlineFiles = true
+			pkg.Name = f
+			pkg.Error = &PackageError{
+				Err: err,
+			}
+			return pkg
+		}
 	}
 
 	var stk ImportStack

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2293,17 +2293,19 @@ func GoFilesPackage(gofiles []string) *Package {
 
 	for _, f := range gofiles {
 		for _, ext := range validFileTypes {
-			if !strings.HasSuffix(f, ext) {
-				pkg := new(Package)
-				pkg.Internal.Local = true
-				pkg.Internal.CmdlineFiles = true
-				pkg.Name = f
-				pkg.Error = &PackageError{
-					Err: fmt.Errorf("invalid named file: %s", pkg.Name),
-				}
-				return pkg
-			}
+			if strings.HasSuffix(f, ext) {
+				break
+            }
+        }
+        
+        pkg := new(Package)
+		pkg.Internal.Local = true
+		pkg.Internal.CmdlineFiles = true
+		pkg.Name = f
+		pkg.Error = &PackageError{
+			Err: fmt.Errorf("invalid named file: %s", pkg.Name),
 		}
+		return pkg
 	}
 
 	var stk ImportStack

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2288,7 +2288,7 @@ func GoFilesPackage(gofiles []string) *Package {
 	// the named files passed to the `go build` command.
 	validFileTypes := []string{
 		".go", ".c", ".s", ".S", ".sx", ".cc", ".cpp", ".cxx", ".f",
-		".F", ".for", ".f90"
+		".F", ".for", ".f90",
 	}
 
 	for _, f := range gofiles {

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2191,7 +2191,7 @@ func PackagesAndErrors(ctx context.Context, patterns []string) []*Package {
 	for _, p := range patterns {
 		err := validateSourceFile(p)
 		if err == nil {
-			return []*Package{GoFilesPackage(patterns)}
+			return []*Package{SourceFilesPackage(patterns)}
 		}
 	}
 
@@ -2315,13 +2315,14 @@ func PackagesForBuild(ctx context.Context, args []string) []*Package {
 	return pkgs
 }
 
-// GoFilesPackage creates a package for building a collection of Go files
-// (typically named on the command line). The target is named p.a for
-// package p or named after the first Go file for package main.
-func GoFilesPackage(gofiles []string) *Package {
+// SourceFilesPackage creates a package for building a collection of
+// Source files (typically named on the command line). The target is
+// named p.a for package p or named after the first Go file for
+// package main.
+func SourceFilesPackage(sourcefiles []string) *Package {
 	ModInit()
 
-	for _, f := range gofiles {
+	for _, f := range sourcefiles {
 		err := validateSourceFile(f)
 		if err != nil {
 			pkg := new(Package)
@@ -2345,13 +2346,13 @@ func GoFilesPackage(gofiles []string) *Package {
 	// consistently, the files must all be in the same directory.
 	var dirent []os.FileInfo
 	var dir string
-	for _, file := range gofiles {
+	for _, file := range sourcefiles {
 		fi, err := os.Stat(file)
 		if err != nil {
 			base.Fatalf("%s", err)
 		}
 		if fi.IsDir() {
-			base.Fatalf("%s is a directory, should be a Go file", file)
+			base.Fatalf("%s is a directory, should be a Source file", file)
 		}
 		dir1, _ := filepath.Split(file)
 		if dir1 == "" {
@@ -2367,7 +2368,7 @@ func GoFilesPackage(gofiles []string) *Package {
 	ctxt.ReadDir = func(string) ([]os.FileInfo, error) { return dirent, nil }
 
 	if cfg.ModulesEnabled {
-		ModImportFromFiles(gofiles)
+		ModImportFromFiles(sourcefiles)
 	}
 
 	var err error
@@ -2387,7 +2388,7 @@ func GoFilesPackage(gofiles []string) *Package {
 	pkg.Internal.LocalPrefix = dirToImportPath(dir)
 	pkg.ImportPath = "command-line-arguments"
 	pkg.Target = ""
-	pkg.Match = gofiles
+	pkg.Match = sourcefiles
 
 	if pkg.Name == "main" {
 		exe := pkg.DefaultExecName() + cfg.ExeSuffix

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2291,20 +2291,20 @@ func GoFilesPackage(gofiles []string) *Package {
 		".F", ".for", ".f90",
 	}
 
-    for _, f := range gofiles {
-        fileExtensionValid := false
+	for _, f := range gofiles {
+		fileExtensionValid := false
 		for _, ext := range validFileTypes {
-            if strings.HasSuffix(f, ext) {
-                fileExtensionValid = true
-                break
-            }
-        }
+			if strings.HasSuffix(f, ext) {
+				fileExtensionValid = true
+				break
+			}
+		}
 
-        if fileExtensionValid {
-            continue
-        }
-        
-        pkg := new(Package)
+		if fileExtensionValid {
+			continue
+		}
+
+		pkg := new(Package)
 		pkg.Internal.Local = true
 		pkg.Internal.CmdlineFiles = true
 		pkg.Name = f

--- a/src/cmd/go/internal/run/run.go
+++ b/src/cmd/go/internal/run/run.go
@@ -72,12 +72,12 @@ func runRun(ctx context.Context, cmd *base.Command, args []string) {
 		files := args[:i]
 		for _, file := range files {
 			if strings.HasSuffix(file, "_test.go") {
-				// GoFilesPackage is going to assign this to TestGoFiles.
+				// SourceFilesPackage is going to assign this to TestGoFiles.
 				// Reject since it won't be part of the build.
 				base.Fatalf("go run: cannot run *_test.go files (%s)", file)
 			}
 		}
-		p = load.GoFilesPackage(files)
+		p = load.SourceFilesPackage(files)
 	} else if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
 		pkgs := load.PackagesAndErrors(ctx, args[:1])
 		if len(pkgs) == 0 {

--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -2888,7 +2888,7 @@ func (b *Builder) swigDoIntSize(objdir string) (intsize string, err error) {
 	}
 	srcs := []string{src}
 
-	p := load.GoFilesPackage(srcs)
+	p := load.SourceFilesPackage(srcs)
 
 	if _, _, e := BuildToolchain.gc(b, &Action{Mode: "swigDoIntSize", Package: p, Objdir: objdir}, "", nil, "", false, srcs); e != nil {
 		return "32", nil

--- a/src/cmd/go/testdata/script/list_test_non_go_files.txt
+++ b/src/cmd/go/testdata/script/list_test_non_go_files.txt
@@ -1,13 +1,14 @@
 env GO111MODULE=off
 
 # issue 29899: handling files with non-Go extension
-go list -e -test -json -- c.c x.go
-stdout '"Err": "named files must be .go files: c.c"'
+# issue 40570: go extensions include all supported file types, not just .go files
+go list -e -test -json -- x.y x.go
+stdout '"Err": "invalid file type: x.y"'
 
-! go list -test -json -- c.c x.go
-stderr '^named files must be \.go files: c\.c$'
+! go list -test -json -- x.y x.go
+stderr '^invalid file type: x\.y$'
 
 -- x.go --
 package main
--- c.c --
-package c
+-- x.y --
+package x


### PR DESCRIPTION
Fixes #40570
