### PR TITLE
Fixes #40926 for HTTP response on write error.

### DIFF
--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -2580,10 +2580,11 @@ func (pc *persistConn) roundTrip(req *transportRequest) (resp *Response, err err
 				req.logf("writeErrCh resv: %T/%#v", err, err)
 			}
 			if err != nil {
-				pc.close(fmt.Errorf("write error: %v", err))
-				return nil, pc.mapRoundTripError(req, startBytesWritten, err)
-			}
-			if d := pc.t.ResponseHeaderTimeout; d > 0 {
+				d := pc.t.ResponseHeaderTimeout
+				if d == 0 {
+					pc.close(fmt.Errorf("write error: %v", err))
+					return nil, pc.mapRoundTripError(req, startBytesWritten, err)
+				}
 				if debugRoundTrip {
 					req.logf("starting timer for %v", d)
 				}

--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -2568,10 +2568,11 @@ func (pc *persistConn) roundTrip(req *transportRequest) (resp *Response, err err
 				req.logf("writeErrCh resv: %T/%#v", err, err)
 			}
 			if err != nil {
-				pc.close(fmt.Errorf("write error: %v", err))
-				return nil, pc.mapRoundTripError(req, startBytesWritten, err)
-			}
-			if d := pc.t.ResponseHeaderTimeout; d > 0 {
+				d := pc.t.ResponseHeaderTimeout
+				if d == 0 {
+					pc.close(fmt.Errorf("write error: %v", err))
+					return nil, pc.mapRoundTripError(req, startBytesWritten, err)
+				}
 				if debugRoundTrip {
 					req.logf("starting timer for %v", d)
 				}

--- a/src/net/http/transport_test.go
+++ b/src/net/http/transport_test.go
@@ -6289,3 +6289,116 @@ func TestTransportRejectsSignInContentLength(t *testing.T) {
 		t.Fatalf("Error mismatch\nGot: %q\nWanted substring: %q", got, want)
 	}
 }
+
+//Tests for issue #40926
+//ResponseHeaderTimeout not honoured - response from server not visible to implementing part
+
+const issue40926Body = "<HTML><HEAD><TITLE>401 Authorization Required</TITLE></HEAD><BODY></BODY></HTML>\r\n"
+const issue40926Resp = "HTTP/1.0 401 Unauthorized\r\n" +
+	"WWW-Authenticate: Basic realm=\"GoTest\"\r\n" +
+	"\r\n" +
+	issue40926Body
+
+var issue40926TestCases = []struct {
+	closeAfterHeaders     bool
+	responseHeaderTimeout time.Duration
+}{
+	{true, time.Second},
+	{false, 0},
+}
+
+func issue40926ContentHandling(t *testing.T, listener net.Listener, listenerDone chan struct{}, closeAfterHeaders bool) {
+	defer close(listenerDone)
+	c, err := listener.Accept()
+	if err != nil {
+		t.Errorf("Accept: %v", err)
+		return
+	}
+	defer c.Close()
+	reqReader := bufio.NewReader(c)
+	//Read data from request
+	req := make([]byte, 1024)
+	var total int64
+	var contentLength int64
+	isHeader := true
+
+	for {
+		var readError error
+		if isHeader {
+			header, err := reqReader.ReadString('\n')
+			if err == nil && (header == "\r" || header == "\r\n" || header == "\n" || header == "") {
+				isHeader = false
+			}
+			if strings.HasPrefix(header, "Content-Length: ") {
+				header = header[16 : len(header)-2]
+				contentLength, _ = strconv.ParseInt(header, 10, 32)
+			}
+			readError = err
+		} else {
+			n, err := reqReader.Read(req)
+			total += int64(n)
+			if err == io.EOF || n == 0 || contentLength == total {
+				break
+			}
+			readError = err
+		}
+
+		if !isHeader && closeAfterHeaders { //After any data is read - close connection
+			break
+		}
+		if readError != nil {
+			t.Errorf("Reading from req failed %s", err.Error())
+			return
+		}
+	}
+	c.Write([]byte(issue40926Resp))
+	c.Close()
+}
+
+func funcIssue40926ResponseHeaderTimeout(t *testing.T, closeAfterHeaders bool, responseHeaderTimeout time.Duration) {
+	listener := newLocalListener(t)
+	defer listener.Close()
+	listenerDone := make(chan struct{})
+	go issue40926ContentHandling(t, listener, listenerDone, closeAfterHeaders)
+
+	//After connection is closed client shall wait for 5 seconds for response
+	c := &Client{
+		Transport: &Transport{
+			ResponseHeaderTimeout: responseHeaderTimeout,
+		},
+	}
+	//Keep the upload size big engought
+	body := make([]byte, 1024*1024*10)
+	rand.Read(body)
+
+	req, err := NewRequest("POST", fmt.Sprintf("http://%s/", listener.Addr().String()), bytes.NewReader(body))
+	req.ContentLength = int64(len(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := c.Do(req)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil {
+		t.Fatal("Response expected")
+	}
+	body, err = ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	bodyText := string(body)
+	if strings.Compare(issue40926Body, bodyText) != 0 {
+		t.Fatal("Response check failed")
+	}
+
+	// Wait unconditionally for the listener goroutine to exit
+	<-listenerDone
+}
+
+func TestIssue40926ResponseHeaderTimeout(t *testing.T) {
+	for _, tc := range issue40926TestCases {
+		t.Run(fmt.Sprintf("Close connection after receiving headers: %t, ResponseHeaderTimeout: %d", tc.closeAfterHeaders, tc.responseHeaderTimeout), func(t *testing.T) {
+			funcIssue40926ResponseHeaderTimeout(t, tc.closeAfterHeaders, tc.responseHeaderTimeout)
+		})
+	}
+}


### PR DESCRIPTION
Fixed behaviour of ResponseHeaderTimeout in http.Transport - even in case property was set it was not honoured.
According to documentation if ResponseHeaderTimeout is set and fully writing the request happens implementation shall wait for specified time for response before sending error.

Steps to reproduce:

    Prepare a POST/PUT request with body.
    Try to send it to the server requiring authentication.
    The server respond with authentication request and closed the client connection (to avoid sending huge file from not authenticated source)

Result the method RoundTrip returned error only without response.
Expectation response will be returned if received within specified time span.