### PR TITLE
syscall: fix typo in exec_windows_test.go

### DIFF
--- a/src/syscall/exec_windows_test.go
+++ b/src/syscall/exec_windows_test.go
@@ -52,7 +52,7 @@ func TestChangingProcessParent(t *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") == "parent" {
 		// in parent process
 
-		// Parent does nothign. It is just used as a parent of a child process.
+		// Parent does nothing. It is just used as a parent of a child process.
 		time.Sleep(time.Minute)
 		os.Exit(0)
 	}


### PR DESCRIPTION
nothign -> nothing