### PR TITLE
runtime: don't crash if vsyscall and vdso are disabled on x86_64

### DIFF
--- a/src/runtime/vdso_linux_amd64.go
+++ b/src/runtime/vdso_linux_amd64.go
@@ -17,8 +17,7 @@ var vdsoSymbolKeys = []vdsoSymbolKey{
 	{"__vdso_clock_gettime", 0xd35ec75, 0x6e43a318, &vdsoClockgettimeSym},
 }
 
-// initialize with vsyscall fallbacks
 var (
-	vdsoGettimeofdaySym uintptr = 0xffffffffff600000
-	vdsoClockgettimeSym uintptr = 0
+	vdsoGettimeofdaySym uintptr
+	vdsoClockgettimeSym uintptr
 )

--- a/src/syscall/asm_linux_amd64.s
+++ b/src/syscall/asm_linux_amd64.s
@@ -9,6 +9,8 @@
 // System calls for AMD64, Linux
 //
 
+#define SYS_gettimeofday 96
+
 // func Syscall(trap int64, a1, a2, a3 uintptr) (r1, r2, err uintptr);
 // Trap # in AX, args in DI SI DX R10 R8 R9, return in AX DX
 // Note that this differs from "standard" ABI convention, which
@@ -144,13 +146,19 @@ TEXT ·gettimeofday(SB),NOSPLIT,$0-16
 	MOVQ	tv+0(FP), DI
 	MOVQ	$0, SI
 	MOVQ	runtime·vdsoGettimeofdaySym(SB), AX
+	TESTQ   AX, AX
+	JZ fallback
 	CALL	AX
-
+ret:
 	CMPQ	AX, $0xfffffffffffff001
 	JLS	ok7
 	NEGQ	AX
 	MOVQ	AX, err+8(FP)
 	RET
+fallback:
+	MOVL	$SYS_gettimeofday, AX
+	SYSCALL
+	JMP ret
 ok7:
 	MOVQ	$0, err+8(FP)
 	RET


### PR DESCRIPTION
If vdso is disabled, the goruntime calls gettimeofday from vsyscall,
but if vsyscall is disabled too, all golang binaries crash:

SIGSEGV {si_signo=SIGSEGV, si_code=SEGV_MAPERR, si_addr=0xffffffffff600000} ---
killed by SIGSEGV (core dumped) ++

vsyscall doesn't work as it was designed for a long time due to security
reasons and now vsyscall is a little more expensive than real syscalls:
https://github.com/torvalds/linux/commit/5cec93c216db

This patch reworks the code to call syscalls if the vdso library isn't
available.