### PR TITLE
encoding/xml: prevent multiple XMLNS attributes

### DIFF
--- a/src/encoding/xml/marshal.go
+++ b/src/encoding/xml/marshal.go
@@ -710,7 +710,7 @@ func (p *printer) writeStart(start *StartElement) error {
 	// Attributes
 	for _, attr := range start.Attr {
 		name := attr.Name
-		if name.Local == "" {
+		if name.Local == "" || (start.Name.Space != "" && name.Local == "xmlns" && name.Space == "") {
 			continue
 		}
 		p.WriteByte(' ')


### PR DESCRIPTION
Having multiple attributes of the same name is a violation of the XML
well-formedness rules. This patch does not fix every possible way this
could happen, but it does prevent marshaling from introducing such an
issue when a start token is encoded that contains both a Name attribute
with a namespace set and an xmlns attribute.

Fixes #42807