### PR TITLE
path/filepath: add JoinList

### DIFF
--- a/src/path/filepath/path.go
+++ b/src/path/filepath/path.go
@@ -180,6 +180,26 @@ func FromSlash(path string) string {
 	return strings.ReplaceAll(path, "/", string(Separator))
 }
 
+// JoinList joins any number of paths into a path list, separating them with an
+// OS-specific ListSeparator, usually found in PATH or GOPATH environment
+// variables. Empty elements are ignored. If the argument list is empty or all
+// its elements are empty, JoinList returns an empty string. On Windows, paths
+// containing embedded separator are assumed to already be quoted.
+func JoinList(elem ...string) string {
+	var (
+		b []byte
+		n int
+	)
+	for _, s := range elem {
+		if s == "" { continue }
+		if n > 0 {
+			b = append(b, ListSeparator)
+		}
+		b, n = append(b, s...), n + 1
+	}
+	return string(b)
+}
+
 // SplitList splits a list of paths joined by the OS-specific ListSeparator,
 // usually found in PATH or GOPATH environment variables.
 // Unlike strings.Split, SplitList returns an empty slice when passed an empty

--- a/src/path/filepath/path_test.go
+++ b/src/path/filepath/path_test.go
@@ -195,6 +195,33 @@ func TestSplitList(t *testing.T) {
 	}
 }
 
+type JoinListTest struct {
+	list []string
+	result string
+}
+
+var joinlisttests = []JoinListTest{
+	{[]string{"", "x" + string(lsep) + "y"}, "x" + string(lsep) + "y"},
+	{[]string{"x" + string(lsep) + "y", "z"}, "x" + string(lsep) + "y" + string(lsep) + "z"},
+}
+
+var winjoinlisttests = []JoinListTest{
+	{[]string{`c:\go;c:\rsc`, `c:\brad`}, `c:\go;c:\rsc;c:\brad`},
+	{[]string{`c:\go;c:\rsc`, `"c:\x;y"`}, `c:\go;c:\rsc;"c:\x;y"`},
+}
+
+func TestJoinList(t *testing.T) {
+	tests := joinlisttests
+	if runtime.GOOS == "windows" {
+		tests = append(tests, winjoinlisttests...)
+	}
+	for _, test := range tests {
+		if s := filepath.JoinList(test.list...); s != test.result {
+			t.Errorf("JoinList(%#q) = %#q, want %#q", test.list, s, test.result)
+		}
+	}
+}
+
 type SplitTest struct {
 	path, dir, file string
 }


### PR DESCRIPTION
Handles the cases described here:

https://github.com/golang/go/issues/25205#issuecomment-387198842

Regarding Windows, input paths are assumed to be already quoted as needed. This allows for code like this:

~~~go
s := os.Getenv("PATH")
s = filepath.JoinList(s, `C:\go\bin`)
~~~

Fixes #25205