### PR TITLE
cmd/go: use exit code from compiled test binary on error

### DIFF
--- a/src/cmd/go/internal/test/test.go
+++ b/src/cmd/go/internal/test/test.go
@@ -1273,6 +1273,10 @@ func (c *runCache) builderRunTest(b *work.Builder, ctx context.Context, a *work.
 		c.saveOutput(a)
 	} else {
 		base.SetExitStatus(1)
+		if exitErr := (*exec.ExitError)(nil); errors.As(err, &exitErr) {
+			base.SetExitStatus(exitErr.ExitCode())
+		}
+
 		// If there was test output, assume we don't need to print the exit status.
 		// Buf there's no test output, do print the exit status.
 		if len(out) == 0 {


### PR DESCRIPTION
Fixes #45508

Use the exit code from the compiled test binary, when the exec
exits with an error. This allows programs which run 'go test -json'
to determine if all the tests were run, or if a panic caused the run
to exit before running all tests.