### PR TITLE
os: unify logic for io.ReadAll and os.ReadFile

### DIFF
--- a/src/os/file.go
+++ b/src/os/file.go
@@ -674,9 +674,9 @@ func ReadFile(name string) ([]byte, error) {
 
 	data := make([]byte, 0, size)
 	for {
-		if len(data) >= cap(data) {
-			d := append(data[:cap(data)], 0)
-			data = d[:len(data)]
+		if len(data) == cap(data) {
+			// Add more capacity (let append pick how much).
+			data = append(data, 0)[:len(data)]
 		}
 		n, err := f.Read(data[len(data):cap(data)])
 		data = data[:len(data)+n]


### PR DESCRIPTION
I think the logic of io.ReadAll and os.ReadFile can be consistent.

See also: https://github.com/golang/go/blob/master/src/io/io.go#L629-L632