### PR TITLE
runtime: clarify GC fractional mode description

### DIFF
--- a/src/runtime/mgc.go
+++ b/src/runtime/mgc.go
@@ -302,9 +302,10 @@ const (
 	// gcMarkWorkerFractionalMode indicates that a P is currently
 	// running the "fractional" mark worker. The fractional worker
 	// is necessary when GOMAXPROCS*gcBackgroundUtilization is not
-	// an integer. The fractional worker should run until it is
-	// preempted and will be scheduled to pick up the fractional
-	// part of GOMAXPROCS*gcBackgroundUtilization.
+	// an integer and each P is too far away from the
+	// gcBackgroundUtilization target. The fractional worker should
+	// run until it is preempted and will be scheduled to pick up the
+	// fractional part of GOMAXPROCS*gcBackgroundUtilization.
 	gcMarkWorkerFractionalMode
 
 	// gcMarkWorkerIdleMode indicates that a P is running the mark

--- a/src/runtime/mgc.go
+++ b/src/runtime/mgc.go
@@ -302,8 +302,8 @@ const (
 	// gcMarkWorkerFractionalMode indicates that a P is currently
 	// running the "fractional" mark worker. The fractional worker
 	// is necessary when GOMAXPROCS*gcBackgroundUtilization is not
-	// an integer and the utilization too far away from the
-	// gcBackgroundUtilization when round the number.
+	// an integer and using only dedicated workers would result in
+	// utilization too far from the target of gcBackgroundUtilization.
 	// The fractional worker should run until it is preempted and
 	// will be scheduled to pick up the fractional part of
 	// GOMAXPROCS*gcBackgroundUtilization.

--- a/src/runtime/mgc.go
+++ b/src/runtime/mgc.go
@@ -302,10 +302,11 @@ const (
 	// gcMarkWorkerFractionalMode indicates that a P is currently
 	// running the "fractional" mark worker. The fractional worker
 	// is necessary when GOMAXPROCS*gcBackgroundUtilization is not
-	// an integer and each P is too far away from the
-	// gcBackgroundUtilization target. The fractional worker should
-	// run until it is preempted and will be scheduled to pick up the
-	// fractional part of GOMAXPROCS*gcBackgroundUtilization.
+	// an integer and the utilization too far away from the
+	// gcBackgroundUtilization when round the number.
+	// The fractional worker should run until it is preempted and
+	// will be scheduled to pick up the fractional part of
+	// GOMAXPROCS*gcBackgroundUtilization.
 	gcMarkWorkerFractionalMode
 
 	// gcMarkWorkerIdleMode indicates that a P is running the mark


### PR DESCRIPTION
nowdays, in runtime/mgc.go,we can see the comment descrition : The fractional worker is necessary when GOMAXPROCS*gcBackgroundUtilization is not an integer.
but it not true such as GOMAXPROCS=5.
in the implemet of startCycle() , Fractional Mode happend only when 
GOMAXPROCS<=3 or GOMAXPROCS=6. so utilization can closest to 25%.
Fixes #44380