### PR TITLE
database/sql,net,net/http,os/exec: Replace ctx.Done() with ctx.Err()

### DIFF
--- a/src/database/sql/ctxutil.go
+++ b/src/database/sql/ctxutil.go
@@ -16,11 +16,9 @@ func ctxDriverPrepare(ctx context.Context, ci driver.Conn, query string) (driver
 	}
 	si, err := ci.Prepare(query)
 	if err == nil {
-		select {
-		default:
-		case <-ctx.Done():
+		if err := ctx.Err(); err != nil {
 			si.Close()
-			return nil, ctx.Err()
+			return nil, err
 		}
 	}
 	return si, err
@@ -35,11 +33,10 @@ func ctxDriverExec(ctx context.Context, execerCtx driver.ExecerContext, execer d
 		return nil, err
 	}
 
-	select {
-	default:
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
+
 	return execer.Exec(query, dargs)
 }
 
@@ -52,11 +49,10 @@ func ctxDriverQuery(ctx context.Context, queryerCtx driver.QueryerContext, query
 		return nil, err
 	}
 
-	select {
-	default:
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
+
 	return queryer.Query(query, dargs)
 }
 
@@ -69,11 +65,10 @@ func ctxDriverStmtExec(ctx context.Context, si driver.Stmt, nvdargs []driver.Nam
 		return nil, err
 	}
 
-	select {
-	default:
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
+
 	return si.Exec(dargs)
 }
 
@@ -86,11 +81,10 @@ func ctxDriverStmtQuery(ctx context.Context, si driver.Stmt, nvdargs []driver.Na
 		return nil, err
 	}
 
-	select {
-	default:
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
+
 	return si.Query(dargs)
 }
 
@@ -123,14 +117,14 @@ func ctxDriverBegin(ctx context.Context, opts *TxOptions, ci driver.Conn) (drive
 	}
 
 	txi, err := ci.Begin()
+
 	if err == nil {
-		select {
-		default:
-		case <-ctx.Done():
+		if err := ctx.Err(); err != nil {
 			txi.Rollback()
-			return nil, ctx.Err()
+			return nil, err
 		}
 	}
+
 	return txi, err
 }
 

--- a/src/database/sql/fakedb_test.go
+++ b/src/database/sql/fakedb_test.go
@@ -772,10 +772,8 @@ func (s *fakeStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (d
 		time.Sleep(s.wait)
 	}
 
-	select {
-	default:
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	db := s.c.db

--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -2170,7 +2170,7 @@ func (tx *Tx) Commit() error {
 		if atomic.LoadInt32(&tx.done) == 1 {
 			return ErrTxDone
 		}
-		return tx.ctx.Err()
+		return err
 	}
 
 	if !atomic.CompareAndSwapInt32(&tx.done, 0, 1) {

--- a/src/database/sql/sql_test.go
+++ b/src/database/sql/sql_test.go
@@ -337,14 +337,16 @@ func TestQueryContext(t *testing.T) {
 		got = append(got, r)
 		index++
 	}
-	select {
-	case <-ctx.Done():
-		if err := ctx.Err(); err != context.Canceled {
-			t.Fatalf("context err = %v; want context.Canceled", err)
-		}
-	default:
+
+	switch err := ctx.Err(); err {
+	case nil:
 		t.Fatalf("context err = nil; want context.Canceled")
+	default:
+		t.Fatalf("context err = %v; want context.Canceled", err)
+	case context.Canceled:
+		// expected context.Canceled
 	}
+
 	want := []row{
 		{age: 1, name: "Alice"},
 		{age: 2, name: "Bob"},
@@ -2957,10 +2959,9 @@ func TestIssue20575(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	select {
-	default:
-	case <-ctx.Done():
-		t.Fatal("timeout: failed to rollback query without closing rows:", ctx.Err())
+
+	if err := ctx.Err(); err != nil {
+		t.Fatal("timeout: failed to rollback query without closing rows:", err)
 	}
 }
 

--- a/src/database/sql/sql_test.go
+++ b/src/database/sql/sql_test.go
@@ -338,13 +338,8 @@ func TestQueryContext(t *testing.T) {
 		index++
 	}
 
-	switch err := ctx.Err(); err {
-	case nil:
-		t.Fatalf("context err = nil; want context.Canceled")
-	default:
+	if err := ctx.Err(); err != context.Cancelled {
 		t.Fatalf("context err = %v; want context.Canceled", err)
-	case context.Canceled:
-		// expected context.Canceled
 	}
 
 	want := []row{

--- a/src/net/dial.go
+++ b/src/net/dial.go
@@ -525,10 +525,8 @@ func (sd *sysDialer) dialSerial(ctx context.Context, ras addrList) (Conn, error)
 	var firstErr error // The error from the first address is most relevant.
 
 	for i, ra := range ras {
-		select {
-		case <-ctx.Done():
-			return nil, &OpError{Op: "dial", Net: sd.network, Source: sd.LocalAddr, Addr: ra, Err: mapErr(ctx.Err())}
-		default:
+		if err := ctx.Err(); err != nil {
+			return nil, &OpError{Op: "dial", Net: sd.network, Source: sd.LocalAddr, Addr: ra, Err: mapErr(err)}
 		}
 
 		dialCtx := ctx

--- a/src/net/fd_unix.go
+++ b/src/net/fd_unix.go
@@ -60,10 +60,8 @@ func (fd *netFD) connect(ctx context.Context, la, ra syscall.Sockaddr) (rsa sysc
 	switch err := connectFunc(fd.pfd.Sysfd, ra); err {
 	case syscall.EINPROGRESS, syscall.EALREADY, syscall.EINTR:
 	case nil, syscall.EISCONN:
-		select {
-		case <-ctx.Done():
-			return nil, mapErr(ctx.Err())
-		default:
+		if err := ctx.Err(); err != nil {
+			return nil, mapErr(err)
 		}
 		if err := fd.pfd.Init(fd.net, true); err != nil {
 			return nil, err
@@ -140,10 +138,8 @@ func (fd *netFD) connect(ctx context.Context, la, ra syscall.Sockaddr) (rsa sysc
 		// succeeded or failed. See issue 7474 for further
 		// details.
 		if err := fd.pfd.WaitWrite(); err != nil {
-			select {
-			case <-ctx.Done():
-				return nil, mapErr(ctx.Err())
-			default:
+			if err := ctx.Err(); err != nil {
+				return nil, mapErr(err)
 			}
 			return nil, err
 		}

--- a/src/net/http/serve_test.go
+++ b/src/net/http/serve_test.go
@@ -4794,10 +4794,8 @@ func testServerRequestContextCancel_ServeHTTPDone(t *testing.T, h2 bool) {
 	ctxc := make(chan context.Context, 1)
 	cst := newClientServerTest(t, h2, HandlerFunc(func(w ResponseWriter, r *Request) {
 		ctx := r.Context()
-		select {
-		case <-ctx.Done():
+		if ctx.Err() != nil {
 			t.Error("should not be Done in ServeHTTP")
-		default:
 		}
 		ctxc <- ctx
 	}))
@@ -4808,9 +4806,7 @@ func testServerRequestContextCancel_ServeHTTPDone(t *testing.T, h2 bool) {
 	}
 	res.Body.Close()
 	ctx := <-ctxc
-	select {
-	case <-ctx.Done():
-	default:
+	if ctx.Err() != nil {
 		t.Error("context should be done after ServeHTTP completes")
 	}
 }
@@ -5850,10 +5846,8 @@ func TestServerHijackGetsBackgroundByte(t *testing.T) {
 			t.Errorf("Peek = %q, %v; want foo, nil", peek, err)
 		}
 
-		select {
-		case <-r.Context().Done():
+		if r.Context().Err() != nil {
 			t.Error("context unexpectedly canceled")
-		default:
 		}
 	}))
 	defer ts.Close()

--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -557,11 +557,9 @@ func (t *Transport) roundTrip(req *Request) (*Response, error) {
 	}
 
 	for {
-		select {
-		case <-ctx.Done():
+		if ctx.Err() != nil {
 			req.closeBody()
 			return nil, ctx.Err()
-		default:
 		}
 
 		// treq gets modified by roundTrip, so we need to recreate for each retry.

--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -557,9 +557,9 @@ func (t *Transport) roundTrip(req *Request) (*Response, error) {
 	}
 
 	for {
-		if ctx.Err() != nil {
+		if err := ctx.Err(); err != nil {
 			req.closeBody()
-			return nil, ctx.Err()
+			return nil, err
 		}
 
 		// treq gets modified by roundTrip, so we need to recreate for each retry.

--- a/src/net/lookup.go
+++ b/src/net/lookup.go
@@ -243,12 +243,10 @@ var _ context.Context = (*onlyValuesCtx)(nil)
 
 // Value performs a lookup if the original context hasn't expired.
 func (ovc *onlyValuesCtx) Value(key interface{}) interface{} {
-	select {
-	case <-ovc.lookupValues.Done():
+	if ovc.lookupValues.Err() != nil {
 		return nil
-	default:
-		return ovc.lookupValues.Value(key)
 	}
+	return ovc.lookupValues.Value(key)
 }
 
 // withUnexpiredValuesPreserved returns a context.Context that only uses lookupCtx

--- a/src/os/exec/exec.go
+++ b/src/os/exec/exec.go
@@ -391,14 +391,10 @@ func (c *Cmd) Start() error {
 	if c.Process != nil {
 		return errors.New("exec: already started")
 	}
-	if c.ctx != nil {
-		select {
-		case <-c.ctx.Done():
-			c.closeDescriptors(c.closeAfterStart)
-			c.closeDescriptors(c.closeAfterWait)
-			return c.ctx.Err()
-		default:
-		}
+	if c.ctx != nil && c.ctx.Err() != nil {
+		c.closeDescriptors(c.closeAfterStart)
+		c.closeDescriptors(c.closeAfterWait)
+		return c.ctx.Err()
 	}
 
 	c.childFiles = make([]*os.File, 0, 3+len(c.ExtraFiles))


### PR DESCRIPTION
Prior to this commit, we performed non-blocking tests for cancellation
by receiving from ctx.Done() in a select block with a default label
like:

  select {
    case <-ctx.Done():
      // handle cancellation
    default:
  }

Unless we're multiplexing over multiple channels, a better way to test
if a context is canceled is to test the result of ctx.Err()

This commit replaces all of the select{} based non-blocking cancellation
checks with a call to ctx.Err().

The src/context BenchmarkCheckCanceled benchmark demonstrates that
calling ctx.Err() is faster and, in general, it is probably clearer to
simply check ctx.Err() than using a select block.