### PR TITLE
design: NewTickerStartingAt doc

### DIFF
--- a/src/time/example_test.go
+++ b/src/time/example_test.go
@@ -205,6 +205,26 @@ func ExampleNewTicker() {
 	}
 }
 
+func ExampleNewTickerRuntimeOffset() {
+	// Wait three seconds from the start of the runtime before ticking
+	ticker := time.NewTickerRuntimeOffset(time.Second, 3*time.Second)
+	defer ticker.Stop()
+	done := make(chan bool)
+	go func() {
+		time.Sleep(10 * time.Second)
+		done <- true
+	}()
+	for {
+		select {
+		case <-done:
+			fmt.Println("Done!")
+			return
+		case t := <-ticker.C:
+			fmt.Println("Current time: ", t)
+		}
+	}
+}
+
 func ExampleTime_Format() {
 	// Parse a time value from a string in the standard Unix format.
 	t, err := time.Parse(time.UnixDate, "Wed Feb 25 11:06:39 PST 2015")

--- a/src/time/example_test.go
+++ b/src/time/example_test.go
@@ -205,24 +205,33 @@ func ExampleNewTicker() {
 	}
 }
 
-func ExampleNewTickerRuntimeOffset() {
-	// Wait three seconds from the start of the runtime before ticking
-	ticker := time.NewTickerRuntimeOffset(time.Second, 3*time.Second)
-	defer ticker.Stop()
-	done := make(chan bool)
-	go func() {
-		time.Sleep(10 * time.Second)
-		done <- true
-	}()
-	for {
-		select {
-		case <-done:
-			fmt.Println("Done!")
-			return
-		case t := <-ticker.C:
-			fmt.Println("Current time: ", t)
-		}
-	}
+func ExampleNewTickerStartingAt() {
+        // A new ticker that marks every second and have the first tick fire now.
+        ticker := time.NewTickerStartingAt(time.Second, time.Now())
+        defer ticker.Stop()
+
+        // Another ticker that gives a count down starting at 5 seconds
+        countdown_ticker := time.NewTickerStartingAt(time.Second, time.Now().Add(5*time.Second))
+        defer countdown_ticker.Stop()
+
+        // Set our countdown to start at 5
+        countdown := 5
+
+        // Print a nice message after we reach the end
+        defer fmt.Println("-- done")
+
+        for {
+                select {
+                case <-countdown_ticker.C:
+                        if countdown == 0 {
+                                return
+                        }
+                        fmt.Println("Counting down...", countdown)
+                        countdown--
+                case t := <-ticker.C:
+                        fmt.Println("Current time: ", t)
+                }
+        }
 }
 
 func ExampleTime_Format() {

--- a/src/time/tick.go
+++ b/src/time/tick.go
@@ -40,6 +40,35 @@ func NewTicker(d Duration) *Ticker {
 	return t
 }
 
+// NewTickerRuntimeOffset returns a new Ticker containing a channel
+// that will send the time on the channel after each tick. The period
+// of the ticks is specified by the duration argument. The ticker
+// will adjust the time interval or drop ticks to make up for slow
+// receivers.  The duration d must be greater than zero; if not,
+// NewTicker will panic. The offset is the nanoseconds since the
+// process has started. Stop the ticker to release associated
+// resources.
+func NewTickerRuntimeOffset(d Duration, offset Duration) *Ticker {
+	if d <= 0 {
+		panic(errors.New("non-positive interval for NewTicker"))
+	}
+	// Give the channel a 1-element time buffer.
+	// If the client falls behind while reading, we drop ticks
+	// on the floor until the client catches up.
+	c := make(chan Time, 1)
+	t := &Ticker{
+		C: c,
+		r: runtimeTimer{
+			when:   startNano + int64(offset),
+			period: int64(d),
+			f:      sendTime,
+			arg:    c,
+		},
+	}
+	startTimer(&t.r)
+	return t
+}
+
 // Stop turns off a ticker. After Stop, no more ticks will be sent.
 // Stop does not close the channel, to prevent a concurrent goroutine
 // reading from the channel from seeing an erroneous "tick".

--- a/src/time/tick.go
+++ b/src/time/tick.go
@@ -40,19 +40,17 @@ func NewTicker(d Duration) *Ticker {
 	return t
 }
 
-// NewTickerStartingAt returns a new Ticker containing a channel
-// that will send the time on the channel after each tick. The period
-// of the ticks is specified by the duration argument. The ticker
-// will adjust the time interval or drop ticks to make up for slow
-// receivers.  The duration d must be greater than zero; if not,
-// NewTicker will panic, and start is the time for the first tick
-// to fire.
+// NewTickerStartingAt returns a new Ticker containing a channel that
+// will send a time.Time on the channel after each tick.  Duration
+// specifies the period of the ticks, and start specifies the initial
+// tick time.  The ticker will adjust the time interval or drop ticks
+// to make up for slow receivers.  The duration d must be greater than
+// zero; if not, NewTicker will panic, and start is the time for the
+// first tick to fire.
 //
-// Note: Since this method uses a duration to derive the time until
-// first tick, should the system get put to sleep or crosses a leap
-// second this time may be off by a second or more.  Also, of less
-// importance, the timer cannot be set greater than 2540400h10m10s
-// in the future. (Approximately 290 years)
+// Note: Since this method calculates the duration until the start--
+// should the system get put to sleep or crosses a leap second, this
+// time may be off by a second or more.
 //
 // Stop the ticker to release associated resources.
 func NewTickerStartingAt(d Duration, start Time) *Ticker {

--- a/src/time/tick.go
+++ b/src/time/tick.go
@@ -48,9 +48,11 @@ func NewTicker(d Duration) *Ticker {
 // NewTicker will panic, and start is the time for the first tick
 // to fire.
 //
-// Note: Since this method uses time.Sub to derive the first tick,
-// if the system is put to sleep or crosses a leap second this time
-// may be off by a second or more.
+// Note: Since this method uses a duration to derive the time until
+// first tick, should the system get put to sleep or crosses a leap
+// second this time may be off by a second or more.  Also, of less
+// importance, the timer cannot be set greater than 2540400h10m10s
+// in the future. (Approximately 290 years)
 //
 // Stop the ticker to release associated resources.
 func NewTickerStartingAt(d Duration, start Time) *Ticker {

--- a/src/time/tick.go
+++ b/src/time/tick.go
@@ -45,8 +45,8 @@ func NewTicker(d Duration) *Ticker {
 // of the ticks is specified by the duration argument. The ticker
 // will adjust the time interval or drop ticks to make up for slow
 // receivers.  The duration d must be greater than zero; if not,
-// NewTicker will panic. The offset is the nanoseconds since the
-// process has started. Stop the ticker to release associated
+// NewTicker will panic. The offset duration is the time to wait from 
+// the process start. Stop the ticker to release associated
 // resources.
 func NewTickerRuntimeOffset(d Duration, offset Duration) *Ticker {
 	if d <= 0 {

--- a/src/time/tick.go
+++ b/src/time/tick.go
@@ -40,33 +40,38 @@ func NewTicker(d Duration) *Ticker {
 	return t
 }
 
-// NewTickerRuntimeOffset returns a new Ticker containing a channel
+// NewTickerStartingAt returns a new Ticker containing a channel
 // that will send the time on the channel after each tick. The period
 // of the ticks is specified by the duration argument. The ticker
 // will adjust the time interval or drop ticks to make up for slow
 // receivers.  The duration d must be greater than zero; if not,
-// NewTicker will panic. The offset duration is the time to wait from 
-// the process start. Stop the ticker to release associated
-// resources.
-func NewTickerRuntimeOffset(d Duration, offset Duration) *Ticker {
-	if d <= 0 {
-		panic(errors.New("non-positive interval for NewTicker"))
-	}
-	// Give the channel a 1-element time buffer.
-	// If the client falls behind while reading, we drop ticks
-	// on the floor until the client catches up.
-	c := make(chan Time, 1)
-	t := &Ticker{
-		C: c,
-		r: runtimeTimer{
-			when:   startNano + int64(offset),
-			period: int64(d),
-			f:      sendTime,
-			arg:    c,
-		},
-	}
-	startTimer(&t.r)
-	return t
+// NewTicker will panic, and start is the time for the first tick
+// to fire.
+//
+// Note: Since this method uses time.Sub to derive the first tick,
+// if the system is put to sleep or crosses a leap second this time
+// may be off by a second or more.
+//
+// Stop the ticker to release associated resources.
+func NewTickerStartingAt(d Duration, start Time) *Ticker {
+        if d <= 0 {
+                panic(errors.New("non-positive interval for NewTicker"))
+        }
+        // Give the channel a 1-element time buffer.
+        // If the client falls behind while reading, we drop ticks
+        // on the floor until the client catches up.
+        c := make(chan Time, 1)
+        t := &Ticker{
+                C: c,
+                r: runtimeTimer{
+                        when:   startNano + int64(start.Sub(RuntimeStarted())),
+                        period: int64(d),
+                        f:      sendTime,
+                        arg:    c,
+                },
+        }
+        startTimer(&t.r)
+        return t
 }
 
 // Stop turns off a ticker. After Stop, no more ticks will be sent.

--- a/src/time/time.go
+++ b/src/time/time.go
@@ -1080,7 +1080,7 @@ var start_sec int64
 var start_nsec int32
 
 func init() {
-	// collect the start time for RuntimeStarted()
+	// Collect the start time for RuntimeStarted().
 	var start_mono int64
 	start_sec, start_nsec, start_mono = now()
 	start_nsec -= int32(start_mono - startNano)

--- a/src/time/time.go
+++ b/src/time/time.go
@@ -1076,19 +1076,23 @@ func Now() Time {
 	return Time{hasMonotonic | uint64(sec)<<nsecShift | uint64(nsec), mono, Local}
 }
 
-var start_sec, start_nsec, start_mono = now()
+var start_sec int64
+var start_nsec int32
 
-// Get the runtime start time.
-func RuntimeStarted() Time {
-	if start_mono != 0 {
-		start_nsec -= int32(start_mono - startNano)
-		if start_nsec < 0 {
-			start_sec--
-			start_nsec += 1e9
-		}
-		start_sec += unixToInternal - minWall
-		start_mono = 0
+func init() {
+	// collect the start time for RuntimeStarted()
+	var start_mono int64
+	start_sec, start_nsec, start_mono = now()
+	start_nsec -= int32(start_mono - startNano)
+	if start_nsec < 0 {
+		start_sec--
+		start_nsec += 1e9
 	}
+	start_sec += unixToInternal - minWall
+}
+
+// RuntimeStarted returns process start time.
+func RuntimeStarted() Time {
 	if uint64(start_sec)>>33 != 0 {
 		return Time{uint64(start_nsec), start_sec + minWall, Local}
 	}

--- a/src/time/time.go
+++ b/src/time/time.go
@@ -1078,8 +1078,8 @@ func Now() Time {
 
 var start_sec, start_nsec, start_mono = now()
 
-// Get the process start time.
-func Started() Time {
+// Get the runtime start time.
+func RuntimeStarted() Time {
 	if start_mono != 0 {
 		start_nsec -= int32(start_mono - startNano)
 		if start_nsec < 0 {


### PR DESCRIPTION
The function NewTicker has been limiting as often I create a new ticker that starts ticking at some arbitrary time.  As I build with go I found many times I was wrapping this timer call in an anonymous function with sleep; hence, I'd like to expose the interface to the underlying timer interface with both inputs of period duration and duration start for programming simplicity.

Getting the process start time, RuntimeStarted(), is useful to have as a way of easily looking up the runtime.  I know something similar can be created by storing this value via an init() function, but having a static value in the time library can be useful in many places. Such as metrics, and the NewTicker Runtime Start seen above, with a future start time, I can imagine doing a time.Sub() between the RuntimeStart and Now(), add an hour, to set the ticker to start an hour from now and run every N minutes.

For #43503