### PR TITLE
src/strings: strings.go -Enhance ContainsIn,EqualsIn to support optional strlist

### DIFF
--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -65,6 +65,16 @@ func ContainsIn(str string, strlist ...string) bool {
 	}
 	return false
 }
+// Similary to ContainsIn, exactly equalto
+func EqualsIn(str string, strlist ...string) bool {
+	for _, info := range strlist {
+		if strings.EqualFold(str, info) {
+			return true
+		}
+	}
+	return false
+}
+
 
 
 // Contains reports whether substr is within s.

--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -56,6 +56,16 @@ func Count(s, substr string) int {
 		s = s[i+len(substr):]
 	}
 }
+// Contains with optianal list of strings  ex. strings.ContainsIn("abcdef", "aa","bb","cc","d") => true
+func ContainsIn(str string, strlist ...string) bool {
+	for _, info := range strlist {
+		if strings.Contains(str, info) {
+			return true
+		}
+	}
+	return false
+}
+
 
 // Contains reports whether substr is within s.
 func Contains(s, substr string) bool {


### PR DESCRIPTION
 Enhance strings library to support contains of optional string list 

 ex. 
Original syntax :
strings.ContainsIn("abcdef","aa") ||
return strings.ContainsIn("abcdef","bb") ||
strings.ContainsIn("abcdef","cc") ||
strings.ContainsIn("abcdef","d")  => true

New Syntax :
strings.ContainsIn("abcdef", "aa","bb","cc","d")  => true
strings.ContainsIn("abcdef", "aa","bb","cc","dd")  => false

