### PR TITLE
misc/cgo: clean up exe.go

### DIFF
--- a/misc/cgo/testshared/testdata/execgo/exe.go
+++ b/misc/cgo/testshared/testdata/execgo/exe.go
@@ -1,7 +1,5 @@
 package main
 
-/*
- */
 import "C"
 
 func main() {


### PR DESCRIPTION
Removes unnecessary multi-line comment

