### PR TITLE
runtime: fix panic if newstack at runtime.acquireLockRank

### DIFF
--- a/src/runtime/lockrank_off.go
+++ b/src/runtime/lockrank_off.go
@@ -18,19 +18,29 @@ func getLockRank(l *mutex) lockRank {
 	return 0
 }
 
+// The following functions may be called in nosplit context.
+// Nosplit is not strictly required for lockWithRank, unlockWithRank
+// and lockWithRankMayAcquire, but these nosplit annotations must
+// be kept consistent with the equivalent functions in lockrank_on.go.
+
+//go:nosplit
 func lockWithRank(l *mutex, rank lockRank) {
 	lock2(l)
 }
 
+//go:nosplit
 func acquireLockRank(rank lockRank) {
 }
 
+//go:nosplit
 func unlockWithRank(l *mutex) {
 	unlock2(l)
 }
 
+//go:nosplit
 func releaseLockRank(rank lockRank) {
 }
 
+//go:nosplit
 func lockWithRankMayAcquire(l *mutex, rank lockRank) {
 }


### PR DESCRIPTION
Process may crash becaues acquireLockRank and releaseLockRank may 
be called in nosplit context. With optimizations and inlining 
disabled, these functions won't get inlined or have their morestack 
calls eliminated. 
Nosplit is not strictly required for lockWithRank, unlockWithRank
and lockWithRankMayAcquire, just keep consistency with lockrank_on.go
here.

Fixes #40843