### PR TITLE
net/rpc: start a new goroutine when sending the request

### DIFF
--- a/src/net/rpc/client.go
+++ b/src/net/rpc/client.go
@@ -312,7 +312,7 @@ func (client *Client) Go(serviceMethod string, args interface{}, reply interface
 		}
 	}
 	call.Done = done
-	client.send(call)
+	go client.send(call)
 	return call
 }
 


### PR DESCRIPTION
It's unnecessary to wait for sending the request to complete. Sending a request can be time-comsuming, so I think it's better to make it asynchronous.