### PR TITLE
context: remove cancel children in cancelCtx

### DIFF
--- a/src/context/context.go
+++ b/src/context/context.go
@@ -406,10 +406,6 @@ func (c *cancelCtx) cancel(removeFromParent bool, err error) {
 	} else {
 		close(c.done)
 	}
-	for child := range c.children {
-		// NOTE: acquiring the child's lock while holding parent's lock.
-		child.cancel(false, err)
-	}
 	c.children = nil
 	c.mu.Unlock()
 


### PR DESCRIPTION
`propagateCancel` has already arranged for the child to be cancelled when the parent is, there is no need to do that in cancelCtx's cancel method.

