### PR TITLE
cmd/cgo: output cgo pragmas as object instead of go

### DIFF
--- a/src/cmd/cgo/doc.go
+++ b/src/cmd/cgo/doc.go
@@ -476,6 +476,8 @@ The following options are available when running cgo directly:
 		Write dynamic linker as part of -dynimport output.
 	-dynout file
 		Write -dynimport output to file.
+	-dynobjout string
+		Write -dynimport output in partial object format to file.
 	-dynpackage package
 		Set Go package for -dynimport output.
 	-exportheader file

--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -2860,11 +2860,11 @@ func (b *Builder) cgo(a *Action, cgoExe, objdir string, pcCFLAGS, pcLDFLAGS, cgo
 
 	switch cfg.BuildToolchainName {
 	case "gc":
-		importGo := objdir + "_cgo_import.go"
-		if err := b.dynimport(a, p, objdir, importGo, cgoExe, cflags, cgoLDFLAGS, outObj); err != nil {
+		importObj := objdir + "_cgo_import.o"
+		if err := b.dynimport(a, p, objdir, importObj, cgoExe, cflags, cgoLDFLAGS, outObj); err != nil {
 			return nil, nil, err
 		}
-		outGo = append(outGo, importGo)
+		outObj = append(outObj, importObj)
 
 	case "gccgo":
 		defunC := objdir + "_cgo_defun.c"
@@ -2959,7 +2959,7 @@ func (b *Builder) cgo(a *Action, cgoExe, objdir string, pcCFLAGS, pcLDFLAGS, cgo
 // dynimport creates a Go source file named importGo containing
 // //go:cgo_import_dynamic directives for each symbol or library
 // dynamically imported by the object files outObj.
-func (b *Builder) dynimport(a *Action, p *load.Package, objdir, importGo, cgoExe string, cflags, cgoLDFLAGS, outObj []string) error {
+func (b *Builder) dynimport(a *Action, p *load.Package, objdir, importObj, cgoExe string, cflags, cgoLDFLAGS, outObj []string) error {
 	cfile := objdir + "_cgo_main.c"
 	ofile := objdir + "_cgo_main.o"
 	if err := b.gcc(a, p, objdir, ofile, cflags, cfile); err != nil {
@@ -2991,7 +2991,7 @@ func (b *Builder) dynimport(a *Action, p *load.Package, objdir, importGo, cgoExe
 	if p.Standard && p.ImportPath == "runtime/cgo" {
 		cgoflags = []string{"-dynlinker"} // record path to dynamic linker
 	}
-	return b.run(a, base.Cwd(), p.ImportPath, b.cCompilerEnv(), cfg.BuildToolexec, cgoExe, "-dynpackage", p.Name, "-dynimport", dynobj, "-dynout", importGo, cgoflags)
+	return b.run(a, base.Cwd(), p.ImportPath, b.cCompilerEnv(), cfg.BuildToolexec, cgoExe, "-dynpackage", p.Name, "-dynimport", dynobj, "-dynobjout", importObj, cgoflags)
 }
 
 // Run SWIG on all SWIG input files.

--- a/src/cmd/link/internal/loader/loader.go
+++ b/src/cmd/link/internal/loader/loader.go
@@ -2067,6 +2067,9 @@ func (l *Loader) FuncInfo(i Sym) FuncInfo {
 // Does not read symbol data.
 // Returns the fingerprint of the object.
 func (l *Loader) Preload(localSymVersion int, f *bio.Reader, lib *sym.Library, unit *sym.CompilationUnit, length int64) goobj.FingerprintType {
+	if length == 0 {
+		return goobj.FingerprintType{}
+	}
 	roObject, readonly, err := f.Slice(uint64(length)) // TODO: no need to map blocks that are for tools only (e.g. RefName)
 	if err != nil {
 		log.Fatal("cannot read object file:", err)


### PR DESCRIPTION
In this commit, cmd/cgo now outputs the -dynimport file into an object
file if the -dynobjout flag is used instead of the -dynout flag.

cmd/go is updated accordingly to directly use the object file instead of
using the written Go file.

This pull request updates issue #15681. It should allow the cgo
compiling processes to be done differently so that it can be faster. It
should also make it easier for gcc to be parallelized.

cc @mdempsky 