### PR TITLE
misc/chrome: clean up the gophertool HTML

### DIFF
--- a/doc/asm.html
+++ b/doc/asm.html
@@ -918,8 +918,6 @@ This assembler is used by GOARCH values ppc64 and ppc64le.
 Reference: <a href="/pkg/cmd/internal/obj/ppc64">Go PPC64 Assembly Instructions Reference Manual</a>
 </p>
 
-</ul>
-
 <h3 id="s390x">IBM z/Architecture, a.k.a. s390x</h3>
 
 <p>

--- a/misc/chrome/gophertool/background.html
+++ b/misc/chrome/gophertool/background.html
@@ -1,4 +1,5 @@
-<html>
+<!doctype html>
+<html lang="en">
 <!--
  Copyright 2011 The Go Authors. All rights reserved.
  Use of this source code is governed by a BSD-style
@@ -9,4 +10,3 @@
 <script src="background.js"></script>
 </head>
 </html>
-

--- a/misc/chrome/gophertool/popup.html
+++ b/misc/chrome/gophertool/popup.html
@@ -1,4 +1,5 @@
-<html>
+<!doctype html>
+<html lang="en">
 <!--
  Copyright 2011 The Go Authors. All rights reserved.
  Use of this source code is governed by a BSD-style
@@ -8,12 +9,12 @@
 <script src="gopher.js"></script>
 <script src="popup.js"></script>
 </head>
-<body style='margin: 0.5em; font-family: sans;'>
+<body style="margin: 0.5em; font-family: sans;">
 <small><a href="#" url="https://golang.org/issue">issue</a>,
 <a href="#" url="https://golang.org/cl">codereview</a>,
 <a href="#" url="https://golang.org/change">commit</a>, or
 <a href="#" url="https://golang.org/pkg/">pkg</a> id/name:</small>
-<form style='margin: 0' id='navform'><nobr><input id="inputbox" size=10 tabindex=1 /><input type="submit" value="go" /></nobr></form>
+<form style="margin: 0" id="navform"><nobr><input id="inputbox" size="10" tabindex="1" /><input type="submit" value="go" /></nobr></form>
 <small>Also: <a href="#" url="https://build.golang.org">buildbots</a>
 <a href="#" url="https://github.com/golang/go">GitHub</a>
 </small>


### PR DESCRIPTION
Remove unneeded HTML ul closing tag
