### PR TITLE
cmd/go: allow output in non-existent directory

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -93,8 +93,9 @@
 //
 // The -o flag forces build to write the resulting executable or object
 // to the named output file or directory, instead of the default behavior described
-// in the last two paragraphs. If the named output is a directory that exists,
-// then any resulting executables will be written to that directory.
+// in the last two paragraphs. If the named output is an existing directory or
+// ends with a slash or backslash, then any resulting executables
+// will be written to that directory.
 //
 // The -i flag installs the packages that are dependencies of the target.
 //

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -53,8 +53,9 @@ serving only as a check that the packages can be built.
 
 The -o flag forces build to write the resulting executable or object
 to the named output file or directory, instead of the default behavior described
-in the last two paragraphs. If the named output is a directory that exists,
-then any resulting executables will be written to that directory.
+in the last two paragraphs. If the named output is an existing directory or
+ends with a slash or backslash, then any resulting executables
+will be written to that directory.
 
 The -i flag installs the packages that are dependencies of the target.
 
@@ -387,10 +388,12 @@ func runBuild(ctx context.Context, cmd *base.Command, args []string) {
 	}
 
 	if cfg.BuildO != "" {
-		// If the -o name exists and is a directory, then
+		// If the -o name exists and is a directory or
+		// ends with a slash or backslash, then
 		// write all main packages to that directory.
 		// Otherwise require only a single package be built.
-		if fi, err := os.Stat(cfg.BuildO); err == nil && fi.IsDir() {
+		if fi, err := os.Stat(cfg.BuildO); (err == nil && fi.IsDir()) ||
+			strings.HasSuffix(cfg.BuildO, string(os.PathSeparator)) {
 			if !explicitO {
 				base.Fatalf("go build: build output %q already exists and is a directory", cfg.BuildO)
 			}

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -393,6 +393,7 @@ func runBuild(ctx context.Context, cmd *base.Command, args []string) {
 		// write all main packages to that directory.
 		// Otherwise require only a single package be built.
 		if fi, err := os.Stat(cfg.BuildO); (err == nil && fi.IsDir()) ||
+			strings.HasSuffix(cfg.BuildO, "/") ||
 			strings.HasSuffix(cfg.BuildO, string(os.PathSeparator)) {
 			if !explicitO {
 				base.Fatalf("go build: build output %q already exists and is a directory", cfg.BuildO)

--- a/src/cmd/go/testdata/script/build_output.txt
+++ b/src/cmd/go/testdata/script/build_output.txt
@@ -18,6 +18,22 @@ go build -o myprog x.go
 exists -exec myprog
 ! exists myprogr.exe
 
+! exists bin
+go build -o bin/x x.go
+exists -exec bin/x
+rm bin
+
+! exists bin
+go build -o bin/ x.go
+exists -exec bin/x
+rm bin
+
+! exists bin
+mkdir bin
+go build -o bin x.go
+exists -exec bin/x
+rm bin
+
 go build p.go
 ! exists p
 ! exists p.a

--- a/src/cmd/go/testdata/script/build_output.txt
+++ b/src/cmd/go/testdata/script/build_output.txt
@@ -25,13 +25,23 @@ rm bin
 
 ! exists bin
 go build -o bin/ x.go
-exists -exec bin/x
+exists -exec bin/x$GOEXE
 rm bin
+
+[windows] ! exists bin
+[windows] go build -o bin\x x.go
+[windows] exists -exec bin\x
+[windows] rm bin
+
+[windows] ! exists bin
+[windows] go build -o bin\ x.go
+[windows] exists -exec bin\x.exe
+[windows] rm bin
 
 ! exists bin
 mkdir bin
 go build -o bin x.go
-exists -exec bin/x
+exists -exec bin/x$GOEXE
 rm bin
 
 go build p.go


### PR DESCRIPTION
When 'go build' is given an output path with -o, if the output path
ends with a path separator, always treat it as a directory.

Fixes #41313