### PR TITLE
os: set the correct op while returning errors from WriteAt, ReadFrom, ReadAt

### DIFF
--- a/src/os/file.go
+++ b/src/os/file.go
@@ -125,7 +125,7 @@ func (f *File) Read(b []byte) (n int, err error) {
 // ReadAt always returns a non-nil error when n < len(b).
 // At end of file, that error is io.EOF.
 func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
-	if err := f.checkValid("read"); err != nil {
+	if err := f.checkValid("readat"); err != nil {
 		return 0, err
 	}
 
@@ -136,7 +136,7 @@ func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
 	for len(b) > 0 {
 		m, e := f.pread(b, off)
 		if e != nil {
-			err = f.wrapErr("read", e)
+			err = f.wrapErr("readat", e)
 			break
 		}
 		n += m
@@ -148,14 +148,14 @@ func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
 
 // ReadFrom implements io.ReaderFrom.
 func (f *File) ReadFrom(r io.Reader) (n int64, err error) {
-	if err := f.checkValid("write"); err != nil {
+	if err := f.checkValid("readfrom"); err != nil {
 		return 0, err
 	}
 	n, handled, e := f.readFrom(r)
 	if !handled {
 		return genericReadFrom(f, r) // without wrapping
 	}
-	return n, f.wrapErr("write", e)
+	return n, f.wrapErr("readfrom", e)
 }
 
 func genericReadFrom(f *File, r io.Reader) (int64, error) {
@@ -198,7 +198,7 @@ var errWriteAtInAppendMode = errors.New("os: invalid use of WriteAt on file open
 //
 // If file was opened with the O_APPEND flag, WriteAt returns an error.
 func (f *File) WriteAt(b []byte, off int64) (n int, err error) {
-	if err := f.checkValid("write"); err != nil {
+	if err := f.checkValid("writeat"); err != nil {
 		return 0, err
 	}
 	if f.appendMode {
@@ -212,7 +212,7 @@ func (f *File) WriteAt(b []byte, off int64) (n int, err error) {
 	for len(b) > 0 {
 		m, e := f.pwrite(b, off)
 		if e != nil {
-			err = f.wrapErr("write", e)
+			err = f.wrapErr("writeat", e)
 			break
 		}
 		n += m


### PR DESCRIPTION
For some of the errors returned from WriteAt, ReadFrom, ReadAt the op set
in PathError does not correctly match the name of the operation.  
For eg. the op is set to "write" in ReadFrom.
This change fixes the ops to match the name of the function they 
correspond to. 