### PR TITLE
cmd/cgo: use -fno-lto in cflags when compiling _cgo_export.c

### DIFF
--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -2776,9 +2776,14 @@ func (b *Builder) cgo(a *Action, cgoExe, objdir string, pcCFLAGS, pcLDFLAGS, cgo
 
 	// gcc
 	cflags := str.StringList(cgoCPPFLAGS, cgoCFLAGS)
+	exportCflags := str.StringList(cflags, "-fno-lto")
 	for _, cfile := range cfiles {
 		ofile := nextOfile()
-		if err := b.gcc(a, p, a.Objdir, ofile, cflags, objdir+cfile); err != nil {
+		currentCflags := cflags
+		if cfile == "_cgo_export.c" {
+			currentCflags = exportCflags
+		}
+		if err := b.gcc(a, p, a.Objdir, ofile, currentCflags, objdir+cfile); err != nil {
 			return nil, nil, err
 		}
 		outObj = append(outObj, ofile)


### PR DESCRIPTION
Currently, cgo declares different types for exported symbols between
_cgo_main.c and _cgo_export.c.  This is not compatible with link time
optimization in GCC and causes builds to fail when compiling with
CGO_CFLAGS="-flto -ffat-lto-objects".

This commit appends -fno-lto to the cflags when building _cgo_export.c
to disable link time optimization locally on the built object.

Fixes #43830