### PR TITLE
cmd/cgo: remove hardcoded '-pie' ldflag for linux/arm

### DIFF
--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -2980,13 +2980,13 @@ func (b *Builder) dynimport(a *Action, p *load.Package, objdir, importGo, cgoExe
 		if str.Contains(ldflags, "-pie") && str.Contains(ldflags, "-static") {
 			// -static -pie doesn't make sense, and causes link errors.
 			// Issue 26197.
-			n := make([]string, 0, len(ldflags))
+			n := make([]string, 0, len(ldflags)-1)
 			for _, flag := range ldflags {
 				if flag != "-static" {
 					n = append(n, flag)
 				}
 			}
-			ldflags = append(n, "-pie")
+			ldflags = n
 		}
 	}
 	if err := b.gccld(a, p, objdir, dynobj, ldflags, linkobj); err != nil {

--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -2971,7 +2971,13 @@ func (b *Builder) dynimport(a *Action, p *load.Package, objdir, importGo, cgoExe
 
 	ldflags := cgoLDFLAGS
 	if (cfg.Goarch == "arm" && cfg.Goos == "linux") || cfg.Goos == "android" {
-		if str.Contains(cgoLDFLAGS, "-pie") && str.Contains(cgoLDFLAGS, "-static") {
+		if !str.Contains(ldflags, "-no-pie") {
+			// if we do'nt see '-no-pie',
+			// we add "-pie" keep backward-compatibility
+			// (https://golang.org/cl/5989058)
+			ldflags = append(ldflags, "-pie")
+		}
+		if str.Contains(ldflags, "-pie") && str.Contains(ldflags, "-static") {
 			// -static -pie doesn't make sense, and causes link errors.
 			// Issue 26197.
 			n := make([]string, 0, len(ldflags))

--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -2972,9 +2972,8 @@ func (b *Builder) dynimport(a *Action, p *load.Package, objdir, importGo, cgoExe
 	ldflags := cgoLDFLAGS
 	if (cfg.Goarch == "arm" && cfg.Goos == "linux") || cfg.Goos == "android" {
 		if !str.Contains(ldflags, "-no-pie") {
-			// if we do'nt see '-no-pie',
-			// we add "-pie" keep backward-compatibility
-			// (https://golang.org/cl/5989058)
+			// we need to use -pie for Linux/ARM to get accurate imported sym (added in https://golang.org/cl/5989058)
+			// this seems to be outdated, but we don't want to break existing builds depending on this (Issue 45940)
 			ldflags = append(ldflags, "-pie")
 		}
 		if str.Contains(ldflags, "-pie") && str.Contains(ldflags, "-static") {


### PR DESCRIPTION
a minimally invasive fix proposal for #45940. which keeps the fix for #26197.

an alternative for (#26197) could be to fail if we have both flags. adding/removing a flag without an message to the user is inconvenient.