### PR TITLE
crypto/tls: use a cache to save x509 certificate in the tls connection

### DIFF
--- a/src/crypto/tls/cache.go
+++ b/src/crypto/tls/cache.go
@@ -1,0 +1,44 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tls
+
+import (
+	"crypto/x509"
+	"sync"
+)
+
+// certificateCache is a x509.Certificate cache indexed by ASN.1 DER data.
+type certificateCache struct {
+	rwmutex sync.RWMutex
+	cache   map[string]*x509.Certificate
+}
+
+var certCache = certificateCache{
+	cache: make(map[string]*x509.Certificate),
+}
+
+// loadOrParseCertificate returns a single certificate from the given ASN.1 DER data.
+func (c *certificateCache) loadOrParseCertificate(der []byte) (*x509.Certificate, error) {
+	c.rwmutex.RLock()
+	if cert, ok := c.cache[string(der)]; ok {
+		c.rwmutex.RUnlock()
+		return cert, nil
+	}
+	c.rwmutex.RUnlock()
+
+	c.rwmutex.Lock()
+	defer c.rwmutex.Unlock()
+
+	cert, ok := c.cache[string(der)]
+	if !ok {
+		var err error
+		cert, err = x509.ParseCertificate(der)
+		if err != nil {
+			return nil, err
+		}
+		c.cache[string(der)] = cert
+	}
+	return cert, nil
+}

--- a/src/crypto/tls/handshake_client.go
+++ b/src/crypto/tls/handshake_client.go
@@ -829,7 +829,7 @@ func (hs *clientHandshakeState) sendFinished(out []byte) error {
 func (c *Conn) verifyServerCertificate(certificates [][]byte) error {
 	certs := make([]*x509.Certificate, len(certificates))
 	for i, asn1Data := range certificates {
-		cert, err := x509.ParseCertificate(asn1Data)
+		cert, err := certCache.loadOrParseCertificate(asn1Data)
 		if err != nil {
 			c.sendAlert(alertBadCertificate)
 			return errors.New("tls: failed to parse certificate from server: " + err.Error())

--- a/src/crypto/tls/handshake_server.go
+++ b/src/crypto/tls/handshake_server.go
@@ -780,7 +780,7 @@ func (c *Conn) processCertsFromClient(certificate Certificate) error {
 	certs := make([]*x509.Certificate, len(certificates))
 	var err error
 	for i, asn1Data := range certificates {
-		if certs[i], err = x509.ParseCertificate(asn1Data); err != nil {
+		if certs[i], err = certCache.loadOrParseCertificate(asn1Data); err != nil {
 			c.sendAlert(alertBadCertificate)
 			return errors.New("tls: failed to parse client certificate: " + err.Error())
 		}


### PR DESCRIPTION
Fixes #46035 