### PR TITLE
encoding/json: fix Is implementation from all errors

### DIFF
--- a/src/encoding/json/decode.go
+++ b/src/encoding/json/decode.go
@@ -138,8 +138,8 @@ func (e *UnmarshalTypeError) Error() string {
 
 // Is returns true if target is a UnmarshalTypeError.
 func (e *UnmarshalTypeError) Is(target error) bool {
-	_, ok := target.(*UnmarshalTypeError)
-	return ok
+	err, ok := target.(*UnmarshalTypeError)
+	return ok && reflect.DeepEqual(err, e)
 }
 
 // An UnmarshalFieldError describes a JSON object key that
@@ -158,8 +158,8 @@ func (e *UnmarshalFieldError) Error() string {
 
 // Is returns true if target is a UnmarshalFieldError.
 func (e *UnmarshalFieldError) Is(target error) bool {
-	_, ok := target.(*UnmarshalFieldError)
-	return ok
+	err, ok := target.(*UnmarshalFieldError)
+	return ok && reflect.DeepEqual(err, e)
 }
 
 // An InvalidUnmarshalError describes an invalid argument passed to Unmarshal.
@@ -170,8 +170,8 @@ type InvalidUnmarshalError struct {
 
 // Is returns true if target is a InvalidUnmarshalError.
 func (e *InvalidUnmarshalError) Is(target error) bool {
-	_, ok := target.(*InvalidUnmarshalError)
-	return ok
+	err, ok := target.(*InvalidUnmarshalError)
+	return ok && reflect.DeepEqual(err, e)
 }
 
 func (e *InvalidUnmarshalError) Error() string {

--- a/src/encoding/json/decode_test.go
+++ b/src/encoding/json/decode_test.go
@@ -2575,7 +2575,7 @@ func TestUnmarshalMaxDepth(t *testing.T) {
 
 func TestInvalidUnmarshalErrorIs(t *testing.T) {
 	err := fmt.Errorf("apackage: %w: failed to parse struct", &InvalidUnmarshalError{reflect.TypeOf("a")})
-	if !errors.Is(err, &InvalidUnmarshalError{}) {
+	if !errors.Is(err, &InvalidUnmarshalError{reflect.TypeOf("a")}) {
 		t.Fatalf("%v should be unwrapped to a InvalidUnmarshalError", err)
 	}
 }
@@ -2586,7 +2586,11 @@ func TestUnmarshalFieldErrorIs(t *testing.T) {
 		Type:  reflect.TypeOf("a"),
 		Field: reflect.StructField{Name: "b"},
 	})
-	if !errors.Is(err, &UnmarshalFieldError{}) {
+	if !errors.Is(err, &UnmarshalFieldError{
+		Key:   "foo",
+		Type:  reflect.TypeOf("a"),
+		Field: reflect.StructField{Name: "b"},
+	}) {
 		t.Fatalf("%v should be unwrapped to a UnmarshalFieldError", err)
 	}
 }
@@ -2599,7 +2603,13 @@ func TestUnmarshalTypeErrorIs(t *testing.T) {
 		Struct: "Foo",
 		Field:  "Bar",
 	})
-	if !errors.Is(err, &UnmarshalTypeError{}) {
+	if !errors.Is(err, &UnmarshalTypeError{
+		Value:  "foo",
+		Type:   reflect.TypeOf("a"),
+		Offset: 1,
+		Struct: "Foo",
+		Field:  "Bar",
+	}) {
 		t.Fatalf("%v should be unwrapped to a UnmarshalTypeError", err)
 	}
 }

--- a/src/encoding/json/encode.go
+++ b/src/encoding/json/encode.go
@@ -247,8 +247,8 @@ func (e *UnsupportedValueError) Error() string {
 
 // Is returns true if target is a UnsupportedValueError.
 func (e *UnsupportedValueError) Is(target error) bool {
-	_, ok := target.(*UnsupportedValueError)
-	return ok
+	err, ok := target.(*UnsupportedValueError)
+	return ok && reflect.DeepEqual(err, e)
 }
 
 // Before Go 1.2, an InvalidUTF8Error was returned by Marshal when
@@ -287,8 +287,8 @@ func (e *MarshalerError) Unwrap() error { return e.Err }
 
 // Is returns true if target is a MarshalerError.
 func (e *MarshalerError) Is(target error) bool {
-	_, ok := target.(*MarshalerError)
-	return ok
+	err, ok := target.(*MarshalerError)
+	return ok && reflect.DeepEqual(err, e)
 }
 
 var hex = "0123456789abcdef"

--- a/src/encoding/json/encode_test.go
+++ b/src/encoding/json/encode_test.go
@@ -212,7 +212,8 @@ var unsupportedValues = []interface{}{
 func TestUnsupportedValues(t *testing.T) {
 	for _, v := range unsupportedValues {
 		if _, err := Marshal(v); err != nil {
-			if !errors.Is(err, &UnsupportedValueError{}) {
+			var unsuportedError = &UnsupportedValueError{}
+			if !errors.As(err, &unsuportedError) {
 				t.Errorf("for %v, got %T want UnsupportedValueError", v, err)
 			}
 		} else {
@@ -1163,7 +1164,11 @@ func TestMarshalerErrorIs(t *testing.T) {
 		fmt.Errorf("something"),
 		"TestMarshalerErrorIs",
 	})
-	if !errors.Is(err, &MarshalerError{}) {
+	if !errors.Is(err, &MarshalerError{
+		reflect.TypeOf("a"),
+		fmt.Errorf("something"),
+		"TestMarshalerErrorIs",
+	}) {
 		t.Fatalf("%v should be unwrapped to a MarshalerError", err)
 	}
 }
@@ -1173,7 +1178,10 @@ func TestUnsupportedValueErrorIs(t *testing.T) {
 		Value: reflect.Value{},
 		Str:   "Foo",
 	})
-	if !errors.Is(err, &UnsupportedValueError{}) {
+	if !errors.Is(err, &UnsupportedValueError{
+		Value: reflect.Value{},
+		Str:   "Foo",
+	}) {
 		t.Fatalf("%v should be unwrapped to a UnsupportedValueError", err)
 	}
 }

--- a/src/encoding/json/scanner.go
+++ b/src/encoding/json/scanner.go
@@ -14,6 +14,7 @@ package json
 // before diving into the scanner itself.
 
 import (
+	"reflect"
 	"strconv"
 	"sync"
 )
@@ -51,8 +52,8 @@ func (e *SyntaxError) Error() string { return e.msg }
 
 // Is returns true if target is a SyntaxError.
 func (e *SyntaxError) Is(target error) bool {
-	_, ok := target.(*SyntaxError)
-	return ok
+	err, ok := target.(*SyntaxError)
+	return ok && reflect.DeepEqual(err, e)
 }
 
 // A scanner is a JSON scanning state machine.

--- a/src/encoding/json/scanner_test.go
+++ b/src/encoding/json/scanner_test.go
@@ -205,7 +205,7 @@ func TestIndentErrors(t *testing.T) {
 
 func TestSyntaxErrorIs(t *testing.T) {
 	err := fmt.Errorf("apackage: %w: failed to parse struct", &SyntaxError{"some error", 43})
-	if !errors.Is(err, &SyntaxError{}) {
+	if !errors.Is(err, &SyntaxError{"some error", 43}) {
 		t.Fatalf("%v should be unwrapped to a SyntaxError", err)
 	}
 }


### PR DESCRIPTION
Is should actually check for the contents of the error as well, not only its type. 

Fixed Is implementation on the following:

- json.UnmarshalTypeError
- json.UnmarshalFieldError
- json.InvalidUnmarshalError
- json.UnsupportedValueError
- json.MarshalerError
- json.SyntaxError

Refs CL 254537 and CL 253037.