### PR TITLE
archive/tar: improve parseOctal performance

### DIFF
--- a/src/archive/tar/strconv.go
+++ b/src/archive/tar/strconv.go
@@ -161,7 +161,9 @@ func (p *parser) parseOctal(b []byte) int64 {
 	// spaces or NULs.
 	// So we remove leading and trailing NULs and spaces to
 	// be sure.
-	b = bytes.Trim(b, " \x00")
+	b = bytes.TrimFunc(b, func(r rune) bool {
+		return r == ' ' || r == '\x00'
+	})
 
 	if len(b) == 0 {
 		return 0


### PR DESCRIPTION
parseOctal is a function that is called many times, and bytes.Trim
is used in the function to cause memory allocation each time by makeASCIISet.
TrimFunc can be used to avoid the problem.

```
name             old time/op    new time/op    delta
/Writer/USTAR-8    3.04µs ± 2%    3.03µs ± 2%     ~     (p=0.362 n=10+10)
/Writer/GNU-8      3.83µs ± 1%    3.75µs ± 1%   -2.03%  (p=0.000 n=10+9)
/Writer/PAX-8      6.65µs ± 1%    6.62µs ± 1%   -0.40%  (p=0.046 n=10+9)
/Reader/USTAR-8    2.93µs ± 2%    2.46µs ± 2%  -16.29%  (p=0.000 n=10+10)
/Reader/GNU-8      1.86µs ± 1%    1.43µs ± 1%  -23.19%  (p=0.000 n=10+10)
/Reader/PAX-8      6.27µs ± 2%    5.25µs ± 0%  -16.21%  (p=0.000 n=10+8)

name             old alloc/op   new alloc/op   delta
/Writer/USTAR-8    1.19kB ± 0%    1.19kB ± 0%     ~     (all equal)
/Writer/GNU-8      1.42kB ± 0%    1.42kB ± 0%     ~     (all equal)
/Writer/PAX-8      2.34kB ± 0%    2.34kB ± 0%     ~     (all equal)
/Reader/USTAR-8    1.36kB ± 0%    0.98kB ± 0%  -28.25%  (p=0.000 n=9+10)
/Reader/GNU-8      1.31kB ± 0%    0.97kB ± 0%  -25.78%  (p=0.002 n=8+10)
/Reader/PAX-8      3.31kB ± 0%    2.54kB ± 0%  -23.24%  (p=0.000 n=8+10)

name             old allocs/op  new allocs/op  delta
/Writer/USTAR-8      26.0 ± 0%      26.0 ± 0%     ~     (all equal)
/Writer/GNU-8        36.0 ± 0%      36.0 ± 0%     ~     (all equal)
/Writer/PAX-8        64.0 ± 0%      64.0 ± 0%     ~     (all equal)
/Reader/USTAR-8      31.0 ± 0%      15.0 ± 0%  -51.61%  (p=0.000 n=10+10)
/Reader/GNU-8        28.0 ± 0%      14.0 ± 0%  -50.00%  (p=0.000 n=10+10)
/Reader/PAX-8        63.0 ± 0%      31.0 ± 0%  -50.79%  (p=0.000 n=10+10)
```
