### PR TITLE
net: condition not need

### DIFF
--- a/src/net/addrselect.go
+++ b/src/net/addrselect.go
@@ -19,9 +19,6 @@ func sortByRFC6724(addrs []IPAddr) {
 }
 
 func sortByRFC6724withSrcs(addrs []IPAddr, srcs []IP) {
-	if len(addrs) != len(srcs) {
-		panic("internal error")
-	}
 	addrAttr := make([]ipAttr, len(addrs))
 	srcAttr := make([]ipAttr, len(srcs))
 	for i, v := range addrs {


### PR DESCRIPTION
there is only one place call sortByRFC6742withSrcs, and the second parameter is return value of srcAddrs([here](https://github.com/golang/go/blob/master/src/net/addrselect.go#L43)), srcAddrs always return same slice len of addrs, so I think checking the slice len is equal is unnecessary !