### PR TITLE
cmd/go: update PWD variable for 'go generate'

### DIFF
--- a/src/cmd/go/internal/generate/generate.go
+++ b/src/cmd/go/internal/generate/generate.go
@@ -334,6 +334,7 @@ func (g *Generator) setEnv() {
 		"GOPACKAGE=" + g.pkg,
 		"DOLLAR=" + "$",
 	}
+	g.env = base.AppendPWD(g.env, g.dir)
 }
 
 // split breaks the line into words, evaluating quoted
@@ -448,7 +449,7 @@ func (g *Generator) exec(words []string) {
 	cmd.Stderr = os.Stderr
 	// Run the command in the package directory.
 	cmd.Dir = g.dir
-	cmd.Env = base.AppendPWD(str.StringList(cfg.OrigEnv, g.env), cmd.Dir)
+	cmd.Env = str.StringList(cfg.OrigEnv, g.env)
 	err := cmd.Run()
 	if err != nil {
 		g.errorf("running %q: %s", words[0], err)

--- a/src/cmd/go/internal/generate/generate.go
+++ b/src/cmd/go/internal/generate/generate.go
@@ -448,7 +448,7 @@ func (g *Generator) exec(words []string) {
 	cmd.Stderr = os.Stderr
 	// Run the command in the package directory.
 	cmd.Dir = g.dir
-	cmd.Env = str.StringList(cfg.OrigEnv, g.env)
+	cmd.Env = base.AppendPWD(str.StringList(cfg.OrigEnv, g.env), cmd.Dir)
 	err := cmd.Run()
 	if err != nil {
 		g.errorf("running %q: %s", words[0], err)

--- a/src/cmd/go/testdata/script/generate.txt
+++ b/src/cmd/go/testdata/script/generate.txt
@@ -28,7 +28,7 @@ stdout 'main_test'
 
 # Test go generate provides the right "$PWD"
 go generate './generate/env_pwd.go'
-stdout $WORK'/gopath/src/generate'
+stdout $WORK'[/\\]gopath[/\\]src[/\\]generate'
 
 -- echo.go --
 package main

--- a/src/cmd/go/testdata/script/generate.txt
+++ b/src/cmd/go/testdata/script/generate.txt
@@ -26,6 +26,10 @@ stdout 'yes' # flag.go should select yes
 go generate './generate/env_test.go'
 stdout 'main_test'
 
+# Test go generate provides the right "$PWD"
+go generate './generate/env_pwd.go'
+stdout $WORK'/gopath/src/generate'
+
 -- echo.go --
 package main
 
@@ -89,3 +93,7 @@ package p
 package main_test
 
 //go:generate echo $GOPACKAGE
+-- generate/env_pwd.go --
+package p
+
+//go:generate echo $PWD


### PR DESCRIPTION
Most subprocess invocations in the go command use base.AppendPWD to
append an accurate value of PWD to the command's environment, which can
speed up calls like os.Getwd and also help to provide less-confusing
output from scripts. Update `go generate` to do so.

Fixes #43862