### PR TITLE
strings: use io.WriteString with slices of s in byteReplacer

### DIFF
--- a/src/strings/replace.go
+++ b/src/strings/replace.go
@@ -454,26 +454,36 @@ func (r *byteReplacer) Replace(s string) string {
 }
 
 func (r *byteReplacer) WriteString(w io.Writer, s string) (n int, err error) {
-	// TODO(bradfitz): use io.WriteString with slices of s, avoiding allocation.
-	bufsize := 32 << 10
-	if len(s) < bufsize {
-		bufsize = len(s)
-	}
-	buf := make([]byte, bufsize)
-
-	for len(s) > 0 {
-		ncopy := copy(buf, s)
-		s = s[ncopy:]
-		for i, b := range buf[:ncopy] {
-			buf[i] = r[b]
+	sw := getStringWriter(w)
+	last := 0
+	singleByte := make([]byte, 1)
+	for i := 0; i<len(s); i++ {
+		b := s[i]
+		if r[b] == b {
+			continue
 		}
-		wn, err := w.Write(buf[:ncopy])
-		n += wn
+		if last != i {
+			nw, err := sw.WriteString(s[last:i])
+			n += nw
+			if err != nil {
+				return n, err
+			}
+		}
+		last = i + 1
+		singleByte[0] = r[b]
+		nw, err := w.Write(singleByte)
+		n += nw
 		if err != nil {
 			return n, err
 		}
 	}
-	return n, nil
+	if last != len(s) {
+		var nw int
+		nw, err = sw.WriteString(s[last:])
+		n += nw
+	}
+
+	return
 }
 
 // byteStringReplacer is the implementation that's used when all the


### PR DESCRIPTION
Hello.
Is it necessary to use writeString to insted of current implementation?
I try to run benchmark for two of implementation, io.WriteString is truly to make allocation down, but it is more slow than current implementation.
Or is there something wrong in my implementation?

```
use io.WriteString
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkByteReplacerWriteString-12    	  368049	      3058 ns/op	       1 B/op	       1 allocs/op
BenchmarkByteReplacerWriteString-12    	  399786	      2989 ns/op	       1 B/op	       1 allocs/op
BenchmarkByteReplacerWriteString-12    	  341246	      2932 ns/op	       1 B/op	       1 allocs/op
PASS
ok  	strings	5.471s

current
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkByteReplacerWriteString-12    	  706578	      1722 ns/op	    2688 B/op	       1 allocs/op
BenchmarkByteReplacerWriteString-12    	  707498	      1719 ns/op	    2688 B/op	       1 allocs/op
BenchmarkByteReplacerWriteString-12    	  699553	      1749 ns/op	    2688 B/op	       1 allocs/op
PASS
ok  	strings	6.130s
```
