### PR TITLE
cmd/go: break after terminal loop condition

### DIFF
--- a/src/cmd/go/internal/envcmd/env.go
+++ b/src/cmd/go/internal/envcmd/env.go
@@ -217,6 +217,7 @@ func runEnv(ctx context.Context, cmd *base.Command, args []string) {
 		needCostly = true
 	} else {
 		needCostly = false
+	checkCostly:
 		for _, arg := range args {
 			switch argKey(arg) {
 			case "CGO_CFLAGS",
@@ -227,6 +228,7 @@ func runEnv(ctx context.Context, cmd *base.Command, args []string) {
 				"PKG_CONFIG",
 				"GOGCCFLAGS":
 				needCostly = true
+				break checkCostly
 			}
 		}
 	}


### PR DESCRIPTION
After the first time needCostly is set to true, there is no need to
continue checking the remaining args.