### PR TITLE
Fixed waiting for HTTP response on write error.

### DIFF
--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -2568,10 +2568,11 @@ func (pc *persistConn) roundTrip(req *transportRequest) (resp *Response, err err
 				req.logf("writeErrCh resv: %T/%#v", err, err)
 			}
 			if err != nil {
-				pc.close(fmt.Errorf("write error: %v", err))
-				return nil, pc.mapRoundTripError(req, startBytesWritten, err)
-			}
-			if d := pc.t.ResponseHeaderTimeout; d > 0 {
+				d := pc.t.ResponseHeaderTimeout
+				if d == 0 {
+					pc.close(fmt.Errorf("write error: %v", err))
+					return nil, pc.mapRoundTripError(req, startBytesWritten, err)
+				}
 				if debugRoundTrip {
 					req.logf("starting timer for %v", d)
 				}


### PR DESCRIPTION
Fixed behaviour of ResponseHeaderTimeout in http.Transport - even in case property was set it was not honoured.
According to documentation if ResponseHeaderTimeout  is set and fully writing the request happens implementation shall wait for specified time for response before sending error.

Steps to reproduce:

- Prepare a POST/PUT request with body.
- Try to send it to the server requiring authentication.
- The server respond with authentication request and closed the client connection (to avoid sending huge file from not authenticated source)

Result the method RoundTrip returned error only without response.
Expectation response will be returned if received within specified time span.
