### PR TITLE
crypto/x509: accept certificate requests that are valid according to spec

### DIFF
--- a/src/crypto/x509/x509.go
+++ b/src/crypto/x509/x509.go
@@ -2479,7 +2479,7 @@ type tbsCertificateRequest struct {
 	Version       int
 	Subject       asn1.RawValue
 	PublicKey     publicKeyInfo
-	RawAttributes []asn1.RawValue `asn1:"tag:0"`
+	RawAttributes []asn1.RawValue `asn1:"optional,tag:0"`
 }
 
 type certificateRequest struct {


### PR DESCRIPTION
This change modifies Go to accept certificate requests that are valid according to spec,
by letting the set of attributes for certificate requests be optional.

Here's the mention of the attributes being optional:
https://tools.ietf.org/html/rfc2986#section-3

The change is in use in production at my current workplace and solved an issue where
a certificate request could not be parsed.

Please review that this change makes sense.