### PR TITLE
sort: inline search convenience wrappers

### DIFF
--- a/src/sort/search.go
+++ b/src/sort/search.go
@@ -81,7 +81,16 @@ func Search(n int, f func(int) bool) int {
 // The slice must be sorted in ascending order.
 //
 func SearchInts(a []int, x int) int {
-	return Search(len(a), func(i int) bool { return a[i] >= x })
+	i, j := 0, len(a)
+	for i < j {
+		h := int(uint(i+j) >> 1) // avoid overflow when computing h
+		if a[h] < x {
+			i = h + 1
+		} else {
+			j = h
+		}
+	}
+	return i
 }
 
 // SearchFloat64s searches for x in a sorted slice of float64s and returns the index
@@ -90,7 +99,16 @@ func SearchInts(a []int, x int) int {
 // The slice must be sorted in ascending order.
 //
 func SearchFloat64s(a []float64, x float64) int {
-	return Search(len(a), func(i int) bool { return a[i] >= x })
+	i, j := 0, len(a)
+	for i < j {
+		h := int(uint(i+j) >> 1) // avoid overflow when computing h
+		if a[h] < x {
+			i = h + 1
+		} else {
+			j = h
+		}
+	}
+	return i
 }
 
 // SearchStrings searches for x in a sorted slice of strings and returns the index
@@ -99,7 +117,16 @@ func SearchFloat64s(a []float64, x float64) int {
 // The slice must be sorted in ascending order.
 //
 func SearchStrings(a []string, x string) int {
-	return Search(len(a), func(i int) bool { return a[i] >= x })
+	i, j := 0, len(a)
+	for i < j {
+		h := int(uint(i+j) >> 1) // avoid overflow when computing h
+		if a[h] < x {
+			i = h + 1
+		} else {
+			j = h
+		}
+	}
+	return i
 }
 
 // Search returns the result of applying SearchInts to the receiver and x.


### PR DESCRIPTION
The SearchInts, SearchFloat64s, and SearchStrings functions are
convenience wrappers around the generic Search function, which takes a
function parameter to determine truthfulness.

However, since this passed function is utilized within a for loop, it
cannot currently be inlined by the Go compiler, resulting in some degree
of performance overhead (see #15561).

This trivial commit manually inlines the Search function itself to these
convenience wrappers, avoiding the function call overhead in the hot
loop.

It replaces 1 line of copy-pasted code with 10 lines of copy-pasted
code, however it has a roughly 2x beneficial effect on performance as
seen below:

    name               old time/op  new time/op  delta
    SearchWrappers-16  84.7ns ± 1%  43.8ns ± 2%  -48.34%  (p=0.000 n=19+19)

In the future, generics may enable similar perf gains while
avoiding the minimal copypasta, but for now this small change can
improve standard library performance and give the existing search
"convenience wrappers" performance benefits as well as convenience.

Updates #15561