### PR TITLE
reflect: fix stack overflow panic when using haveIdenticalUnderlyingType

### DIFF
--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -14,10 +14,9 @@ import (
 	"math"
 	"math/rand"
 	"os"
-	"reflect"
 	. "reflect"
-	example1 "reflect/internal/example1"
-	example2 "reflect/internal/example2"
+	"reflect/internal/example1"
+	"reflect/internal/example2"
 	"runtime"
 	"sort"
 	"strconv"
@@ -7236,9 +7235,30 @@ func iterateToString(it *MapIter) string {
 }
 
 func TestConvertibleTo(t *testing.T) {
-	t1 := reflect.ValueOf(example1.MyStruct{}).Type()
-	t2 := reflect.ValueOf(example2.MyStruct{}).Type()
+	t1 := ValueOf(example1.MyStruct{}).Type()
+	t2 := ValueOf(example2.MyStruct{}).Type()
 	if !t1.ConvertibleTo(t2) {
-		t.Errorf("(%s).ConvertibleTo(%s) = false, want true", t1, t2)
+		t.Fatalf("(%s).ConvertibleTo(%s) = false, want true", t1, t2)
+	}
+
+	v1 := example1.MyStruct{
+		Name: "hello",
+		MyStruct: &example1.MyStruct{
+			Name: "world",
+		},
+		MyStructs: []example1.MyStruct{
+			{Name: "hello world 1"},
+			{Name: "hello world 2"},
+		},
+	}
+
+	v2, ok := ValueOf(v1).Convert(t2).Interface().(example2.MyStruct)
+
+	if !ok {
+		t.Fatalf("(%s).Convert(%s) failed", t1, t2)
+	}
+
+	if fmt.Sprintf("%+v", v2) != fmt.Sprintf("%+v", v1) {
+		t.Fatalf("(%s).Convert(%s) got %+v, expecting %+v", t1, t2, v2, v1)
 	}
 }

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -3810,6 +3810,16 @@ type Empty struct{}
 type MyStruct struct {
 	x int `some:"tag"`
 }
+type MyStruct1 struct {
+	x struct {
+		int `some:"bar"`
+	}
+}
+type MyStruct2 struct {
+	x struct {
+		int `some:"foo"`
+	}
+}
 type MyString string
 type MyBytes []byte
 type MyRunes []int32
@@ -4159,6 +4169,9 @@ var convertTests = []struct {
 	{V(struct {
 		x int `some:"bar"`
 	}{}), V(MyStruct{})},
+
+	{V(MyStruct1{}), V(MyStruct2{})},
+	{V(MyStruct2{}), V(MyStruct1{})},
 
 	// can convert *byte and *MyByte
 	{V((*byte)(nil)), V((*MyByte)(nil))},

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -14,7 +14,10 @@ import (
 	"math"
 	"math/rand"
 	"os"
+	"reflect"
 	. "reflect"
+	example1 "reflect/internal/example1"
+	example2 "reflect/internal/example2"
 	"runtime"
 	"sort"
 	"strconv"
@@ -7230,4 +7233,12 @@ func iterateToString(it *MapIter) string {
 	}
 	sort.Strings(got)
 	return "[" + strings.Join(got, ", ") + "]"
+}
+
+func TestConvertibleTo(t *testing.T) {
+	t1 := reflect.ValueOf(example1.MyStruct{}).Type()
+	t2 := reflect.ValueOf(example2.MyStruct{}).Type()
+	if !t1.ConvertibleTo(t2) {
+		t.Errorf("(%s).ConvertibleTo(%s) = false, want true", t1, t2)
+	}
 }

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -7237,28 +7237,9 @@ func iterateToString(it *MapIter) string {
 func TestConvertibleTo(t *testing.T) {
 	t1 := ValueOf(example1.MyStruct{}).Type()
 	t2 := ValueOf(example2.MyStruct{}).Type()
-	if !t1.ConvertibleTo(t2) {
-		t.Fatalf("(%s).ConvertibleTo(%s) = false, want true", t1, t2)
-	}
 
-	v1 := example1.MyStruct{
-		Name: "hello",
-		MyStruct: &example1.MyStruct{
-			Name: "world",
-		},
-		MyStructs: []example1.MyStruct{
-			{Name: "hello world 1"},
-			{Name: "hello world 2"},
-		},
-	}
-
-	v2, ok := ValueOf(v1).Convert(t2).Interface().(example2.MyStruct)
-
-	if !ok {
-		t.Fatalf("(%s).Convert(%s) failed", t1, t2)
-	}
-
-	if fmt.Sprintf("%+v", v2) != fmt.Sprintf("%+v", v1) {
-		t.Fatalf("(%s).Convert(%s) got %+v, expecting %+v", t1, t2, v2, v1)
+	// Shouldn't raise stack overflow
+	if t1.ConvertibleTo(t2) {
+		t.Fatalf("(%s).ConvertibleTo(%s) = true, want false", t1, t2)
 	}
 }

--- a/src/reflect/internal/example1/example.go
+++ b/src/reflect/internal/example1/example.go
@@ -1,0 +1,6 @@
+package example
+
+type MyStruct struct {
+	MyStructs []MyStruct
+	MyStruct  *MyStruct
+}

--- a/src/reflect/internal/example1/example.go
+++ b/src/reflect/internal/example1/example.go
@@ -1,6 +1,7 @@
-package example
+package example1
 
 type MyStruct struct {
+	Name      string
 	MyStructs []MyStruct
 	MyStruct  *MyStruct
 }

--- a/src/reflect/internal/example1/example.go
+++ b/src/reflect/internal/example1/example.go
@@ -1,7 +1,6 @@
 package example1
 
 type MyStruct struct {
-	Name      string
 	MyStructs []MyStruct
 	MyStruct  *MyStruct
 }

--- a/src/reflect/internal/example2/example.go
+++ b/src/reflect/internal/example2/example.go
@@ -1,6 +1,7 @@
-package example
+package example2
 
 type MyStruct struct {
+	Name      string
 	MyStructs []MyStruct
 	MyStruct  *MyStruct
 }

--- a/src/reflect/internal/example2/example.go
+++ b/src/reflect/internal/example2/example.go
@@ -1,7 +1,6 @@
 package example2
 
 type MyStruct struct {
-	Name      string
 	MyStructs []MyStruct
 	MyStruct  *MyStruct
 }

--- a/src/reflect/internal/example2/example.go
+++ b/src/reflect/internal/example2/example.go
@@ -1,0 +1,6 @@
+package example
+
+type MyStruct struct {
+	MyStructs []MyStruct
+	MyStruct  *MyStruct
+}

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -1679,7 +1679,7 @@ func haveIdenticalUnderlyingType(T, V *rtype, cmpTags bool) bool {
 			if tf.name.name() != vf.name.name() {
 				return false
 			}
-			if tf.typ.str != vf.typ.str {
+			if tf.typ.Kind() != Struct && tf.typ.str != vf.typ.str {
 				return false
 			}
 			if !haveIdenticalType(tf.typ, vf.typ, cmpTags) {

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -1599,7 +1599,7 @@ func haveIdenticalType(T, V Type, cmpTags bool) bool {
 		return T == V
 	}
 
-	if T.Name() != V.Name() || T.Kind() != V.Kind() {
+	if T.Name() != V.Name() || T.Kind() != V.Kind() || T.PkgPath() != V.PkgPath() {
 		return false
 	}
 
@@ -1677,9 +1677,6 @@ func haveIdenticalUnderlyingType(T, V *rtype, cmpTags bool) bool {
 			tf := &t.fields[i]
 			vf := &v.fields[i]
 			if tf.name.name() != vf.name.name() {
-				return false
-			}
-			if tf.typ.Kind() != Struct && tf.typ.str != vf.typ.str {
 				return false
 			}
 			if !haveIdenticalType(tf.typ, vf.typ, cmpTags) {

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -1681,11 +1681,11 @@ func haveIdenticalUnderlyingType(T, V *rtype, cmpTags bool, compared map[cacheKe
 			}
 
 			ckey := cacheKey{Struct, tf.typ, tf.typ, 0}
-			if _, ok := compared[ckey]; ok {
+			if compared[ckey] {
 				continue
-			} else {
-				compared[ckey] = true
 			}
+			compared[ckey] = true
+
 			if !haveIdenticalType(tf.typ, vf.typ, cmpTags, compared) {
 				return false
 			}

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -2841,14 +2841,14 @@ func convertOp(dst, src *rtype) func(Value, Type) Value {
 	}
 
 	// dst and src have same underlying type.
-	if haveIdenticalUnderlyingType(dst, src, false) {
+	if haveIdenticalUnderlyingType(dst, src, false, map[cacheKey]bool{}) {
 		return cvtDirect
 	}
 
 	// dst and src are non-defined pointer types with same underlying base type.
 	if dst.Kind() == Ptr && dst.Name() == "" &&
 		src.Kind() == Ptr && src.Name() == "" &&
-		haveIdenticalUnderlyingType(dst.Elem().common(), src.Elem().common(), false) {
+		haveIdenticalUnderlyingType(dst.Elem().common(), src.Elem().common(), false, map[cacheKey]bool{}) {
 		return cvtDirect
 	}
 

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -2841,14 +2841,14 @@ func convertOp(dst, src *rtype) func(Value, Type) Value {
 	}
 
 	// dst and src have same underlying type.
-	if haveIdenticalUnderlyingType(dst, src, false, map[cacheKey]bool{}) {
+	if haveIdenticalUnderlyingType(dst, src, false) {
 		return cvtDirect
 	}
 
 	// dst and src are non-defined pointer types with same underlying base type.
 	if dst.Kind() == Ptr && dst.Name() == "" &&
 		src.Kind() == Ptr && src.Name() == "" &&
-		haveIdenticalUnderlyingType(dst.Elem().common(), src.Elem().common(), false, map[cacheKey]bool{}) {
+		haveIdenticalUnderlyingType(dst.Elem().common(), src.Elem().common(), false) {
 		return cvtDirect
 	}
 


### PR DESCRIPTION
haveIdenticalUnderlyingType raises stack overflow when compares 
self-referential structs having same structure in different packages.