### PR TITLE
mime: define CharsetError

### DIFF
--- a/src/mime/encodedword.go
+++ b/src/mime/encodedword.go
@@ -29,6 +29,12 @@ var (
 	errInvalidWord = errors.New("mime: invalid RFC 2047 encoded-word")
 )
 
+type CharsetError string
+
+func (e CharsetError) Error() string {
+	return fmt.Sprintf("charset not supported: %q", string(e))
+}
+
 // Encode returns the encoded-word form of s. If s is ASCII without special
 // characters, it is returned unchanged. The provided charset is the IANA
 // charset name of s. It is case insensitive.
@@ -340,7 +346,7 @@ func (d *WordDecoder) convert(buf *strings.Builder, charset string, content []by
 		}
 	default:
 		if d.CharsetReader == nil {
-			return fmt.Errorf("mime: unhandled charset %q", charset)
+			return CharsetError(charset)
 		}
 		r, err := d.CharsetReader(strings.ToLower(charset), bytes.NewReader(content))
 		if err != nil {

--- a/src/net/mail/message.go
+++ b/src/net/mail/message.go
@@ -741,7 +741,8 @@ func (p *addrParser) decodeRFC2047Word(s string) (word string, isEncoded bool, e
 		return word, true, nil
 	}
 
-	if _, ok := err.(mime.CharsetError); ok {
+	var charsetErr mime.CharsetError
+	if errors.As(err, &charsetErr) {
 		return s, true, err
 	}
 

--- a/src/net/mail/message.go
+++ b/src/net/mail/message.go
@@ -741,7 +741,7 @@ func (p *addrParser) decodeRFC2047Word(s string) (word string, isEncoded bool, e
 		return word, true, nil
 	}
 
-	if _, ok := err.(charsetError); ok {
+	if _, ok := err.(mime.CharsetError); ok {
 		return s, true, err
 	}
 
@@ -751,14 +751,8 @@ func (p *addrParser) decodeRFC2047Word(s string) (word string, isEncoded bool, e
 
 var rfc2047Decoder = mime.WordDecoder{
 	CharsetReader: func(charset string, input io.Reader) (io.Reader, error) {
-		return nil, charsetError(charset)
+		return nil, mime.CharsetError(charset)
 	},
-}
-
-type charsetError string
-
-func (e charsetError) Error() string {
-	return fmt.Sprintf("charset not supported: %q", string(e))
 }
 
 // isAtext reports whether r is an RFC 5322 atext character.

--- a/src/net/mail/message_test.go
+++ b/src/net/mail/message_test.go
@@ -6,6 +6,7 @@ package mail
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"mime"
@@ -898,6 +899,13 @@ func TestAddressParserUnsupportedCharset(t *testing.T) {
 			(&AddressParser{WordDecoder: &mime.WordDecoder{
 				CharsetReader: func(charset string, input io.Reader) (io.Reader, error) {
 					return nil, mime.CharsetError(charset)
+				},
+			}}).Parse,
+		},
+		{
+			(&AddressParser{WordDecoder: &mime.WordDecoder{
+				CharsetReader: func(charset string, input io.Reader) (io.Reader, error) {
+					return nil, fmt.Errorf("%w", mime.CharsetError(charset))
 				},
 			}}).Parse,
 		},


### PR DESCRIPTION
This defines an error type that callers can recognize and which can be used in custom decoders to trigger the same behavior as the internal one used for parsing mail addresses.

Fixes #41625