### PR TITLE
go/parser: ignore subdirectories in ParseDir

### DIFF
--- a/src/go/parser/interface.go
+++ b/src/go/parser/interface.go
@@ -140,7 +140,7 @@ func ParseDir(fset *token.FileSet, path string, filter func(fs.FileInfo) bool, m
 
 	pkgs = make(map[string]*ast.Package)
 	for _, d := range list {
-		if strings.HasSuffix(d.Name(), ".go") && (filter == nil || filter(d)) {
+		if !d.IsDir() && strings.HasSuffix(d.Name(), ".go") && (filter == nil || filter(d)) {
 			filename := filepath.Join(path, d.Name())
 			if src, err := ParseFile(fset, filename, nil, mode); err == nil {
 				name := src.Name.Name

--- a/src/go/parser/parser_test.go
+++ b/src/go/parser/parser_test.go
@@ -82,6 +82,14 @@ func TestParseDir(t *testing.T) {
 	}
 }
 
+func TestIssue42951(t *testing.T) {
+	path := "./testdata/issue42951"
+	_, err := ParseDir(token.NewFileSet(), path, nil, 0)
+	if err != nil {
+		t.Errorf("ParseDir(%s): %v", path, err)
+	}
+}
+
 func TestParseExpr(t *testing.T) {
 	// just kicking the tires:
 	// a valid arithmetic expression

--- a/src/go/parser/testdata/issue42951/not_a_file.go/invalid.go
+++ b/src/go/parser/testdata/issue42951/not_a_file.go/invalid.go
@@ -1,0 +1,1 @@
+This file should not be parsed by ParseDir.


### PR DESCRIPTION
Issue and PR on GoReleaser:
- https://github.com/goreleaser/goreleaser/issues/1897
- https://github.com/goreleaser/goreleaser/pull/1899

Fixes #42951.