### PR TITLE
mime: fix FormatMediaType's RFC 2616 compliance

### DIFF
--- a/src/mime/grammar.go
+++ b/src/mime/grammar.go
@@ -22,11 +22,22 @@ func isTokenChar(r rune) bool {
 	return r > 0x20 && r < 0x7f && !isTSpecial(r)
 }
 
-// isToken reports whether s is a 'token' as defined by RFC 1521
-// and RFC 2045.
-func isToken(s string) bool {
+func isNot2616TokenChar(r rune) bool {
+	// CHAR           = <any US-ASCII character (octets 0 - 127)>
+	// CTL            = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
+	// token          = 1*<any CHAR except CTLs or separators>
+	// separators     = "(" | ")" | "<" | ">" | "@"
+	//                | "," | ";" | ":" | "\" | <">
+	//                | "/" | "[" | "]" | "?" | "="
+	//                | "{" | "}" | SP | HT
+	return r <= 0x20 || r >= 0x7f || strings.ContainsRune(`()<>@,;:\"/[]?={}`, r)
+}
+
+// is2616Token reports whether s is a 'token' as defined by RFC 2616,
+// which is more restrictive than RFC 1521 and RFC 2045.
+func is2616Token(s string) bool {
 	if s == "" {
 		return false
 	}
-	return strings.IndexFunc(s, isNotTokenChar) < 0
+	return strings.IndexFunc(s, isNot2616TokenChar) < 0
 }

--- a/src/mime/mediatype.go
+++ b/src/mime/mediatype.go
@@ -20,13 +20,13 @@ import (
 func FormatMediaType(t string, param map[string]string) string {
 	var b strings.Builder
 	if slash := strings.IndexByte(t, '/'); slash == -1 {
-		if !isToken(t) {
+		if !is2616Token(t) {
 			return ""
 		}
 		b.WriteString(strings.ToLower(t))
 	} else {
 		major, sub := t[:slash], t[slash+1:]
-		if !isToken(major) || !isToken(sub) {
+		if !is2616Token(major) || !is2616Token(sub) {
 			return ""
 		}
 		b.WriteString(strings.ToLower(major))
@@ -44,7 +44,7 @@ func FormatMediaType(t string, param map[string]string) string {
 		value := param[attribute]
 		b.WriteByte(';')
 		b.WriteByte(' ')
-		if !isToken(attribute) {
+		if !is2616Token(attribute) {
 			return ""
 		}
 		b.WriteString(strings.ToLower(attribute))
@@ -80,7 +80,7 @@ func FormatMediaType(t string, param map[string]string) string {
 			continue
 		}
 
-		if isToken(value) {
+		if is2616Token(value) {
 			b.WriteString(value)
 			continue
 		}

--- a/src/mime/mediatype_test.go
+++ b/src/mime/mediatype_test.go
@@ -397,6 +397,10 @@ func TestParseMediaType(t *testing.T) {
 		// Microsoft browers in intranet mode do not think they need to escape \ in file name.
 		{`form-data; name="file"; filename="C:\dev\go\robots.txt"`, "form-data", m("name", "file", "filename", `C:\dev\go\robots.txt`)},
 		{`form-data; name="file"; filename="C:\新建文件件\中文第二次测试.mp4"`, "form-data", m("name", "file", "filename", `C:\新建文件件\中文第二次测试.mp4`)},
+
+		// `{` and `}` are excluded from RFC 2616 token character set but included in RFC 2045 one.
+		{`attachment; foo=}{`, "attachment", m("foo", "}{")},
+		{`attachment; foo*=UTF-8''%01}{`, "attachment", m("foo", "\001}{")},
 	}
 	for _, test := range tests {
 		mt, params, err := ParseMediaType(test.in)
@@ -498,6 +502,7 @@ var formatTests = []formatTest{
 	{"foo/bar", map[string]string{"a": "av", "b": "bv", "c": "cv"}, "foo/bar; a=av; b=bv; c=cv"},
 	{"foo/bar", map[string]string{"0": "'", "9": "'"}, "foo/bar; 0='; 9='"},
 	{"foo", map[string]string{"bar": ""}, `foo; bar=""`},
+	{"foo", map[string]string{"bar": "}{"}, `foo; bar="}{"`},
 }
 
 func TestFormatMediaType(t *testing.T) {


### PR DESCRIPTION
The existing implementation may produce values which aren't compliant
with RFC 2616 because they may include `{` and `}` in tokens.
Apply stricter RFC 2616 token defintion for FormatMediaType, but ensure
that ParseMediaType can still correctly parse tokens produced in
accordance to more lax RFC 2045 definition.

Fixes #43128