### PR TITLE
database/sql: close driver.Connector if it implements io.Closer

### DIFF
--- a/src/database/sql/driver/driver.go
+++ b/src/database/sql/driver/driver.go
@@ -116,8 +116,8 @@ type DriverContext interface {
 // access to context and to avoid repeated parsing of driver
 // configuration.
 //
-// If a Connector implements io.Closer interface, the sql package's
-// DB.Close will call the Close method and return the error (if any).
+// If a Connector implements io.Closer, the sql package's DB.Close
+// method will call Close and return error (if any).
 type Connector interface {
 	// Connect returns a connection to the database.
 	// Connect may return a cached connection (one previously

--- a/src/database/sql/driver/driver.go
+++ b/src/database/sql/driver/driver.go
@@ -116,8 +116,8 @@ type DriverContext interface {
 // access to context and to avoid repeated parsing of driver
 // configuration.
 //
-// A Connector may optionally implement io.Closer interface
-// to release the resources when sql.DB is closed.
+// If a Connector implements io.Closer interface, the sql package's
+// DB.Close will call the Close method and return the error (if any).
 type Connector interface {
 	// Connect returns a connection to the database.
 	// Connect may return a cached connection (one previously

--- a/src/database/sql/driver/driver.go
+++ b/src/database/sql/driver/driver.go
@@ -115,6 +115,9 @@ type DriverContext interface {
 // DriverContext's OpenConnector method, to allow drivers
 // access to context and to avoid repeated parsing of driver
 // configuration.
+//
+// A Connector may optionally implement io.Closer interface
+// to release the resources when sql.DB is closed.
 type Connector interface {
 	// Connect returns a connection to the database.
 	// Connect may return a cached connection (one previously

--- a/src/database/sql/fakedb_test.go
+++ b/src/database/sql/fakedb_test.go
@@ -56,6 +56,7 @@ type fakeConnector struct {
 	name string
 
 	waiter func(context.Context)
+	closed bool
 }
 
 func (c *fakeConnector) Connect(context.Context) (driver.Conn, error) {
@@ -66,6 +67,14 @@ func (c *fakeConnector) Connect(context.Context) (driver.Conn, error) {
 
 func (c *fakeConnector) Driver() driver.Driver {
 	return fdriver
+}
+
+func (c *fakeConnector) Close() error {
+	if c.closed {
+		return errors.New("fakedb: connector is closed")
+	}
+	c.closed = true
+	return nil
 }
 
 type fakeDriverCtx struct {

--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -850,6 +850,9 @@ func (db *DB) Close() error {
 		}
 	}
 	db.stop()
+	if c, ok := db.connector.(io.Closer); ok {
+		err = c.Close()
+	}
 	return err
 }
 

--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -851,7 +851,10 @@ func (db *DB) Close() error {
 	}
 	db.stop()
 	if c, ok := db.connector.(io.Closer); ok {
-		err = c.Close()
+		err1 := c.Close()
+		if err1 != nil {
+			err = err1
+		}
 	}
 	return err
 }

--- a/src/database/sql/sql_test.go
+++ b/src/database/sql/sql_test.go
@@ -4059,8 +4059,17 @@ func TestOpenConnector(t *testing.T) {
 	}
 	defer db.Close()
 
-	if _, is := db.connector.(*fakeConnector); !is {
+	c, ok := db.connector.(*fakeConnector)
+	if !ok {
 		t.Fatal("not using *fakeConnector")
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !c.closed {
+		t.Fatal("connector is not closed")
 	}
 }
 


### PR DESCRIPTION
This change allows driver implementations to manage resources in
driver.Connector, e.g. to share the same underlying database handle
between multiple connections. That is, it allows embedded databases
with in-memory backends like SQLite and Genji to safely release the
resources once the sql.DB is closed.

This makes it possible to address oddities with in-memory stores in
SQLite and Genji drivers without introducing too much complexity in
the driver implementations.

See also:
- https://github.com/mattn/go-sqlite3/issues/204
- https://github.com/mattn/go-sqlite3/issues/511
- https://github.com/genjidb/genji/issues/210

Fixes #41790