### PR TITLE
encoding/json: When Decoder has EOF err, try to refill

### DIFF
--- a/src/encoding/json/stream.go
+++ b/src/encoding/json/stream.go
@@ -48,7 +48,12 @@ func (dec *Decoder) DisallowUnknownFields() { dec.d.disallowUnknownFields = true
 // the conversion of JSON into a Go value.
 func (dec *Decoder) Decode(v interface{}) error {
 	if dec.err != nil {
-		return dec.err
+		// if can refill, like by buf.write(newDate), then can keep going to Decode
+		if dec.err == io.EOF && dec.refill() == nil {
+			dec.err = nil
+		} else {
+			return dec.err
+		}
 	}
 
 	if err := dec.tokenPrepareForDecode(); err != nil {

--- a/src/encoding/json/stream_test.go
+++ b/src/encoding/json/stream_test.go
@@ -201,6 +201,44 @@ func TestDecoder(t *testing.T) {
 	}
 }
 
+func TestDecoderAutoRefill(t *testing.T) {
+	var buf bytes.Buffer
+	dec := NewDecoder(&buf)
+	buf.Write([]byte("[1,"))
+	out := 0
+
+	// read '['
+	if _, err := dec.Token(); err != nil {
+		t.Errorf("Unexpected error '%#v' in Token", err)
+	}
+	// read 1
+	if err := dec.Decode(&out); err != nil {
+		t.Errorf("Unexpected error '%#v' in Decode", err)
+	}
+	if out != 1 {
+		t.Errorf("Unexpected Decode output '%v', should be 1", out)
+	}
+
+	// read eof
+	if err := dec.Decode(&out); err == nil {
+		t.Errorf("Unexpected success '%#v' in Decode", out)
+	}
+	// write
+	buf.Write([]byte("2]"))
+	// read 2
+	if err := dec.Decode(&out); err != nil {
+		t.Errorf("Unexpected error '%#v' in Decode", err)
+	}
+	if out != 2 {
+		t.Errorf("Unexpected Decode output '%v', should be 2", out)
+	}
+
+	// read ']'
+	if _, err := dec.Token(); err != nil {
+		t.Errorf("Unexpected error '%#v' in Token", err)
+	}
+}
+
 func TestDecoderBuffered(t *testing.T) {
 	r := strings.NewReader(`{"Name": "Gopher"} extra `)
 	var m struct {


### PR DESCRIPTION
In order to decode stream json data, and the stream may be suspend when the Decoder got an EOF error. So try to refill the Decoder buffer and keep going to decode.