### PR TITLE
os: add comment clarifying behavior of (*File).Read

### DIFF
--- a/src/os/file.go
+++ b/src/os/file.go
@@ -108,6 +108,7 @@ func (e *LinkError) Unwrap() error {
 
 // Read reads up to len(b) bytes from the File.
 // It returns the number of bytes read and any error encountered.
+// Subsequent calls to Read reads from the File with an offset, eventually reaching the end of the File.
 // At end of file, Read returns 0, io.EOF.
 func (f *File) Read(b []byte) (n int, err error) {
 	if err := f.checkValid("read"); err != nil {


### PR DESCRIPTION
Current documentation could be clearer about the fact that a file can be read in its entirety with repeated calls to (*File).Read without the user having to worry about handling offsets.