### PR TITLE
net: only perform IPv4 map check for AF_INET6 sockets

### DIFF
--- a/src/net/sockopt_bsd.go
+++ b/src/net/sockopt_bsd.go
@@ -26,7 +26,7 @@ func setDefaultSockopts(s, family, sotype int, ipv6only bool) error {
 			syscall.SetsockoptInt(s, syscall.IPPROTO_IPV6, syscall.IPV6_PORTRANGE, syscall.IPV6_PORTRANGE_HIGH)
 		}
 	}
-	if supportsIPv4map() && family == syscall.AF_INET6 && sotype != syscall.SOCK_RAW {
+	if family == syscall.AF_INET6 && sotype != syscall.SOCK_RAW && supportsIPv4map() {
 		// Allow both IP versions even if the OS default
 		// is otherwise. Note that some operating systems
 		// never admit this option.


### PR DESCRIPTION
This change avoids executing syscalls testing if IPv4 address mapping
is possible unless the socket being opened belongs to the AF_INET6
family.

In a pledged OpenBSD process, this test is only allowed when the
"inet" pledge is granted; however this check was also being performed
for AF_UNIX sockets (separately permitted under the "unix" pledge),
and would cause the process to be killed by the kernel.  By avoiding
the IPv4 address mapping check until the socket is checked to be
AF_INET6, a pledged OpenBSD process using AF_UNIX sockets without the
"inet" pledge won't be killed for this misbehavior.

The OpenBSD kernel is not currently ready to support using UNIX domain
sockets with only the "unix" pledge (and without "inet"), but this is
one change necessary to support this.