### PR TITLE
net/http: support mulit same transfer-encoding header

### DIFF
--- a/src/net/http/transfer_test.go
+++ b/src/net/http/transfer_test.go
@@ -311,6 +311,10 @@ func TestParseTransferEncoding(t *testing.T) {
 			hdr:     Header{"Transfer-Encoding": {"chunked"}},
 			wantErr: nil,
 		},
+		{
+			hdr:     Header{"Transfer-Encoding": {"chunked", "chunked"}},
+			wantErr: nil,
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
Hello Golang STD Maintainers, 

Here is a proposal about the `net/http/transfer`, we can discuss about this. 

In my scenario,  the java spring framework will allow application response result with duplicated `transfer-encoding` header, as a result, when the `go service` call the `java app`, the `go service` will raise an error about transfer-encoding. 

so, as a result, I want to create a PR to make `go/net/http` could process response with duplicated `chunked` values in `tranfer-encoding` header.

Is that possible ?

Thanks

