### PR TITLE
cmd/go/internal/get: warn about -insecure deprecation

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -661,9 +661,12 @@
 // this automatically as well.
 //
 // The -insecure flag permits fetching from repositories and resolving
-// custom domains using insecure schemes such as HTTP. Use with caution. The
-// GOINSECURE environment variable is usually a better alternative, since it
-// provides control over which modules may be retrieved using an insecure scheme.
+// custom domains using insecure schemes such as HTTP. Use with caution.
+// This flag is deprecated and will be removed in a future version of go.
+// The GOINSECURE environment variable is usually a better alternative, since
+// it provides control over which modules may be retrieved using an insecure
+// scheme. It should be noted that the -insecure flag also turns the module
+// checksum validation off. GOINSECURE does not do that, use GONOSUMDB.
 // See 'go help environment' for details.
 //
 // The second step is to download (if needed), build, and install
@@ -2199,10 +2202,11 @@
 // before resolving dependencies or building the code.
 //
 // The -insecure flag permits fetching from repositories and resolving
-// custom domains using insecure schemes such as HTTP. Use with caution. The
-// GOINSECURE environment variable is usually a better alternative, since it
-// provides control over which modules may be retrieved using an insecure scheme.
-// See 'go help environment' for details.
+// custom domains using insecure schemes such as HTTP. Use with caution.
+// This flag is deprecated and will be removed in a future version of go.
+// The GOINSECURE environment variable is usually a better alternative, since
+// it provides control over which modules may be retrieved using an insecure
+// scheme. See 'go help environment' for details.
 //
 // The -t flag instructs get to also download the packages required to build
 // the tests for the specified packages.

--- a/src/cmd/go/internal/get/get.go
+++ b/src/cmd/go/internal/get/get.go
@@ -130,7 +130,7 @@ func runGet(ctx context.Context, cmd *base.Command, args []string) {
 		base.Fatalf("go get: cannot use -f flag without -u")
 	}
 	if cfg.Insecure {
-		fmt.Fprintf(os.Stderr, "go get: -insecure flag is deprecated; see go help get for details\n")
+		fmt.Fprintf(os.Stderr, "go get: -insecure flag is deprecated; see 'go help get' for details\n")
 	}
 
 	// Disable any prompting for passwords by Git.

--- a/src/cmd/go/internal/get/get.go
+++ b/src/cmd/go/internal/get/get.go
@@ -44,10 +44,11 @@ The -fix flag instructs get to run the fix tool on the downloaded packages
 before resolving dependencies or building the code.
 
 The -insecure flag permits fetching from repositories and resolving
-custom domains using insecure schemes such as HTTP. Use with caution. The
-GOINSECURE environment variable is usually a better alternative, since it
-provides control over which modules may be retrieved using an insecure scheme.
-See 'go help environment' for details.
+custom domains using insecure schemes such as HTTP. Use with caution.
+This flag is deprecated and will be removed in a future version of go.
+The GOINSECURE environment variable is usually a better alternative, since
+it provides control over which modules may be retrieved using an insecure
+scheme. See 'go help environment' for details.
 
 The -t flag instructs get to also download the packages required to build
 the tests for the specified packages.
@@ -127,6 +128,9 @@ func runGet(ctx context.Context, cmd *base.Command, args []string) {
 
 	if *getF && !*getU {
 		base.Fatalf("go get: cannot use -f flag without -u")
+	}
+	if cfg.Insecure {
+		fmt.Fprintf(os.Stderr, "go get: -insecure flag is deprecated; see go help get for details\n")
 	}
 
 	// Disable any prompting for passwords by Git.

--- a/src/cmd/go/internal/modget/get.go
+++ b/src/cmd/go/internal/modget/get.go
@@ -282,7 +282,7 @@ func runGet(ctx context.Context, cmd *base.Command, args []string) {
 		base.Fatalf("go get: -m flag is no longer supported; consider -d to skip building packages")
 	}
 	if cfg.Insecure {
-		fmt.Fprintf(os.Stderr, "go get: -insecure flag is deprecated; see go help get for details\n")
+		fmt.Fprintf(os.Stderr, "go get: -insecure flag is deprecated; see 'go help get' for details\n")
 	}
 	modload.LoadTests = *getT
 

--- a/src/cmd/go/internal/modget/get.go
+++ b/src/cmd/go/internal/modget/get.go
@@ -115,9 +115,12 @@ require downgrading other dependencies, and 'go get' does
 this automatically as well.
 
 The -insecure flag permits fetching from repositories and resolving
-custom domains using insecure schemes such as HTTP. Use with caution. The
-GOINSECURE environment variable is usually a better alternative, since it
-provides control over which modules may be retrieved using an insecure scheme.
+custom domains using insecure schemes such as HTTP. Use with caution.
+This flag is deprecated and will be removed in a future version of go.
+The GOINSECURE environment variable is usually a better alternative, since
+it provides control over which modules may be retrieved using an insecure
+scheme. It should be noted that the -insecure flag also turns the module
+checksum validation off. GOINSECURE does not do that, use GONOSUMDB.
 See 'go help environment' for details.
 
 The second step is to download (if needed), build, and install
@@ -277,6 +280,9 @@ func runGet(ctx context.Context, cmd *base.Command, args []string) {
 	}
 	if *getM {
 		base.Fatalf("go get: -m flag is no longer supported; consider -d to skip building packages")
+	}
+	if cfg.Insecure {
+		fmt.Fprintf(os.Stderr, "go get: -insecure flag is deprecated; see go help get for details\n")
 	}
 	modload.LoadTests = *getT
 

--- a/src/cmd/go/testdata/script/get_insecure_deprecated.txt
+++ b/src/cmd/go/testdata/script/get_insecure_deprecated.txt
@@ -3,19 +3,19 @@ env GO111MODULE=off
 
 # GOPATH: Fetch without insecure, no warning
 ! go get test
-! stderr 'go get: -insecure flag is deprecated; see go help get for details'
+! stderr 'go get: -insecure flag is deprecated; see ''go help get'' for details'
 
 # GOPATH: Fetch with insecure, should warn
 ! go get -insecure test
-stderr 'go get: -insecure flag is deprecated; see go help get for details'
+stderr 'go get: -insecure flag is deprecated; see ''go help get'' for details'
 
 # Modules: Set up
 env GO111MODULE=on
 
 # Modules: Fetch without insecure, no warning
 ! go get test
-! stderr 'go get: -insecure flag is deprecated; see go help get for details'
+! stderr 'go get: -insecure flag is deprecated; see ''go help get'' for details'
 
 # Modules: Fetch with insecure, should warn
 ! go get -insecure test
-stderr 'go get: -insecure flag is deprecated; see go help get for details'
+stderr 'go get: -insecure flag is deprecated; see ''go help get'' for details'

--- a/src/cmd/go/testdata/script/get_insecure_deprecated.txt
+++ b/src/cmd/go/testdata/script/get_insecure_deprecated.txt
@@ -1,0 +1,21 @@
+# GOPATH: Set up
+env GO111MODULE=off
+
+# GOPATH: Fetch without insecure, no warning
+! go get test
+! stderr 'go get: -insecure flag is deprecated; see go help get for details'
+
+# GOPATH: Fetch with insecure, should warn
+! go get -insecure test
+stderr 'go get: -insecure flag is deprecated; see go help get for details'
+
+# Modules: Set up
+env GO111MODULE=on
+
+# Modules: Fetch without insecure, no warning
+! go get test
+! stderr 'go get: -insecure flag is deprecated; see go help get for details'
+
+# Modules: Fetch with insecure, should warn
+! go get -insecure test
+stderr 'go get: -insecure flag is deprecated; see go help get for details'


### PR DESCRIPTION
Adds deprecation warning for -insecure flag on go get in both modules
and GOPATH mode.

Updates #37519.