### PR TITLE
cmd/go: add the Retract field to 'go help mod edit' definition of the GoMod struct

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -1192,6 +1192,7 @@
 // 		Require []Require
 // 		Exclude []Module
 // 		Replace []Replace
+// 		Retract []Retract
 // 	}
 //
 // 	type Require struct {

--- a/src/cmd/go/internal/modcmd/edit.go
+++ b/src/cmd/go/internal/modcmd/edit.go
@@ -95,6 +95,7 @@ writing it back to go.mod. The JSON output corresponds to these Go types:
 		Require []Require
 		Exclude []Module
 		Replace []Replace
+		Retract []Retract
 	}
 
 	type Require struct {


### PR DESCRIPTION
Fixes #43281 