### PR TITLE
net/http: fix typo in comment

### DIFF
--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -145,7 +145,7 @@ type Request struct {
 	// then
 	//
 	//	Header = map[string][]string{
-	//		"Accept-Encoding": {"gzip, deflate"},
+	//		"Accept-Encoding": {"gzip", "deflate"},
 	//		"Accept-Language": {"en-us"},
 	//		"Foo": {"Bar", "two"},
 	//	}


### PR DESCRIPTION
Enclose the example words (`gzip` and `deflate`) in double quotes to represent a Go string type.