### PR TITLE
cmd/go: fix non-script staleness checks interacting badly with GOFLAGS

### DIFF
--- a/src/cmd/go/go_test.go
+++ b/src/cmd/go/go_test.go
@@ -216,6 +216,7 @@ func TestMain(m *testing.M) {
 	}
 	// Don't let these environment variables confuse the test.
 	os.Setenv("GOENV", "off")
+	os.Unsetenv("GOFLAGS")
 	os.Unsetenv("GOBIN")
 	os.Unsetenv("GOPATH")
 	os.Unsetenv("GIT_ALLOW_PROTOCOL")


### PR DESCRIPTION
Fixes #43012.
