### PR TITLE
crypto/tls: add crypto/tls.VersionName function

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -36,6 +36,24 @@ const (
 	VersionSSL30 = 0x0300
 )
 
+var versionNames = map[uint16]string{
+	VersionSSL30: "SSLv3",
+	VersionTLS10: "TLSv1.0",
+	VersionTLS11: "TLSv1.1",
+	VersionTLS12: "TLSv1.2",
+	VersionTLS13: "TLSv1.3",
+}
+
+// VersionName returns the name for the passed TLS version number (e.g. "TLSv1.3"),
+// or a fallback representation of the value if the version is not implemented by this package.
+func VersionName(version uint16) string {
+	if name, ok := versionNames[version]; ok {
+		return name
+	}
+
+	return fmt.Sprintf("0x%04X", version)
+}
+
 const (
 	maxPlaintext       = 16384        // maximum plaintext payload length
 	maxCiphertext      = 16384 + 2048 // maximum ciphertext payload length

--- a/src/crypto/tls/tls_test.go
+++ b/src/crypto/tls/tls_test.go
@@ -1609,3 +1609,15 @@ func TestPKCS1OnlyCert(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestVersionName(t *testing.T) {
+	for version, name := range versionNames {
+		if got := VersionName(version); got != name {
+			t.Errorf("%#04x: unexpected VersionName: got %q, expected %q", version, got, name)
+		}
+	}
+
+	if got := VersionName(0x123); got != "0x0123" {
+		t.Errorf("unexpected fallback VersionName: got %q, expected 0x0123", got)
+	}
+}


### PR DESCRIPTION
This function returns an string representation (`TLSv1.0`, `TLSv1.1`, ...)
given a TLS version number.

Fixes #46308