### PR TITLE
crypto/tls: add no-shared to openssl build instructions

### DIFF
--- a/src/crypto/tls/handshake_test.go
+++ b/src/crypto/tls/handshake_test.go
@@ -86,7 +86,7 @@ func checkOpenSSLVersion() error {
 	println("to update the test data.")
 	println("")
 	println("Configure it with:")
-	println("./Configure enable-weak-ssl-ciphers")
+	println("./Configure enable-weak-ssl-ciphers no-shared")
 	println("and then add the apps/ directory at the front of your PATH.")
 	println("***********************************************")
 


### PR DESCRIPTION
This prevents the custom-built version of openssl prefering the system
libraries over the ones compiled with the specified (weak crypto)
options necessary to generate the updates. This difference can lead to
confusing failures when updating the tests.

Fixes #31809
