### PR TITLE
net/http: fix 302 empty location header error

### DIFF
--- a/src/net/http/client.go
+++ b/src/net/http/client.go
@@ -500,7 +500,13 @@ func redirectBehavior(reqMethod string, resp *Response, ireq *Request) (redirect
 		redirectMethod = reqMethod
 		shouldRedirect = true
 		includeBody = false
-
+		if resp.Header.Get("Location") == "" {
+			shouldRedirect = false
+			break
+		}
+		if ireq.GetBody == nil && ireq.outgoingLength() != 0 {
+			shouldRedirect = false
+		}
 		// RFC 2616 allowed automatic redirection only with GET and
 		// HEAD requests. RFC 7231 lifts this restriction, but we still
 		// restrict other methods to GET to maintain compatibility.


### PR DESCRIPTION
We need to add a Location check for other redirection codes, otherwise in some cases it causes a fatal error.

Example:
```
package main

import (
	"fmt"
	"io/ioutil"
	"net/http"
)

func main() {
	/**
	index.php
		<?php
		http_response_code(302);
		?>
		<!DOCTYPE html>
		<html>
			<body>
				body
			</body>
		</html>
	**/
	resp, _ := http.Get("http://example.com")
	defer resp.Body.Close()
	body, _ := ioutil.ReadAll(resp.Body)
	fmt.Println(string(body))
}
```

And error:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x564a6681987e]

goroutine 1 [running]:
main.main
        /home/test2.go:23
exit status 2
```
