### PR TITLE
crypto/rand: limit getRandomValues buffer size

### DIFF
--- a/misc/wasm/wasm_exec.js
+++ b/misc/wasm/wasm_exec.js
@@ -106,6 +106,9 @@
 		const nodeCrypto = require("crypto");
 		global.crypto = {
 			getRandomValues(b) {
+				if (b.byteLength > 65536) {
+					throw new Error(`Failed to execute 'getRandomValues' on 'Crypto': The ArrayBufferView's byte length (${b.byteLength}) exceeds the number of bytes of entropy available via this API (65536).`);
+				}
 				nodeCrypto.randomFillSync(b);
 			},
 		};

--- a/src/crypto/rand/rand_js.go
+++ b/src/crypto/rand/rand_js.go
@@ -22,6 +22,11 @@ var uint8Array = js.Global().Get("Uint8Array")
 type reader struct{}
 
 func (r *reader) Read(b []byte) (int, error) {
+	// the specification states that getRandomValues fails if called with
+	// a buffer length of over 65536 bytes
+	if len(b) > 65536 {
+		b = b[:65536]
+	}
 	a := uint8Array.New(len(b))
 	jsCrypto.Call("getRandomValues", a)
 	js.CopyBytesToGo(b, a)


### PR DESCRIPTION
 crypto/rand: limit read size on js/wasm

The crypto.getRandomValues API specifies a maximum of 65536 bytes per
call. If a larger byte slice is passed to rand.Reader.Read, only fill
the first 65536 bytes.

Fixes #46256.