### PR TITLE
[dev.fuzz] internal/fuzz: enable fuzzing for freebsd

### DIFF
--- a/src/cmd/go/testdata/script/test_fuzz.txt
+++ b/src/cmd/go/testdata/script/test_fuzz.txt
@@ -1,5 +1,5 @@
 # TODO(jayconrod): support shared memory on more platforms.
-[!darwin] [!linux] [!windows] skip
+[!freebsd] [!darwin] [!linux] [!windows] skip
 
 # Test that running a fuzz target that returns without failing or calling
 # f.Fuzz fails and causes a non-zero exit status.

--- a/src/cmd/go/testdata/script/test_fuzz_cache.txt
+++ b/src/cmd/go/testdata/script/test_fuzz_cache.txt
@@ -1,5 +1,5 @@
 # TODO(jayconrod): support shared memory on more platforms.
-[!darwin] [!linux] [!windows] skip
+[!freebsd] [!darwin] [!linux] [!windows] skip
 
 [short] skip
 env GOCACHE=$WORK/cache

--- a/src/cmd/go/testdata/script/test_fuzz_chatty.txt
+++ b/src/cmd/go/testdata/script/test_fuzz_chatty.txt
@@ -1,5 +1,5 @@
 # TODO(jayconrod): support shared memory on more platforms.
-[!darwin] [!linux] [!windows] skip
+[!freebsd] [!darwin] [!linux] [!windows] skip
 
 [short] skip
 

--- a/src/cmd/go/testdata/script/test_fuzz_cleanup.txt
+++ b/src/cmd/go/testdata/script/test_fuzz_cleanup.txt
@@ -1,5 +1,5 @@
 # TODO(jayconrod): support shared memory on more platforms.
-[!darwin] [!linux] [!windows] skip
+[!freebsd] [!darwin] [!linux] [!windows] skip
 [short] skip
 
 # Cleanup should run after F.Skip.

--- a/src/cmd/go/testdata/script/test_fuzz_fuzztime.txt
+++ b/src/cmd/go/testdata/script/test_fuzz_fuzztime.txt
@@ -1,5 +1,5 @@
 # TODO(jayconrod): support shared memory on more platforms.
-[!darwin] [!linux] [!windows] skip
+[!freebsd] [!darwin] [!linux] [!windows] skip
 
 [short] skip
 

--- a/src/cmd/go/testdata/script/test_fuzz_io_error.txt
+++ b/src/cmd/go/testdata/script/test_fuzz_io_error.txt
@@ -6,7 +6,7 @@
 # This is unlikely, but possible. It's difficult to simulate interruptions
 # due to ^C and EOF errors which are more common. We don't report those.
 [short] skip
-[!darwin] [!linux] [!windows] skip
+[!freebsd] [!darwin] [!linux] [!windows] skip
 
 # If the I/O error occurs before F.Fuzz is called, the coordinator should
 # stop the worker and say that.

--- a/src/cmd/go/testdata/script/test_fuzz_match.txt
+++ b/src/cmd/go/testdata/script/test_fuzz_match.txt
@@ -1,5 +1,5 @@
 # TODO(jayconrod): support shared memory on more platforms.
-[!darwin] [!linux] [!windows] skip
+[!freebsd] [!darwin] [!linux] [!windows] skip
 
 # Matches only fuzz targets to test.
 go test standalone_fuzz_test.go

--- a/src/cmd/go/testdata/script/test_fuzz_minimize.txt
+++ b/src/cmd/go/testdata/script/test_fuzz_minimize.txt
@@ -1,5 +1,5 @@
 # TODO(jayconrod): support shared memory on more platforms.
-[!darwin] [!linux] [!windows] skip
+[!freebsd] [!darwin] [!linux] [!windows] skip
 
 [short] skip
 

--- a/src/cmd/go/testdata/script/test_fuzz_mutate_crash.txt
+++ b/src/cmd/go/testdata/script/test_fuzz_mutate_crash.txt
@@ -1,5 +1,5 @@
 # TODO(jayconrod): support shared memory on more platforms.
-[!darwin] [!linux] [!windows] skip
+[!freebsd] [!darwin] [!linux] [!windows] skip
 
 # Tests that a crash caused by a mutator-discovered input writes the bad input
 # to testdata, and fails+reports correctly. This tests the end-to-end behavior

--- a/src/cmd/go/testdata/script/test_fuzz_mutate_fail.txt
+++ b/src/cmd/go/testdata/script/test_fuzz_mutate_fail.txt
@@ -1,5 +1,5 @@
 # TODO(jayconrod): support shared memory on more platforms.
-[!darwin] [!linux] [!windows] skip
+[!freebsd] [!darwin] [!linux] [!windows] skip
 
 # Check that if a worker does not call F.Fuzz or calls F.Fail first,
 # 'go test' exits non-zero and no crasher is recorded.

--- a/src/cmd/go/testdata/script/test_fuzz_mutator.txt
+++ b/src/cmd/go/testdata/script/test_fuzz_mutator.txt
@@ -1,5 +1,5 @@
 # TODO(jayconrod): support shared memory on more platforms.
-[!darwin] [!linux] [!windows] skip
+[!freebsd] [!darwin] [!linux] [!windows] skip
 
 # Test basic fuzzing mutator behavior.
 #

--- a/src/cmd/go/testdata/script/test_fuzz_parallel.txt
+++ b/src/cmd/go/testdata/script/test_fuzz_parallel.txt
@@ -1,5 +1,5 @@
 # TODO(jayconrod): support shared memory on more platforms.
-[!darwin] [!linux] [!windows] skip
+[!freebsd] [!darwin] [!linux] [!windows] skip
 
 [short] skip
 

--- a/src/internal/fuzz/sys_posix.go
+++ b/src/internal/fuzz/sys_posix.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build darwin || linux
-// +build darwin linux
+//go:build darwin || linux || freebsd
+// +build darwin linux freebsd
 
 package fuzz
 

--- a/src/internal/fuzz/sys_unimplemented.go
+++ b/src/internal/fuzz/sys_unimplemented.go
@@ -3,8 +3,8 @@
 // license that can be found in the LICENSE file.
 
 // TODO(jayconrod): support more platforms.
-//go:build !darwin && !linux && !windows
-// +build !darwin,!linux,!windows
+//go:build !darwin && !linux && !windows && !freebsd
+// +build !darwin,!linux,!windows,!freebsd
 
 package fuzz
 


### PR DESCRIPTION
This commit adds the freebsd GOOS to the list of build tags for the
posix calls related to fuzzing.

Fixes #46554