### PR TITLE
go/doc: avoid panic on references to functions with no body

### DIFF
--- a/src/go/doc/example.go
+++ b/src/go/doc/example.go
@@ -237,7 +237,10 @@ func playExample(file *ast.File, f *ast.FuncDecl) *ast.File {
 				}
 			}
 
-			ast.Inspect(d.Body, inspectFunc)
+			// Functions might not have a body. See #42706.
+			if d.Body != nil {
+				ast.Inspect(d.Body, inspectFunc)
+			}
 		case *ast.GenDecl:
 			for _, spec := range d.Specs {
 				switch s := spec.(type) {

--- a/src/go/doc/example_test.go
+++ b/src/go/doc/example_test.go
@@ -354,21 +354,20 @@ func main() {
 
 const exampleWholeFileExternalFunction = `package foo_test
 
-func foo(x int)
+func foo(int)
 
 func Example() {
-	foo(42) // External function reference
-	fmt.Println("Hello, world!")
-	// Output: Hello, world!
+	foo(42)
+	// Output:
 }
 `
 
 const exampleWholeFileExternalFunctionOutput = `package main
 
-func foo(x int)
+func foo(int)
 
 func main() {
-	fmt.Println("Hello, world!")
+	foo(42)
 }
 `
 
@@ -391,7 +390,7 @@ var exampleWholeFileTestCases = []struct {
 		"ExternalFunction",
 		exampleWholeFileExternalFunction,
 		exampleWholeFileExternalFunctionOutput,
-		"Hello, world!\n",
+		"",
 	},
 }
 

--- a/src/go/doc/example_test.go
+++ b/src/go/doc/example_test.go
@@ -352,6 +352,26 @@ func main() {
 }
 `
 
+const exampleWholeFileExternalFunction = `package foo_test
+
+func foo(x int)
+
+func Example() {
+	foo(42) // External function reference
+	fmt.Println("Hello, world!")
+	// Output: Hello, world!
+}
+`
+
+const exampleWholeFileExternalFunctionOutput = `package main
+
+func foo(x int)
+
+func main() {
+	fmt.Println("Hello, world!")
+}
+`
+
 var exampleWholeFileTestCases = []struct {
 	Title, Source, Play, Output string
 }{
@@ -365,6 +385,12 @@ var exampleWholeFileTestCases = []struct {
 		"Function",
 		exampleWholeFileFunction,
 		exampleWholeFileFunctionOutput,
+		"Hello, world!\n",
+	},
+	{
+		"ExternalFunction",
+		exampleWholeFileExternalFunction,
+		exampleWholeFileExternalFunctionOutput,
 		"Hello, world!\n",
 	},
 }


### PR DESCRIPTION
This change guards a call to ast.Inspect with a nil check on the first
argument. This avoids a panic when inspecting a reference to a function
with a nil body. This can only happen when a function body is defined outside Go.

Fixes #42706