### PR TITLE
all: fix some typos

### DIFF
--- a/src/cmd/compile/internal/ssa/expand_calls.go
+++ b/src/cmd/compile/internal/ssa/expand_calls.go
@@ -1450,7 +1450,7 @@ func expandCalls(f *Func) {
 
 	// Step 6: elide any copies introduced.
 	// Update named values.
-	if false { // TODO: reeanable. It caused compiler OOMing on large input.
+	if false { // TODO: reenable. It caused compiler OOMing on large input.
 		for _, name := range f.Names {
 			values := f.NamedValues[name]
 			for i, v := range values {

--- a/test/live_regabi.go
+++ b/test/live_regabi.go
@@ -1,7 +1,7 @@
 // errorcheckwithauto -0 -l -live -wb=0 -d=ssa/insert_resched_checks/off
 // +build amd64,goexperiment.regabidefer,goexperiment.regabiargs,ignore
 
-// Disabled for now. The compiler sometimes has bad name-value association
+// Disabled for now. The compiler sometimes has a bad name-value association
 // for args, causing args appears as autotmps.
 
 // Copyright 2014 The Go Authors. All rights reserved.


### PR DESCRIPTION
This follows the spelling choices that the Go project has made for English words.
https://github.com/golang/go/wiki/Spelling