### PR TITLE
reflect: fix stack overflow panic when using ConvertibleTo

### DIFF
--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -14,7 +14,10 @@ import (
 	"math"
 	"math/rand"
 	"os"
+	"reflect"
 	. "reflect"
+	example1 "reflect/internal/example1"
+	example2 "reflect/internal/example2"
 	"runtime"
 	"sort"
 	"strconv"
@@ -7230,4 +7233,10 @@ func iterateToString(it *MapIter) string {
 	}
 	sort.Strings(got)
 	return "[" + strings.Join(got, ", ") + "]"
+}
+
+func TestConvertibleTo(t *testing.T) {
+	t1 := reflect.ValueOf(example1.MyStruct{}).Type()
+	t2 := reflect.ValueOf(example2.MyStruct{}).Type()
+	t1.ConvertibleTo(t2)
 }

--- a/src/reflect/internal/example1/example.go
+++ b/src/reflect/internal/example1/example.go
@@ -1,0 +1,6 @@
+package example
+
+type MyStruct struct {
+	MyStructs []MyStruct
+	MyStruct  *MyStruct
+}

--- a/src/reflect/internal/example2/example.go
+++ b/src/reflect/internal/example2/example.go
@@ -1,0 +1,6 @@
+package example
+
+type MyStruct struct {
+	MyStructs []MyStruct
+	MyStruct  *MyStruct
+}

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -2841,14 +2841,14 @@ func convertOp(dst, src *rtype) func(Value, Type) Value {
 	}
 
 	// dst and src have same underlying type.
-	if haveIdenticalUnderlyingType(dst, src, false) {
+	if haveIdenticalUnderlyingType(dst, src, false, map[cacheKey]bool{}) {
 		return cvtDirect
 	}
 
 	// dst and src are non-defined pointer types with same underlying base type.
 	if dst.Kind() == Ptr && dst.Name() == "" &&
 		src.Kind() == Ptr && src.Name() == "" &&
-		haveIdenticalUnderlyingType(dst.Elem().common(), src.Elem().common(), false) {
+		haveIdenticalUnderlyingType(dst.Elem().common(), src.Elem().common(), false, map[cacheKey]bool{}) {
 		return cvtDirect
 	}
 


### PR DESCRIPTION
reflect.ConvertibleTo will raise stack overflow when using with self referential struct having same structure

for example:

type MyStruct struct {
	MyStructs []MyStruct
	MyStruct  *MyStruct
}

error message like:

```
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0xc020596390 stack=[0xc020596000, 0xc040596000]
fatal error: stack overflow

runtime stack:
runtime.throw(0x125ec63, 0xe)
        /Users/jinzhu/Projects/jinzhu/go/src/runtime/panic.go:1191 +0x74
runtime.newstack()
        /Users/jinzhu/Projects/jinzhu/go/src/runtime/stack.go:1086 +0x6a5
runtime.morestack()
        /Users/jinzhu/Projects/jinzhu/go/src/runtime/asm_amd64.s:465 +0x8b

goroutine 4056 [running]:
reflect.(*rtype).Elem(0x1209e00, 0x0, 0x0)
        /Users/jinzhu/Projects/jinzhu/go/src/reflect/type.go:903 +0x1ab fp=0xc0205963a0 sp=0xc020596398 pc=0x10c284b
reflect.haveIdenticalUnderlyingType(0x1209e00, 0x1209dc0, 0x0, 0xc040595c40, 0x0)
        /Users/jinzhu/Projects/jinzhu/go/src/reflect/type.go:1665 +0x405 fp=0xc020596480 sp=0xc0205963a0 pc=0x10c6be5
reflect.haveIdenticalType(0x13a9980, 0x1209e00, 0x13a9980, 0x1209dc0, 0x0, 0xc040595c40, 0x0)
        /Users/jinzhu/Projects/jinzhu/go/src/reflect/type.go:1606 +0x192 fp=0xc0205964d8 sp=0xc020596480 pc=0x10c67b2
reflect.haveIdenticalUnderlyingType(0x1232420, 0x1232380, 0x0, 0xc040595c40, 0x0)
        /Users/jinzhu/Projects/jinzhu/go/src/reflect/type.go:1683 +0x7b7 fp=0xc0205965b8 sp=0xc0205964d8 pc=0x10c6f97
reflect.haveIdenticalType(0x13a9980, 0x1232420, 0x13a9980, 0x1232380, 0x0, 0xc040595c40, 0x0)
        /Users/jinzhu/Projects/jinzhu/go/src/reflect/type.go:1606 +0x192 fp=0xc020596610 sp=0xc0205965b8 pc=0x10c67b2
reflect.haveIdenticalUnderlyingType(0x1209e00, 0x1209dc0, 0x0, 0xc040595c40, 0x0)
        /Users/jinzhu/Projects/jinzhu/go/src/reflect/type.go:1665 +0x47b fp=0xc0205966f0 sp=0xc020596610 pc=0x10c6c5b
reflect.haveIdenticalType(0x13a9980, 0x1209e00, 0x13a9980, 0x1209dc0, 0x0, 0xc040595c40, 0x0)
        /Users/jinzhu/Projects/jinzhu/go/src/reflect/type.go:1606 +0x192 fp=0xc020596748 sp=0xc0205966f0 pc=0x10c67b2
reflect.haveIdenticalUnderlyingType(0x1232420, 0x1232380, 0x0, 0xc040595c40, 0x0)
        /Users/jinzhu/Projects/jinzhu/go/src/reflect/type.go:1683 +0x7b7 fp=0xc020596828 sp=0xc020596748 pc=0x10c6f97
reflect.haveIdenticalType(0x13a9980, 0x1232420, 0x13a9980, 0x1232380, 0x0, 0xc040595c40, 0x0)
        /Users/jinzhu/Projects/jinzhu/go/src/reflect/type.go:1606 +0x192 fp=0xc020596880 sp=0xc020596828 pc=0x10c67b2
reflect.haveIdenticalUnderlyingType(0x1209e00, 0x1209dc0, 0x0, 0xc040595c40, 0x0)
        /Users/jinzhu/Projects/jinzhu/go/src/reflect/type.go:1665 +0x47b fp=0xc020596960 sp=0xc020596880 pc=0x10c6c5b
reflect.haveIdenticalType(0x13a9980, 0x1209e00, 0x13a9980, 0x1209dc0, 0x0, 0xc040595c40, 0x0)
        /Users/jinzhu/Projects/jinzhu/go/src/reflect/type.go:1606 +0x192 fp=0xc0205969b8 sp=0xc020596960 pc=0x10c67b2
reflect.haveIdenticalUnderlyingType(0x1232420, 0x1232380, 0x0, 0xc040595c40, 0x0)
        /Users/jinzhu/Projects/jinzhu/go/src/reflect/type.go:1683 +0x7b7 fp=0xc020596a98 sp=0xc0205969b8 pc=0x10c6f97
reflect.haveIdenticalType(0x13a9980, 0x1232420, 0x13a9980, 0x1232380, 0x0, 0xc040595c40, 0x0)
        /Users/jinzhu/Projects/jinzhu/go/src/reflect/type.go:1606 +0x192 fp=0xc020596af0 sp=0xc020596a98 pc=0x10c67b2
reflect.haveIdenticalUnderlyingType(0x1209e00, 0x1209dc0, 0x0, 0xc040595c40, 0x0)
        /Users/jinzhu/Projects/jinzhu/go/src/reflect/type.go:1665 +0x47b fp=0xc020596bd0 sp=0xc020596af0 pc=0x10c6c5b
```