### PR TITLE
crypto/x509/pkix: add missing RFC 5280 RDN OIDs

### DIFF
--- a/src/crypto/x509/pkix/pkix.go
+++ b/src/crypto/x509/pkix/pkix.go
@@ -24,15 +24,24 @@ type AlgorithmIdentifier struct {
 type RDNSequence []RelativeDistinguishedNameSET
 
 var attributeTypeNames = map[string]string{
-	"2.5.4.6":  "C",
-	"2.5.4.10": "O",
-	"2.5.4.11": "OU",
-	"2.5.4.3":  "CN",
-	"2.5.4.5":  "SERIALNUMBER",
-	"2.5.4.7":  "L",
-	"2.5.4.8":  "ST",
-	"2.5.4.9":  "STREET",
-	"2.5.4.17": "POSTALCODE",
+	"2.5.4.6":                    "C",
+	"2.5.4.10":                   "O",
+	"2.5.4.11":                   "OU",
+	"2.5.4.3":                    "CN",
+	"2.5.4.5":                    "SERIALNUMBER",
+	"2.5.4.7":                    "L",
+	"2.5.4.8":                    "ST",
+	"2.5.4.9":                    "STREET",
+	"2.5.4.17":                   "POSTALCODE",
+	"0.9.2342.19200300.100.1.25": "DC", // domainComponent
+	"2.5.4.46":                   "DNQUALIFIER",
+	"1.2.840.113549.1.9.1":       "EMAIL", // emailAddress
+	"2.5.4.12":                   "TITLE",
+	"2.5.4.4":                    "SN", // surname
+	"2.5.4.42":                   "GIVENNAME",
+	"2.5.4.43":                   "INITIALS",
+	"2.5.4.44":                   "GENERATIONQUALIFIER",
+	"2.5.4.65":                   "PSEUDONYM",
 }
 
 // String returns a string representation of the sequence r,


### PR DESCRIPTION
This PR modifies Go to comply to RFC 5280 with regard of human
readable representation of X.509 certificate distinguished names.

RFC 5280 section 4.1.2.4 states that conforming implementations
must/should expect a list of attribute types in Subject and
Issuer names. Some of the required attributes were not supported
by pkix.String(). This commit adds support for the missing RDN
attributes.

Updates #41750.