### PR TITLE
cmd/go/internal/modfetch/codehost: add support for new fossil info hash prefix

### DIFF
--- a/src/cmd/go/internal/modfetch/codehost/vcs.go
+++ b/src/cmd/go/internal/modfetch/codehost/vcs.go
@@ -568,7 +568,7 @@ func bzrParseStat(rev, out string) (*RevInfo, error) {
 
 func fossilParseStat(rev, out string) (*RevInfo, error) {
 	for _, line := range strings.Split(out, "\n") {
-		if strings.HasPrefix(line, "uuid:") {
+		if strings.HasPrefix(line, "uuid:") || strings.HasPrefix(line, "hash:") {
 			f := strings.Fields(line)
 			if len(f) != 5 || len(f[1]) != 40 || f[4] != "UTC" {
 				return nil, vcsErrorf("unexpected response from fossil info: %q", line)

--- a/src/cmd/go/testdata/script/mod_get_fossil.txt
+++ b/src/cmd/go/testdata/script/mod_get_fossil.txt
@@ -1,0 +1,26 @@
+[!net] skip
+[!exec:fossil] skip
+
+# Regression test for 'go get' to ensure repositories
+# provided by fossil v2.12 and up are able to be fetched
+# and parsed correctly.
+# Verifies golang.org/issue/42323.
+
+
+env GO111MODULE=on
+env GOPROXY=direct
+env GOSUMDB=off
+
+# 'go get' for the fossil repo will fail if fossil
+# is unable to determine your fossil user. Easiest
+# way to set it for use by 'go get' is specifying 
+# a any non-empty $USER; the value doesn't otherwise matter.
+env USER=fossiluser
+
+# Attempting to get the latest version of a fossil repo.
+go get vcs-test.golang.org/fossil/hello.fossil
+! stderr 'unexpected response from fossil info'
+grep 'vcs-test.golang.org/fossil/hello.fossil' go.mod
+
+-- go.mod --
+module x


### PR DESCRIPTION
A recent update of the Fossil SCM application changes
the line prefix when the fossil info command is used.
Instead of the revision hash starting with "uuid:", it has been
changed to "hash:".

Fossil check-in introducing this change:

https://fossil-scm.org/home/info/8ad5e4690854a81a

To support older and new versions, fossilParseStat will
now check for either version of the prefix when attempting
to find the line containing the hash of the desired revision.

Fixes #42323
