### PR TITLE
crypto/tls: reuse the tls Conn's outBuf to reduce memory cost on large number of tls connections

### DIFF
--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -20,6 +20,13 @@ import (
 	"time"
 )
 
+// outBufPool pools the record-sized scratch buffers used by (*Conn).writeRecordLocked.
+var outBufPool = sync.Pool{
+	New: func() interface{} {
+		return new([]byte)
+	},
+}
+
 // A Conn represents a secured connection.
 // It implements the net.Conn interface.
 type Conn struct {
@@ -931,6 +938,20 @@ func (c *Conn) flush() (int, error) {
 // writeRecordLocked writes a TLS record with the given type and payload to the
 // connection and updates the record layer state.
 func (c *Conn) writeRecordLocked(typ recordType, data []byte) (int, error) {
+	bufPtr := outBufPool.Get().(*[]byte)
+	c.outBuf = *bufPtr
+
+	defer func() {
+		if len(c.outBuf) > len(*bufPtr) {
+			buf := c.outBuf
+			bufPtr = &buf
+		}
+
+		// return buffer to pool
+		outBufPool.Put(bufPtr)
+		c.outBuf = nil
+	}()
+
 	var n int
 	for len(data) > 0 {
 		m := len(data)

--- a/src/crypto/tls/conn_bench_test.go
+++ b/src/crypto/tls/conn_bench_test.go
@@ -1,0 +1,29 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tls
+
+import (
+	"net"
+	"testing"
+)
+
+func BenchmarkConnOutbufWithPool(b *testing.B) {
+	data := make([]byte, 10240)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		c := &Conn{config: testConfig.Clone(), conn: testConn{}}
+		c.writeRecord(recordTypeApplicationData, data)
+	}
+}
+
+type testConn struct{
+	net.Conn
+}
+
+// mock this Write for outBuf pooling test
+func (m testConn) Write(b []byte) (n int, err error) {
+	return len(b), nil
+}
+


### PR DESCRIPTION
benchstat old.txt new.txt

name                  old time/op    new time/op    delta
ConnOutbufWithPool-8    1.95µs ± 1%    0.62µs ± 1%  -68.16%  (p=0.000 n=9+10)

name                  old alloc/op   new alloc/op   delta
ConnOutbufWithPool-8    10.6kB ± 0%     1.3kB ± 0%  -87.79%  (p=0.000 n=10+10)

name                  old allocs/op  new allocs/op  delta
ConnOutbufWithPool-8      7.00 ± 0%      3.00 ± 0%  -57.14%  (p=0.000 n=10+10)

Fixes #42035