### PR TITLE
encoding/json: return a different error type for unknown field if they are disallowed

### DIFF
--- a/src/encoding/json/decode.go
+++ b/src/encoding/json/decode.go
@@ -136,6 +136,16 @@ func (e *UnmarshalTypeError) Error() string {
 	return "json: cannot unmarshal " + e.Value + " into Go value of type " + e.Type.String()
 }
 
+// An UnknownFieldError describes an unknown JSON
+// key if they are disallowed.
+type UnknownFieldError struct {
+	Key string
+}
+
+func (e *UnknownFieldError) Error() string {
+	return "json: unknown field " + strconv.Quote(e.Key)
+}
+
 // An UnmarshalFieldError describes a JSON object key that
 // led to an unexported (and therefore unwritable) struct field.
 //
@@ -735,7 +745,7 @@ func (d *decodeState) object(v reflect.Value) error {
 				d.errorContext.FieldStack = append(d.errorContext.FieldStack, f.name)
 				d.errorContext.Struct = t
 			} else if d.disallowUnknownFields {
-				d.saveError(fmt.Errorf("json: unknown field %q", key))
+				d.saveError(&UnknownFieldError{Key: string(key)})
 			}
 		}
 

--- a/src/encoding/json/decode_test.go
+++ b/src/encoding/json/decode_test.go
@@ -424,7 +424,7 @@ var unmarshalTests = []unmarshalTest{
 	{in: `{"X": [1,2,3], "Y": 4}`, ptr: new(T), out: T{Y: 4}, err: &UnmarshalTypeError{"array", reflect.TypeOf(""), 7, "T", "X"}},
 	{in: `{"X": 23}`, ptr: new(T), out: T{}, err: &UnmarshalTypeError{"number", reflect.TypeOf(""), 8, "T", "X"}}, {in: `{"x": 1}`, ptr: new(tx), out: tx{}},
 	{in: `{"x": 1}`, ptr: new(tx), out: tx{}},
-	{in: `{"x": 1}`, ptr: new(tx), err: fmt.Errorf("json: unknown field \"x\""), disallowUnknownFields: true},
+	{in: `{"x": 1}`, ptr: new(tx), err: &UnknownFieldError{Key: "x"}, disallowUnknownFields: true},
 	{in: `{"S": 23}`, ptr: new(W), out: W{}, err: &UnmarshalTypeError{"number", reflect.TypeOf(SS("")), 0, "W", "S"}},
 	{in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: float64(1), F2: int32(2), F3: Number("3")}},
 	{in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: Number("1"), F2: int32(2), F3: Number("3")}, useNumber: true},
@@ -440,13 +440,13 @@ var unmarshalTests = []unmarshalTest{
 
 	// Z has a "-" tag.
 	{in: `{"Y": 1, "Z": 2}`, ptr: new(T), out: T{Y: 1}},
-	{in: `{"Y": 1, "Z": 2}`, ptr: new(T), err: fmt.Errorf("json: unknown field \"Z\""), disallowUnknownFields: true},
+	{in: `{"Y": 1, "Z": 2}`, ptr: new(T), err: &UnknownFieldError{Key: "Z"}, disallowUnknownFields: true},
 
 	{in: `{"alpha": "abc", "alphabet": "xyz"}`, ptr: new(U), out: U{Alphabet: "abc"}},
-	{in: `{"alpha": "abc", "alphabet": "xyz"}`, ptr: new(U), err: fmt.Errorf("json: unknown field \"alphabet\""), disallowUnknownFields: true},
+	{in: `{"alpha": "abc", "alphabet": "xyz"}`, ptr: new(U), err: &UnknownFieldError{Key: "alphabet"}, disallowUnknownFields: true},
 	{in: `{"alpha": "abc"}`, ptr: new(U), out: U{Alphabet: "abc"}},
 	{in: `{"alphabet": "xyz"}`, ptr: new(U), out: U{}},
-	{in: `{"alphabet": "xyz"}`, ptr: new(U), err: fmt.Errorf("json: unknown field \"alphabet\""), disallowUnknownFields: true},
+	{in: `{"alphabet": "xyz"}`, ptr: new(U), err: &UnknownFieldError{Key: "alphabet"}, disallowUnknownFields: true},
 
 	// syntax errors
 	{in: `{"X": "foo", "Y"}`, err: &SyntaxError{"invalid character '}' after object key", 17}},
@@ -647,7 +647,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		in:                    `{"X": 1,"Y":2}`,
 		ptr:                   new(S5),
-		err:                   fmt.Errorf("json: unknown field \"X\""),
+		err:                   &UnknownFieldError{Key: "X"},
 		disallowUnknownFields: true,
 	},
 	{
@@ -658,7 +658,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		in:                    `{"X": 1,"Y":2}`,
 		ptr:                   new(S10),
-		err:                   fmt.Errorf("json: unknown field \"X\""),
+		err:                   &UnknownFieldError{Key: "X"},
 		disallowUnknownFields: true,
 	},
 	{
@@ -872,7 +872,7 @@ var unmarshalTests = []unmarshalTest{
 			"extra": true
 		}`,
 		ptr:                   new(Top),
-		err:                   fmt.Errorf("json: unknown field \"extra\""),
+		err:                   &UnknownFieldError{Key: "extra"},
 		disallowUnknownFields: true,
 	},
 	{
@@ -899,7 +899,7 @@ var unmarshalTests = []unmarshalTest{
 			"Q": 18
 		}`,
 		ptr:                   new(Top),
-		err:                   fmt.Errorf("json: unknown field \"extra\""),
+		err:                   &UnknownFieldError{Key: "extra"},
 		disallowUnknownFields: true,
 	},
 	// issue 26444

--- a/src/encoding/json/stream.go
+++ b/src/encoding/json/stream.go
@@ -36,9 +36,9 @@ func NewDecoder(r io.Reader) *Decoder {
 // Number instead of as a float64.
 func (dec *Decoder) UseNumber() { dec.d.useNumber = true }
 
-// DisallowUnknownFields causes the Decoder to return an error when the destination
-// is a struct and the input contains object keys which do not match any
-// non-ignored, exported fields in the destination.
+// DisallowUnknownFields causes the Decoder to return an UnknownFieldError
+// when the destination is a struct and the input contains object keys which
+// do not match any non-ignored, exported fields in the destination.
 func (dec *Decoder) DisallowUnknownFields() { dec.d.disallowUnknownFields = true }
 
 // Decode reads the next JSON-encoded value from its


### PR DESCRIPTION
This PR adds a new error type `UnknownFieldError` which is the error type returned by the decoder when a unknown field is found and they are disallowed.

No change to the public API, and users relying on the error string to detect this are also not impacted.

Fixes https://github.com/golang/go/issues/40982