### PR TITLE
doc/go1.17: document net/url changes for Go 1.17

### DIFF
--- a/doc/go1.17.html
+++ b/doc/go1.17.html
@@ -440,7 +440,7 @@ Do not send CLs removing the interior tags from such phrases.
 <dl id="net/url"><dt><a href="/pkg/net/url/">net/url</a></dt>
   <dd>
     <p><!-- CL 314850 -->
-      TODO: <a href="https://golang.org/cl/314850">https://golang.org/cl/314850</a>: add Values.Has
+      The new <a href="/pkg/net/url/#Values.Has"><code>Values.Has</code></a> method reports whether a given key is set.
     </p>
   </dd>
 </dl><!-- net/url -->


### PR DESCRIPTION
For #44513. Fixes #46017.
