### PR TITLE
cmd/go: add -modversion flag setting main module version on debug.ReadBuildInfo

### DIFF
--- a/src/cmd/go/internal/base/flag.go
+++ b/src/cmd/go/internal/base/flag.go
@@ -67,5 +67,6 @@ func AddModFlag(flags *flag.FlagSet) {
 func AddModCommonFlags(flags *flag.FlagSet) {
 	flags.BoolVar(&cfg.ModCacheRW, "modcacherw", false, "")
 	flags.StringVar(&cfg.ModFile, "modfile", "", "")
+	flags.StringVar(&cfg.ModVersion, "modversion", "", "")
 	flags.StringVar(&fsys.OverlayFile, "overlay", "", "")
 }

--- a/src/cmd/go/internal/base/flag.go
+++ b/src/cmd/go/internal/base/flag.go
@@ -67,6 +67,5 @@ func AddModFlag(flags *flag.FlagSet) {
 func AddModCommonFlags(flags *flag.FlagSet) {
 	flags.BoolVar(&cfg.ModCacheRW, "modcacherw", false, "")
 	flags.StringVar(&cfg.ModFile, "modfile", "", "")
-	flags.StringVar(&cfg.ModVersion, "modversion", "", "")
 	flags.StringVar(&fsys.OverlayFile, "overlay", "", "")
 }

--- a/src/cmd/go/internal/cfg/cfg.go
+++ b/src/cmd/go/internal/cfg/cfg.go
@@ -50,6 +50,7 @@ var (
 
 	ModCacheRW bool   // -modcacherw flag
 	ModFile    string // -modfile flag
+	ModVersion string // -modversion flag
 
 	Insecure bool // -insecure flag
 

--- a/src/cmd/go/internal/modload/build.go
+++ b/src/cmd/go/internal/modload/build.go
@@ -275,7 +275,7 @@ func PackageBuildInfo(path string, deps []string) string {
 	writeEntry := func(token string, m module.Version) {
 		mv := m.Version
 		if mv == "" {
-			mv = "(devel)"
+			mv = cfg.ModVersion
 		}
 		fmt.Fprintf(&buf, "%s\t%s\t%s", token, m.Path, mv)
 		if r := Replacement(m); r.Path == "" {

--- a/src/cmd/go/internal/modload/init.go
+++ b/src/cmd/go/internal/modload/init.go
@@ -389,6 +389,7 @@ func LoadModFile(ctx context.Context) {
 
 	setDefaultBuildMod() // possibly enable automatic vendoring
 	modFileToBuildList()
+	setDefaultModVersion()
 	if cfg.BuildMod == "vendor" {
 		readVendorList()
 		checkVendorConsistency()
@@ -626,6 +627,15 @@ func setDefaultBuildMod() {
 	}
 
 	cfg.BuildMod = "readonly"
+}
+
+// setDefaultModVersion sets a default value for cfg.ModVersion if the -modversion flag
+// wasn't provided. setDefaultModVersion may be called multiple times.
+func setDefaultModVersion() {
+	if cfg.ModVersion == "" {
+		// we could attempt to infer mod version from VCS or common CI environments like BUILD_TAG
+		cfg.ModVersion = "(devel)"
+	}
 }
 
 // convertLegacyConfig imports module requirements from a legacy vendoring

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -275,6 +275,8 @@ func AddBuildFlags(cmd *base.Command, mask BuildFlagMask) {
 	cmd.Flag.Var(&load.BuildGccgoflags, "gccgoflags", "")
 	if mask&OmitModFlag == 0 {
 		base.AddModFlag(&cmd.Flag)
+		// Add the modversion flag only for build command, has no effect in fmt.
+		cmd.Flag.StringVar(&cfg.ModVersion, "modversion", "", "")
 	}
 	if mask&OmitModCommonFlags == 0 {
 		base.AddModCommonFlags(&cmd.Flag)

--- a/src/cmd/go/testdata/script/mod_modinfo_custom_version.txt
+++ b/src/cmd/go/testdata/script/mod_modinfo_custom_version.txt
@@ -1,0 +1,31 @@
+# Test to ensure runtime/debug.ReadBuildInfo parses
+# the correct version for the main module
+# when set from -modversion.
+env GO111MODULE=on
+
+cd x
+
+# Build the binary with a custom version and ensure that
+# the main module version is being set accordingly.
+# (golang.org/issue/29228)
+go build -modversion=custom_version
+exec ./x$GOEXE
+stderr 'mod\s+x\s+custom_version'
+
+-- x/go.mod --
+module x
+
+-- x/main.go --
+package main
+
+import (
+	"runtime/debug"
+)
+
+func main() {
+    m, ok := debug.ReadBuildInfo()
+	if !ok {
+		panic("failed debug.ReadBuildInfo")
+	}
+	println("mod", m.Main.Path, m.Main.Version)
+}


### PR DESCRIPTION
As discussed in #29228 currently it is required very hacky workarounds to get the version of the built binary.  
From my understanding the most used are variations of 'go build -ldflags="-X main.version=${version}"' and reading from the injected variable.

Currently building a binary using "go build" has a hardcoded "(devel)" version for the main module on the data for ReadBuildInfo. The program has to be installed from "go get" or "go install" in order for the version to be added.

This PR adds a "-modversion" to set the value for the main module version.