### PR TITLE
make.bash: this change modifies Go to correctly select a dyamic linker

### DIFF
--- a/src/make.bash
+++ b/src/make.bash
@@ -132,10 +132,10 @@ fi
 
 # Test which linker/loader our system is using
 if type readelf >/dev/null 2>&1; then
-        echo "int main() { return 0; }" | ${CC:-cc} -o ./test-musl-ldso -x c - || continue
-        LDSO=$(readelf -l ./test-musl-ldso | grep 'interpreter:' | sed -e 's/^.*interpreter: \(.*\)[]]/\1/') >/dev/null 2>&1
-        [ -z "$LDSO" ] || export GO_LDSO="$LDSO"
-    rm -f ./test-musl-ldso
+	echo "int main() { return 0; }" | ${CC:-cc} -o ./test-musl-ldso -x c - || continue
+	LDSO=$(readelf -l ./test-musl-ldso | grep 'interpreter:' | sed -e 's/^.*interpreter: \(.*\)[]]/\1/') >/dev/null 2>&1
+	[ -z "$LDSO" ] || export GO_LDSO="$LDSO"
+	rm -f ./test-musl-ldso
 fi
 
 # Clean old generated file that will cause problems in the build.

--- a/src/make.bash
+++ b/src/make.bash
@@ -132,8 +132,9 @@ fi
 
 # Test which linker/loader our system is using
 if type readelf >/dev/null 2>&1; then
-    echo "int main() { return 0; }" | ${CC:-cc} -o ./test-musl-ldso -x c -
-    export GO_LDSO=$(readelf -l ./test-musl-ldso | grep 'interpreter:' | sed -e 's/^.*interpreter: \(.*\)[]]/\1/')
+        echo "int main() { return 0; }" | ${CC:-cc} -o ./test-musl-ldso -x c - || continue
+        LDSO=$(readelf -l ./test-musl-ldso | grep 'interpreter:' | sed -e 's/^.*interpreter: \(.*\)[]]/\1/') >/dev/null 2>&1
+        [ -z "$LDSO" ] || export GO_LDSO="$LDSO"
     rm -f ./test-musl-ldso
 fi
 

--- a/src/make.bash
+++ b/src/make.bash
@@ -130,13 +130,11 @@ if [ "$(uname -s)" = "GNU/kFreeBSD" ]; then
 	export CGO_ENABLED=0
 fi
 
-# On Alpine Linux, use the musl dynamic linker/loader
-if [ -f "/etc/alpine-release" ]; then
-	if type readelf >/dev/null 2>&1; then
-		echo "int main() { return 0; }" | ${CC:-gcc} -o ./test-alpine-ldso -x c -
-		export GO_LDSO=$(readelf -l ./test-alpine-ldso | grep 'interpreter:' | sed -e 's/^.*interpreter: \(.*\)[]]/\1/')
-		rm -f ./test-alpine-ldso
-	fi
+# Test which linker/loader our system is using
+if type readelf >/dev/null 2>&1; then
+    echo "int main() { return 0; }" | ${CC:-cc} -o ./test-musl-ldso -x c -
+    export GO_LDSO=$(readelf -l ./test-musl-ldso | grep 'interpreter:' | sed -e 's/^.*interpreter: \(.*\)[]]/\1/')
+    rm -f ./test-musl-ldso
 fi
 
 # Clean old generated file that will cause problems in the build.


### PR DESCRIPTION
Alpine Linux is not the only musl-based Linux distribution. Checking for
/etc/alpine-release excludes many other distributions (Oasis, KISS,
Sabotage, sta.li). Not having the correct GO_LDSO set during go builds will
result in the wrong linker/loader on nonalpine musl systems for pie builds.
Instead, the dynamic loader should be checked for every system and set. This
results in the correct dynamic linker being found on glibc systems
(/lib/ld-linux-x86-64.so.2) and musl systems (/lib/ld-musl-x84_64.so.1).

Fixes #45034 

