### PR TITLE
doc: fix misspelling of “initialization” in diagnostics.html

### DIFF
--- a/doc/diagnostics.html
+++ b/doc/diagnostics.html
@@ -455,7 +455,7 @@ environmental variable is set accordingly.</p>
 each collection, summarizing the amount of memory collected
 and the length of the pause.</li>
 <li>GODEBUG=inittrace=1 prints a summary of execution time and memory allocation
-information for completed package initilization work.</li>
+information for completed package initialization work.</li>
 <li>GODEBUG=schedtrace=X prints scheduling events every X milliseconds.</li>
 </ul>
 


### PR DESCRIPTION
initilization -> initialization