### PR TITLE
cmd/cgo: add JNI's jmethodID/jfieldID to uintptr for Android NDK

### DIFF
--- a/misc/cgo/test/testdata/cgo_test.go
+++ b/misc/cgo/test/testdata/cgo_test.go
@@ -16,3 +16,4 @@ func Test9510(t *testing.T)     { test9510(t) }
 func Test20266(t *testing.T)    { test20266(t) }
 func Test26213(t *testing.T)    { test26213(t) }
 func TestGCC68255(t *testing.T) { testGCC68255(t) }
+func Test40954(t *testing.T)    { test40954(t) }

--- a/misc/cgo/test/testdata/issue40954/jni.h
+++ b/misc/cgo/test/testdata/issue40954/jni.h
@@ -1,0 +1,14 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// It's going to be hard to include a whole real JVM to test this.
+// So we'll simulate a really easy JVM using just the parts we need.
+
+// This is the relevant part of jni.h.
+
+struct _jfieldID;                       /* opaque structure */
+typedef struct _jfieldID* jfieldID;     /* field IDs */
+
+struct _jmethodID;                      /* opaque structure */
+typedef struct _jmethodID* jmethodID;   /* method IDs */

--- a/misc/cgo/test/testdata/issue40954/test40954.go
+++ b/misc/cgo/test/testdata/issue40954/test40954.go
@@ -1,0 +1,20 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package issue40954
+
+/*
+#include "jni.h"
+*/
+import "C"
+import (
+	"testing"
+)
+
+func Test40954(t *testing.T) {
+	var x1 C.jmethodID = 0 // Note: 0, not nil. That makes sure we use uintptr for these types.
+	_ = x1
+	var x2 C.jfieldID = 0
+	_ = x2
+}

--- a/misc/cgo/test/testdata/test40954.go
+++ b/misc/cgo/test/testdata/test40954.go
@@ -1,0 +1,15 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cgotest
+
+import (
+	"testing"
+
+	"cgotest/issue40954"
+)
+
+func test40954(t *testing.T) {
+	issue40954.Test40954(t)
+}

--- a/src/cmd/cgo/gcc.go
+++ b/src/cmd/cgo/gcc.go
@@ -3150,15 +3150,18 @@ func (c *typeConv) badJNI(dt *dwarf.TypedefType) bool {
 			case *dwarf.VoidType:
 				return true
 			case *dwarf.StructType:
-				if v.StructName == "_jobject" && len(v.Field) == 0 {
-					switch v.Kind {
-					case "struct":
-						if v.Incomplete {
-							return true
-						}
-					case "class":
-						if !v.Incomplete {
-							return true
+				if len(v.Field) == 0 {
+					switch v.StructName {
+					case "_jobject", "_jmethodID", "_jfieldID":
+						switch v.Kind {
+						case "struct":
+							if v.Incomplete {
+								return true
+							}
+						case "class":
+							if !v.Incomplete {
+								return true
+							}
 						}
 					}
 				}
@@ -3199,4 +3202,6 @@ var jniTypes = map[string]string{
 	"jdoubleArray":  "jarray",
 	"jobjectArray":  "jarray",
 	"jweak":         "jobject",
+	"jmethodID":     "",
+	"jfieldID":      "",
 }


### PR DESCRIPTION
In Android's NDK, jmethodID and jfieldID are defined as:

	struct _jfieldID;                       /* opaque structure */
	typedef struct _jfieldID* jfieldID;     /* field IDs */
	struct _jmethodID;                      /* opaque structure */
	typedef struct _jmethodID* jmethodID;   /* method IDs */

Since Go seems them as pointers, a crash can occur at runtime if the GC
tries to dereference those pointers. This is very reproducible in
Android 11 for some reason.

Add those two types to the badJNI types and rework the check logic a
bit.

Fixes #40954