### PR TITLE
cmd/go: allow generate to skip missing files

### DIFF
--- a/src/cmd/go/internal/generate/generate.go
+++ b/src/cmd/go/internal/generate/generate.go
@@ -201,6 +201,10 @@ func runGenerate(ctx context.Context, cmd *base.Command, args []string) {
 func generate(absFile string) bool {
 	src, err := os.ReadFile(absFile)
 	if err != nil {
+		if os.IsNotExist(err) {
+			// Disappeared during generation - ignore file.
+			return true
+		}
 		log.Fatalf("generate: %s", err)
 	}
 

--- a/src/cmd/go/testdata/script/generate_removed.txt
+++ b/src/cmd/go/testdata/script/generate_removed.txt
@@ -1,0 +1,36 @@
+# Install an rm command because some systems don't have it.
+env GOBIN=$WORK/tmp/bin
+go install rm.go
+[plan9] env path=$GOBIN${:}$path
+[!plan9] env PATH=$GOBIN${:}$PATH
+
+go generate ./...
+
+-- go.mod --
+module genclean
+
+go 1.16
+
+-- a.go --
+package genclean
+
+//go:generate rm b.go
+
+-- b.go --
+package genclean
+
+-- rm.go --
+// +build ignore
+
+package main
+
+import (
+	"log"
+	"os"
+)
+
+func main() {
+	if err := os.Remove(os.Args[1]); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
This change allows go generate to process packages where files may
disappear during code generation. See also #36422.

Updates #36068
