### PR TITLE
cmd/go: add support for wildcards in 'go list -m'

### DIFF
--- a/src/cmd/go/internal/modload/list.go
+++ b/src/cmd/go/internal/modload/list.go
@@ -153,12 +153,12 @@ func listModules(ctx context.Context, rs *Requirements, args []string, mode List
 				matches = append(matches, path)
 			}
 
-			for _, m := range matches {
+			for _, mPath := range matches {
 				var current string
 				if mg == nil {
-					current, _ = rs.rootSelected(m)
+					current, _ = rs.rootSelected(mPath)
 				} else {
-					current = mg.Selected(m)
+					current = mg.Selected(mPath)
 				}
 
 				if current == "none" && mgErr != nil {
@@ -170,20 +170,20 @@ func listModules(ctx context.Context, rs *Requirements, args []string, mode List
 					}
 				}
 
-				info, err := Query(ctx, m, vers, current, allowed)
+				info, err := Query(ctx, mPath, vers, current, allowed)
 					if err != nil {
 					mods = append(mods, &modinfo.ModulePublic{
-						Path:    m,
+						Path:    mPath,
 						Version: vers,
-						Error:   modinfoError(m, vers, err),
+						Error:   modinfoError(mPath, vers, err),
 					})
 					continue
 				}
 
 				// Indicate that m was resolved from outside of rs by passing a nil
-				// *Requirements instead.
+				// *Requirements instead thereby marking the module as "not indirect".
 				var noRS *Requirements
-				version := module.Version{Path: m, Version: info.Version}
+				version := module.Version{Path: mPath, Version: info.Version}
 				if !matchedModule[version] {
 					matchedModule[version] = true
 					mods = append(mods, moduleInfo(ctx, noRS, version, mode))

--- a/src/cmd/go/testdata/script/mod_query.txt
+++ b/src/cmd/go/testdata/script/mod_query.txt
@@ -33,7 +33,19 @@ go list -m -e -f '{{.Error.Err}}' rsc.io/quote@>v1.5.3
 stdout 'no matching versions for query ">v1.5.3"'
 
 go list -m rsc.io/...@latest
-stdout 'rsc.io/quote v1.5.2\n'
+stdout 'rsc.io/quote v1.5.2$'
+
+go list -m .../quote@latest rsc.io/...@latest
+stdout 'rsc.io/quote v1.5.2$'
+
+go list -m rsc.io/...@latest rsc.io/...@patch
+stdout 'rsc.io/quote v1.5.2\nrsc.io/quote v1.0.0$'
+
+go list -m rsc.io/...@latest rsc.io/quote rsc.io/...@patch
+stdout 'rsc.io/quote v1.5.2\nrsc.io/quote v1.0.0$'
+
+go list -m rsc.io/...@latest rsc.io/quote rsc.io/...
+stdout 'rsc.io/quote v1.5.2\nrsc.io/quote v1.0.0$'
 
 -- go.mod --
 module x

--- a/src/cmd/go/testdata/script/mod_query.txt
+++ b/src/cmd/go/testdata/script/mod_query.txt
@@ -32,6 +32,9 @@ stderr 'go list -m: module rsc.io/quote: no matching versions for query ">v1.5.3
 go list -m -e -f '{{.Error.Err}}' rsc.io/quote@>v1.5.3
 stdout 'no matching versions for query ">v1.5.3"'
 
+go list -m rsc.io/...@latest
+stdout 'rsc.io/quote v1.5.2\n'
+
 -- go.mod --
 module x
 require rsc.io/quote v1.0.0


### PR DESCRIPTION
go list -m supports wildcards. however, when combined with version queries, it errors out. the commit makes it work when both are provided.

Fixes #45485
