### PR TITLE
net/http/fcgi: eliminate race, keep request id until end of stdin 

### DIFF
--- a/src/net/http/fcgi/fcgi_test.go
+++ b/src/net/http/fcgi/fcgi_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 var sizeTests = []struct {
@@ -393,5 +394,57 @@ func TestResponseWriterSniffsContentType(t *testing.T) {
 				t.Errorf("got a Content-Type of %q; expected it to start with %q", got, tt.wantCT)
 			}
 		})
+	}
+}
+
+type signallingNopCloser struct {
+	io.Reader
+	closed chan bool
+}
+
+func (*signallingNopCloser) Write(buf []byte) (int, error) {
+	return len(buf), nil
+}
+
+func (rc *signallingNopCloser) Close() error {
+	close(rc.closed)
+	return nil
+}
+
+// Test whether server properly closes connection when processing slow
+// requests
+func TestSlowRequest(t *testing.T) {
+	pr, pw := io.Pipe()
+	go func(w io.Writer) {
+		for _, buf := range [][]byte{
+			streamBeginTypeStdin,
+			makeRecord(typeStdin, 1, nil),
+		} {
+			pw.Write(buf)
+			time.Sleep(100 * time.Millisecond)
+		}
+	}(pw)
+
+	rc := &signallingNopCloser{pr, make(chan bool)}
+	handlerDone := make(chan bool)
+
+	c := newChild(rc, http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		w.WriteHeader(200)
+		close(handlerDone)
+	}))
+	go c.serve()
+	defer c.cleanUp()
+
+	timeout := time.After(2 * time.Second)
+
+	<-handlerDone
+	select {
+	case <-rc.closed:
+		t.Log("FastCGI child closed connection")
+	case <-timeout:
+		t.Error("FastCGI child did not close socket after handling request")
 	}
 }


### PR DESCRIPTION
There was a race condition that could lead to child.serveRequest
removing the request ID before child.handleRequest had read the empty
FCGI_STDIN message that indicates end-of-stream which in turn could
lead to child.serveRequest blocking while trying to consume the
request body.

Now, we remove the request ID from within child.handleRequest after
the end of stdin has been detected, eliminating the race condition.

Since there are no more concurrent modifications/accesses
to child.requests, we remove the accompanying sync.Mutex.