### PR TITLE
net: report local address on unsuccessful TCP dial attempts

### DIFF
--- a/src/net/dial_test.go
+++ b/src/net/dial_test.go
@@ -827,8 +827,12 @@ func TestDialCancel(t *testing.T) {
 				t.Fatalf("dial error after %d ticks (%d before cancel sent): %v",
 					ticks, cancelTick-ticks, err)
 			}
-			if oe, ok := err.(*OpError); !ok || oe.Err != errCanceled {
+			oe, ok := err.(*OpError);
+			if !ok || oe.Err != errCanceled {
 				t.Fatalf("dial error = %v (%T); want OpError with Err == errCanceled", err, err)
+			}
+			if la, ok := oe.Source.(*TCPAddr); !ok || la == nil || la.Port == 0 {
+				t.Fatalf("dial error = %v (%T); expected Source (local address) details, got %#v", err, err, oe.Source)
 			}
 			return // success.
 		}

--- a/src/net/sock_posix.go
+++ b/src/net/sock_posix.go
@@ -68,8 +68,12 @@ func socket(ctx context.Context, net string, family, sotype, proto int, ipv6only
 		}
 	}
 	if err := fd.dial(ctx, laddr, raddr, ctrlFn); err != nil {
+		// get the local socket address for better error information,
+		// if available
+		lsa, _ := syscall.Getsockname(fd.pfd.Sysfd)
+		fd.setAddr(fd.addrFunc()(lsa), raddr)
 		fd.Close()
-		return nil, err
+		return fd, err
 	}
 	return fd, nil
 }

--- a/src/net/tcpsock_posix.go
+++ b/src/net/tcpsock_posix.go
@@ -96,7 +96,10 @@ func (sd *sysDialer) doDialTCP(ctx context.Context, laddr, raddr *TCPAddr) (*TCP
 	}
 
 	if err != nil {
-		return nil, err
+		// this TCP connection won't be used; it contains the laddr
+		// used in the failed connection attempt if there was one for
+		// better error information from net.Dial
+		return &TCPConn{conn{fd}}, err
 	}
 	return newTCPConn(fd), nil
 }


### PR DESCRIPTION
This can significantly help debugging network connection failures, as described in #44127.

Fixes #44127 