### PR TITLE
cmd/go: when module enabled, `go clean` removes built binary

### DIFF
--- a/src/cmd/go/internal/clean/clean.go
+++ b/src/cmd/go/internal/clean/clean.go
@@ -276,6 +276,13 @@ func clean(p *load.Package) {
 			elem,
 			elem+".exe",
 		)
+		// Binary's module name isn't 'main'
+		if modload.Enabled() && p.Name != p.ImportPath {
+			allRemove = append(allRemove,
+				p.ImportPath,
+				p.ImportPath+".exe",
+			)
+		}
 	}
 
 	// Remove package test executables.

--- a/src/cmd/go/internal/clean/clean.go
+++ b/src/cmd/go/internal/clean/clean.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -267,45 +268,20 @@ func clean(p *load.Package) {
 		keep(p.XTestGoFiles)
 	}
 
-	_, elem := filepath.Split(p.Dir)
 	var allRemove []string
 
-	// Remove dir-named executable only if this is package main.
+	// Remove executable only if this is package main.
 	if p.Name == "main" {
-		allRemove = append(allRemove,
-			elem,
-			elem+".exe",
-		)
-		// Binary's module name isn't 'main'
-		if modload.Enabled() && p.Name != p.ImportPath {
-			allRemove = append(allRemove,
-				p.ImportPath,
-				p.ImportPath+".exe",
-			)
-		}
+		allRemove = append(allRemove, collectExecutables(p)...)
 	}
 
 	// Remove package test executables.
-	allRemove = append(allRemove,
-		elem+".test",
-		elem+".test.exe",
-	)
+	allRemove = append(allRemove, collectTestFiles(p)...)
 
-	// Remove a potential executable for each .go file in the directory that
-	// is not part of the directory's package.
-	for _, dir := range dirs {
-		name := dir.Name()
-		if packageFile[name] {
-			continue
-		}
-		if !dir.IsDir() && strings.HasSuffix(name, ".go") {
-			// TODO(adg,rsc): check that this .go file is actually
-			// in "package main", and therefore capable of building
-			// to an executable file.
-			base := name[:len(name)-len(".go")]
-			allRemove = append(allRemove, base, base+".exe")
-		}
-	}
+	// Remove potential executables or test files.
+	allRemove = append(allRemove, collectPotentialFiles(packageFile, dirs)...)
+
+	allRemove = uniq(allRemove)
 
 	if cfg.BuildN || cfg.BuildX {
 		b.Showcmd(p.Dir, "rm -f %s", strings.Join(allRemove, " "))
@@ -380,4 +356,142 @@ func removeFile(f string) {
 		}
 	}
 	base.Errorf("go clean: %v", err)
+}
+
+// collectExecutables collect executable filenames to be cleaned
+//
+// go build, there're several cases:
+// - GO111MODULE=on go build, module-named executable
+// - GO111MODULE=off go build, directory-named executable
+// - GO111MODULE=on/off go build <filename>, file-named executable
+func collectExecutables(p *load.Package) []string {
+	if p.Name != "main" {
+		return nil
+	}
+
+	executables := []string{}
+
+	// directory-named
+	_, elem := filepath.Split(p.Dir)
+	executables = append(executables,
+		elem,
+		elem+".exe",
+	)
+
+	flagValue := p.Internal.CmdlineFiles
+	defer func() {
+		p.Internal.CmdlineFiles = flagValue
+	}()
+
+	// module-named
+	p.Internal.CmdlineFiles = false
+	dftExecName := p.DefaultExecName()
+	if dftExecName != elem {
+		executables = append(executables,
+			dftExecName,
+			dftExecName+".exe",
+		)
+	}
+
+	// file-named
+	p.Internal.CmdlineFiles = true
+	dftExecName = p.DefaultExecName()
+	if dftExecName != elem {
+		executables = append(executables,
+			dftExecName,
+			dftExecName+".exe",
+		)
+	}
+
+	return executables
+}
+
+// collectTestFiles collect test filenames to be cleaned
+//
+// go test, there're several cases:
+// - GO111MODULE=on go test -c, module-named test file
+// - GO111MODULE=off go test -c, directory-named test file
+// - GO111MODULE=on/off go test -c <*_test.go>, file-named test file
+func collectTestFiles(p *load.Package) []string {
+
+	fileNames := []string{}
+
+	// directory-named
+	_, elem := filepath.Split(p.Dir)
+	fileNames = append(fileNames,
+		elem+".test",
+		elem+".test.exe",
+	)
+
+	flagValue := p.Internal.CmdlineFiles
+	defer func() {
+		p.Internal.CmdlineFiles = flagValue
+	}()
+
+	// module-named
+	p.Internal.CmdlineFiles = false
+	dftExecName := p.DefaultExecName()
+	if len(dftExecName) != 0 && dftExecName != elem {
+		fileNames = append(fileNames,
+			dftExecName+".test",
+			dftExecName+".test.exe",
+		)
+	}
+
+	// file-named
+	p.Internal.CmdlineFiles = true
+	dftExecName = p.DefaultExecName()
+	if len(dftExecName) != 0 && dftExecName != elem {
+		fileNames = append(fileNames,
+			dftExecName+".test",
+			dftExecName+".test.exe",
+		)
+	}
+
+	return fileNames
+}
+
+// collectPotentialFiles collect potential executable files and test files
+func collectPotentialFiles(packageFile map[string]bool, files []os.FileInfo) []string {
+
+	var fileNames []string
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		name := file.Name()
+
+		if strings.HasSuffix(name, "_test.go") {
+			base := name[:len(name)-len("_test.go")]
+			fileNames = append(fileNames, base+".test", base+".test.exe")
+			continue
+		}
+
+		if strings.HasSuffix(name, ".go") {
+			// TODO(adg,rsc): check that this .go file is actually
+			// in "package main", and therefore capable of building
+			// to an executable file.
+			base := name[:len(name)-len(".go")]
+			fileNames = append(fileNames, base, base+".exe")
+		}
+	}
+
+	return fileNames
+}
+
+func uniq(elements []string) []string {
+	m := map[string]struct{}{}
+	for _, e := range elements {
+		m[e] = struct{}{}
+	}
+
+	all := make([]string, 0, len(m))
+	for k, _ := range m {
+		all = append(all, k)
+	}
+	sort.Strings(all)
+
+	return all
 }

--- a/src/cmd/go/testdata/script/clean_binary.txt
+++ b/src/cmd/go/testdata/script/clean_binary.txt
@@ -1,58 +1,61 @@
 # Build something to create the executable, including several cases
 
+[windows] env EXT='.exe'
+[!windows] env EXT=''
+
 # --------------------- clean executables -------------------------
 
 # case1: test file-named executable 'main'
 env GO111MODULE=on
 
-! exists main
+! exists main$EXT
 go build main.go
-exists -exec main
+exists -exec main$EXT
 go clean
-! exists main
+! exists main$EXT
 
 # case2: test module-named executable 'a.b.c'
-! exists a.b.c
+! exists a.b.c$EXT
 go build
-exists -exec a.b.c
+exists -exec a.b.c$EXT
 go clean
-! exists a.b.c
+! exists a.b.c$EXT
 
 # case3: directory-named executable 'src'
 env GO111MODULE=off
 
-! exists src
+! exists src$EXT
 go build
-exists -exec src
+exists -exec src$EXT
 go clean
-! exists src
+! exists src$EXT
 
 # --------------------- clean test files -------------------------
 
 # case1: test file-named test file
 env GO111MODULE=on
 
-! exists main.test
+! exists main.test$EXT
 go test -c main_test.go
-exists -exec main.test
+exists -exec main.test$EXT
 go clean
-! exists main.test
+! exists main.test$EXT
 
 # case2: test module-named test file
-! exists a.b.c.test
+! exists a.b.c.test$EXT
 go test -c
-exists -exec a.b.c.test
+exists -exec a.b.c.test$EXT
 go clean
-! exists a.b.c.test
+! exists a.b.c.test$EXT
 
 # case3: test directory-based test file
 env GO111MODULE=off
 
-! exists src.test
+! exists src.test$EXT
 go test -c
-exists -exec src.test
+exists -exec src.test$EXT
 go clean
-! exists src.test
+! exists src.test$EXT
 
 -- main.go --
 package main

--- a/src/cmd/go/testdata/script/clean_binary.txt
+++ b/src/cmd/go/testdata/script/clean_binary.txt
@@ -1,61 +1,59 @@
 # Build something to create the executable, including several cases
-
-[windows] env EXT='.exe'
-[!windows] env EXT=''
+[short] skip
 
 # --------------------- clean executables -------------------------
 
 # case1: test file-named executable 'main'
 env GO111MODULE=on
 
-! exists main$EXT
+! exists main$GOEXE
 go build main.go
-exists -exec main$EXT
+exists -exec main$GOEXE
 go clean
-! exists main$EXT
+! exists main$GOEXE
 
 # case2: test module-named executable 'a.b.c'
-! exists a.b.c$EXT
+! exists a.b.c$GOEXE
 go build
-exists -exec a.b.c$EXT
+exists -exec a.b.c$GOEXE
 go clean
-! exists a.b.c$EXT
+! exists a.b.c$GOEXE
 
 # case3: directory-named executable 'src'
 env GO111MODULE=off
 
-! exists src$EXT
+! exists src$GOEXE
 go build
-exists -exec src$EXT
+exists -exec src$GOEXE
 go clean
-! exists src$EXT
+! exists src$GOEXE
 
 # --------------------- clean test files -------------------------
 
 # case1: test file-named test file
 env GO111MODULE=on
 
-! exists main.test$EXT
+! exists main.test$GOEXE
 go test -c main_test.go
-exists -exec main.test$EXT
+exists -exec main.test$GOEXE
 go clean
-! exists main.test$EXT
+! exists main.test$GOEXE
 
 # case2: test module-named test file
-! exists a.b.c.test$EXT
+! exists a.b.c.test$GOEXE
 go test -c
-exists -exec a.b.c.test$EXT
+exists -exec a.b.c.test$GOEXE
 go clean
-! exists a.b.c.test$EXT
+! exists a.b.c.test$GOEXE
 
 # case3: test directory-based test file
 env GO111MODULE=off
 
-! exists src.test$EXT
+! exists src.test$GOEXE
 go test -c
-exists -exec src.test$EXT
+exists -exec src.test$GOEXE
 go clean
-! exists src.test$EXT
+! exists src.test$GOEXE
 
 -- main.go --
 package main

--- a/src/cmd/go/testdata/script/clean_binary.txt
+++ b/src/cmd/go/testdata/script/clean_binary.txt
@@ -1,11 +1,10 @@
 # Build something to create the executable, including several cases
 
-# ----------------------------------------------------------------
-# go module enabled
-
-env GO111MODULE=on
+# --------------------- clean executables -------------------------
 
 # case1: test file-named executable 'main'
+env GO111MODULE=on
+
 ! exists main
 go build main.go
 exists -exec main
@@ -19,18 +18,41 @@ exists -exec a.b.c
 go clean
 ! exists a.b.c
 
-# -----------------------------------------------------------------
-# go module disabled
-
-env GO111MODULE=off
-
 # case3: directory-named executable 'src'
+env GO111MODULE=off
 
 ! exists src
 go build
 exists -exec src
 go clean
 ! exists src
+
+# --------------------- clean test files -------------------------
+
+# case1: test file-named test file
+env GO111MODULE=on
+
+! exists main.test
+go test -c main_test.go
+exists -exec main.test
+go clean
+! exists main.test
+
+# case2: test module-named test file
+! exists a.b.c.test
+go test -c
+exists -exec a.b.c.test
+go clean
+! exists a.b.c.test
+
+# case3: test directory-based test file
+env GO111MODULE=off
+
+! exists src.test
+go test -c
+exists -exec src.test
+go clean
+! exists src.test
 
 -- main.go --
 package main
@@ -39,6 +61,14 @@ import "fmt"
 
 func main() {
 	fmt.Println("hello!")
+}
+
+-- main_test.go --
+package main
+
+import "testing"
+
+func TestSomething(t *testing.T) {
 }
 
 -- go.mod --

--- a/src/cmd/go/testdata/script/clean_binary.txt
+++ b/src/cmd/go/testdata/script/clean_binary.txt
@@ -1,0 +1,47 @@
+# Build something to create the executable, including several cases
+
+# ----------------------------------------------------------------
+# go module enabled
+
+env GO111MODULE=on
+
+# case1: test file-named executable 'main'
+! exists main
+go build main.go
+exists -exec main
+go clean
+! exists main
+
+# case2: test module-named executable 'a.b.c'
+! exists a.b.c
+go build
+exists -exec a.b.c
+go clean
+! exists a.b.c
+
+# -----------------------------------------------------------------
+# go module disabled
+
+env GO111MODULE=off
+
+# case3: directory-named executable 'src'
+
+! exists src
+go build
+exists -exec src
+go clean
+! exists src
+
+-- main.go --
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello!")
+}
+
+-- go.mod --
+module example.com/a.b.c/v2
+
+go 1.12


### PR DESCRIPTION
Now "go clean" can remove binary as expected, when module enabled and the module name isn't  "main" or the name of folder.

Fixes issue #41656
