### PR TITLE
syscall/plan9: remove spooky fd action at a distance

### DIFF
--- a/src/syscall/exec_plan9.go
+++ b/src/syscall/exec_plan9.go
@@ -320,14 +320,15 @@ func cexecPipe(p []int) error {
 		return e
 	}
 
-	fd, e := Open("#d/"+itoa(p[1]), O_CLOEXEC)
+	fd, e := Open("#d/"+itoa(p[1]), O_RDWR|O_CLOEXEC)
 	if e != nil {
 		Close(p[0])
 		Close(p[1])
 		return e
 	}
 
-	Close(fd)
+	Close(p[1])
+	p[1] = fd
 	return nil
 }
 


### PR DESCRIPTION
Change Plan 9 fork/exec to use the O_CLOEXEC file
descriptor, instead of relying on spooky at a
distance.

Historically, Plan 9 has set the O_CLOEXEC flag on
the underlying channels in the kernel, rather
than the file descriptors -- if two fds pointed
at a single channel, as with dup, changing the
flags on one of them would be observable on the
other.

The per-Chan semantics are ok, if unexpected,
when a chan is only handled within a single
process, but this isn't always the case.

Forked processes share Chans, but even more of
a problem is the interaction between /srv and
OCEXEC, which can lead to unexectedly closed
file descriptors in completely unrelated
proceses. For example:

	func exists() bool {
		// If some other thread execs here,
		// we don't want to leak the fd, so
		// open it O_CLOEXEC
		fd := Open("/srv/foo", O_CLOEXEC)
		if fd != -1 {
			Close(fd)
			return true
		}
		return false
	}

would close the connection to any file descriptor
(maybe even for the root fs) in ALL other processes
that have it open if an exec were to happen(!),
which is quite undesriable.

As a result, 9front will be changing this behavior
for the next release.

Go is the only code observed so far that relies on
this behavior on purpose, and  It's easy to make the
code work with both semantics: simply using the file
descriptor that was opened with O_CEXEC instead of
throwing it away.

So we do that here.

Fixes #43524
