### PR TITLE
cmd/go: support go go gadget syntax

### DIFF
--- a/src/cmd/go/main.go
+++ b/src/cmd/go/main.go
@@ -90,6 +90,12 @@ func main() {
 	log.SetFlags(0)
 
 	args := flag.Args()
+
+	// go go gadget build
+	if len(args) >= 2 && args[0] == "go" && args[1] == "gadget" {
+		args = args[2:]
+	}
+
 	if len(args) < 1 {
 		base.Usage()
 	}


### PR DESCRIPTION
Supports `go go gadget` syntax.
`go go gadget build` is interpreted as `go build`