### PR TITLE
syscall/js Implement runtimeError so that func can throw exceptions by returnFeature syscall js runtime error

### DIFF
--- a/misc/wasm/wasm_exec.js
+++ b/misc/wasm/wasm_exec.js
@@ -438,6 +438,14 @@
 						}
 					},
 
+					// func runtimeError(m ref) ref
+					"syscall/js.runtimeError": (sp) => {
+					  sp >>>= 0;
+					  const message = loadValue(sp + 8);
+					  const result = new GoRuntimeError(message);
+					  storeValue(sp + 16, result);
+					},
+
 					// func valueLength(v ref) int
 					"syscall/js.valueLength": (sp) => {
 						sp >>>= 0;
@@ -587,10 +595,15 @@
 				const event = { id: id, this: this, args: arguments };
 				go._pendingEvent = event;
 				go._resume();
-				return event.result;
+				const result = event.result;
+				if (result instanceof GoRuntimeError) {
+					throw result;
+				}
+				return result;
 			};
 		}
 	}
+	class GoRuntimeError extends Error {}
 
 	if (
 		typeof module !== "undefined" &&

--- a/misc/wasm/wasm_exec.js
+++ b/misc/wasm/wasm_exec.js
@@ -604,6 +604,7 @@
 		}
 	}
 	class GoRuntimeError extends Error {}
+	global.Go.RuntimeError = GoRuntimeError;
 
 	if (
 		typeof module !== "undefined" &&

--- a/src/syscall/js/js.go
+++ b/src/syscall/js/js.go
@@ -442,6 +442,14 @@ func (v Value) New(args ...interface{}) Value {
 
 func valueNew(v ref, args []ref) (ref, bool)
 
+// Return RuntimeError, will be throw in javascript-function.
+func RuntimeError(message string) Value {
+	m := makeValue(stringVal(message))
+	res := runtimeError(m.ref)
+	return makeValue(res)
+}
+func runtimeError(m ref) ref
+
 func (v Value) isNumber() bool {
 	return v.ref == valueZero.ref ||
 		v.ref == valueNaN.ref ||

--- a/src/syscall/js/js_js.s
+++ b/src/syscall/js/js_js.s
@@ -44,6 +44,10 @@ TEXT ·valueNew(SB), NOSPLIT, $0
   CallImport
   RET
 
+TEXT ·runtimeError(SB), NOSPLIT, $0
+  CallImport
+  RET
+
 TEXT ·valueLength(SB), NOSPLIT, $0
   CallImport
   RET


### PR DESCRIPTION
Implement runtimeError, so that exceptions can be thrown by returning RuntimeError.

```go
func testRuntimeError(this js.Value, args []js.Value) interface{} {
	return js.RuntimeError("use return RuntimeError to alertnative throw Error in javascript.")
}
```
then call this func in javascript:
![image](https://user-images.githubusercontent.com/2151644/115370382-985c9680-a1fb-11eb-8435-5051af61ca5e.png)
