### PR TITLE
strings: add StripSlashes function for strings pkg

### DIFF
--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -1100,3 +1100,24 @@ func Index(s, substr string) int {
 	}
 	return -1
 }
+
+// Un-quotes a quoted string
+// Returns a string with backslashes stripped off. (\' becomes ' and so on.)
+// Double backslashes (\\) are made into a single backslash (\).
+func StripSlashes(str string) string {
+	var buf Builder
+	buf.Grow(len(str))
+	l, skip := len(str), false
+	for i, char := range str {
+		if skip {
+			skip = false
+		} else if char == '\\' {
+			if i+1 < l && str[i+1] == '\\' {
+				skip = true
+			}
+			continue
+		}
+		buf.WriteRune(char)
+	}
+	return buf.String()
+}

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -1593,7 +1593,7 @@ var SlashesTests = []struct {
 	},
 	{
 		s:   `"f\\'oo" and "b\\'ar"`,
-		t:   `"f\oo" and "b\ar"`,
+		t:   `"f\'oo" and "b\'ar"`,
 		out: true,
 	},
 	{
@@ -1605,9 +1605,9 @@ var SlashesTests = []struct {
 
 func TestStripSlashes(t *testing.T) {
 	for _, item := range SlashesTests {
-		outFlag := !StripSlashes(item.s, item.t)
-		if outFlag {
-			t.Errorf("StripSlashes(%#q, %#q) = %v, want %v", item.t, item.s, item.out, outFlag)
+		stripStr := StripSlashes(item.s)
+		if stripStr != item.t {
+			t.Errorf("StripSlashes(%#q) = %v, want %v", item.s, stripStr, item.t)
 		}
 	}
 }

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -1582,6 +1582,36 @@ func TestCount(t *testing.T) {
 	}
 }
 
+var SlashesTests = []struct {
+	s, t string
+	out  bool
+}{
+	{
+		s:   `Is your name O\'reilly?`,
+		t:   "Is your name O'reilly?",
+		out: true,
+	},
+	{
+		s:   `"f\\'oo" and "b\\'ar"`,
+		t:   `"f\oo" and "b\ar"`,
+		out: true,
+	},
+	{
+		s:   `\\\\1`,
+		t:   `\\1`,
+		out: true,
+	},
+}
+
+func TestStripSlashes(t *testing.T) {
+	for _, item := range SlashesTests {
+		outFlag := !StripSlashes(item.s, item.t)
+		if outFlag {
+			t.Errorf("StripSlashes(%#q, %#q) = %v, want %v", item.t, item.s, item.out, outFlag)
+		}
+	}
+}
+
 func makeBenchInputHard() string {
 	tokens := [...]string{
 		"<a>", "<p>", "<b>", "<strong>",

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -1583,31 +1583,27 @@ func TestCount(t *testing.T) {
 }
 
 var SlashesTests = []struct {
-	s, t string
-	out  bool
+	in, out string
 }{
 	{
-		s:   `Is your name O\'reilly?`,
-		t:   "Is your name O'reilly?",
-		out: true,
+		in:  `Is your name O\'reilly?`,
+		out: "Is your name O'reilly?",
 	},
 	{
-		s:   `"f\\'oo" and "b\\'ar"`,
-		t:   `"f\'oo" and "b\'ar"`,
-		out: true,
+		in:  `"f\\'oo" and "b\\'ar"`,
+		out: `"f\'oo" and "b\'ar"`,
 	},
 	{
-		s:   `\\\\1`,
-		t:   `\\1`,
-		out: true,
+		in:  `\\\\1`,
+		out: `\\1`,
 	},
 }
 
 func TestStripSlashes(t *testing.T) {
 	for _, item := range SlashesTests {
-		stripStr := StripSlashes(item.s)
-		if stripStr != item.t {
-			t.Errorf("StripSlashes(%#q) = %v, want %v", item.s, stripStr, item.t)
+		stripStr := StripSlashes(item.in)
+		if stripStr != item.out {
+			t.Errorf("StripSlashes(%#q) = %v, want %v", item.in, stripStr, item.out)
 		}
 	}
 }


### PR DESCRIPTION
Add a StripSlashes function , Un-quotes a quoted string.

Description：
Returns a string with backslashes stripped off. (' becomes ' and so on.)
Double backslashes (\) are made into a single backslash ().