### PR TITLE
mime/multipart: wrap error returned from Part.NextPart()

### DIFF
--- a/src/mime/multipart/multipart.go
+++ b/src/mime/multipart/multipart.go
@@ -336,7 +336,7 @@ func (r *Reader) nextPart(rawPart bool) (*Part, error) {
 			return nil, io.EOF
 		}
 		if err != nil {
-			return nil, fmt.Errorf("multipart: NextPart: %v", err)
+			return nil, fmt.Errorf("multipart: NextPart: %w", err)
 		}
 
 		if r.isBoundaryDelimiterLine(line) {


### PR DESCRIPTION
Part.NextPart() returns io.EOF on the first NextPart call that reaches the end of
a form. On subsequent calls it returns an unwrapped io.EOF. Change the
returned error to a wrapped error so at least `errors.Is` can be used to introspect
the true nature of the returned error.
