### PR TITLE
net/http: add new error type to be returned on unsuccessful CONNECT request

### DIFF
--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -1553,6 +1553,7 @@ type erringRoundTripper interface {
 	RoundTripErr() error
 }
 
+// ProxyConnectError holds the response to an unsuccessful proxy CONNECT request.
 type ProxyConnectError struct {
 	Response *Response
 }


### PR DESCRIPTION
Add new error type, ProxyConnectError, which is returned when the response
to a CONNECT request has a non 200 StatusCode; instead of returning text
from the Response.Status. The strings returned by ProxyConnectError.Error()
match that of the current error for backwards compatibility

Fixes #38143