### PR TITLE
net/smtp: Add 'From' header to smtp/example_test.go

### DIFF
--- a/src/net/smtp/example_test.go
+++ b/src/net/smtp/example_test.go
@@ -73,6 +73,7 @@ func ExampleSendMail() {
 	// and send the email all in one step.
 	to := []string{"recipient@example.net"}
 	msg := []byte("To: recipient@example.net\r\n" +
+		"From: sender@example.org\r\n" +
 		"Subject: discount Gophers!\r\n" +
 		"\r\n" +
 		"This is the email body.\r\n")


### PR DESCRIPTION
I was following the `ExampleSendMail` example to send mails, but it showed the error of `send mail error: 550 MIME message is missing 'From' header`. And I see the document of `smtp.SendMail`, it says 
> ... The msg headers should usually include fields such as "From", "To", "Subject", ...

And it works for me after I added the 'From' header in the msg.

Note: The SMTP server I used is SendGrid.
