### PR TITLE
cmd/compile,go/parser: support Allman brace style. ABLM: Allman Brace Lives Matter

### DIFF
--- a/src/go/parser/testdata/issue34946.src
+++ b/src/go/parser/testdata/issue34946.src
@@ -8,15 +8,14 @@
 
 package p
 
-// accept Allman/BSD-style declaration but complain
-// (implicit semicolon between signature and body)
+// accept Allman/BSD-style declaration
 func _() int
-{ /* ERROR "unexpected semicolon or newline before {" */
+{
 	{ return 0 }
 }
 
 func _() {}
 
-func _(); { /* ERROR "unexpected semicolon or newline before {" */ }
+func _(); { /* ERROR "unexpected semicolon before {" */ }
 
 func _() {}

--- a/test/fixedbugs/issue18747.go
+++ b/test/fixedbugs/issue18747.go
@@ -23,6 +23,6 @@ func _ () {
 
 	if ; foo {}
 
-	if foo // ERROR "unexpected newline, expecting { after if clause"
+	if foo
 	{}
 }

--- a/test/syntax/semi4.go
+++ b/test/syntax/semi4.go
@@ -8,5 +8,5 @@ package main
 
 func main() {
 	for x		// GCCGO_ERROR "undefined"
-	{		// ERROR "unexpected {, expecting for loop condition|expecting .*{.* after for clause"
+	{
 		z	// GCCGO_ERROR "undefined"

--- a/test/syntax/semi5.go
+++ b/test/syntax/semi5.go
@@ -7,7 +7,7 @@
 package main
 
 func main()
-{	// ERROR "unexpected semicolon or newline before .?{.?"
+{
 
 
 

--- a/test/syntax/semi7.go
+++ b/test/syntax/semi7.go
@@ -8,7 +8,7 @@ package main
 
 func main() {
 	if x { }	// GCCGO_ERROR "undefined"
-	else { }	// ERROR "unexpected semicolon or newline before .?else.?|unexpected else"
+	else { }
 }
 
 


### PR DESCRIPTION
I'm surprised nobody did it before because it's easy as hell.
Nobody should force anyone else to use a specific coding style.
The parser of course remains compatible with all existing k&r code.

Fixes #39421 :-)