### PR TITLE
codehost: forward the error from the underlying git call

### DIFF
--- a/src/cmd/go/internal/modfetch/codehost/git.go
+++ b/src/cmd/go/internal/modfetch/codehost/git.go
@@ -296,6 +296,9 @@ func (r *gitRepo) stat(rev string) (*RevInfo, error) {
 	// Or maybe it's the prefix of a hash of a named ref.
 	// Try to resolve to both a ref (git name) and full (40-hex-digit) commit hash.
 	r.refsOnce.Do(r.loadRefs)
+	if r.refsErr != nil {
+		return nil, r.refsErr
+	}
 	var ref, hash string
 	if r.refs["refs/tags/"+rev] != "" {
 		ref = "refs/tags/" + rev


### PR DESCRIPTION
The loadRefs() method is called in several places in this file. The 3 line pattern is used in all other calls to loadRefs(), but for some reason this one has been missed, and not having that underlying error has made finding the true error much more difficult, because I have encountered several different reasons already. 