### PR TITLE
runtime: add force_small_arena build tag

### DIFF
--- a/src/runtime/malloc_force_small_arena_disabled.go
+++ b/src/runtime/malloc_force_small_arena_disabled.go
@@ -1,0 +1,7 @@
+// +build !force_small_arena
+//
+// See malloc.go.
+
+package runtime
+
+const forceSmallArena = 0

--- a/src/runtime/malloc_force_small_arena_enabled.go
+++ b/src/runtime/malloc_force_small_arena_enabled.go
@@ -1,0 +1,7 @@
+// +build force_small_arena
+//
+// See malloc.go.
+
+package runtime
+
+const forceSmallArena = 1


### PR DESCRIPTION
# Problem

Fixes #42612

Some embedded Linux platforms disable overcommit to reduce dynamic
behavior in the system. Go already uses 4MB arenas on 32-bit platforms,
but on 64-bit platforms the initial 64MB arena adds a steep cost to any
Go binary.

# Changes

* Add `force_small_arena` tag to allow users to opt into 4MB arenas.
* Reduce `heapAddrBits` when set so we don't use 512MB for L2.
* Make `const` logic marginally more sane.

# Regression testing

Default `logHeapArenaBytes` behavior before and after change:

| 64-bit | WASM | Windows | Before | After |   |
|--------|------|---------|--------|-------|---|
|      0 |    0 |       0 |     22 |    22 | ✔️ |
|      0 |    0 |       1 |     22 |    22 | ✔️ |
|      1 |    0 |       0 |     26 |    26 | ✔️ |
|      1 |    0 |       1 |     22 |    22 | ✔️ |
|      1 |    1 |       0 |     22 |    22 | ✔️ |

Default `heapAddrBits` behavior before and after change:

| 64-bit | MIPS | WASM | Windows | iOS Arm64 | Before | After |   |
|--------|------|------|---------|-----------|--------|-------|---|
|      0 |    0 |    0 |       0 |         0 |     32 |    32 | ✔️ |
|      0 |    0 |    0 |       1 |         0 |     32 |    32 | ✔️ |
|      0 |    1 |    0 |       0 |         0 |     31 |    31 | ✔️ |
|      0 |    1 |    0 |       1 |         0 |     31 |    31 | ✔️ |
|      1 |    0 |    0 |       0 |         0 |     48 |    48 | ✔️ |
|      1 |    0 |    0 |       0 |         1 |     33 |    33 | ✔️ |
|      1 |    0 |    0 |       1 |         0 |     48 |    48 | ✔️ |
|      1 |    0 |    1 |       0 |         0 |     32 |    32 | ✔️ |