### PR TITLE
cmd/go/internal/modfetch: fix comment that mentions no-longer returned error

### DIFF
--- a/src/cmd/go/internal/modfetch/repo.go
+++ b/src/cmd/go/internal/modfetch/repo.go
@@ -183,6 +183,9 @@ type lookupCacheKey struct {
 // from its origin, and "noproxy" indicates that the patch should be fetched
 // directly only if GONOPROXY matches the given path.
 //
+// For the distinguished proxy "off", Lookup now returns a Repo that returns
+// a non-nil error for every method call.
+//
 // A successful return does not guarantee that the module
 // has any defined versions.
 func Lookup(proxy, path string) Repo {

--- a/src/cmd/go/internal/modfetch/repo.go
+++ b/src/cmd/go/internal/modfetch/repo.go
@@ -183,7 +183,7 @@ type lookupCacheKey struct {
 // from its origin, and "noproxy" indicates that the patch should be fetched
 // directly only if GONOPROXY matches the given path.
 //
-// For the distinguished proxy "off", Lookup now returns a Repo that returns
+// For the distinguished proxy "off", Lookup always returns a Repo that returns
 // a non-nil error for every method call.
 //
 // A successful return does not guarantee that the module

--- a/src/cmd/go/internal/modfetch/repo.go
+++ b/src/cmd/go/internal/modfetch/repo.go
@@ -183,8 +183,6 @@ type lookupCacheKey struct {
 // from its origin, and "noproxy" indicates that the patch should be fetched
 // directly only if GONOPROXY matches the given path.
 //
-// For the distinguished proxy "off", Lookup always returns a non-nil error.
-//
 // A successful return does not guarantee that the module
 // has any defined versions.
 func Lookup(proxy, path string) Repo {


### PR DESCRIPTION
In c9211577eb77df9c51f0565f1da7d20ff91d59df @bcmills removed the returned error from
`Lookup`. However, the function docstring still mentions that this can return an error.

So this corrects the docs.