### PR TITLE
cmd/compile/internal/noder: fix a deadlock when compiling large packages of incorrect files

### DIFF
--- a/src/cmd/compile/internal/noder/noder.go
+++ b/src/cmd/compile/internal/noder/noder.go
@@ -40,7 +40,7 @@ func LoadPackage(filenames []string) {
 	noders := make([]*noder, len(filenames))
 	for i, filename := range filenames {
 		p := noder{
-			err:         make(chan syntax.Error),
+			err:         make(chan syntax.Error, 10),
 			trackScopes: base.Flag.Dwarf,
 		}
 		noders[i] = &p


### PR DESCRIPTION
When compiling large packages of files that are syntactically correct, but otherwise incorrect (types, etc...), a deadlock happens because the line 62 `syntax.Parse` is trying to push multiple errors to the unbuffered error channel on the node, stopping the goroutines, and halting the main routine at line 68 waiting to range over an open channel.

Buffering the channel to allow for multiple errors to be pushed to the node fixes this problem.