### PR TITLE
cmd/go/internal/lockedfile: ignore errors if locks are not supported

### DIFF
--- a/src/cmd/go/internal/lockedfile/internal/filelock/filelock_windows.go
+++ b/src/cmd/go/internal/lockedfile/internal/filelock/filelock_windows.go
@@ -58,7 +58,7 @@ func unlock(f File) error {
 
 func isNotSupported(err error) bool {
 	switch err {
-	case windows.ERROR_NOT_SUPPORTED, windows.ERROR_CALL_NOT_IMPLEMENTED, ErrNotSupported:
+	case windows.ERROR_INVALID_FUNCTION, windows.ERROR_NOT_SUPPORTED, windows.ERROR_CALL_NOT_IMPLEMENTED, ErrNotSupported:
 		return true
 	default:
 		return false

--- a/src/cmd/go/internal/lockedfile/lockedfile_filelock.go
+++ b/src/cmd/go/internal/lockedfile/lockedfile_filelock.go
@@ -31,7 +31,7 @@ func openFile(name string, flag int, perm fs.FileMode) (*os.File, error) {
 	default:
 		err = filelock.RLock(f)
 	}
-	if err != nil {
+	if err != nil && !filelock.IsNotSupported(err) {
 		f.Close()
 		return nil, err
 	}

--- a/src/internal/syscall/windows/syscall_windows.go
+++ b/src/internal/syscall/windows/syscall_windows.go
@@ -36,6 +36,7 @@ func UTF16PtrToString(p *uint16) string {
 }
 
 const (
+	ERROR_INVALID_FUNCTION       syscall.Errno = 1
 	ERROR_SHARING_VIOLATION      syscall.Errno = 32
 	ERROR_LOCK_VIOLATION         syscall.Errno = 33
 	ERROR_NOT_SUPPORTED          syscall.Errno = 50


### PR DESCRIPTION
Some file systems do not support file locking.
Ignore lock errors in these environments.
I used the already implemented IsNotSupported function.

If the file system does not support locking on Windows,
ERROR_INVALID_FUNCTION is returned.
Edited isNotSupported to ignore this.

References #37461