### PR TITLE
io/ioutil: fix example test for WriteFile to allow it to run in the playground

### DIFF
--- a/src/io/ioutil/example_test.go
+++ b/src/io/ioutil/example_test.go
@@ -125,7 +125,7 @@ func ExampleReadFile() {
 
 func ExampleWriteFile() {
 	message := []byte("Hello, Gophers!")
-	err := ioutil.WriteFile("testdata/hello", message, 0644)
+	err := ioutil.WriteFile("hello", message, 0644)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
The example for WriteFile assumed the existence of a testdata/ directory, which is not present on the playground. The example now writes the file to the current working directory, rather than to testdata/.

Fixes #32916
