### PR TITLE
crypto/x509: add new FreeBSD 12.2+ trusted certificate folder

### DIFF
--- a/src/crypto/x509/root_bsd.go
+++ b/src/crypto/x509/root_bsd.go
@@ -18,6 +18,7 @@ var certFiles = []string{
 // Possible directories with certificate files; stop after successfully
 // reading at least one file from a directory.
 var certDirectories = []string{
+	"/etc/ssl/certs",         // FreeBSD 12.2+
 	"/usr/local/share/certs", // FreeBSD
 	"/etc/openssl/certs",     // NetBSD
 }


### PR DESCRIPTION
Up to FreeBSD 12.1 the package ca_root_nss was needed in order to have
certificates under /usr/local/share/certs as the base system didn't have
a system trusted certificate store.

This has been fixed in FreeBSD 12.2 using /etc/ssl/certs:
https://svnweb.freebsd.org/base?view=revision&revision=357082

Fixes #46284