### PR TITLE
encoding/json: implement Is on SyntaxError

### DIFF
--- a/src/encoding/json/scanner.go
+++ b/src/encoding/json/scanner.go
@@ -49,6 +49,12 @@ type SyntaxError struct {
 
 func (e *SyntaxError) Error() string { return e.msg }
 
+// Is returns true if target is a SyntaxError.
+func (e *SyntaxError) Is(target error) bool {
+	_, ok := target.(*SyntaxError)
+	return ok
+}
+
 // A scanner is a JSON scanning state machine.
 // Callers call scan.reset and then pass bytes in one at a time
 // by calling scan.step(&scan, c) for each byte.

--- a/src/encoding/json/scanner_test.go
+++ b/src/encoding/json/scanner_test.go
@@ -6,6 +6,8 @@ package json
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"math"
 	"math/rand"
 	"reflect"
@@ -198,6 +200,13 @@ func TestIndentErrors(t *testing.T) {
 				continue
 			}
 		}
+	}
+}
+
+func TestSyntaxErrorIs(t *testing.T) {
+	err := fmt.Errorf("apackage: %w: failed to parse struct", &SyntaxError{"some error", 43})
+	if !errors.Is(err, &SyntaxError{}) {
+		t.Fatalf("%v should be unwrapped to a SyntaxError", err)
 	}
 }
 


### PR DESCRIPTION
Allows users to check:

      errors.Is(err, &json.SyntaxError{})

which is the recommended way of checking for kinds of errors.