### PR TITLE
cmd/link: disable TestPIESize if CGO isn't enabled

### DIFF
--- a/src/cmd/link/elf_test.go
+++ b/src/cmd/link/elf_test.go
@@ -226,6 +226,8 @@ func main() {
 
 func TestPIESize(t *testing.T) {
 	testenv.MustHaveGoBuild(t)
+	testenv.MustHaveCGO(t)
+
 	if !sys.BuildModeSupported(runtime.Compiler, "pie", runtime.GOOS, runtime.GOARCH) {
 		t.Skip("-buildmode=pie not supported")
 	}


### PR DESCRIPTION
With CGO disabled, the test throws the following error:
```
elf_test.go:291: # command-line-arguments
    loadinternal: cannot find runtime/cgo
```