### PR TITLE
cmd/compile/internal/ssagen: conditon not need

### DIFF
--- a/src/cmd/compile/internal/ssagen/ssa.go
+++ b/src/cmd/compile/internal/ssagen/ssa.go
@@ -1801,7 +1801,7 @@ func (s *state) stmt(n ir.Node) {
 				b.AddEdgeTo(bCond)
 				// It can happen that bIncr ends in a block containing only VARKILL,
 				// and that muddles the debugging experience.
-				if n.Op() != ir.OFORUNTIL && b.Pos == src.NoXPos {
+				if b.Pos == src.NoXPos {
 					b.Pos = bCond.Pos
 				}
 			}


### PR DESCRIPTION
 n.Op() == ir.OFOR so n.Op() != ir.OFORUNTIL is always true