### PR TITLE
all: remove unneeded 'type="text/javascript"' from HTML script tag

### DIFF
--- a/src/cmd/compile/internal/ssa/html.go
+++ b/src/cmd/compile/internal/ssa/html.go
@@ -362,7 +362,7 @@ body.darkmode ellipse.outline-black { outline: gray solid 2px; }
 
 </style>
 
-<script type="text/javascript">
+<script>
 
 // Contains phase names which are expanded by default. Other columns are collapsed.
 let expandedDefault = [

--- a/src/cmd/trace/mmu.go
+++ b/src/cmd/trace/mmu.go
@@ -166,9 +166,9 @@ var templMMU = `<!doctype html>
 <html>
   <head>
     <meta charset="utf-8">
-    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
-    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-    <script type="text/javascript">
+    <script src="https://www.gstatic.com/charts/loader.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script>
       google.charts.load('current', {'packages':['corechart']});
       var chartsReady = false;
       google.charts.setOnLoadCallback(function() { chartsReady = true; refreshChart(); });

--- a/src/html/template/content_test.go
+++ b/src/html/template/content_test.go
@@ -184,7 +184,7 @@ func TestTypedContent(t *testing.T) {
 			},
 		},
 		{
-			`<script type="text/javascript">alert("{{.}}")</script>`,
+			`<script>alert("{{.}}")</script>`,
 			[]string{
 				`\u003cb\u003e \u0022foo%\u0022 O\u0027Reilly \u0026bar;`,
 				`a[href =~ \u0022\/\/example.com\u0022]#foo`,
@@ -199,7 +199,7 @@ func TestTypedContent(t *testing.T) {
 			},
 		},
 		{
-			`<script type="text/javascript">alert({{.}})</script>`,
+			`<script>alert({{.}})</script>`,
 			[]string{
 				`"\u003cb\u003e \"foo%\" O'Reilly \u0026bar;"`,
 				`"a[href =~ \"//example.com\"]#foo"`,

--- a/src/html/template/html_test.go
+++ b/src/html/template/html_test.go
@@ -59,7 +59,7 @@ func TestStripTags(t *testing.T) {
 		{"Foo <!-- Bar --> Baz", "Foo  Baz"},
 		{"<", "<"},
 		{"foo < bar", "foo < bar"},
-		{`Foo<script type="text/javascript">alert(1337)</script>Bar`, "FooBar"},
+		{`Foo<script>alert(1337)</script>Bar`, "FooBar"},
 		{`Foo<div title="1>2">Bar`, "FooBar"},
 		{`I <3 Ponies!`, `I <3 Ponies!`},
 		{`<script>foo()</script>`, ``},


### PR DESCRIPTION
Omitted or a JavaScript MIME type: This indicates the script is JavaScript. The HTML5 specification urges authors to omit the attribute rather than provide a redundant MIME type.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
