### PR TITLE
cmd/go: exclude empty cover package

### DIFF
--- a/src/cmd/go/internal/test/test.go
+++ b/src/cmd/go/internal/test/test.go
@@ -731,6 +731,11 @@ func runTest(ctx context.Context, cmd *base.Command, args []string) {
 				continue
 			}
 
+			// There is nothing to cover, just make building fail.
+			if len(p.GoFiles) == 0 && !p.UsesCgo() && !p.UsesSwig() {
+				continue
+			}
+
 			if haveMatch {
 				testCoverPkgs = append(testCoverPkgs, p)
 			}

--- a/src/cmd/go/testdata/script/test_cover_empty_issue43242.txt
+++ b/src/cmd/go/testdata/script/test_cover_empty_issue43242.txt
@@ -1,0 +1,10 @@
+go test -v -coverpkg=./... ./...
+
+-- go.mod --
+module test
+-- bar/bar.go --
+package bar
+-- bar/bar_test.go --
+package bar
+-- nogo/nogo_test.go --
+package nogo


### PR DESCRIPTION
Fixes #43242


