### PR TITLE
cmd/link: disable TestPIESize if CGO isn't enabled

### DIFF
--- a/src/cmd/link/elf_test.go
+++ b/src/cmd/link/elf_test.go
@@ -226,6 +226,12 @@ func main() {
 
 func TestPIESize(t *testing.T) {
 	testenv.MustHaveGoBuild(t)
+
+	// We don't want to test -linkmode=external if cgo is not supported.
+	// On some systems -buildmode=pie implies -linkmode=external, so just
+	// always skip the test if cgo is not supported.
+	testenv.MustHaveCGO(t)
+
 	if !sys.BuildModeSupported(runtime.Compiler, "pie", runtime.GOOS, runtime.GOARCH) {
 		t.Skip("-buildmode=pie not supported")
 	}


### PR DESCRIPTION
With CGO disabled, the test throws the following error:

elf_test.go:291: # command-line-arguments
    loadinternal: cannot find runtime/cgo