### PR TITLE
runtime: update the variable name in comment

### DIFF
--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -529,8 +529,8 @@ var (
 	allglock mutex
 	allgs    []*g
 
-	// allglen and allgptr are atomic variables that contain len(allg) and
-	// &allg[0] respectively. Proper ordering depends on totally-ordered
+	// allglen and allgptr are atomic variables that contain len(allgs) and
+	// &allgs[0] respectively. Proper ordering depends on totally-ordered
 	// loads and stores. Writes are protected by allglock.
 	//
 	// allgptr is updated before allglen. Readers should read allglen


### PR DESCRIPTION
The comment use allg to refer to allgs in code. Update the comment to
use the same variable name.