### PR TITLE
unicode/utf8: make accept_range comparison more readable

### DIFF
--- a/src/unicode/utf8/utf8.go
+++ b/src/unicode/utf8/utf8.go
@@ -393,14 +393,12 @@ func RuneCount(p []byte) int {
 			continue
 		}
 		accept := acceptRanges[x>>4]
-		if c := p[i+1]; c < accept.lo || accept.hi < c {
-			size = 1
-		} else if size == 2 {
-		} else if c := p[i+2]; c < locb || hicb < c {
-			size = 1
-		} else if size == 3 {
-		} else if c := p[i+3]; c < locb || hicb < c {
-			size = 1
+		for j := 1; j < size; j++ {
+			if c := p[i+j]; c < accept.lo || accept.hi < c {
+				size = 1
+				break
+			}
+			accept = acceptRange[0]
 		}
 		i += size
 	}
@@ -428,14 +426,12 @@ func RuneCountInString(s string) (n int) {
 			continue
 		}
 		accept := acceptRanges[x>>4]
-		if c := s[i+1]; c < accept.lo || accept.hi < c {
-			size = 1
-		} else if size == 2 {
-		} else if c := s[i+2]; c < locb || hicb < c {
-			size = 1
-		} else if size == 3 {
-		} else if c := s[i+3]; c < locb || hicb < c {
-			size = 1
+		for j := 1; j < size; j++ {
+			if c := s[i+j]; c < accept.lo || accept.hi < c {
+				size = 1
+				break
+			}
+			accept = acceptRange[0]
 		}
 		i += size
 	}
@@ -479,14 +475,11 @@ func Valid(p []byte) bool {
 			return false // Short or invalid.
 		}
 		accept := acceptRanges[x>>4]
-		if c := p[i+1]; c < accept.lo || accept.hi < c {
-			return false
-		} else if size == 2 {
-		} else if c := p[i+2]; c < locb || hicb < c {
-			return false
-		} else if size == 3 {
-		} else if c := p[i+3]; c < locb || hicb < c {
-			return false
+		for j := 1; j < size; j++ {
+			if c := p[i+j]; c < accept.lo || accept.hi < c {
+				return false
+			}
+			accept = acceptRange[0]
 		}
 		i += size
 	}
@@ -525,14 +518,11 @@ func ValidString(s string) bool {
 			return false // Short or invalid.
 		}
 		accept := acceptRanges[x>>4]
-		if c := s[i+1]; c < accept.lo || accept.hi < c {
-			return false
-		} else if size == 2 {
-		} else if c := s[i+2]; c < locb || hicb < c {
-			return false
-		} else if size == 3 {
-		} else if c := s[i+3]; c < locb || hicb < c {
-			return false
+		for j := 1; j < size; j++ {
+			if c := s[i+j]; c < accept.lo || accept.hi < c {
+				return false
+			}
+			accept = acceptRange[0]
 		}
 		i += size
 	}


### PR DESCRIPTION
Hello, the new code has the similar performance and the acceptRange comparison code is easier to read.
```
name                                 old time/op  new time/op  delta
RuneCountTenASCIIChars-4             12.4ns ± 1%  12.4ns ± 1%    ~     (p=0.307 n=8+8)
RuneCountTenJapaneseChars-4          42.6ns ± 1%  42.3ns ± 1%  -0.70%  (p=0.038 n=8+8)
RuneCountInStringTenASCIIChars-4     9.53ns ± 1%  9.54ns ± 1%    ~     (p=0.663 n=8+8)
RuneCountInStringTenJapaneseChars-4  42.4ns ± 1%  42.4ns ± 2%    ~     (p=0.732 n=8+8)
ValidTenASCIIChars-4                 10.4ns ± 0%  10.4ns ± 1%    ~     (p=0.755 n=8+7)
ValidTenJapaneseChars-4              37.1ns ± 2%  37.2ns ± 3%    ~     (p=0.761 n=8+7)
ValidStringTenASCIIChars-4           10.0ns ± 0%  10.1ns ± 1%    ~     (p=0.233 n=6+8)
ValidStringTenJapaneseChars-4        36.9ns ± 2%  36.6ns ± 1%    ~     (p=0.152 n=8+7)
```