### PR TITLE
testing: update helperNames just before checking it

### DIFF
--- a/src/testing/helper_test.go
+++ b/src/testing/helper_test.go
@@ -71,6 +71,38 @@ func TestTBHelperParallel(t *T) {
 	}
 }
 
+func TestTBHelperLineNumer(t *T) {
+	var buf bytes.Buffer
+	ctx := newTestContext(1, newMatcher(regexp.MatchString, "", ""))
+	t1 := &T{
+		common: common{
+			signal: make(chan bool),
+			w:      &buf,
+		},
+		context: ctx,
+	}
+	t1.Run("Test", func(t *T) {
+		helperA := func(t *T) {
+			t.Helper()
+			t.Run("subtest", func(t *T) {
+				t.Helper()
+				t.Fatal("fatal error message")
+			})
+		}
+		helperA(t)
+	})
+
+	want := "helper_test.go:92: fatal error message"
+	got := ""
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) > 0 {
+		got = strings.TrimSpace(lines[len(lines)-1])
+	}
+	if got != want {
+		t.Errorf("got output:\n\n%v\nwant:\n\n%v", got, want)
+	}
+}
+
 type noopWriter int
 
 func (nw *noopWriter) Write(b []byte) (int, error) { return len(b), nil }

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -509,6 +509,7 @@ func (c *common) frameSkip(skip int) runtime.Frame {
 			}
 			return prevFrame
 		}
+		// If more helper PCs have been added since we last did the conversion
 		if c.helperNames == nil {
 			c.helperNames = make(map[string]struct{})
 			for pc := range c.helperPCs {

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -509,6 +509,12 @@ func (c *common) frameSkip(skip int) runtime.Frame {
 			}
 			return prevFrame
 		}
+		if c.helperNames == nil {
+			c.helperNames = make(map[string]struct{})
+			for pc := range c.helperPCs {
+				c.helperNames[pcToName(pc)] = struct{}{}
+			}
+		}
 		if _, ok := c.helperNames[frame.Function]; !ok {
 			// Found a frame that wasn't inside a helper function.
 			return frame
@@ -521,14 +527,6 @@ func (c *common) frameSkip(skip int) runtime.Frame {
 // and inserts the final newline if needed and indentation spaces for formatting.
 // This function must be called with c.mu held.
 func (c *common) decorate(s string, skip int) string {
-	// If more helper PCs have been added since we last did the conversion
-	if c.helperNames == nil {
-		c.helperNames = make(map[string]struct{})
-		for pc := range c.helperPCs {
-			c.helperNames[pcToName(pc)] = struct{}{}
-		}
-	}
-
 	frame := c.frameSkip(skip)
 	file := frame.File
 	line := frame.Line


### PR DESCRIPTION
parent's helperNames has not been set when frameSkip called, moving
helperNames initilazing to frameSkip.

Fixes #44887