### PR TITLE
io: fix spelling in documentation for io.Discard

### DIFF
--- a/src/io/io.go
+++ b/src/io/io.go
@@ -566,7 +566,7 @@ func (t *teeReader) Read(p []byte) (n int, err error) {
 	return
 }
 
-// Discard is an Writer on which all Write calls succeed
+// Discard is a Writer on which all Write calls succeed
 // without doing anything.
 var Discard Writer = discard{}
 


### PR DESCRIPTION
   
In the process of refactoring ioutil.Discard to io.Discard in
CL 263141 "an" should have been changed to "a" but was likely
missed in the process.
    
This commit corrects the spelling of the documentation.
