### PR TITLE
[release-branch.go1.15] cmd/link/internal/ld/pe: fix segfault adding resource section

### DIFF
--- a/src/cmd/link/internal/ld/pe.go
+++ b/src/cmd/link/internal/ld/pe.go
@@ -1515,6 +1515,17 @@ func Asmbpe(ctxt *Link) {
 	case sys.AMD64, sys.I386, sys.ARM:
 	}
 
+	if rsrcsym != 0 {
+		// rsrc.P resides in mmap'd memory, which could be munmap'd
+		// underneath us before it comes time to actually use it.
+		// To avoid any issues we copy the data to the heap to ensure
+		// we don't segfault later when trying to access it.
+		rsrc := ctxt.loader.Syms[rsrcsym]
+		data := make([]byte, len(rsrc.P))
+		copy(data, rsrc.P)
+		rsrc.P = data
+	}
+
 	t := pefile.addSection(".text", int(Segtext.Length), int(Segtext.Length))
 	t.characteristics = IMAGE_SCN_CNT_CODE | IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_EXECUTE | IMAGE_SCN_MEM_READ
 	if ctxt.LinkMode == LinkExternal {

--- a/src/cmd/link/internal/ld/pe.go
+++ b/src/cmd/link/internal/ld/pe.go
@@ -1516,10 +1516,11 @@ func Asmbpe(ctxt *Link) {
 	}
 
 	if rsrcsym != 0 {
-		// rsrc.P resides in mmap'd memory, which could be munmap'd
-		// underneath us before it comes time to actually use it.
-		// To avoid any issues we copy the data to the heap to ensure
-		// we don't segfault later when trying to access it.
+		// The resource symbol may have been copied to the mmap'd
+		// output buffer. If so, certain conditions can cause that
+		// mmap'd output buffer to be munmap'd before we get a chance
+		// to use it. To avoid any issues we copy the data to the heap
+		// when the resource symbol exists.
 		rsrc := ctxt.loader.Syms[rsrcsym]
 		data := make([]byte, len(rsrc.P))
 		copy(data, rsrc.P)


### PR DESCRIPTION
The resource symbol may have been copied to the mmap'd
output buffer. If so, certain conditions can cause that
mmap'd output buffer to be munmap'd before we get a chance
to use it. To avoid any issues we copy the data to the heap
when the resource symbol exists.

Fixes #42384