### PR TITLE
Add 'any' type as shorthand to interface{} for better code readability

### DIFF
--- a/src/builtin/builtin.go
+++ b/src/builtin/builtin.go
@@ -10,6 +10,9 @@
 */
 package builtin
 
+// any is an universal type, shorthand of interface{}
+type any interface{}
+
 // bool is the set of boolean values, true and false.
 type bool bool
 


### PR DESCRIPTION
It would be better if we allow programmers to use "any" instead of "interface{}" because it's quicker to type and has better common sense. For your information, this changes inspired from TypeScript which has "any" type, similar with golang's "interface{}".