### PR TITLE
compress/flate: fix corrupted output

### DIFF
--- a/src/compress/flate/deflate_test.go
+++ b/src/compress/flate/deflate_test.go
@@ -923,21 +923,21 @@ func TestBestSpeedShiftOffsets(t *testing.T) {
 	// Part 1 before wrap, should match clean state.
 	got := len(enc.encode(nil, testData))
 	if wantFirstTokens != got {
-		t.Errorf("want %d tokens, got %d", wantFirstTokens, got)
+		t.Errorf("got %d, want %d tokens", got, wantFirstTokens)
 	}
 
-	// Verify we are about to wrap
+	// Verify we are about to wrap.
 	if enc.cur != bufferReset {
-		t.Errorf("want e.cur to be at bufferReset (%d), got %d", bufferReset, enc.cur)
+		t.Errorf("got %d, want e.cur to be at bufferReset (%d)", enc.cur, bufferReset)
 	}
 
 	// Part 2 should match clean state as well even if wrapped.
 	got = len(enc.encode(nil, testData))
 	if wantSecondTokens != got {
-		t.Errorf("want %d tokens, got %d", wantSecondTokens, got)
+		t.Errorf("got %d, want %d token", got, wantSecondTokens)
 	}
 
-	// Verify that we wrapped
+	// Verify that we wrapped.
 	if enc.cur >= bufferReset {
 		t.Errorf("want e.cur to be < bufferReset (%d), got %d", bufferReset, enc.cur)
 	}
@@ -949,7 +949,7 @@ func TestBestSpeedShiftOffsets(t *testing.T) {
 	// Ensure that no matches were picked up.
 	got = len(enc.encode(nil, testData))
 	if wantFirstTokens != got {
-		t.Errorf("want %d tokens, got %d", wantFirstTokens, got)
+		t.Errorf("got %d, want %d tokens", got, wantFirstTokens)
 	}
 }
 

--- a/src/compress/flate/deflate_test.go
+++ b/src/compress/flate/deflate_test.go
@@ -11,6 +11,7 @@ import (
 	"internal/testenv"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"reflect"
 	"runtime/debug"
 	"sync"
@@ -893,6 +894,62 @@ func TestBestSpeedMaxMatchOffset(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func TestBestSpeedShiftOffsets(t *testing.T) {
+	// Test if shiftoffsets properly preserves matches and resets out-of-range matches
+	// seen in https://github.com/golang/go/issues/4142
+	enc := newDeflateFast()
+
+	// testData may not generate internal matches.
+	testData := make([]byte, 32)
+	rng := rand.New(rand.NewSource(0))
+	for i := range testData {
+		testData[i] = byte(rng.Uint32())
+	}
+
+	// Encode the testdata with clean state.
+	// Second part should pick up matches from the first block.
+	wantFirstTokens := len(enc.encode(nil, testData))
+	wantSecondTokens := len(enc.encode(nil, testData))
+
+	if wantFirstTokens <= wantSecondTokens {
+		t.Fatalf("test needs matches between inputs to be generated")
+	}
+	// Forward the current indicator to before wraparound.
+	enc.cur = bufferReset - int32(len(testData))
+
+	// Part 1 before wrap, should match clean state.
+	got := len(enc.encode(nil, testData))
+	if wantFirstTokens != got {
+		t.Errorf("want %d tokens, got %d", wantFirstTokens, got)
+	}
+
+	// Verify we are about to wrap
+	if enc.cur != bufferReset {
+		t.Errorf("want e.cur to be at bufferReset (%d), got %d", bufferReset, enc.cur)
+	}
+
+	// Part 2 should match clean state as well even if wrapped.
+	got = len(enc.encode(nil, testData))
+	if wantSecondTokens != got {
+		t.Errorf("want %d tokens, got %d", wantSecondTokens, got)
+	}
+
+	// Verify that we wrapped
+	if enc.cur >= bufferReset {
+		t.Errorf("want e.cur to be < bufferReset (%d), got %d", bufferReset, enc.cur)
+	}
+
+	// Forward the current buffer, leaving the matches at the bottom.
+	enc.cur = bufferReset
+	enc.shiftOffsets()
+
+	// Ensure that no matches were picked up.
+	got = len(enc.encode(nil, testData))
+	if wantFirstTokens != got {
+		t.Errorf("want %d tokens, got %d", wantFirstTokens, got)
 	}
 }
 

--- a/src/compress/flate/deflatefast.go
+++ b/src/compress/flate/deflatefast.go
@@ -297,7 +297,10 @@ func (e *deflateFast) shiftOffsets() {
 	for i := range e.table[:] {
 		v := e.table[i].offset - e.cur + maxMatchOffset + 1
 		if v < 0 {
-			// Indicate that this table entry is invalid.
+			// We want to reset e.cur to maxMatchOffset + 1, so we need to shift
+			// all table entries down by (e.cur - (maxMatchOffset + 1)).
+			// Because we ignore matches > maxMatchOffset, we can cap
+			// any negative offsets at 0.
 			v = 0
 		}
 		e.table[i].offset = v

--- a/src/compress/flate/deflatefast.go
+++ b/src/compress/flate/deflatefast.go
@@ -270,7 +270,7 @@ func (e *deflateFast) matchLen(s, t int32, src []byte) int32 {
 func (e *deflateFast) reset() {
 	e.prev = e.prev[:0]
 	// Bump the offset, so all matches will fail distance check.
-	// Nothing should be >= e.cur in the table
+	// Nothing should be >= e.cur in the table.
 	e.cur += maxMatchOffset
 
 	// Protect against e.cur wraparound.
@@ -297,7 +297,7 @@ func (e *deflateFast) shiftOffsets() {
 	for i := range e.table[:] {
 		v := e.table[i].offset - e.cur + maxMatchOffset + 1
 		if v < 0 {
-			// Indicate that this is invalid
+			// Indicate that this table entry is invalid.
 			v = 0
 		}
 		e.table[i].offset = v

--- a/src/compress/flate/deflatefast.go
+++ b/src/compress/flate/deflatefast.go
@@ -270,6 +270,7 @@ func (e *deflateFast) matchLen(s, t int32, src []byte) int32 {
 func (e *deflateFast) reset() {
 	e.prev = e.prev[:0]
 	// Bump the offset, so all matches will fail distance check.
+	// Nothing should be >= e.cur in the table
 	e.cur += maxMatchOffset
 
 	// Protect against e.cur wraparound.
@@ -288,17 +289,18 @@ func (e *deflateFast) shiftOffsets() {
 		for i := range e.table[:] {
 			e.table[i] = tableEntry{}
 		}
-		e.cur = maxMatchOffset
+		e.cur = maxMatchOffset + 1
 		return
 	}
 
 	// Shift down everything in the table that isn't already too far away.
 	for i := range e.table[:] {
-		v := e.table[i].offset - e.cur + maxMatchOffset
+		v := e.table[i].offset - e.cur + maxMatchOffset + 1
 		if v < 0 {
+			// Indicate that this is invalid
 			v = 0
 		}
 		e.table[i].offset = v
 	}
-	e.cur = maxMatchOffset
+	e.cur = maxMatchOffset + 1
 }


### PR DESCRIPTION
The fastest compression mode can pick up a false match for every 2GB
of input data resulting in incorrectly decompressed data.

Since matches are allowed to be up to and including at maxMatchOffset
we must offset the buffer by an additional element to prevent the first
4 bytes to match after an out-of-reach value after shiftOffsets has
been called.

We offset by `maxMatchOffset + 1` so offset 0 in the table will now
fail the `if offset > maxMatchOffset` in all cases.

Fixes #41420