### PR TITLE
io: add a new ReadSeekCloser interface

### DIFF
--- a/src/io/io.go
+++ b/src/io/io.go
@@ -149,6 +149,13 @@ type ReadSeeker interface {
 	Seeker
 }
 
+// ReadSeekCloser is the interface that groups the basic Read, Seek and Close methods.
+type ReadSeekCloser interface {
+	Reader
+	Seeker
+	Closer
+}
+
 // WriteSeeker is the interface that groups the basic Write and Seek methods.
 type WriteSeeker interface {
 	Writer

--- a/src/io/io.go
+++ b/src/io/io.go
@@ -149,7 +149,8 @@ type ReadSeeker interface {
 	Seeker
 }
 
-// ReadSeekCloser is the interface that groups the basic Read, Seek and Close methods.
+// ReadSeekCloser is the interface that groups the basic Read, Seek and Close
+// methods.
 type ReadSeekCloser interface {
 	Reader
 	Seeker


### PR DESCRIPTION
Research showed that this interface is defined frequently enough in 
real-world usage to justify its addition to the standard library.

Fixes #40962