### PR TITLE
cmd/go: the "build_plugin_non_main" test case cannot pass for linux/mips64le.

### DIFF
--- a/src/cmd/go/testdata/script/build_plugin_non_main.txt
+++ b/src/cmd/go/testdata/script/build_plugin_non_main.txt
@@ -1,7 +1,5 @@
-# Plugins are only supported on linux,cgo (!riscv64) and darwin,cgo.
-[!linux] [!darwin] skip
-[linux] [riscv64] skip
-[!cgo] skip
+# Plugins are not supported on all platforms.
+[!buildmode:plugin] skip
 
 go build -n testdep
 ! go build -buildmode=plugin testdep


### PR DESCRIPTION
Fixes: #42474