### PR TITLE
spec: improve the example in Type assertions section

### DIFF
--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -3400,7 +3400,12 @@ A type assertion used in an <a href="#Assignments">assignment</a> or initializat
 v, ok = x.(T)
 v, ok := x.(T)
 var v, ok = x.(T)
-var v, ok T1 = x.(T)
+
+var v, ok interface{} = x.(T)
+
+type v T
+type ok T1
+v, ok = x.(T) // type T1 is derived from interface{} or bool
 </pre>
 
 <p>

--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -1,6 +1,6 @@
 <!--{
 	"Title": "The Go Programming Language Specification",
-	"Subtitle": "Version of Oct 7, 2020",
+	"Subtitle": "Version of Feb 2, 2021",
 	"Path": "/ref/spec"
 }-->
 
@@ -3400,12 +3400,7 @@ A type assertion used in an <a href="#Assignments">assignment</a> or initializat
 v, ok = x.(T)
 v, ok := x.(T)
 var v, ok = x.(T)
-
-var v, ok interface{} = x.(T)
-
-type v T
-type ok T1
-v, ok = x.(T) // type T1 is derived from interface{} or bool
+var v, ok interface{} = x.(T) // dynamic types of v and ok are T and bool
 </pre>
 
 <p>


### PR DESCRIPTION
The example, var v, ok T1 = x.(T), can be interpreted as type T1 interface{} or type T = bool; type T1 = T.
Separating the example would help understanding for readers.