### PR TITLE
syscall/js: simplify if condition

### DIFF
--- a/src/syscall/js/js.go
+++ b/src/syscall/js/js.go
@@ -170,9 +170,8 @@ func ValueOf(x interface{}) Value {
 	case bool:
 		if x {
 			return valueTrue
-		} else {
-			return valueFalse
 		}
+		return valueFalse
 	case int:
 		return floatValue(float64(x))
 	case int8:


### PR DESCRIPTION
We simplify a if statement by dropping the else part and outdenting its block.