### PR TITLE
BigEndian add int16 to process negative value

### DIFF
--- a/src/encoding/binary/binary.go
+++ b/src/encoding/binary/binary.go
@@ -32,11 +32,9 @@ import (
 // A ByteOrder specifies how to convert byte sequences into
 // 16-, 32-, or 64-bit unsigned integers.
 type ByteOrder interface {
-	Int16([]byte) int16
 	Uint16([]byte) uint16
 	Uint32([]byte) uint32
 	Uint64([]byte) uint64
-	Putint16([]byte, int16)
 	PutUint16([]byte, uint16)
 	PutUint32([]byte, uint32)
 	PutUint64([]byte, uint64)
@@ -99,14 +97,14 @@ func (littleEndian) GoString() string { return "binary.LittleEndian" }
 
 type bigEndian struct{}
 
+func (bigEndian) Int16(b []byte) int16 { //uint to int
+	_ = b[1]                            // bounds check hint to compiler; see golang.org/issue/14808
+	return int16(b[1]) | int16(b[0])<<8 //uint to int
+}
+
 func (bigEndian) Uint16(b []byte) uint16 {
 	_ = b[1] // bounds check hint to compiler; see golang.org/issue/14808
 	return uint16(b[1]) | uint16(b[0])<<8
-}
-
-func (bigEndian) Int16(b []byte) int16 {
-	_ = b[1] // bounds check hint to compiler; see golang.org/issue/14808
-	return int16(b[1]) | int16(b[0])<<8
 }
 
 func (bigEndian) PutUint16(b []byte, v uint16) {
@@ -115,7 +113,7 @@ func (bigEndian) PutUint16(b []byte, v uint16) {
 	b[1] = byte(v)
 }
 
-func (bigEndian) Putint16(b []byte, v int16) {
+func (bigEndian) Putint16(b []byte, v int16) { //uint to int
 	_ = b[1] // early bounds check to guarantee safety of writes below
 	b[0] = byte(v >> 8)
 	b[1] = byte(v)

--- a/src/encoding/binary/binary.go
+++ b/src/encoding/binary/binary.go
@@ -32,9 +32,11 @@ import (
 // A ByteOrder specifies how to convert byte sequences into
 // 16-, 32-, or 64-bit unsigned integers.
 type ByteOrder interface {
+	Int16([]byte) int16
 	Uint16([]byte) uint16
 	Uint32([]byte) uint32
 	Uint64([]byte) uint64
+	Putint16([]byte, int16)
 	PutUint16([]byte, uint16)
 	PutUint32([]byte, uint32)
 	PutUint64([]byte, uint64)
@@ -102,7 +104,18 @@ func (bigEndian) Uint16(b []byte) uint16 {
 	return uint16(b[1]) | uint16(b[0])<<8
 }
 
+func (bigEndian) Int16(b []byte) int16 {
+	_ = b[1] // bounds check hint to compiler; see golang.org/issue/14808
+	return int16(b[1]) | int16(b[0])<<8
+}
+
 func (bigEndian) PutUint16(b []byte, v uint16) {
+	_ = b[1] // early bounds check to guarantee safety of writes below
+	b[0] = byte(v >> 8)
+	b[1] = byte(v)
+}
+
+func (bigEndian) Putint16(b []byte, v int16) {
 	_ = b[1] // early bounds check to guarantee safety of writes below
 	b[0] = byte(v >> 8)
 	b[1] = byte(v)


### PR DESCRIPTION
I ran into a little bug that BigEndian doesn't support negative value, since it only has uint type parameter so I just add int16 to it.