### PR TITLE
mime: support reading shared mime-info database on unix systems

### DIFF
--- a/src/mime/testdata/test.types.globs2
+++ b/src/mime/testdata/test.types.globs2
@@ -1,0 +1,8 @@
+# Copyright 2021 The Go Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+# mime package test for globs2
+50:application/test:*.t1
+50:text/test:*.t2

--- a/src/mime/testdata/test.types.globs2
+++ b/src/mime/testdata/test.types.globs2
@@ -4,5 +4,5 @@
 
 
 # mime package test for globs2
-50:application/test:*.t1
-50:text/test:*.t2
+50:document/test:*.t3
+50:example/test:*.t4

--- a/src/mime/type_unix.go
+++ b/src/mime/type_unix.go
@@ -43,7 +43,9 @@ func loadMimeGlobsFile(filename string) error {
 	for scanner.Scan() {
 		// Each line should be of format: weight:mimetype:*.ext
 		fields := strings.Split(scanner.Text(), ":")
-		if len(fields) < 2 || fields[0][0] == '#' || fields[2][0] != '*' {
+		if len(fields) < 3 || len(fields[0]) < 1 || len(fields[2]) < 2 {
+			continue
+		} else if fields[0][0] == '#' || fields[2][0] != '*' {
 			continue
 		}
 

--- a/src/mime/type_unix.go
+++ b/src/mime/type_unix.go
@@ -17,11 +17,42 @@ func init() {
 	osInitMime = initMimeUnix
 }
 
+// See https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-0.21.html
+// for the FreeDesktop Shared MIME-info Database specification.
+var mimeGlobs = []string{
+	"/usr/local/share/mime/globs2",
+	"/usr/share/mime/globs2",
+}
+
+// Common locations for mime.types files on unix.
 var typeFiles = []string{
 	"/etc/mime.types",
 	"/etc/apache2/mime.types",
 	"/etc/apache/mime.types",
 	"/etc/httpd/conf/mime.types",
+}
+
+func loadMimeGlobsFile(filename string) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		// Each line should be of format: weight:mimetype:*.ext
+		fields := strings.Split(scanner.Text(), ":")
+		if len(fields) < 2 || fields[0][0] == '#' || fields[2][0] != '*' {
+			continue
+		}
+
+		setExtensionType(fields[2][1:], fields[1])
+	}
+	if err := scanner.Err(); err != nil {
+		panic(err)
+	}
+	return nil
 }
 
 func loadMimeFile(filename string) {
@@ -51,12 +82,20 @@ func loadMimeFile(filename string) {
 }
 
 func initMimeUnix() {
+	for _, filename := range mimeGlobs {
+		if err := loadMimeGlobsFile(filename); err == nil {
+			return // Stop checking more files if mimetype database is found.
+		}
+	}
+
+	// Fallback if no system-generated mimetype database exists.
 	for _, filename := range typeFiles {
 		loadMimeFile(filename)
 	}
 }
 
 func initMimeForTests() map[string]string {
+	mimeGlobs = []string{"testdata/test.types.globs2"}
 	typeFiles = []string{"testdata/test.types"}
 	return map[string]string{
 		".T1":  "application/test",

--- a/src/mime/type_unix.go
+++ b/src/mime/type_unix.go
@@ -97,7 +97,7 @@ func initMimeUnix() {
 }
 
 func initMimeForTests() map[string]string {
-	mimeGlobs = []string{"testdata/test.types.globs2"}
+	mimeGlobs = []string{""}
 	typeFiles = []string{"testdata/test.types"}
 	return map[string]string{
 		".T1":  "application/test",

--- a/src/mime/type_unix_test.go
+++ b/src/mime/type_unix_test.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
+
 package mime
 
 import (

--- a/src/mime/type_unix_test.go
+++ b/src/mime/type_unix_test.go
@@ -8,20 +8,22 @@ import (
 	"testing"
 )
 
-func initMimeUnixTest() {
+func initMimeUnixTest(t *testing.T) {
 	err := loadMimeGlobsFile("testdata/test.types.globs2")
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	loadMimeFile("testdata/test.types")
 }
 
 func TestTypeByExtensionUNIX(t *testing.T) {
-	initMimeUnixTest()
+	initMimeUnixTest(t)
 	typeTests := map[string]string{
 		".T1":  "application/test",
 		".t2":  "text/test; charset=utf-8",
+		".t3":  "document/test",
+		".t4":  "example/test",
 		".png": "image/png",
 	}
 

--- a/src/mime/type_unix_test.go
+++ b/src/mime/type_unix_test.go
@@ -1,0 +1,34 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mime
+
+import (
+	"testing"
+)
+
+func initMimeUnixTest() {
+	err := loadMimeGlobsFile("testdata/test.types.globs2")
+	if err != nil {
+		panic(err)
+	}
+
+	loadMimeFile("testdata/test.types")
+}
+
+func TestTypeByExtensionUNIX(t *testing.T) {
+	initMimeUnixTest()
+	typeTests := map[string]string{
+		".T1":  "application/test",
+		".t2":  "text/test; charset=utf-8",
+		".png": "image/png",
+	}
+
+	for ext, want := range typeTests {
+		val := TypeByExtension(ext)
+		if val != want {
+			t.Errorf("TypeByExtension(%q) = %q, want %q", ext, val, want)
+		}
+	}
+}


### PR DESCRIPTION
This adds support for reading the FreeDesktop Shared MIME-info Database on Unix systems, if it exists.
It should make lookups work on systems where the mime.types files are not present and
should lead to better mimetype lookup in general. If the shared mimetype database does not exist,
we will fall back to reading mime.types files in common locations.

Related to a bug on Solus bugtracker: https://dev.getsol.us/T9394
This change makes the mime package work on Solus.