### PR TITLE
runtime: fix stack alignment for Windows amd64 lib entry

### DIFF
--- a/src/runtime/rt0_windows_amd64.s
+++ b/src/runtime/rt0_windows_amd64.s
@@ -16,24 +16,12 @@ TEXT _rt0_amd64_windows(SB),NOSPLIT,$-8
 // phase.
 // Leave space for four pointers on the stack as required
 // by the Windows amd64 calling convention.
-TEXT _rt0_amd64_windows_lib(SB),NOSPLIT,$0x48
-	MOVQ	BP, 0x20(SP)
-	MOVQ	BX, 0x28(SP)
-	MOVQ	AX, 0x30(SP)
-	MOVQ  CX, 0x38(SP)
-	MOVQ  DX, 0x40(SP)
-
+TEXT _rt0_amd64_windows_lib(SB),NOSPLIT,$0x20
 	// Create a new thread to do the runtime initialization and return.
 	MOVQ	_cgo_sys_thread_create(SB), AX
 	MOVQ	$_rt0_amd64_windows_lib_go(SB), CX
 	MOVQ	$0, DX
 	CALL	AX
-
-	MOVQ	0x20(SP), BP
-	MOVQ	0x28(SP), BX
-	MOVQ	0x30(SP), AX
-	MOVQ	0x38(SP), CX
-	MOVQ	0x40(SP), DX
 	RET
 
 TEXT _rt0_amd64_windows_lib_go(SB),NOSPLIT,$0


### PR DESCRIPTION
Windows amd64 calling convention requires 16-bytes aligned
stack pointer. Before this patch, the real frame size is
0x48 (frame size) + 0x10 (frame pointer & return address),
which does not satisfy the alignment requirement.

_cgo_sys_thread_create eventually calls NtCreateThread,
which receives a pointer to a ThreadContext structure
allocated from (mis-aligned) stack, and may fail with
STATUS_DATATYPE_MISALIGNMENT on some implementations.

BP is saved/restored by prolog/epilog.
AX, CX, DX are volatile, no need to save and restore.

Fixes #41075