### PR TITLE
net/url: improve performance for resolvePath

### DIFF
--- a/src/net/url/url_test.go
+++ b/src/net/url/url_test.go
@@ -1114,6 +1114,14 @@ func TestResolvePath(t *testing.T) {
 	}
 }
 
+func BenchmarkResolvePath(b *testing.B) {
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		resolvePath("a/b/c", ".././d")
+	}
+}
+
 var resolveReferenceTests = []struct {
 	base, rel, expected string
 }{


### PR DESCRIPTION
benchmark compare results:

benchmark                   old ns/op     new ns/op     delta
BenchmarkResolvePath-12     297           141           -52.53%

benchmark                   old allocs     new allocs     delta
BenchmarkResolvePath-12     5              3              -40.00%

benchmark                   old bytes     new bytes     delta
BenchmarkResolvePath-12     181           24            -86.74%