### PR TITLE
sync: update misleading comment in map.go about entry type

### DIFF
--- a/src/sync/map.go
+++ b/src/sync/map.go
@@ -73,7 +73,8 @@ var expunged = unsafe.Pointer(new(interface{}))
 type entry struct {
 	// p points to the interface{} value stored for the entry.
 	//
-	// If p == nil, the entry has been deleted and m.dirty == nil.
+	// If p == nil, the entry has been deleted, and either m.dirty == nil or
+	// m.dirty[key] is e.
 	//
 	// If p == expunged, the entry has been deleted, m.dirty != nil, and the entry
 	// is missing from m.dirty.


### PR DESCRIPTION
As discussed in: https://github.com/golang/go/issues/45429,  about entry
type comments, it is possible for p == nil when m.dirty != nil, so
update the commemt about it.

Fixes #45429