### PR TITLE
net: change hostLookupOrder when /etc/nsswitch.conf not exists

### DIFF
--- a/src/net/conf.go
+++ b/src/net/conf.go
@@ -203,9 +203,9 @@ func (c *conf) hostLookupOrder(r *Resolver, hostname string) (ret hostLookupOrde
 			return fallbackOrder
 		}
 		if c.goos == "linux" {
-			// glibc says the default is "dns [!UNAVAIL=return] files"
+			// Work as expected
 			// https://www.gnu.org/software/libc/manual/html_node/Notes-on-NSS-Configuration-File.html.
-			return hostLookupDNSFiles
+			return hostLookupFilesDNS
 		}
 		return hostLookupFilesDNS
 	}


### PR DESCRIPTION
when /etc/nsswitch.conf not exists ,Go's DNS doesn't work as expected.
for ping curl php app java app and so on will resolve host with file first,however  golang use dns first .
There are disturbing problems
for example, i hava a docker regsitry as a mirror in my k8s.
the mirror remoteurl is test.dregsitry.com 
i want change the ip in different k8s , so i write a hosts recorder in pod template .
it will doesn't work  
change hostLookupOrder when /etc/nsswitch.conf not exists 
from hostLookupDNSFiles to hostLookupFilesDNS can reslove this problem
`Fixes #40920`
