### PR TITLE
modload: alldocs: assist the digest of module documentation

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -2423,6 +2423,13 @@
 //
 // For a detailed reference on modules, see https://golang.org/ref/mod.
 //
+// Versioning is intrinsic to go modules, it should be noted that once the
+// version of a public module has been defined and registered with a public
+// proxy server; The version is permanent and can no longer be modified.
+//
+// For a detailed reference on versioning, see
+// https://golang.org/doc/modules/version-numbers
+//
 // By default, the go command may download modules from https://proxy.golang.org.
 // It may authenticate modules using the checksum database at
 // https://sum.golang.org. Both services are operated by the Go team at Google.
@@ -2434,6 +2441,14 @@
 // GOPRIVATE, and other environment variables. See 'go help environment'
 // and https://golang.org/ref/mod#private-module-privacy for more information.
 //
+// Public modules may incur delays upon modification, thus new versions may not
+// be available for remote update instantaneously.
+//
+// In the case that a rapid cycle of continuous integration be required; The
+// module should either be made accessible locally, by way of the 'replace'
+// directive, else, the public version proxy cache can be accelerated by
+// revving the modules version number and the use of an in development
+// numbering strategy.
 //
 // Module authentication using go.sum
 //

--- a/src/cmd/go/internal/modload/help.go
+++ b/src/cmd/go/internal/modload/help.go
@@ -21,6 +21,13 @@ https://golang.org/doc/tutorial/create-module.
 
 For a detailed reference on modules, see https://golang.org/ref/mod.
 
+Versioning is intrinsic to go modules, it should be noted that once the
+version of a public module has been defined and registered with a public
+proxy server; The version is permanent and can no longer be modified.
+
+For a detailed reference on versioning, see
+https://golang.org/doc/modules/version-numbers
+
 By default, the go command may download modules from https://proxy.golang.org.
 It may authenticate modules using the checksum database at
 https://sum.golang.org. Both services are operated by the Go team at Google.
@@ -31,6 +38,15 @@ respectively.
 The go command's download behavior may be configured using GOPROXY, GOSUMDB,
 GOPRIVATE, and other environment variables. See 'go help environment'
 and https://golang.org/ref/mod#private-module-privacy for more information.
+
+Public modules may incur delays upon modification, thus new versions may not
+be available for remote update instantaneously.
+
+In the case that a rapid cycle of continuous integration be required; The
+module can either be made accessible locally, by way of the 'replace'
+directive, else, the public version proxy cache can be accelerated by
+revving the modules version number and the use of an in development
+numbering strategy.
 	`,
 }
 


### PR DESCRIPTION
The current module documentation assumes knowledge of the permanent
nature of cached public versioning, as well as versioning itself; In
effect, restricting more novice programmers ability to understand the
functioning in a manor that can be disruptive.

Highlighting specific information sooner facilitates its digest.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
