### PR TITLE
crypto/ecdsa: change hashToBytes to use copy instead of calling another function

### DIFF
--- a/src/crypto/ecdsa/ecdsa_s390x.go
+++ b/src/crypto/ecdsa/ecdsa_s390x.go
@@ -69,26 +69,26 @@ func hashToBytes(dst, hash []byte, c elliptic.Curve) {
 		panic("crypto/ecdsa: dst too small to fit value")
 	}
 
-	// figure out the excess bits between the hash size and order of the curve
-	pad := lenDst - orderBytes
-
 	// pad with zeros
+	pad := lenDst - orderBits/8
 	for i := 0; i <= pad; i++ {
 		dst[i] = 0
 	}
 
+	// figure out the excess bits between the hash size and order of the curve
+	excess := lenDst - orderBytes
+
 	// determine the shifts needed
-	shiftBits := ((orderBits - 1) % 8) + 1
-	truncateBits := (8 - shiftBits) % 8
+	truncateBits := ((orderBits - 1) % 8) + 1
+	shiftBits := (8 - truncateBits) % 8
 
 	// loop over the bytes fill in the dst values
 	carry := byte(0)
-	for i := orderBytes - 1; i >= 0; i-- {
-		dst[pad+i] = (hash[i] << shiftBits)
-		dst[pad+i] |= carry
-		carry = hash[i] >> truncateBits
+	for i := 0; i < orderBytes; i++ {
+		dst[excess+i] = (hash[i] >> shiftBits)
+		dst[excess+i] |= carry
+		carry = hash[i] << truncateBits
 	}
-	dst[pad-1] |= carry
 }
 
 func sign(priv *PrivateKey, csprng *cipher.StreamReader, c elliptic.Curve, hash []byte) (r, s *big.Int, err error) {

--- a/src/crypto/ecdsa/ecdsa_s390x.go
+++ b/src/crypto/ecdsa/ecdsa_s390x.go
@@ -69,14 +69,11 @@ func hashToBytes(dst, hash []byte, c elliptic.Curve) {
 		panic("crypto/ecdsa: dst too small to fit value")
 	}
 
-	// pad with zeros
-	pad := lenDst - orderBits/8
-	for i := 0; i <= pad; i++ {
-		dst[i] = 0
-	}
-
 	// figure out the excess bytes between the hash size and order of the curve
 	excess := lenDst - orderBytes
+	for i := 0; i < excess; i++ {
+		dst[i] = 0
+	}
 
 	// determine the shifts needed
 	truncateBits := ((orderBits - 1) % 8) + 1

--- a/src/crypto/ecdsa/ecdsa_s390x.go
+++ b/src/crypto/ecdsa/ecdsa_s390x.go
@@ -70,23 +70,25 @@ func hashToBytes(dst, hash []byte, c elliptic.Curve) {
 	}
 
 	// figure out the excess bits between the hash size and order of the curve
-	pad := lenDst - (orderBits / 8)
+	pad := lenDst - orderBytes
 
 	// pad with zeros
-	for i := 0; i < pad; i++ {
+	for i := 0; i <= pad; i++ {
 		dst[i] = 0
 	}
 
 	// determine the shifts needed
-	truncateBits := ((orderBits - 1) % 8) + 1
-	shiftBits := (8 - truncateBits) % 8
+	shiftBits := ((orderBits - 1) % 8) + 1
+	truncateBits := (8 - shiftBits) % 8
 
 	// loop over the bytes fill in the dst values
 	carry := byte(0)
 	for i := orderBytes - 1; i >= 0; i-- {
-		dst[pad+i] = (hash[i] << shiftBits) | carry
+		dst[pad+i] = (hash[i] << shiftBits)
+		dst[pad+i] |= carry
 		carry = hash[i] >> truncateBits
 	}
+	dst[pad-1] |= carry
 }
 
 func sign(priv *PrivateKey, csprng *cipher.StreamReader, c elliptic.Curve, hash []byte) (r, s *big.Int, err error) {

--- a/src/crypto/ecdsa/ecdsa_s390x.go
+++ b/src/crypto/ecdsa/ecdsa_s390x.go
@@ -75,7 +75,7 @@ func hashToBytes(dst, hash []byte, c elliptic.Curve) {
 		dst[i] = 0
 	}
 
-	// figure out the excess bits between the hash size and order of the curve
+	// figure out the excess bytes between the hash size and order of the curve
 	excess := lenDst - orderBytes
 
 	// determine the shifts needed


### PR DESCRIPTION
Resolve a TODO, remove a double function call