### PR TITLE
net/http: remove DualStack in DefaultTransport

### DIFF
--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -44,7 +44,6 @@ var DefaultTransport RoundTripper = &Transport{
 	DialContext: (&net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
-		DualStack: true,
 	}).DialContext,
 	ForceAttemptHTTP2:     true,
 	MaxIdleConns:          100,


### PR DESCRIPTION
Removing `DualStack` from `http.DefaultTransport` since it is deprecated
https://github.com/golang/go/blob/master/src/net/dial.go#L61