### PR TITLE
net/http: attempt deadlock fix in TestDisableKeepAliveUpgrade

### DIFF
--- a/src/net/http/response.go
+++ b/src/net/http/response.go
@@ -361,7 +361,12 @@ func (r *Response) isProtocolSwitch() bool {
 // isProtocolSwitchResponse reports whether the response code and
 // response header indicate a successful protocol upgrade response.
 func isProtocolSwitchResponse(code int, h Header) bool {
-	return code == StatusSwitchingProtocols &&
-		h.Get("Upgrade") != "" &&
+	return code == StatusSwitchingProtocols && isProtocolSwitchHeader(h)
+}
+
+// isProtocolSwitchHeader reports whether the request or response header
+// is for a protocol switch.
+func isProtocolSwitchHeader(h Header) bool {
+	return h.Get("Upgrade") != "" &&
 		httpguts.HeaderValuesContainsToken(h["Connection"], "Upgrade")
 }

--- a/src/net/http/serve_test.go
+++ b/src/net/http/serve_test.go
@@ -6481,6 +6481,10 @@ func TestDisableKeepAliveUpgrade(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != StatusSwitchingProtocols {
+		t.Fatalf("unexpected status code: %v", resp.StatusCode)
+	}
+
 	rwc, ok := resp.Body.(io.ReadWriteCloser)
 	if !ok {
 		t.Fatalf("Response.Body is not a io.ReadWriteCloser: %T", resp.Body)

--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -2564,7 +2564,9 @@ func (pc *persistConn) roundTrip(req *transportRequest) (resp *Response, err err
 		continueCh = make(chan struct{}, 1)
 	}
 
-	if pc.t.DisableKeepAlives && !req.wantsClose() {
+	if pc.t.DisableKeepAlives &&
+		!req.wantsClose() &&
+		!isProtocolSwitchHeader(req.Header) {
 		req.extraHeaders().Set("Connection", "close")
 	}
 


### PR DESCRIPTION
1. The test now checks the response status code.
2. The transport has been changed to not set "Connection: Close" if
   DisableKeepAlive is set and the request is a HTTP/1.1 protocol
   upgrade.

Updates #43073
