### PR TITLE
sync/cond.go: add explanation comments to check func

### DIFF
--- a/src/sync/cond.go
+++ b/src/sync/cond.go
@@ -79,8 +79,10 @@ func (c *Cond) Broadcast() {
 type copyChecker uintptr
 
 func (c *copyChecker) check() {
+	// fail fast before doing atomic operation
 	if uintptr(*c) != uintptr(unsafe.Pointer(c)) &&
 		!atomic.CompareAndSwapUintptr((*uintptr)(c), 0, uintptr(unsafe.Pointer(c))) &&
+		// intentionally comparing agai, since *c may has changed after atomic operation
 		uintptr(*c) != uintptr(unsafe.Pointer(c)) {
 		panic("sync.Cond is copied")
 	}
@@ -93,6 +95,5 @@ func (c *copyChecker) check() {
 // for details.
 type noCopy struct{}
 
-// Lock is a no-op used by -copylocks checker from `go vet`.
 func (*noCopy) Lock()   {}
 func (*noCopy) Unlock() {}

--- a/src/sync/cond.go
+++ b/src/sync/cond.go
@@ -82,7 +82,7 @@ func (c *copyChecker) check() {
 	// fail fast before doing atomic operation
 	if uintptr(*c) != uintptr(unsafe.Pointer(c)) &&
 		!atomic.CompareAndSwapUintptr((*uintptr)(c), 0, uintptr(unsafe.Pointer(c))) &&
-		// intentionally comparing agai, since *c may has changed after atomic operation
+		// intentionally comparing again, since *c may has changed after atomic operation
 		uintptr(*c) != uintptr(unsafe.Pointer(c)) {
 		panic("sync.Cond is copied")
 	}


### PR DESCRIPTION
It adds two internal comments explaining why `c` is checked twice in a row and is intentional.

There has been confusion about why this was done, confusion should not occur anymore:
- #34516
- #40924