### PR TITLE
cmd/cgo: define exported Go func as function

### DIFF
--- a/src/cmd/cgo/gcc.go
+++ b/src/cmd/cgo/gcc.go
@@ -1614,6 +1614,8 @@ func (p *Package) gccCmd() []string {
 		c = append(c, "-maix64")
 		c = append(c, "-mcmodel=large")
 	}
+	// disable LTO so we get a real object
+	c = append(c, "-fno-lto")
 	c = append(c, "-") //read input from standard input
 	return c
 }

--- a/src/cmd/cgo/out.go
+++ b/src/cmd/cgo/out.go
@@ -168,6 +168,11 @@ func (p *Package) writeDefs() {
 			if *gccgo {
 				fmt.Fprintf(fc, "extern byte *%s;\n", n.C)
 			} else {
+				// Only emit the following symbols if they are not for
+				// a function pointer variable. The function symbol is already defined
+				// and redefining it here as such will break compilation when
+				// used in conjunction with link time optimization in external
+				// linkers.
 				if n.Kind != "fpvar" {
 					fmt.Fprintf(fm, "extern char %s[];\n", n.C)
 					fmt.Fprintf(fm, "void *_cgohack_%s = %s;\n\n", n.C, n.C)

--- a/src/cmd/cgo/out.go
+++ b/src/cmd/cgo/out.go
@@ -172,6 +172,8 @@ func (p *Package) writeDefs() {
 				// reference to all symbols Go code is referring
 				// to -- because otherwise the system linker might decline
 				// to add DT_NEEDED entries for the library that has the symbol definition.
+				// We treat function pointer types differently to avoid link-time failures
+				// when using LTO with an external linker.
 				if n.Kind == "fpvar" {
 					fmt.Fprintf(fm, "extern void %s();\n", n.C)
 				} else {

--- a/src/cmd/cgo/out.go
+++ b/src/cmd/cgo/out.go
@@ -1028,7 +1028,7 @@ func (p *Package) writeExports(fgo2, fm, fgcc, fgcch io.Writer) {
 		fmt.Fprintf(fgo2, "//go:cgo_export_static _cgoexp%s_%s\n", cPrefix, exp.ExpName)
 		fmt.Fprintf(fgo2, "func _cgoexp%s_%s(a *%s) {\n", cPrefix, exp.ExpName, gotype)
 
-		fmt.Fprintf(fm, "int _cgoexp%s_%s;\n", cPrefix, exp.ExpName)
+		fmt.Fprintf(fm, "void _cgoexp%s_%s(void* p){};\n", cPrefix, exp.ExpName)
 
 		if gccResult != "void" {
 			// Write results back to frame.

--- a/src/cmd/cgo/out.go
+++ b/src/cmd/cgo/out.go
@@ -168,8 +168,10 @@ func (p *Package) writeDefs() {
 			if *gccgo {
 				fmt.Fprintf(fc, "extern byte *%s;\n", n.C)
 			} else {
-				fmt.Fprintf(fm, "extern char %s[];\n", n.C)
-				fmt.Fprintf(fm, "void *_cgohack_%s = %s;\n\n", n.C, n.C)
+				if n.Kind != "fpvar" {
+					fmt.Fprintf(fm, "extern char %s[];\n", n.C)
+					fmt.Fprintf(fm, "void *_cgohack_%s = %s;\n\n", n.C, n.C)
+				}
 				fmt.Fprintf(fgo2, "//go:linkname __cgo_%s %s\n", n.C, n.C)
 				fmt.Fprintf(fgo2, "//go:cgo_import_static %s\n", n.C)
 				fmt.Fprintf(fgo2, "var __cgo_%s byte\n", n.C)

--- a/src/cmd/go/testdata/script/issue_43830.txt
+++ b/src/cmd/go/testdata/script/issue_43830.txt
@@ -1,6 +1,7 @@
 # tests golang.org/issue/43830
 
-[!cgo] skip
+[!cgo] skip "skipping test without cgo"
+[!exec:gcc] skip "skipping test without gcc present"
 
 env CGO_CFLAGS='-flto -ffat-lto-objects'
 go build main.go add.go

--- a/src/cmd/go/testdata/script/issue_43830.txt
+++ b/src/cmd/go/testdata/script/issue_43830.txt
@@ -5,7 +5,7 @@
 [openbsd] env CC='clang'
 [!openbsd] env CC='gcc'
 
-env CGO_CFLAGS='-flto -ffat-lto-objects'
+env CGO_CFLAGS='-Wno-ignored-optimization-argument -flto -ffat-lto-objects'
 
 go build main.go add.go
 

--- a/src/cmd/go/testdata/script/issue_43830.txt
+++ b/src/cmd/go/testdata/script/issue_43830.txt
@@ -1,7 +1,7 @@
 # tests golang.org/issue/43830
 
-[!cgo] skip "skipping test without cgo"
-[!exec:gcc] skip "skipping test without gcc present"
+[!cgo] skip 'skipping test without cgo'
+[!exec:gcc] skip 'skipping test without gcc present'
 
 env CGO_CFLAGS='-flto -ffat-lto-objects'
 go build main.go add.go

--- a/src/cmd/go/testdata/script/issue_43830.txt
+++ b/src/cmd/go/testdata/script/issue_43830.txt
@@ -2,10 +2,10 @@
 
 [!cgo] skip 'skipping test without cgo'
 [!exec:gcc] skip 'skipping test without gcc present'
-[openbsd] skip 'skipping test on openbsd due to older gcc'
+[openbsd] env CC='clang'
+[!openbsd] env CC=`gcc`
 
 env CGO_CFLAGS='-flto -ffat-lto-objects'
-env CC='gcc'
 
 go build main.go add.go
 

--- a/src/cmd/go/testdata/script/issue_43830.txt
+++ b/src/cmd/go/testdata/script/issue_43830.txt
@@ -2,6 +2,7 @@
 
 [!cgo] skip 'skipping test without cgo'
 [!exec:gcc] skip 'skipping test without gcc present'
+[openbsd] skip 'skipping test on openbsd due to older gcc'
 
 env CGO_CFLAGS='-flto -ffat-lto-objects'
 env CC='gcc'

--- a/src/cmd/go/testdata/script/issue_43830.txt
+++ b/src/cmd/go/testdata/script/issue_43830.txt
@@ -3,7 +3,7 @@
 [!cgo] skip 'skipping test without cgo'
 [!exec:gcc] skip 'skipping test without gcc present'
 [openbsd] env CC='clang'
-[!openbsd] env CC=`gcc`
+[!openbsd] env CC='gcc'
 
 env CGO_CFLAGS='-flto -ffat-lto-objects'
 

--- a/src/cmd/go/testdata/script/issue_43830.txt
+++ b/src/cmd/go/testdata/script/issue_43830.txt
@@ -4,6 +4,8 @@
 [!exec:gcc] skip 'skipping test without gcc present'
 
 env CGO_CFLAGS='-flto -ffat-lto-objects'
+env CC='gcc'
+
 go build main.go add.go
 
 -- main.go --

--- a/src/cmd/go/testdata/script/issue_43830.txt
+++ b/src/cmd/go/testdata/script/issue_43830.txt
@@ -1,0 +1,34 @@
+# tests golang.org/issue/43830
+
+[!cgo] skip
+
+env CGO_CFLAGS='-flto -ffat-lto-objects'
+go build main.go add.go
+
+-- main.go --
+
+package main
+
+/*
+int c_add(int a, int b) {
+	return myadd(a, b);
+}
+*/
+import "C"
+
+func main() {
+	println(C.c_add(1, 2))
+}
+
+-- add.go --
+
+package main
+
+import "C"
+
+/* test */
+
+//export myadd
+func myadd(a C.int, b C.int) C.int {
+	return a + b
+}

--- a/src/cmd/go/testdata/script/issue_43830_2.txt
+++ b/src/cmd/go/testdata/script/issue_43830_2.txt
@@ -1,0 +1,28 @@
+# tests golang.org/issue/43830
+
+[!cgo] skip
+
+env CGO_CFLAGS='-flto -ffat-lto-objects'
+go build main.go
+
+-- main.go --
+
+package main
+
+import "fmt"
+
+// #include "hello.h"
+import "C"
+
+func main() {
+	hello := C.hello
+	fmt.Printf("%v\n", hello)
+}
+
+-- hello.h --
+
+#include <stdio.h>
+
+void hello(void) {
+  printf("hello\n");
+}

--- a/src/cmd/go/testdata/script/issue_43830_2.txt
+++ b/src/cmd/go/testdata/script/issue_43830_2.txt
@@ -5,7 +5,7 @@
 [openbsd] env CC='clang'
 [!openbsd] env CC='gcc'
 
-env CGO_CFLAGS='-flto -ffat-lto-objects'
+env CGO_CFLAGS='-Wno-ignored-optimization-argument -flto -ffat-lto-objects'
 
 go build main.go
 

--- a/src/cmd/go/testdata/script/issue_43830_2.txt
+++ b/src/cmd/go/testdata/script/issue_43830_2.txt
@@ -2,10 +2,10 @@
 
 [!cgo] skip 'skipping test without cgo'
 [!exec:gcc] skip 'skipping test without gcc present'
-[openbsd] skip 'skipping test on openbsd due to older gcc'
+[openbsd] env CC='clang'
+[!openbsd] env CC=`gcc`
 
 env CGO_CFLAGS='-flto -ffat-lto-objects'
-env CC='gcc'
 
 go build main.go
 

--- a/src/cmd/go/testdata/script/issue_43830_2.txt
+++ b/src/cmd/go/testdata/script/issue_43830_2.txt
@@ -2,6 +2,7 @@
 
 [!cgo] skip 'skipping test without cgo'
 [!exec:gcc] skip 'skipping test without gcc present'
+[openbsd] skip 'skipping test on openbsd due to older gcc'
 
 env CGO_CFLAGS='-flto -ffat-lto-objects'
 env CC='gcc'

--- a/src/cmd/go/testdata/script/issue_43830_2.txt
+++ b/src/cmd/go/testdata/script/issue_43830_2.txt
@@ -1,7 +1,7 @@
 # tests golang.org/issue/43830
 
-[!cgo] skip "skipping test without cgo"
-[!exec:gcc] skip "skipping test without gcc present"
+[!cgo] skip 'skipping test without cgo'
+[!exec:gcc] skip 'skipping test without gcc present'
 
 env CGO_CFLAGS='-flto -ffat-lto-objects'
 go build main.go

--- a/src/cmd/go/testdata/script/issue_43830_2.txt
+++ b/src/cmd/go/testdata/script/issue_43830_2.txt
@@ -1,6 +1,7 @@
 # tests golang.org/issue/43830
 
-[!cgo] skip
+[!cgo] skip "skipping test without cgo"
+[!exec:gcc] skip "skipping test without gcc present"
 
 env CGO_CFLAGS='-flto -ffat-lto-objects'
 go build main.go

--- a/src/cmd/go/testdata/script/issue_43830_2.txt
+++ b/src/cmd/go/testdata/script/issue_43830_2.txt
@@ -3,7 +3,7 @@
 [!cgo] skip 'skipping test without cgo'
 [!exec:gcc] skip 'skipping test without gcc present'
 [openbsd] env CC='clang'
-[!openbsd] env CC=`gcc`
+[!openbsd] env CC='gcc'
 
 env CGO_CFLAGS='-flto -ffat-lto-objects'
 

--- a/src/cmd/go/testdata/script/issue_43830_2.txt
+++ b/src/cmd/go/testdata/script/issue_43830_2.txt
@@ -4,6 +4,8 @@
 [!exec:gcc] skip 'skipping test without gcc present'
 
 env CGO_CFLAGS='-flto -ffat-lto-objects'
+env CC='gcc'
+
 go build main.go
 
 -- main.go --


### PR DESCRIPTION
In order to resolve symbols correctly during C compilation with CGO
the compiler emits a _cgo_main.c file which holds definitions for
symbols. The problem is that the definitions in the _cgo_main.c do not
match up with what's declared in _cgo_export.c which causes compilation
to fail if using CGO_CFLAGS="-flto -ffat-lto-objects" due to an
incompatibility with link time optimization in GCC.

This patch makes it so that the symbol emitted in _cgo_main.c lines up
with the type declared in _cgo_export.c. This should be safe to do as
the actual exported C symbol ends up as an argument to crosscall2 which
defines the function signature for these exported symbols. The function
sig will be consistent in that way since CGO generates wrappers and
structs to handle argument / return value passing.

Fixes #43830