### PR TITLE
spec: clarify that signed integers>=0 are permitted as shift counts

### DIFF
--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -1,6 +1,6 @@
 <!--{
 	"Title": "The Go Programming Language Specification",
-	"Subtitle": "Version of Feb 24, 2021",
+	"Subtitle": "Version of Mar 16, 2021",
 	"Path": "/ref/spec"
 }-->
 
@@ -3681,8 +3681,8 @@ The bitwise logical and shift operators apply to integers only.
 ^    bitwise XOR            integers
 &amp;^   bit clear (AND NOT)    integers
 
-&lt;&lt;   left shift             integer &lt;&lt; unsigned integer
-&gt;&gt;   right shift            integer &gt;&gt; unsigned integer
+&lt;&lt;   left shift             integer &lt;&lt; integer >= 0
+&gt;&gt;   right shift            integer &gt;&gt; integer >= 0
 </pre>
 
 


### PR DESCRIPTION
In Go1.13 and above, signed integers are permitted as shift counts as long as they are >=0.
However, the comments in the "Arithmetic operators" section says shift operators accept "unsigned integer" as of right operands. Replacing this with "integer>=0" resolves the misunderstanding that shift
operators permit only unsigned integers.

Reference: Go1.13 Release Notes: https://golang.org/doc/go1.13