### PR TITLE
cpu: add HasSHA3 on darwin/arm64

### DIFF
--- a/src/internal/cpu/cpu.go
+++ b/src/internal/cpu/cpu.go
@@ -54,6 +54,7 @@ var ARM struct {
 }
 
 // The booleans in ARM64 contain the correspondingly named cpu feature bit.
+// Only the using features are added.
 // The struct is padded to avoid false sharing.
 var ARM64 struct {
 	_            CacheLinePad
@@ -61,6 +62,7 @@ var ARM64 struct {
 	HasPMULL     bool
 	HasSHA1      bool
 	HasSHA2      bool
+	HasSHA3      bool
 	HasCRC32     bool
 	HasATOMICS   bool
 	HasCPUID     bool

--- a/src/internal/cpu/cpu_arm64_darwin.go
+++ b/src/internal/cpu/cpu_arm64_darwin.go
@@ -19,6 +19,7 @@ func osInit() {
 	ARM64.HasPMULL = true
 	ARM64.HasSHA1 = true
 	ARM64.HasSHA2 = true
+	ARM64.HasSHA3 = true
 }
 
 //go:noescape


### PR DESCRIPTION
darwin/arm64 is using M1 chip which uses instruction set ARMv8.4-A.
ARMv8.4-A has SHA3 support.
