### PR TITLE
cmd/go/internal/modfetch/codehost: forward the error from the underlying git call

### DIFF
--- a/src/cmd/go/internal/modfetch/codehost/git.go
+++ b/src/cmd/go/internal/modfetch/codehost/git.go
@@ -296,6 +296,9 @@ func (r *gitRepo) stat(rev string) (*RevInfo, error) {
 	// Or maybe it's the prefix of a hash of a named ref.
 	// Try to resolve to both a ref (git name) and full (40-hex-digit) commit hash.
 	r.refsOnce.Do(r.loadRefs)
+	if r.refsErr != nil {
+		return nil, r.refsErr
+	}
 	var ref, hash string
 	if r.refs["refs/tags/"+rev] != "" {
 		ref = "refs/tags/" + rev

--- a/src/cmd/go/internal/modfetch/codehost/git.go
+++ b/src/cmd/go/internal/modfetch/codehost/git.go
@@ -247,23 +247,6 @@ func (r *gitRepo) Latest() (*RevInfo, error) {
 	return r.Stat(r.refs["HEAD"])
 }
 
-// findRef finds some ref name for the given hash,
-// for use when the server requires giving a ref instead of a hash.
-// There may be multiple ref names for a given hash,
-// in which case this returns some name - it doesn't matter which.
-func (r *gitRepo) findRef(hash string) (ref string, ok bool) {
-	r.refsOnce.Do(r.loadRefs)
-	if r.refsErr != nil {
-		return "", r.refsErr
-	}
-	for ref, h := range r.refs {
-		if h == hash {
-			return ref, true
-		}
-	}
-	return "", false
-}
-
 // minHashDigits is the minimum number of digits to require
 // before accepting a hex digit sequence as potentially identifying
 // a specific commit in a git repo. (Of course, users can always

--- a/src/cmd/go/internal/modfetch/codehost/git.go
+++ b/src/cmd/go/internal/modfetch/codehost/git.go
@@ -253,6 +253,9 @@ func (r *gitRepo) Latest() (*RevInfo, error) {
 // in which case this returns some name - it doesn't matter which.
 func (r *gitRepo) findRef(hash string) (ref string, ok bool) {
 	r.refsOnce.Do(r.loadRefs)
+	if r.refsErr != nil {
+		return "", r.refsErr
+	}
 	for ref, h := range r.refs {
 		if h == hash {
 			return ref, true


### PR DESCRIPTION
The `loadRefs()` method is called in several places in this file.
It sets `refsErr` on error, which is not always checked and returned.
In a common case, an "unknown revision" error is thrown,
which is not the correct error.
This change is to ensure that refsErr is always forwarded.