### PR TITLE
encoding/asn1: error instead of panic on invalid value to Unmarshal

### DIFF
--- a/src/encoding/asn1/asn1.go
+++ b/src/encoding/asn1/asn1.go
@@ -1118,7 +1118,7 @@ func Unmarshal(b []byte, val interface{}) (rest []byte, err error) {
 func UnmarshalWithParams(b []byte, val interface{}, params string) (rest []byte, err error) {
 	v := reflect.ValueOf(val)
 	if v.Kind() != reflect.Ptr || v.IsNil() {
-		return nil, &InvalidUnmarshalError{v.Type()}
+		return nil, &InvalidUnmarshalError{reflect.TypeOf(val)}
 	}
 	offset, err := parseField(v.Elem(), b, 0, parseFieldParameters(params))
 	if err != nil {

--- a/src/encoding/asn1/asn1.go
+++ b/src/encoding/asn1/asn1.go
@@ -1118,7 +1118,7 @@ func Unmarshal(b []byte, val interface{}) (rest []byte, err error) {
 func UnmarshalWithParams(b []byte, val interface{}, params string) (rest []byte, err error) {
 	v := reflect.ValueOf(val)
 	if v.Kind() != reflect.Ptr || v.IsNil() {
-		return nil, &InvalidUnmarshalError{reflect.TypeOf(val)}
+		return nil, &InvalidUnmarshalError{v.Type()}
 	}
 	offset, err := parseField(v.Elem(), b, 0, parseFieldParameters(params))
 	if err != nil {

--- a/src/encoding/asn1/asn1.go
+++ b/src/encoding/asn1/asn1.go
@@ -1036,7 +1036,7 @@ func setDefaultValue(v reflect.Value, params fieldParameters) (ok bool) {
 // and uses the reflect package to fill in an arbitrary value pointed at by val.
 // Because Unmarshal uses the reflect package, the structs
 // being written to must use upper case field names. If val
-// is null or not a pointer, Unmarshal returns an invalidUnmarshalError.
+// is null or not a pointer, Unmarshal returns an error.
 //
 // After parsing b, any bytes that were leftover and not used to fill
 // val will be returned in rest. When parsing a SEQUENCE into a struct,

--- a/src/encoding/asn1/asn1.go
+++ b/src/encoding/asn1/asn1.go
@@ -46,6 +46,23 @@ type SyntaxError struct {
 
 func (e SyntaxError) Error() string { return "asn1: syntax error: " + e.Msg }
 
+// An InvalidUnmarshalError describes an invalid argument passed to Unmarshal.
+// (The argument to Unmarshal must be a non-nil pointer.)
+type InvalidUnmarshalError struct {
+	Type reflect.Type
+}
+
+func (e *InvalidUnmarshalError) Error() string {
+	if e.Type == nil {
+		return "asn1: Unmarshal(nil)"
+	}
+
+	if e.Type.Kind() != reflect.Ptr {
+		return "asn1: Unmarshal(non-pointer " + e.Type.String() + ")"
+	}
+	return "asn1: Unmarshal(nil " + e.Type.String() + ")"
+}
+
 // We start by dealing with each of the primitive types in turn.
 
 // BOOLEAN
@@ -1035,7 +1052,8 @@ func setDefaultValue(v reflect.Value, params fieldParameters) (ok bool) {
 // Unmarshal parses the DER-encoded ASN.1 data structure b
 // and uses the reflect package to fill in an arbitrary value pointed at by val.
 // Because Unmarshal uses the reflect package, the structs
-// being written to must use upper case field names.
+// being written to must use upper case field names. If val
+// is null or not a pointer, Unmarshal returns an InvalidUnmarshalError.
 //
 // After parsing b, any bytes that were leftover and not used to fill
 // val will be returned in rest. When parsing a SEQUENCE into a struct,
@@ -1098,8 +1116,11 @@ func Unmarshal(b []byte, val interface{}) (rest []byte, err error) {
 // UnmarshalWithParams allows field parameters to be specified for the
 // top-level element. The form of the params is the same as the field tags.
 func UnmarshalWithParams(b []byte, val interface{}, params string) (rest []byte, err error) {
-	v := reflect.ValueOf(val).Elem()
-	offset, err := parseField(v, b, 0, parseFieldParameters(params))
+	v := reflect.ValueOf(val)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return nil, &InvalidUnmarshalError{reflect.TypeOf(val)}
+	}
+	offset, err := parseField(v.Elem(), b, 0, parseFieldParameters(params))
 	if err != nil {
 		return nil, err
 	}

--- a/src/encoding/asn1/asn1.go
+++ b/src/encoding/asn1/asn1.go
@@ -1036,7 +1036,7 @@ func setDefaultValue(v reflect.Value, params fieldParameters) (ok bool) {
 // and uses the reflect package to fill in an arbitrary value pointed at by val.
 // Because Unmarshal uses the reflect package, the structs
 // being written to must use upper case field names. If val
-// is null or not a pointer, Unmarshal returns an error.
+// is nil or not a pointer, Unmarshal returns an error.
 //
 // After parsing b, any bytes that were leftover and not used to fill
 // val will be returned in rest. When parsing a SEQUENCE into a struct,

--- a/src/encoding/asn1/asn1_test.go
+++ b/src/encoding/asn1/asn1_test.go
@@ -518,18 +518,18 @@ func TestUnmarshal(t *testing.T) {
 	}
 }
 
-var invalidUnmarshalTests = []struct {
-	b    []byte
-	v    interface{}
-	want string
-}{
-	{b: []byte{0x05, 0x00}, v: nil, want: "asn1: Unmarshal(nil)"},
-	{b: []byte{0x05, 0x00}, v: RawValue{}, want: "asn1: Unmarshal(non-pointer asn1.RawValue)"},
-	{b: []byte{0x05, 0x00}, v: (*RawValue)(nil), want: "asn1: Unmarshal(nil *asn1.RawValue)"},
-}
-
 func TestInvalidUnmarshal(t *testing.T) {
-	for _, test := range invalidUnmarshalTests {
+	tests := []struct {
+		b    []byte
+		v    interface{}
+		want string
+	}{
+		{b: []byte{0x05, 0x00}, v: nil, want: "asn1: Unmarshal(nil)"},
+		{b: []byte{0x05, 0x00}, v: RawValue{}, want: "asn1: Unmarshal(non-pointer asn1.RawValue)"},
+		{b: []byte{0x05, 0x00}, v: (*RawValue)(nil), want: "asn1: Unmarshal(nil *asn1.RawValue)"},
+	}
+
+	for _, test := range tests {
 		_, err := Unmarshal(test.b, test.v)
 		if err == nil {
 			t.Errorf("Unmarshal expecting error, got nil")

--- a/src/encoding/asn1/asn1_test.go
+++ b/src/encoding/asn1/asn1_test.go
@@ -518,6 +518,29 @@ func TestUnmarshal(t *testing.T) {
 	}
 }
 
+var invalidUnmarshalTests = []struct {
+	b    []byte
+	v    interface{}
+	want string
+}{
+	{b: []byte{0x05, 0x00}, v: nil, want: "asn1: Unmarshal(nil)"},
+	{b: []byte{0x05, 0x00}, v: RawValue{}, want: "asn1: Unmarshal(non-pointer asn1.RawValue)"},
+	{b: []byte{0x05, 0x00}, v: (*RawValue)(nil), want: "asn1: Unmarshal(nil *asn1.RawValue)"},
+}
+
+func TestInvalidUnmarshal(t *testing.T) {
+	for _, test := range invalidUnmarshalTests {
+		_, err := Unmarshal(test.b, test.v)
+		if err == nil {
+			t.Errorf("Unmarshal expecting error, got nil")
+			continue
+		}
+		if got := err.Error(); got != test.want {
+			t.Errorf("Unmarshal = %q; want %q", got, test.want)
+		}
+	}
+}
+
 type Certificate struct {
 	TBSCertificate     TBSCertificate
 	SignatureAlgorithm AlgorithmIdentifier

--- a/src/encoding/asn1/asn1_test.go
+++ b/src/encoding/asn1/asn1_test.go
@@ -518,7 +518,7 @@ func TestUnmarshal(t *testing.T) {
 	}
 }
 
-func TestInvalidUnmarshal(t *testing.T) {
+func TestUnmarshalWithNilOrNonPointer(t *testing.T) {
 	tests := []struct {
 		b    []byte
 		v    interface{}

--- a/src/encoding/asn1/asn1_test.go
+++ b/src/encoding/asn1/asn1_test.go
@@ -524,9 +524,9 @@ func TestInvalidUnmarshal(t *testing.T) {
 		v    interface{}
 		want string
 	}{
-		{b: []byte{0x05, 0x00}, v: nil, want: "asn1: Unmarshal(nil)"},
-		{b: []byte{0x05, 0x00}, v: RawValue{}, want: "asn1: Unmarshal(non-pointer asn1.RawValue)"},
-		{b: []byte{0x05, 0x00}, v: (*RawValue)(nil), want: "asn1: Unmarshal(nil *asn1.RawValue)"},
+		{b: []byte{0x05, 0x00}, v: nil, want: "asn1: Unmarshal recipient value is nil"},
+		{b: []byte{0x05, 0x00}, v: RawValue{}, want: "asn1: Unmarshal recipient value is non-pointer asn1.RawValue"},
+		{b: []byte{0x05, 0x00}, v: (*RawValue)(nil), want: "asn1: Unmarshal recipient value is nil *asn1.RawValue"},
 	}
 
 	for _, test := range tests {

--- a/src/encoding/asn1/asn1_test.go
+++ b/src/encoding/asn1/asn1_test.go
@@ -535,8 +535,8 @@ func TestInvalidUnmarshal(t *testing.T) {
 			t.Errorf("Unmarshal expecting error, got nil")
 			continue
 		}
-		if got := err.Error(); got != test.want {
-			t.Errorf("Unmarshal = %q; want %q", got, test.want)
+		if g, w := err.Error(), test.want; g != w {
+			t.Errorf("InvalidUnmarshalError mismatch\nGot:  %q\nWant: %q", g, w)
 		}
 	}
 }


### PR DESCRIPTION
Changes Unmarshal to return an error, instead of
panicking when its value is nil or not a pointer.

This change matches the behavior of other encoding
packages like json.

Fixes #41509.