### PR TITLE
strconv/ftoa.go: add comment when format print float but Grisu3 algorithm failed

### DIFF
--- a/src/strconv/ftoa.go
+++ b/src/strconv/ftoa.go
@@ -120,6 +120,7 @@ func genericFtoa(dst []byte, val float64, fmt byte, prec, bitSize int) []byte {
 		digs.d = buf[:]
 		ok = f.ShortestDecimal(&digs, &lower, &upper)
 		if !ok {
+			// Grisu3 algorithm failed and switch to slower complete algorithm
 			return bigFtoa(dst, prec, fmt, neg, mant, exp, flt)
 		}
 		// Precision for shortest representation mode.


### PR DESCRIPTION
when format print float but Grisu3 algorithm failed, add comment  for clear description