### PR TITLE
net: use the size be sent as the count param of sendfile

### DIFF
--- a/src/net/sendfile_linux.go
+++ b/src/net/sendfile_linux.go
@@ -31,6 +31,14 @@ func sendFile(c *netFD, r io.Reader) (written int64, err error, handled bool) {
 	if !ok {
 		return 0, nil, false
 	}
+	if fi, err := f.Stat(); err == nil {
+		if pos, err := f.Seek(0, io.SeekCurrent); err == nil {
+			siz := fi.Size() - pos
+			if remain > siz {
+				remain = siz
+			}
+		}
+	}
 
 	sc, err := f.SyscallConn()
 	if err != nil {


### PR DESCRIPTION
if the count param of sendfile larger than the file size to be sent,
the TCP will cause a 200ms delay somehow.

Fixes #41513
Fixes #45256