### PR TITLE
Adjust code position:(t.nextProtoOnce.Do(t.onceSetNextProtoDefaults))

### DIFF
--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -509,9 +509,21 @@ func (t *Transport) roundTrip(req *Request) (*Response, error) {
 		req.closeBody()
 		return nil, errors.New("http: nil Request.Header")
 	}
+	
+	if req.Method != "" && !validMethod(req.Method) {
+		req.closeBody()
+		return nil, fmt.Errorf("net/http: invalid method %q", req.Method)
+	}
+	if req.URL.Host == "" {
+		req.closeBody()
+		return nil, errors.New("http: no Host in request URL")
+	}
 	scheme := req.URL.Scheme
 	isHTTP := scheme == "http" || scheme == "https"
-	if isHTTP {
+	if !isHTTP {
+		req.closeBody()
+		return nil, badStringError("unsupported protocol scheme", scheme)
+	}else {
 		for k, vv := range req.Header {
 			if !httpguts.ValidHeaderFieldName(k) {
 				req.closeBody()
@@ -544,18 +556,6 @@ func (t *Transport) roundTrip(req *Request) (*Response, error) {
 		if err != nil {
 			return nil, err
 		}
-	}
-	if !isHTTP {
-		req.closeBody()
-		return nil, badStringError("unsupported protocol scheme", scheme)
-	}
-	if req.Method != "" && !validMethod(req.Method) {
-		req.closeBody()
-		return nil, fmt.Errorf("net/http: invalid method %q", req.Method)
-	}
-	if req.URL.Host == "" {
-		req.closeBody()
-		return nil, errors.New("http: no Host in request URL")
 	}
 
 	for {

--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -500,10 +500,7 @@ func (t *Transport) alternateRoundTripper(req *Request) RoundTripper {
 
 // roundTrip implements a RoundTripper over HTTP.
 func (t *Transport) roundTrip(req *Request) (*Response, error) {
-	t.nextProtoOnce.Do(t.onceSetNextProtoDefaults)
-	ctx := req.Context()
-	trace := httptrace.ContextClientTrace(ctx)
-
+	
 	if req.URL == nil {
 		req.closeBody()
 		return nil, errors.New("http: nil Request.URL")
@@ -528,7 +525,12 @@ func (t *Transport) roundTrip(req *Request) (*Response, error) {
 			}
 		}
 	}
+	
+	t.nextProtoOnce.Do(t.onceSetNextProtoDefaults)
+	ctx := req.Context()
+	trace := httptrace.ContextClientTrace(ctx)
 
+	
 	origReq := req
 	cancelKey := cancelKey{origReq}
 	req = setupRewindBody(req)


### PR DESCRIPTION
Modify and adjust the code position here. The content of t.oncesetnext protodefaults is not related to the req judgment, so as to avoid the execution of req and scheme & header verification failure sync.noe The problem of
Code:
```
t.nextProtoOnce.Do(t.onceSetNextProtoDefaults)
ctx := req.Context()
trace := httptrace.ContextClientTrace(ctx)

origReq := req
...
```
req.Method & req.URL.Host &! is ishttp allowed to be judged in front of it? Does this method mean that it supports HTTP protocol? Can it be changed like this?(<https://github.com/golang/go/pull/42869>)

Code:
```
func (t *Transport) roundTrip(req *Request) (*Response, error) {
	if req.URL == nil {
		req.closeBody()
		return nil, errors.New("http: nil Request.URL")
	}
	if req.Header == nil {
		req.closeBody()
		return nil, errors.New("http: nil Request.Header")
	}

	if req.Method != "" && !validMethod(req.Method) {
		req.closeBody()
		return nil, fmt.Errorf("net/http: invalid method %q", req.Method)
	}
	if req.URL.Host == "" {
		req.closeBody()
		return nil, errors.New("http: no Host in request URL")
	}
	scheme := req.URL.Scheme
	isHTTP := scheme == "http" || scheme == "https"
	if !isHTTP {
		req.closeBody()
		return nil, badStringError("unsupported protocol scheme", scheme)
	} else {
		for k, vv := range req.Header {
			if !httpguts.ValidHeaderFieldName(k) {
				req.closeBody()
				return nil, fmt.Errorf("net/http: invalid header field name %q", k)
			}
			for _, v := range vv {
				if !httpguts.ValidHeaderFieldValue(v) {
					req.closeBody()
					return nil, fmt.Errorf("net/http: invalid header field value %q for key %v", v, k)
				}
			}
		}
	}

	t.nextProtoOnce.Do(t.onceSetNextProtoDefaults)
	ctx := req.Context()
	trace := httptrace.ContextClientTrace(ctx)
        ...

}
```