### PR TITLE
doc/go1.17: document archive/zip changes for Go 1.17 

### DIFF
--- a/doc/go1.17.html
+++ b/doc/go1.17.html
@@ -247,7 +247,7 @@ Do not send CLs removing the interior tags from such phrases.
 <dl id="archive/zip"><dt><a href="/pkg/archive/zip/">archive/zip</a></dt>
   <dd>
     <p><!-- CL 312310 -->
-      TODO: <a href="https://golang.org/cl/312310">https://golang.org/cl/312310</a>: add File.OpenRaw, Writer.CreateRaw, Writer.Copy
+      The new methods <a href="/pkg/archive/zip#File.OpenRaw"><code>File.OpenRaw</code></a>, <a href="/pkg/archive/zip#Writer.CreateRaw"><code>Writer.CreateRaw</code></a>, <a href="/pkg/archive/zip#Writer.Copy"><code>Writer.Copy</code></a> provide support for cases where performance is a primary concern.
     </p>
   </dd>
 </dl><!-- archive/zip -->


### PR DESCRIPTION
For #44513. Fixes #46000