### PR TITLE
internal/fmtsort: sort the unsafe pointers in map

### DIFF
--- a/src/internal/fmtsort/sort.go
+++ b/src/internal/fmtsort/sort.go
@@ -130,7 +130,7 @@ func compare(aVal, bVal reflect.Value) int {
 		default:
 			return -1
 		}
-	case reflect.Ptr:
+	case reflect.Ptr, reflect.UnsafePointer:
 		a, b := aVal.Pointer(), bVal.Pointer()
 		switch {
 		case a < b:


### PR DESCRIPTION
Currently storing keys that contain unsafe.
Pointer in a map could result inruntime panic when printing the map.
The root cause is that unsafe.Pointer is not comparable.

Fixes #42622.