### PR TITLE
runtime/proc.go: add comment when schedule in the GC mark phase

### DIFF
--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -3103,6 +3103,7 @@ top:
 		}
 	}
 	if gp == nil && gcBlackenEnabled != 0 {
+		// we're in the GC mark phase, check if the P need to run background mark worker
 		gp = gcController.findRunnableGCWorker(_g_.m.p.ptr())
 		tryWakeP = tryWakeP || gp != nil
 	}


### PR DESCRIPTION
* add comment when schedule in the GC mark phase。 
* when schedule in the GC mark phase，check if the P need to run background mark worker.
* i add comment for clear description
