### PR TITLE
debug/pe: support arm64 PE file

### DIFF
--- a/src/debug/pe/file.go
+++ b/src/debug/pe/file.go
@@ -86,7 +86,7 @@ func NewFile(r io.ReaderAt) (*File, error) {
 		return nil, err
 	}
 	switch f.FileHeader.Machine {
-	case IMAGE_FILE_MACHINE_UNKNOWN, IMAGE_FILE_MACHINE_ARMNT, IMAGE_FILE_MACHINE_AMD64, IMAGE_FILE_MACHINE_I386:
+	case IMAGE_FILE_MACHINE_UNKNOWN, IMAGE_FILE_MACHINE_ARMNT, IMAGE_FILE_MACHINE_ARM64, IMAGE_FILE_MACHINE_AMD64, IMAGE_FILE_MACHINE_I386:
 	default:
 		return nil, fmt.Errorf("Unrecognised COFF file header machine value of 0x%x.", f.FileHeader.Machine)
 	}
@@ -309,7 +309,7 @@ func (f *File) ImportedSymbols() ([]string, error) {
 		return nil, nil
 	}
 
-	pe64 := f.Machine == IMAGE_FILE_MACHINE_AMD64
+	pe64 := f.FileHeader.SizeOfOptionalHeader == OptionalHeader64Size
 
 	// grab the number of data directory entries
 	var dd_length uint32

--- a/src/debug/pe/pe.go
+++ b/src/debug/pe/pe.go
@@ -86,6 +86,9 @@ type OptionalHeader64 struct {
 	DataDirectory               [16]DataDirectory
 }
 
+// OptionalHeader64Size OptionalHeader64 struct size
+const OptionalHeader64Size = 240
+
 const (
 	IMAGE_FILE_MACHINE_UNKNOWN   = 0x0
 	IMAGE_FILE_MACHINE_AM33      = 0x1d3


### PR DESCRIPTION
This PR will support the parsing of PE files whose machine target is arm64
