### PR TITLE
strings: adjust and add tests for strings.Index and strings.LastIndex

### DIFF
--- a/src/strings/example_test.go
+++ b/src/strings/example_test.go
@@ -107,9 +107,13 @@ func ExampleHasSuffix() {
 }
 
 func ExampleIndex() {
+	fmt.Println(strings.Index("go gopher", "go"))
+	fmt.Println(strings.Index("go gopher", ""))
 	fmt.Println(strings.Index("chicken", "ken"))
 	fmt.Println(strings.Index("chicken", "dmr"))
 	// Output:
+	// 0
+	// 0
 	// 4
 	// -1
 }
@@ -151,12 +155,12 @@ func ExampleIndexRune() {
 }
 
 func ExampleLastIndex() {
-	fmt.Println(strings.Index("go gopher", "go"))
 	fmt.Println(strings.LastIndex("go gopher", "go"))
+	fmt.Println(strings.LastIndex("go gopher", ""))
 	fmt.Println(strings.LastIndex("go gopher", "rodent"))
 	// Output:
-	// 0
 	// 3
+	// 9
 	// -1
 }
 


### PR DESCRIPTION
A strings.Index test is implemented in ExampleLastIndex,
so moved to ExampleIndex. strings.Index and strings.LastIndex do not
have empty substr test, so added them.
