### PR TITLE
cmd/go: permit wrongly rejected -Wl,-O... linker flags

### DIFF
--- a/src/cmd/go/internal/work/security.go
+++ b/src/cmd/go/internal/work/security.go
@@ -179,7 +179,7 @@ var validLinkerFlags = []*lazyregexp.Regexp{
 	re(`-Wl,-berok`),
 	re(`-Wl,-Bstatic`),
 	re(`-Wl,-Bsymbolic-functions`),
-	re(`-WL,-O([^@,\-][^,]*)?`),
+	re(`-Wl,-O([^@,\-][^,]*)?`),
 	re(`-Wl,-d[ny]`),
 	re(`-Wl,--disable-new-dtags`),
 	re(`-Wl,-e[=,][a-zA-Z0-9]*`),


### PR DESCRIPTION
A typo caused the validation rule to check against -WL,-O... which is
not a regular flag because the L should be lowercase as in the other
rules. This caused valid linker flags to be rejected and people had to
work around this by filtering their default flags that include, e.g.,
-Wl,-O1 for a simple link optimization.
Fix the typo that wrongly rejected -Wl,-O... but allowed a non-existing
-WL,-O flag.
