### PR TITLE
net/http/httputil: fix NewSingleHostReverseProxy lost host info

### DIFF
--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -151,6 +151,7 @@ func NewSingleHostReverseProxy(target *url.URL) *ReverseProxy {
 		} else {
 			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
 		}
+		req.Host = target.Host
 		if _, ok := req.Header["User-Agent"]; !ok {
 			// explicitly disable User-Agent so it's not set to default value
 			req.Header.Set("User-Agent", "")


### PR DESCRIPTION
When multiple domain names point to an IP, the agent created by newsinglehostreverseproxy loses the host information, such as:

```
const (
    TARGET_ 1 = " http://target1.example.com "
    TARGET_ 2 = " http://target2.example.com "
)
target1, _ := url.Parse(TARGET_ 1)
target2, _ := url.Parse(TARGET_ 2)
proxy1 := httputil.NewSingleHostReverseProxy(target1)
proxy2 := httputil.NewSingleHostReverseProxy(target2)
http.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
    if strings.HasPrefix(request.RequestURI, "/v1") {
        proxy1.ServeHTTP(writer, request)
    } else {
        proxy2.ServeHTTP(writer, request)
    }
})
http.ListenAndServe(":12345", nil)

```

Fixes NewSingleHostReverseProxy lost host info