### PR TITLE
misc/ios: change to explicitly use python3 in Xcode

### DIFF
--- a/misc/ios/go_ios_exec.go
+++ b/misc/ios/go_ios_exec.go
@@ -564,7 +564,8 @@ func runLLDB(target, appdir, deviceapp string, args []string) ([]byte, error) {
 		env = append(env, e)
 	}
 	lldb := exec.Command(
-		"python",
+		"xcrun",
+		"python3",
 		"-", // Read script from stdin.
 		target,
 		appdir,
@@ -813,7 +814,7 @@ env = []
 for k, v in os.environ.items():
 	env.append(k + "=" + v)
 
-sys.path.append('/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Resources/Python')
+sys.path.append('/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Resources/Python3')
 
 import lldb
 


### PR DESCRIPTION
In `misc/ios/go_ios_exec.go`, it calls python to use the llvm api.
However, since it is simply calling python, if other python is used, such as in pyenv, it will give an error like `Fatal Python error: _PyInterpreterState_Get(): no current thread state`. Since lldb library depends on the python in Xcode, we must use the python in Xcode.

So I changed the xcrun command to explicitly use the python in Xcode.