### PR TITLE
net/http: add MaxConnLifespan to Transport

### DIFF
--- a/api/next.txt
+++ b/api/next.txt
@@ -1,0 +1,1 @@
+pkg net/http, type Transport struct, MaxConnLifespan time.Duration


### PR DESCRIPTION
Existing implementation appeared to have no way to set a connection
max lifetime. A max lifetime allows for refreshing connection lifecycle
concerns such as dns resolutions for those that need it.

When initialized to a non-zero value the connection will be closed after
the duration has passed. This change is backwards compatible.

Fixes #23427
---

The only other knob I would like to add to the default transport is an assurance that at most MaxConns # of connections will be opened but I think I can use the round-tripper interface to add this knob as long as the net.Conn interface is always guaranteed to have Close() called.