### PR TITLE
doc/go1.16: fix closing brace in .Export format

### DIFF
--- a/doc/go1.16.html
+++ b/doc/go1.16.html
@@ -275,7 +275,7 @@ Do not send CLs removing the interior tags from such phrases.
   When the <code>-export</code> flag is specified, the <code>BuildID</code>
   field is now set to the build ID of the compiled package. This is equivalent
   to running <code>go</code> <code>tool</code> <code>buildid</code> on
-  <code>go</code> <code>list</code> <code>-exported</code> <code>-f</code> <code>{{.Export}</code>,
+  <code>go</code> <code>list</code> <code>-exported</code> <code>-f</code> <code>{{.Export}}</code>,
   but without the extra step.
 </p>
 


### PR DESCRIPTION
A parenthesis of go list "-f" flag format is double curly braces.