### PR TITLE
math/rand: fix typo in comment

### DIFF
--- a/src/math/rand/gen_cooked.go
+++ b/src/math/rand/gen_cooked.go
@@ -4,7 +4,7 @@
 
 // +build ignore
 
-// This program computes the value of rng_cooked in rng.go,
+// This program computes the value of rngCooked in rng.go,
 // which is used for seeding all instances of rand.Source.
 // a 64bit and a 63bit version of the array is printed to
 // the standard output.


### PR DESCRIPTION
Fix a case of identifier `rngCooked` into lower camel case.

We do not have the variable of `rng_cooked` in golang. On the other hand, the `rngCooked` is defined [here](https://github.com/golang/go/blob/master/src/math/rand/rng.go#L24).