### PR TITLE
net/http/httputil: flush ReverseProxy immediately if Content-Length is -1

### DIFF
--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -58,9 +58,9 @@ type ReverseProxy struct {
 	// A negative value means to flush immediately
 	// after each write to the client.
 	// The FlushInterval is ignored when ReverseProxy
-	// recognizes a response as a streaming response;
-	// for such responses, writes are flushed to the client
-	// immediately.
+	// recognizes a response as a streaming response, or
+	// Content-Length is -1; for such responses, writes
+	// are flushed to the client immediately.
 	FlushInterval time.Duration
 
 	// ErrorLog specifies an optional logger for errors
@@ -325,7 +325,7 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	rw.WriteHeader(res.StatusCode)
 
-	err = p.copyResponse(rw, res.Body, p.flushInterval(req, res))
+	err = p.copyResponse(rw, res.Body, p.flushInterval(res))
 	if err != nil {
 		defer res.Body.Close()
 		// Since we're streaming the response, if we run into an error all we can do
@@ -397,7 +397,7 @@ func removeConnectionHeaders(h http.Header) {
 
 // flushInterval returns the p.FlushInterval value, conditionally
 // overriding its value for a specific request/response.
-func (p *ReverseProxy) flushInterval(req *http.Request, res *http.Response) time.Duration {
+func (p *ReverseProxy) flushInterval(res *http.Response) time.Duration {
 	resCT := res.Header.Get("Content-Type")
 
 	// For Server-Sent Events responses, flush immediately.
@@ -406,7 +406,11 @@ func (p *ReverseProxy) flushInterval(req *http.Request, res *http.Response) time
 		return -1 // negative means immediately
 	}
 
-	// TODO: more specific cases? e.g. res.ContentLength == -1?
+	resCL := res.Header.Get("Content-Length")
+	if resCL == "-1" {
+		return -1
+	}
+
 	return p.FlushInterval
 }
 

--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -402,9 +402,13 @@ func (p *ReverseProxy) flushInterval(res *http.Response) time.Duration {
 
 	// For Server-Sent Events responses, flush immediately.
 	// The MIME type is defined in https://www.w3.org/TR/eventsource/#text-event-stream
-	// We might have the case of streaming for which Content-Length might be unset.
-	if resCT == "text/event-stream" || res.ContentLength == -1 {
+	if resCT == "text/event-stream" {
 		return -1 // negative means immediately
+	}
+
+	// We might have the case of streaming for which Content-Length might be unset.
+	if res.ContentLength == -1 {
+		return -1
 	}
 
 	return p.FlushInterval

--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -59,7 +59,7 @@ type ReverseProxy struct {
 	// after each write to the client.
 	// The FlushInterval is ignored when ReverseProxy
 	// recognizes a response as a streaming response, or
-	// Content-Length is -1; for such responses, writes
+	// if its ContentLength is -1; for such responses, writes
 	// are flushed to the client immediately.
 	FlushInterval time.Duration
 
@@ -402,13 +402,8 @@ func (p *ReverseProxy) flushInterval(res *http.Response) time.Duration {
 
 	// For Server-Sent Events responses, flush immediately.
 	// The MIME type is defined in https://www.w3.org/TR/eventsource/#text-event-stream
-	if resCT == "text/event-stream" {
+	if resCT == "text/event-stream" || res.ContentLength == -1 {
 		return -1 // negative means immediately
-	}
-
-	resCL := res.Header.Get("Content-Length")
-	if resCL == "-1" {
-		return -1
 	}
 
 	return p.FlushInterval

--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -402,6 +402,7 @@ func (p *ReverseProxy) flushInterval(res *http.Response) time.Duration {
 
 	// For Server-Sent Events responses, flush immediately.
 	// The MIME type is defined in https://www.w3.org/TR/eventsource/#text-event-stream
+	// We might have the case of streaming for which Content-Length might be unset.
 	if resCT == "text/event-stream" || res.ContentLength == -1 {
 		return -1 // negative means immediately
 	}

--- a/src/net/http/httputil/reverseproxy_test.go
+++ b/src/net/http/httputil/reverseproxy_test.go
@@ -1067,7 +1067,6 @@ func TestSelectFlushInterval(t *testing.T) {
 	tests := []struct {
 		name string
 		p    *ReverseProxy
-		req  *http.Request
 		res  *http.Response
 		want time.Duration
 	}{
@@ -1097,10 +1096,30 @@ func TestSelectFlushInterval(t *testing.T) {
 			p:    &ReverseProxy{FlushInterval: 0},
 			want: -1,
 		},
+		{
+			name: "Content-Length: -1, overrides non-zero",
+			res: &http.Response{
+				Header: http.Header{
+					"Content-Length": {"-1"},
+				},
+			},
+			p:    &ReverseProxy{FlushInterval: 123},
+			want: -1,
+		},
+		{
+			name: "Content-Length: -1, overrides zero",
+			res: &http.Response{
+				Header: http.Header{
+					"Content-Length": {"-1"},
+				},
+			},
+			p:    &ReverseProxy{FlushInterval: 0},
+			want: -1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.p.flushInterval(tt.req, tt.res)
+			got := tt.p.flushInterval(tt.res)
 			if got != tt.want {
 				t.Errorf("flushLatency = %v; want %v", got, tt.want)
 			}

--- a/src/net/http/httputil/reverseproxy_test.go
+++ b/src/net/http/httputil/reverseproxy_test.go
@@ -1099,9 +1099,7 @@ func TestSelectFlushInterval(t *testing.T) {
 		{
 			name: "Content-Length: -1, overrides non-zero",
 			res: &http.Response{
-				Header: http.Header{
-					"Content-Length": {"-1"},
-				},
+				ContentLength: -1,
 			},
 			p:    &ReverseProxy{FlushInterval: 123},
 			want: -1,
@@ -1109,9 +1107,7 @@ func TestSelectFlushInterval(t *testing.T) {
 		{
 			name: "Content-Length: -1, overrides zero",
 			res: &http.Response{
-				Header: http.Header{
-					"Content-Length": {"-1"},
-				},
+				ContentLength: -1,
 			},
 			p:    &ReverseProxy{FlushInterval: 0},
 			want: -1,


### PR DESCRIPTION
Finish up a prior TODO by making ReverseProxy flush immediately
if Content-Length is -1, which is a case that can occur if for
example we have a streamed response, or chunked encoding, or when
the body's length wasn't known.

Fixes #41642 