### PR TITLE
crypto/rsa: correct EncryptOAEP doc comment

### DIFF
--- a/src/crypto/rsa/rsa.go
+++ b/src/crypto/rsa/rsa.go
@@ -401,7 +401,7 @@ func encrypt(c *big.Int, pub *PublicKey, m *big.Int) *big.Int {
 //
 // The label parameter may contain arbitrary data that will not be encrypted,
 // but which gives important context to the message. For example, if a given
-// public key is used to decrypt two types of messages then distinct label
+// public key is used to encrypt two types of messages then distinct label
 // values could be used to ensure that a ciphertext for one purpose cannot be
 // used for another by an attacker. If not required it can be empty.
 //


### PR DESCRIPTION
Fixes #44777

Corrected the documentation comment on the EncryptOAEP function from
'if a given public key is used to decrypt two types of messages' to
'if a given public key is used to encrypt two types of messages'.