### PR TITLE
runtime: add force_small_arena build tag

### DIFF
--- a/src/runtime/malloc.go
+++ b/src/runtime/malloc.go
@@ -242,12 +242,17 @@ const (
 	// This is particularly important with the race detector,
 	// since it significantly amplifies the cost of committed
 	// memory.
+	//
+	// Pass "-tags force_small_arena" to force 4MB heap arenas.
 	heapArenaBytes = 1 << logHeapArenaBytes
+
+	// Whether to use small (4MB) heap arenas.
+	useSmallArena = (1-_64bit) | sys.GoarchWasm | sys.GoosWindows | forceSmallArena
 
 	// logHeapArenaBytes is log_2 of heapArenaBytes. For clarity,
 	// prefer using heapArenaBytes where possible (we need the
 	// constant to compute some other constants).
-	logHeapArenaBytes = (6+20)*(_64bit*(1-sys.GoosWindows)*(1-sys.GoarchWasm)) + (2+20)*(_64bit*sys.GoosWindows) + (2+20)*(1-_64bit) + (2+20)*sys.GoarchWasm
+	logHeapArenaBytes = (6+20) * (1-useSmallArena) + (2+20)* useSmallArena
 
 	// heapArenaBitmapBytes is the size of each heap arena's bitmap.
 	heapArenaBitmapBytes = heapArenaBytes / (sys.PtrSize * 8 / 2)

--- a/src/runtime/malloc_force_small_arena_disabled.go
+++ b/src/runtime/malloc_force_small_arena_disabled.go
@@ -1,0 +1,7 @@
+// +build !force_small_arena
+//
+// See malloc.go.
+
+package runtime
+
+const forceSmallArena = 0

--- a/src/runtime/malloc_force_small_arena_enabled.go
+++ b/src/runtime/malloc_force_small_arena_enabled.go
@@ -1,0 +1,7 @@
+// +build force_small_arena
+//
+// See malloc.go.
+
+package runtime
+
+const forceSmallArena = 1


### PR DESCRIPTION
Some embedded Linux platforms disable overcommit to reduce dynamic behavior
in the system. Go already uses 4MB arenas on 32-bit platforms, but on
64-bit platforms the 64MB arena adds a steep cost to any Go binary.

This PR adds a `force_small_arena` build tag to allow users to opt into 4MB
arenas at build time.