### PR TITLE
path/filepath: allow EvalSymlinks to work on UNC share roots on Windows

### DIFF
--- a/src/path/filepath/path_windows_test.go
+++ b/src/path/filepath/path_windows_test.go
@@ -412,6 +412,9 @@ func TestToNorm(t *testing.T) {
 		{`{{tmp}}\test`, `.\foo\bar`, `foo\bar`},
 		{`{{tmp}}\test`, `foo\..\foo\bar`, `foo\bar`},
 		{`{{tmp}}\test`, `FOO\BAR`, `foo\bar`},
+
+		// test UNC paths
+		{".", `\\localhost\c$`, `\\localhost\c$`},
 	}
 
 	tmp, err := ioutil.TempDir("", "testToNorm")

--- a/src/path/filepath/symlink_windows.go
+++ b/src/path/filepath/symlink_windows.go
@@ -68,7 +68,7 @@ func toNorm(path string, normBase func(string) (string, error)) (string, error) 
 	path = path[len(volume):]
 
 	// skip special cases
-	if path == "." || path == `\` {
+	if path == "" || path == "." || path == `\` {
 		return volume + path, nil
 	}
 


### PR DESCRIPTION
Fixes #42079

Previously, EvalSymlinks returned an error when called with the root of
a UNC share (e.g. \\server\share). This was due to Windows's
FindFirstFile function not supporting a share root path.

To resolve this, now return early from toNorm in the case where the path
after the volume name is empty. Skipping the later path component
resolution shouldn't have any negative impact in this case, as if the
path is empty, there aren't any path components to resolve anyways.

The test case uses the localhost admin share (c$), as it should be
present in most situations. This allows testing without setting up an
external file share. However, this fix applies to all UNC share root
paths.