### PR TITLE
database/sql: fix comment on DB.stop()

### DIFF
--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -434,7 +434,7 @@ type DB struct {
 	maxIdleTimeClosed int64 // Total number of connections closed due to idle time.
 	maxLifetimeClosed int64 // Total number of connections closed due to max connection lifetime limit.
 
-	stop func() // stop cancels the connection opener and the session resetter.
+	stop func() // stop cancels the connection opener.
 }
 
 // connReuseStrategy determines how (*DB).conn returns database connections.


### PR DESCRIPTION
Previously, 2 goroutines were created in OpenDB and a comment in the DB.close() field indicated that they were canceled. Later, session Resetter () was removed, but the comment remained the same. This commit just fixes this message