### PR TITLE
debug/elf: don't apply DWARF relocations for ET_EXEC binaries

### DIFF
--- a/src/debug/elf/file.go
+++ b/src/debug/elf/file.go
@@ -1164,6 +1164,13 @@ func (f *File) DWARF() (*dwarf.Data, error) {
 			b = dbuf
 		}
 
+		if f.Type == ET_EXEC {
+			// Do not apply relocations to DWARF sections for ET_EXEC binaries.
+			// Relocations should already be applied, and .rela sections may
+			// contain incorrect data.
+			return b, nil
+		}
+
 		for _, r := range f.Sections {
 			if r.Type != SHT_RELA && r.Type != SHT_REL {
 				continue


### PR DESCRIPTION
Some ET_EXEC binaries might have relocations for non-loadable sections
like .debug_info. These relocations must not be applied, because:
* They may be incorrect
* The correct relocations were already applied at link time

Binaries in Linux Kernel debug packages like Fedora/Centos kernel-debuginfo
are such examples. Relocations for .debug_* sections are included in the
final binaries because they are compiled with --emit-relocs, but the resulting
relocations are incorrect and shouldn't be used when reading DWARF sections.

Fixes #46673