### PR TITLE
doc: add linux/riscv64 valid combination

### DIFF
--- a/doc/install-source.html
+++ b/doc/install-source.html
@@ -600,6 +600,9 @@ The valid combinations of <code>$GOOS</code> and <code>$GOARCH</code> are:
 <td></td><td><code>linux</code></td> <td><code>mips64le</code></td>
 </tr>
 <tr>
+<td></td><td><code>linux</code></td> <td><code>riscv64</code></td>
+</tr>
+<tr>
 <td></td><td><code>linux</code></td> <td><code>s390x</code></td>
 </tr>
 <tr>


### PR DESCRIPTION
Mention valid combination GOOS=linux and GOARCH=riscv64
in the "Installing Go from source" document.

Updates #27532