### PR TITLE
crypto/x509: add Unwrap to SystemRootsError

### DIFF
--- a/src/crypto/x509/verify.go
+++ b/src/crypto/x509/verify.go
@@ -187,6 +187,8 @@ func (se SystemRootsError) Error() string {
 	return msg
 }
 
+func (se SystemRootsError) Unwrap() error { return se.Err }
+
 // errNotParsed is returned when a certificate without ASN.1 contents is
 // verified. Platform-specific verification needs the ASN.1 contents.
 var errNotParsed = errors.New("x509: missing ASN.1 contents; use ParseCertificate")

--- a/src/crypto/x509/verify_test.go
+++ b/src/crypto/x509/verify_test.go
@@ -2005,3 +2005,11 @@ func TestSystemRootsError(t *testing.T) {
 		t.Errorf("error was not SystemRootsError: %v", err)
 	}
 }
+
+func TestSystemRootsErrorUnwrap(t *testing.T) {
+	var err1 = errors.New("err1")
+	err := SystemRootsError{Err: err1}
+	if !errors.Is(err, err1) {
+		t.Error("errors.Is failed, wanted success")
+	}
+}


### PR DESCRIPTION
This change modifies Go to add the Unwrap method to SystemRootsError

Updates #30322

