### PR TITLE
make.bat: fix compare between GOROOT and srcdir paths, when either contains whitespace.

### DIFF
--- a/src/make.bat
+++ b/src/make.bat
@@ -77,7 +77,7 @@ if not "x%GOROOT_BOOTSTRAP%"=="x" goto bootstrapset
 for /f "tokens=*" %%g in ('where go 2^>nul') do (
 	if "x%GOROOT_BOOTSTRAP%"=="x" (
 		for /f "tokens=*" %%i in ('%%g env GOROOT 2^>nul') do (
-			if /I not %%i==%GOROOT_TEMP% (
+			if /I not "%%i"=="%GOROOT_TEMP%" (
 				set GOROOT_BOOTSTRAP=%%i
 			)
 		)


### PR DESCRIPTION
CL 96455 brings CL 57753 to Windows
However, a path comparison within it was left unquoted.
If the Go source directory resides in a path containing whitespace,
the interpreter will compare against the first portion of the path string,
and treat the remainder as an expression.
This patch amends that.

For example, consider the path
`C:\Users\Dominic Della Valle\Projects\Go\goroot\src`
Issuing `make.bat` will print out `'Della' is not recognized as an internal or external command, operable program or batch file.` before proceeding.
