### PR TITLE
os: export ErrProcessDone variable in windows and plan9

### DIFF
--- a/src/os/exec.go
+++ b/src/os/exec.go
@@ -5,6 +5,7 @@
 package os
 
 import (
+	"errors"
 	"internal/testlog"
 	"runtime"
 	"sync"
@@ -12,6 +13,9 @@ import (
 	"syscall"
 	"time"
 )
+
+// ErrProcessDone indicates a Process has finished.
+var ErrProcessDone = errors.New("os: process already finished")
 
 // Process stores the information about a process created by StartProcess.
 type Process struct {

--- a/src/os/exec_plan9.go
+++ b/src/os/exec_plan9.go
@@ -5,7 +5,6 @@
 package os
 
 import (
-	"errors"
 	"runtime"
 	"syscall"
 	"time"
@@ -49,9 +48,6 @@ func (p *Process) writeProcFile(file string, data string) error {
 	_, e = f.Write([]byte(data))
 	return e
 }
-
-// ErrProcessDone indicates a Process has finished.
-var ErrProcessDone = errors.New("os: process already finished")
 
 func (p *Process) signal(sig Signal) error {
 	if p.done() {

--- a/src/os/exec_plan9.go
+++ b/src/os/exec_plan9.go
@@ -50,9 +50,12 @@ func (p *Process) writeProcFile(file string, data string) error {
 	return e
 }
 
+// ErrProcessDone indicates a Process has finished.
+var ErrProcessDone = errors.New("os: process already finished")
+
 func (p *Process) signal(sig Signal) error {
 	if p.done() {
-		return errors.New("os: process already finished")
+		return ErrProcessDone
 	}
 	if e := p.writeProcFile("note", sig.String()); e != nil {
 		return NewSyscallError("signal", e)

--- a/src/os/exec_unix.go
+++ b/src/os/exec_unix.go
@@ -59,9 +59,6 @@ func (p *Process) wait() (ps *ProcessState, err error) {
 	return ps, nil
 }
 
-// ErrProcessDone indicates a Process has finished.
-var ErrProcessDone = errors.New("os: process already finished")
-
 func (p *Process) signal(sig Signal) error {
 	if p.Pid == -1 {
 		return errors.New("os: process already released")

--- a/src/os/exec_windows.go
+++ b/src/os/exec_windows.go
@@ -55,9 +55,6 @@ func terminateProcess(pid, exitcode int) error {
 	return NewSyscallError("TerminateProcess", e)
 }
 
-// ErrProcessDone indicates a Process has finished.
-var ErrProcessDone = errors.New("os: process already finished")
-
 func (p *Process) signal(sig Signal) error {
 	handle := atomic.LoadUintptr(&p.handle)
 	if handle == uintptr(syscall.InvalidHandle) {

--- a/src/os/exec_windows.go
+++ b/src/os/exec_windows.go
@@ -55,13 +55,16 @@ func terminateProcess(pid, exitcode int) error {
 	return NewSyscallError("TerminateProcess", e)
 }
 
+// ErrProcessDone indicates a Process has finished.
+var ErrProcessDone = errors.New("os: process already finished")
+
 func (p *Process) signal(sig Signal) error {
 	handle := atomic.LoadUintptr(&p.handle)
 	if handle == uintptr(syscall.InvalidHandle) {
 		return syscall.EINVAL
 	}
 	if p.done() {
-		return errors.New("os: process already finished")
+		return ErrProcessDone
 	}
 	if sig == Kill {
 		err := terminateProcess(p.Pid, 1)


### PR DESCRIPTION
Exposes ErrProcessDone variable in windows and plan9
also returns this error code instead of
errors.New("os: process already finished")

Fixes #42311 

