### PR TITLE
runtime: remove unnecessary bitwise XOR in noescape

### DIFF
--- a/src/runtime/stubs.go
+++ b/src/runtime/stubs.go
@@ -159,7 +159,7 @@ func memequal(a, b unsafe.Pointer, size uintptr) bool
 //go:nosplit
 func noescape(p unsafe.Pointer) unsafe.Pointer {
 	x := uintptr(p)
-	return unsafe.Pointer(x ^ 0)
+	return unsafe.Pointer(x)
 }
 
 // Not all cgocallback frames are actually cgocallback,


### PR DESCRIPTION
This change improves readability by removing an unnecessary bitwise XOR operation in the noescape function.

