### PR TITLE
strings: add AppendJoin function for strings.Builder

### DIFF
--- a/src/strings/builder.go
+++ b/src/strings/builder.go
@@ -123,3 +123,27 @@ func (b *Builder) WriteString(s string) (int, error) {
 	b.buf = append(b.buf, s...)
 	return len(s), nil
 }
+
+// AppendJoin joins the elements with the separator just like Join.
+// But instead of creating a new string result, it appends to the current Builder.
+// It returns the length of the joined string and a nil error.
+func (b *Builder) AppendJoin(elems []string, sep string) (int, error) {
+	switch len(elems) {
+	case 0:
+		return 0, nil
+	case 1:
+		return b.WriteString(elems[0])
+	}
+	n := len(sep) * (len(elems) - 1)
+	for _, e := range elems {
+		n += len(e)
+	}
+
+	b.Grow(n)
+	b.WriteString(elems[0])
+	for _, s := range elems[1:] {
+		b.WriteString(sep)
+		b.WriteString(s)
+	}
+	return n, nil
+}

--- a/src/strings/builder_test.go
+++ b/src/strings/builder_test.go
@@ -177,6 +177,18 @@ func TestBuilderWriteByte(t *testing.T) {
 	check(t, &b, "a\x00")
 }
 
+func TestBuilderAppendJoin(t *testing.T) {
+	var b Builder
+	if n, err := b.AppendJoin([]string{"123", "Go", "GoGo"}, "-"); err != nil {
+		t.Error(err)
+	} else {
+		if n != 11 {
+			t.Errorf("Got n=%d; want %d", n, 11)
+		}
+		check(t, &b, "123-Go-GoGo")
+	}
+}
+
 func TestBuilderAllocs(t *testing.T) {
 	// Issue 23382; verify that copyCheck doesn't force the
 	// Builder to escape and be heap allocated.


### PR DESCRIPTION
With the existing API, we have to call Join and then
Builder.WriteString to append a joined string to an existing Builder.

If AppendJoin is supported like in C#'s StringBuilder.AppendJoin, we can
avoid some extra allocation (Join creates a strings.Builder under the
hood).
