### PR TITLE
cmd/go: skip issue33139 when the 'cc' script command is unavailable

### DIFF
--- a/src/cmd/go/testdata/script/link_syso_issue33139.txt
+++ b/src/cmd/go/testdata/script/link_syso_issue33139.txt
@@ -2,7 +2,7 @@
 # embedded in a package, that is referenced by a Go assembly function.
 # See issue 33139.
 [!gc] skip
-[!exec:cc] skip
+[!cgo] skip
 
 # External linking is not supported on linux/ppc64.
 # See: https://github.com/golang/go/issues/8912


### PR DESCRIPTION
With CGO disabled, the test suite tries to run the following and fail:

CGO_ENABLED=0 go test -run=TestScript/link_syso_issue33139 cmd/go
go test proxy running at GOPROXY=http://127.0.0.1:38829/mod
--- FAIL: TestScript (0.01s)
    --- FAIL: TestScript/link_syso_issue33139 (0.01s)
        script_test.go:215:
            # Test that we can use the external linker with a host syso file that is
            # embedded in a package, that is referenced by a Go assembly function.
            # See issue 33139. (0.000s)
            # External linking is not supported on linux/ppc64.
            # See: https://github.com/golang/go/issues/8912 (0.000s)
            # External linking is not supported on linux/riscv64.
            # See: https://github.com/golang/go/issues/36739 (0.001s)
            > [linux] [riscv64] skip
            > cc -c -o syso/objTestImpl.syso syso/src/objTestImpl.c
            FAIL: testdata/script/link_syso_issue33139.txt:15:
                unexpected error starting command:
                        fork/exec /dev/null: permission denied

CC was set to /dev/null (during build) in the scenario mentioned above

This patch replaces [!exec:cc] with [!cgo] because we care about the
availability of the 'cc' builtin and not the 'cc' executable in $PATH