### PR TITLE
doc/go1.17: trim unnecessary '>'

### DIFF
--- a/doc/go1.17.html
+++ b/doc/go1.17.html
@@ -763,9 +763,9 @@ func Foo() bool {
 <dl id="net/http/httptest"><dt><a href="/pkg/net/http/httptest/">net/http/httptest</a></dt>
   <dd>
     <p><!-- CL 308950 -->
-      <a href="/pkg/net/http/httptest/#ResponseRecorder.WriteHeader"><code>ResponseRecorder.WriteHeader></code></a>
+      <a href="/pkg/net/http/httptest/#ResponseRecorder.WriteHeader"><code>ResponseRecorder.WriteHeader</code></a>
       now panics when the provided code is not a valid three-digit HTTP status code.
-      This matches the behavior of <a href="/pkg/net/http/#ResponseWriter"><code>ResponseWriter></code></a>
+      This matches the behavior of <a href="/pkg/net/http/#ResponseWriter"><code>ResponseWriter</code></a>
       implementations in the <a href="/pkg/net/http/"><code>net/http</code></a> package.
     </p>
   </dd>


### PR DESCRIPTION
It should be removed because it is being rendered incorrectly by an unnecessary '>'.