### PR TITLE
sync: document keys of sync.Map will never be deleted

### DIFF
--- a/src/sync/map.go
+++ b/src/sync/map.go
@@ -24,6 +24,7 @@ import (
 // contention compared to a Go map paired with a separate Mutex or RWMutex.
 //
 // The zero Map is empty and ready for use. A Map must not be copied after first use.
+// Keys in the Map will never be deleted, thus they will never be garbage collected.
 type Map struct {
 	mu Mutex
 


### PR DESCRIPTION
Keys of sync.Map will never be deleted, this behaviour isn't the same as the native map.
We should document this clearly.

Fixes #40999 .