### PR TITLE
net: never probe IPv4 map support on DragonFly BSD, OpenBSD

### DIFF
--- a/src/net/ipsock.go
+++ b/src/net/ipsock.go
@@ -7,6 +7,7 @@ package net
 import (
 	"context"
 	"internal/bytealg"
+	"runtime"
 	"sync"
 )
 
@@ -44,6 +45,13 @@ func supportsIPv6() bool {
 // IPv4 address inside an IPv6 address at transport layer
 // protocols. See RFC 4291, RFC 4038 and RFC 3493.
 func supportsIPv4map() bool {
+	// Some operating systems provide no support for mapping IPv4
+	// addresses to IPv6, and a runtime check is unnecessary.
+	switch runtime.GOOS {
+	case "dragonfly", "openbsd":
+		return false
+	}
+
 	ipStackCaps.Once.Do(ipStackCaps.probe)
 	return ipStackCaps.ipv4MappedIPv6Enabled
 }


### PR DESCRIPTION
DragonFly BSD and OpenBSD do not implement mapping IPv4 addresses to
the IPv6 address space, and a runtime check can be avoided.

As the IP stack capabilities probe was only being called from
supportsIPv4map to check for this support, the OS-specific handling
can be added to this function rather than continuing to run the probe.
