### PR TITLE
cmd/go: updates documentation for 'go help build'

### DIFF
--- a/src/cmd/go/internal/help/helpdoc.go
+++ b/src/cmd/go/internal/help/helpdoc.go
@@ -25,6 +25,10 @@ When either cgo or SWIG is used, go build will pass any .c, .m, .s, .S
 or .sx files to the C compiler, and any .cc, .cpp, .cxx files to the C++
 compiler. The CC or CXX environment variables may be set to determine
 the C or C++ compiler, respectively, to use.
+
+Non .go files cannot be included in named files when invoking the go
+build command. If you need to specify non .go named files to build you
+should instead use build constraints. (see 'go help buildconstraint')
 	`,
 }
 

--- a/src/cmd/go/internal/help/helpdoc.go
+++ b/src/cmd/go/internal/help/helpdoc.go
@@ -25,10 +25,6 @@ When either cgo or SWIG is used, go build will pass any .c, .m, .s, .S
 or .sx files to the C compiler, and any .cc, .cpp, .cxx files to the C++
 compiler. The CC or CXX environment variables may be set to determine
 the C or C++ compiler, respectively, to use.
-
-Non .go files cannot be included in named files when invoking the go
-build command. If you need to specify non .go named files to build you
-should instead use build constraints. (see 'go help buildconstraint')
 	`,
 }
 

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -32,6 +32,10 @@ along with their dependencies, but it does not install the results.
 If the arguments to build are a list of .go files from a single directory,
 build treats them as a list of source files specifying a single package.
 
+Only .go files are accepted when naming files. If you wish to build a
+subset of files that include non .go files you should instead use
+build constraints. (see 'go help buildconstraint')
+
 When compiling packages, build ignores files that end in '_test.go'.
 
 When compiling a single main package, build writes


### PR DESCRIPTION
Fixes #40570.