### PR TITLE
net/http/fcgi: make test message adhere to FastCGI spec

### DIFF
--- a/src/net/http/fcgi/fcgi_test.go
+++ b/src/net/http/fcgi/fcgi_test.go
@@ -293,8 +293,8 @@ var streamFullRequestStdin = bytes.Join([][]byte{
 	makeRecord(typeParams, 1, nil),
 	// begin sending body of request
 	makeRecord(typeStdin, 1, []byte("0123456789abcdef")),
-	// end request
-	makeRecord(typeEndRequest, 1, nil),
+	makeRecord(typeStdin, 1, nil),
+	// request ends on empty stdin message
 },
 	nil)
 


### PR DESCRIPTION
According to the FastCGI specification, FCGI_END_REQUEST is only ever sent
from the application to the web server. The web server indicates the
end of its request with an empty FCGI_STDIN message.