### PR TITLE
text/template: add lock for Template.tmpl to fix data race

### DIFF
--- a/src/text/template/exec.go
+++ b/src/text/template/exec.go
@@ -179,10 +179,7 @@ func errRecover(errp *error) {
 // A template may be executed safely in parallel, although if parallel
 // executions share a Writer the output may be interleaved.
 func (t *Template) ExecuteTemplate(wr io.Writer, name string, data interface{}) error {
-	var tmpl *Template
-	if t.common != nil {
-		tmpl = t.tmpl[name]
-	}
+	tmpl := t.Lookup(name)
 	if tmpl == nil {
 		return fmt.Errorf("template: no template %q associated with template %q", name, t.name)
 	}
@@ -230,6 +227,8 @@ func (t *Template) DefinedTemplates() string {
 		return ""
 	}
 	var b strings.Builder
+	t.muTmpl.RLock()
+	defer t.muTmpl.RUnlock()
 	for name, tmpl := range t.tmpl {
 		if tmpl.Tree == nil || tmpl.Root == nil {
 			continue
@@ -397,7 +396,7 @@ func (s *state) walkRange(dot reflect.Value, r *parse.RangeNode) {
 
 func (s *state) walkTemplate(dot reflect.Value, t *parse.TemplateNode) {
 	s.at(t)
-	tmpl := s.tmpl.tmpl[t.Name]
+	tmpl := s.tmpl.Lookup(t.Name)
 	if tmpl == nil {
 		s.errorf("template %q not defined", t.Name)
 	}


### PR DESCRIPTION
This adds a new lock protecting "tmpl".

Alternatively, the existing `muFunc` lock could be reused for simplicity
and safety. At the time I wrote this patch, I checked the usage of
`muFunc` and it didn't seem that adding a second lock would cause issues.

In my very unscientific tests running the `hugo` static site builder,
the additional lock had no observable impact on performance.

Thanks to @bep for providing the test case.

Fixes #39807