### PR TITLE
cmd/link: bring back R_ARM_V4BX for Annapurna AL-212 …

### DIFF
--- a/src/cmd/link/internal/arm/asm.go
+++ b/src/cmd/link/internal/arm/asm.go
@@ -189,6 +189,14 @@ func adddynrel(target *ld.Target, ldr *loader.Loader, syms *ld.ArchSyms, s loade
 		su.SetRelocType(rIdx, objabi.R_ADDR)
 		return true
 
+       case objabi.ElfRelocOffset + objabi.RelocType(elf.R_ARM_V4BX):
+               if targType == sym.SDYNIMPORT {
+                       ldr.Errorf(s, "unexpected R_ARM_V4BX relocation for dynamic symbol %s", ldr.SymName(targ))
+               }
+               su := ldr.MakeSymbolUpdater(s)
+               su.SetRelocType(rIdx, objabi.R_ADDR)
+               return true
+
 	case objabi.ElfRelocOffset + objabi.RelocType(elf.R_ARM_PC24),
 		objabi.ElfRelocOffset + objabi.RelocType(elf.R_ARM_JUMP24):
 		su := ldr.MakeSymbolUpdater(s)


### PR DESCRIPTION
…and possibly others

When trying to upgrade Go from 1.15.8 to 1.16 on my Netgear ReadyNAS RN204 and
it's Annapurna AL-212 ARM chip I ran into a compile time error:

$ cd src
go-go1.16.2/$ cd src
go-go1.16.2/src$ ./make.bash
Building Go cmd/dist using /usr/lib/go-1.15. (go1.15.8 linux/arm)
Building Go toolchain1 using /usr/lib/go-1.16.
Building Go bootstrap cmd/go (go_bootstrap) using Go toolchain1.
Building Go toolchain2 using go_bootstrap and Go toolchain1.
Building Go toolchain3 using go_bootstrap and Go toolchain2.
Building packages and commands for linux/arm.
net(.text): unexpected relocation type 296 (R_ARM_V4BX)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x115a84]

Inspection of the changes showed that the code for handling R_ARM_V4BX that
was included in 1.15.x is mossing from 1.16 onwards. Since R_ARM_v4BX is
essentially a no-op accoring to the comment in the 1.15 tree I thought it
safe to just re-use the code for R_ARM_ABS32.

Using that I was able to build a working go 1.16.2, run the test suit and
build some apps for testing.

However, since I just copied the code, I have no idea about possible side
effects or whether there's an easier way to handle this. So I'd be more 
than happy if someone with more knowledge could give this a look.
