### PR TITLE
Refactor to use constant for http method

### DIFF
--- a/src/net/http/client.go
+++ b/src/net/http/client.go
@@ -468,7 +468,7 @@ func Get(url string) (resp *Response, err error) {
 //
 // To make a request with custom headers, use NewRequest and Client.Do.
 func (c *Client) Get(url string) (resp *Response, err error) {
-	req, err := NewRequest("GET", url, nil)
+	req, err := NewRequest(MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -838,7 +838,7 @@ func Post(url, contentType string, body io.Reader) (resp *Response, err error) {
 // See the Client.Do method documentation for details on how redirects
 // are handled.
 func (c *Client) Post(url, contentType string, body io.Reader) (resp *Response, err error) {
-	req, err := NewRequest("POST", url, body)
+	req, err := NewRequest(MethodPost, url, body)
 	if err != nil {
 		return nil, err
 	}

--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -594,7 +594,7 @@ func (r *Request) write(w io.Writer, usingProxy bool, extraHeaders Header, waitF
 		w = bw
 	}
 
-	_, err = fmt.Fprintf(w, "%s %s HTTP/1.1\r\n", valueOrDefault(r.Method, "GET"), ruri)
+	_, err = fmt.Fprintf(w, "%s %s HTTP/1.1\r\n", valueOrDefault(r.Method, MethodGet), ruri)
 	if err != nil {
 		return err
 	}
@@ -840,7 +840,7 @@ func NewRequestWithContext(ctx context.Context, method, url string, body io.Read
 		// We document that "" means "GET" for Request.Method, and people have
 		// relied on that from NewRequest, so keep that working.
 		// We still enforce validMethod for non-empty methods.
-		method = "GET"
+		method = MethodGet
 	}
 	if !validMethod(method) {
 		return nil, fmt.Errorf("net/http: invalid method %q", method)
@@ -1236,7 +1236,7 @@ func parsePostForm(r *Request) (vs url.Values, err error) {
 func (r *Request) ParseForm() error {
 	var err error
 	if r.PostForm == nil {
-		if r.Method == "POST" || r.Method == "PUT" || r.Method == "PATCH" {
+		if r.Method == MethodPost || r.Method == MethodPut || r.Method == MethodPatch {
 			r.PostForm, err = parsePostForm(r)
 		}
 		if r.PostForm == nil {
@@ -1391,8 +1391,8 @@ func (r *Request) closeBody() {
 
 func (r *Request) isReplayable() bool {
 	if r.Body == nil || r.Body == NoBody || r.GetBody != nil {
-		switch valueOrDefault(r.Method, "GET") {
-		case "GET", "HEAD", "OPTIONS", "TRACE":
+		switch valueOrDefault(r.Method, MethodGet) {
+		case MethodGet, MethodHead, MethodOptions, MethodTrace:
 			return true
 		}
 		// The Idempotency-Key, while non-standard, is widely used to
@@ -1426,7 +1426,7 @@ func (r *Request) outgoingLength() int64 {
 // shouldSendChunkedRequestBody.
 func requestMethodUsuallyLacksBody(method string) bool {
 	switch method {
-	case "GET", "HEAD", "DELETE", "OPTIONS", "PROPFIND", "SEARCH":
+	case MethodGet, MethodHead, MethodDelete, MethodOptions, "PROPFIND", "SEARCH":
 		return true
 	}
 	return false


### PR DESCRIPTION
This PR refactors to use http method constant instead of string