### PR TITLE
cmd/go/internal/get: add support for go get in azure devops repos

### DIFF
--- a/src/cmd/go/internal/get/vcs.go
+++ b/src/cmd/go/internal/get/vcs.go
@@ -1050,6 +1050,15 @@ var vcsPaths = []*vcsPath{
 		check:  noVCSSuffix,
 	},
 
+	// Azure Devops
+	{
+		prefix: "dev.azure.com/",
+		regexp: lazyregexp.New(`^(?P<root>dev\.azure\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+((/_git)?)/[A-Za-z0-9_.\-]+)(/[A-Za-z0-9_.\-]+)*$`),
+		vcs:    "git",
+		repo:   "https://{root}",
+		check:  azureVCS,
+	},
+
 	// Git at Apache
 	{
 		prefix: "git.apache.org/",
@@ -1107,6 +1116,13 @@ func noVCSSuffix(match map[string]string) error {
 			return fmt.Errorf("invalid version control suffix in %s path", match["prefix"])
 		}
 	}
+	return nil
+}
+
+// azureVCS handles legacy azure devops import paths
+// ending in .git
+func azureVCS(match map[string]string) error {
+	match["repo"] = strings.TrimSuffix(match["repo"], ".git")
 	return nil
 }
 

--- a/src/cmd/go/internal/get/vcs_test.go
+++ b/src/cmd/go/internal/get/vcs_test.go
@@ -178,6 +178,46 @@ func TestRepoRootForImportPath(t *testing.T) {
 			"chiselapp.com/user/kyle/fossilgg",
 			nil,
 		},
+		{
+			// Azure DevOps standard SSH path
+			path: "dev.azure.com/org/project/repo",
+			want: &RepoRoot{
+				vcs:  vcsGit,
+				Repo: "https://dev.azure.com/org/project/repo",
+			},
+		},
+		{
+			// Azure DevOps standard HTTPS path
+			path: "dev.azure.com/org/project/_git/repo",
+			want: &RepoRoot{
+				vcs:  vcsGit,
+				Repo: "https://dev.azure.com/org/project/_git/repo",
+			},
+		},
+		{
+			// Azure DevOps standard SSH path with subpackage
+			path: "dev.azure.com/org/project/repo/package",
+			want: &RepoRoot{
+				vcs:  vcsGit,
+				Repo: "https://dev.azure.com/org/project/repo/package",
+			},
+		},
+		{
+			// Azure DevOps with optional .git extension
+			path: "dev.azure.com/org/project/repo.git",
+			want: &RepoRoot{
+				vcs:  vcsGit,
+				Repo: "https://dev.azure.com/org/project/repo",
+			},
+		},
+		{
+			// Azure DevOps with optional .git extension and subpackage
+			path: "dev.azure.com/org/project/repo.git/package",
+			want: &RepoRoot{
+				vcs:  vcsGit,
+				Repo: "https://dev.azure.com/org/project/repo/package",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Currently using go get with an Azure DevOps repository requires a
.git suffix to be able to use as ADO clone paths that do not include
a .git suffix.

This commit adds native support for ADO repositories enabling
the use of go get for repositories and modules not ending in .git

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

Fixes https://github.com/golang/go/issues/41030
