### PR TITLE
cmd/compile/internal/ssa: remove unnecessary low index 0

### DIFF
--- a/src/cmd/compile/internal/ssa/dom.go
+++ b/src/cmd/compile/internal/ssa/dom.go
@@ -77,7 +77,7 @@ func (cache *Cache) scratchBlocksForDom(maxBlockID int) (a, b, c, d, e, f, g []I
 		cache.domblockstore = scratch
 	} else {
 		// Clear as much of scratch as we will (re)use
-		scratch = scratch[0:tot]
+		scratch = scratch[:tot]
 		for i := range scratch {
 			scratch[i] = 0
 		}

--- a/src/cmd/compile/internal/ssa/expand_calls.go
+++ b/src/cmd/compile/internal/ssa/expand_calls.go
@@ -1107,7 +1107,7 @@ func (x *expandState) rewriteArgs(v *Value, firstArg int) {
 		}
 	}
 	var preArgStore [2]*Value
-	preArgs := append(preArgStore[:0], v.Args[0:firstArg]...)
+	preArgs := append(preArgStore[:0], v.Args[:firstArg]...)
 	v.resetArgs()
 	v.AddArgs(preArgs...)
 	v.AddArgs(newArgs...)


### PR DESCRIPTION
A missing low index defaults to zero. a zero low index is unnecessary