### PR TITLE
doc/go1.16: add missed heading tag in vet section

### DIFF
--- a/doc/go1.16.html
+++ b/doc/go1.16.html
@@ -364,6 +364,8 @@ func TestFoo(t *testing.T) {
 }
 </pre>
 
+<h4 id="vet-frame-pointer">New warning for frame pointer</h4>
+
 <p><!-- CL 248686, CL 276372 -->
   The vet tool now warns about amd64 assembly that clobbers the BP
   register (the frame pointer) without saving and restoring it,


### PR DESCRIPTION
Add missed heading tag in CL 276373.

For #40700