### PR TITLE
net: add tcp WriteTo func to enable splice socket data to file

### DIFF
--- a/src/go/build/deps_test.go
+++ b/src/go/build/deps_test.go
@@ -102,7 +102,9 @@ var depsRules = `
 	< container/heap;
 
 	RUNTIME
-	< io;
+	< io
+	< internal/iointernal
+	< IO;
 
 	syscall !< io;
 	reflect !< sort;
@@ -162,7 +164,7 @@ var depsRules = `
 	# OS is basic OS access, including helpers (path/filepath, os/exec, etc).
 	# OS includes string routines, but those must be layered above package os.
 	# OS does not include reflection.
-	io/fs
+	IO, io/fs
 	< internal/testlog
 	< internal/poll
 	< os
@@ -354,6 +356,7 @@ var depsRules = `
 	# This is a long-looking list but most of these
 	# are small with few dependencies.
 	CGO,
+	IO,
 	golang.org/x/net/dns/dnsmessage,
 	golang.org/x/net/lif,
 	golang.org/x/net/route,

--- a/src/internal/iointernal/limited_writer.go
+++ b/src/internal/iointernal/limited_writer.go
@@ -1,0 +1,29 @@
+package iointernal
+
+import "io"
+
+// LimitWriter returns a Writer that writes to w
+// but stops with EOF after n bytes.
+// The underlying implementation is a *LimitedWriter.
+func LimitWriter(w io.Writer, n int64) io.Writer { return &LimitedWriter{w, n} }
+
+// A LimitedWriter writes to W but limits the amount of
+// data returned to just N bytes. Each call to Write
+// updates N to reflect the new amount remaining.
+// Read returns EOF when N <= 0 or when the underlying W returns EOF.
+type LimitedWriter struct {
+	W io.Writer // underlying writer
+	N int64     // max bytes remaining
+}
+
+func (l *LimitedWriter) Write(p []byte) (n int, err error) {
+	if l.N <= 0 {
+		return 0, io.EOF
+	}
+	if int64(len(p)) > l.N {
+		p = p[0:l.N]
+	}
+	n, err = l.W.Write(p)
+	l.N -= int64(n)
+	return
+}

--- a/src/net/net.go
+++ b/src/net/net.go
@@ -658,6 +658,17 @@ func genericReadFrom(w io.Writer, r io.Reader) (n int64, err error) {
 	return io.Copy(writerOnly{w}, r)
 }
 
+type readerOnly struct {
+	io.Reader
+}
+
+// Fallback implementation of io.WriteTo's WriteTo, when splice isn't
+// applicable.
+func genericWriteTo(w io.Writer, r io.Reader) (n int64, err error) {
+	// Use wrapper to hide existing r.ReadFrom from io.Copy.
+	return io.Copy(w, readerOnly{r})
+}
+
 // Limit the number of concurrent cgo-using goroutines, because
 // each will block an entire operating system thread. The usual culprit
 // is resolving many DNS names in separate goroutines but the DNS

--- a/src/net/splice_linux.go
+++ b/src/net/splice_linux.go
@@ -5,8 +5,10 @@
 package net
 
 import (
+	"internal/iointernal"
 	"internal/poll"
 	"io"
+	"os"
 )
 
 // splice transfers data from r to c using the splice system call to minimize
@@ -41,4 +43,49 @@ func splice(c *netFD, r io.Reader) (written int64, err error, handled bool) {
 		lr.N -= written
 	}
 	return written, wrapSyscallError(sc, err), handled
+}
+
+// spliceW transfers data from c to w using the splice system call to minimize
+// copies from and to userspace. c must be a TCP connection. Currently, spliceW
+// is only enabled if r is a os.File.
+//
+// If spliceW returns handled == false, it has performed no work.
+func spliceW(c *netFD, w io.Writer) (written int64, err error, handled bool) {
+	var remain int64 = 1 << 62 // by default, copy until EOF
+	lw, ok := w.(*iointernal.LimitedWriter)
+	if ok {
+		remain, w = lw.N, lw.W
+		if remain <= 0 {
+			return 0, nil, true
+		}
+	}
+
+	f, ok := w.(*os.File)
+	if !ok {
+		return 0, nil, false
+	}
+
+	sc, err := f.SyscallConn()
+	if err != nil {
+		return 0, nil, false
+	}
+
+	var scall string
+	var werr error
+	err = sc.Write(func(fd uintptr) (done bool) {
+		written, handled, scall, werr = poll.Splice(&poll.FD{
+			Sysfd:         int(fd),
+			IsStream:      true,
+			ZeroReadIsEOF: true,
+		}, &c.pfd, remain)
+		if lw != nil {
+			lw.N -= written
+		}
+		return true
+	})
+	if err == nil {
+		err = werr
+	}
+
+	return written, wrapSyscallError(scall, err), handled
 }

--- a/src/net/splice_linux.go
+++ b/src/net/splice_linux.go
@@ -60,6 +60,13 @@ func spliceW(c *netFD, w io.Writer) (written int64, err error, handled bool) {
 		}
 	}
 
+	if conn, ok := w.(*TCPConn); ok {
+		// handle original path from TCPConn to TCPConn
+		if n, err, handled := splice(conn.fd, io.LimitReader(c, remain)); handled {
+			return n, err, true
+		}
+	}
+
 	f, ok := w.(*os.File)
 	if !ok {
 		return 0, nil, false

--- a/src/net/splice_stub.go
+++ b/src/net/splice_stub.go
@@ -12,3 +12,7 @@ import "io"
 func splice(c *netFD, r io.Reader) (int64, error, bool) {
 	return 0, nil, false
 }
+
+func spliceW(c *netFD, w io.Writer) (int64, error, bool) {
+	return 0, nil, false
+}

--- a/src/net/tcpsock.go
+++ b/src/net/tcpsock.go
@@ -108,6 +108,18 @@ func (c *TCPConn) ReadFrom(r io.Reader) (int64, error) {
 	return n, err
 }
 
+// WriteTo implements the io.WriteTo WriteTo method.
+func (c *TCPConn) WriteTo(w io.Writer) (int64, error) {
+	if !c.ok() {
+		return 0, syscall.EINVAL
+	}
+	n, err := c.writeTo(w)
+	if err != nil && err != io.EOF {
+		err = &OpError{Op: "writeto", Net: c.fd.net, Source: c.fd.laddr, Addr: c.fd.raddr, Err: err}
+	}
+	return n, err
+}
+
 // CloseRead shuts down the reading side of the TCP connection.
 // Most callers should just use Close.
 func (c *TCPConn) CloseRead() error {

--- a/src/net/tcpsock_plan9.go
+++ b/src/net/tcpsock_plan9.go
@@ -14,6 +14,10 @@ func (c *TCPConn) readFrom(r io.Reader) (int64, error) {
 	return genericReadFrom(c, r)
 }
 
+func (c *TCPConn) writeTo(w io.Writer) (int64, error) {
+	return genericWriteTo(w, c)
+}
+
 func (sd *sysDialer) dialTCP(ctx context.Context, laddr, raddr *TCPAddr) (*TCPConn, error) {
 	if testHookDialTCP != nil {
 		return testHookDialTCP(ctx, sd.network, laddr, raddr)

--- a/src/net/tcpsock_posix.go
+++ b/src/net/tcpsock_posix.go
@@ -55,6 +55,13 @@ func (c *TCPConn) readFrom(r io.Reader) (int64, error) {
 	return genericReadFrom(c, r)
 }
 
+func (c *TCPConn) writeTo(w io.Writer) (int64, error) {
+	if n, err, handled := spliceW(c.fd, w); handled {
+		return n, err
+	}
+	return genericWriteTo(w, c)
+}
+
 func (sd *sysDialer) dialTCP(ctx context.Context, laddr, raddr *TCPAddr) (*TCPConn, error) {
 	if testHookDialTCP != nil {
 		return testHookDialTCP(ctx, sd.network, laddr, raddr)


### PR DESCRIPTION
When transfer data from tcp socket to file, splice will help us with low time cost in linux.

To do this in linux, there are some changes:
1. add LimitWriter to detect writing limit in internal package.
2. add spliceW to splice data from tcp socket to file.
3. add WriteTo for TCPConn.