### PR TITLE
cmd/go: delete useless git cmd option

### DIFF
--- a/src/cmd/go/internal/modfetch/codehost/git.go
+++ b/src/cmd/go/internal/modfetch/codehost/git.go
@@ -156,7 +156,7 @@ func (r *gitRepo) loadLocalTags() {
 	// The git protocol sends all known refs and ls-remote filters them on the client side,
 	// so we might as well record both heads and tags in one shot.
 	// Most of the time we only care about tags but sometimes we care about heads too.
-	out, err := Run(r.dir, "git", "tag", "-l")
+	out, err := Run(r.dir, "git", "tag")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
`git tag` is same effect as `git tag -l`.
this work since 2007-07-20 at https://github.com/git/git/commit/62e09ce998dd7f6b844deb650101c743a5c4ce50#diff-12f932d78961ec6339e6d057f3d1c23520965b0a596280ace8077eb3a78580b5R72