### PR TITLE
image/gif: avoid decoding past the first frame in decode()

### DIFF
--- a/src/image/gif/reader.go
+++ b/src/image/gif/reader.go
@@ -250,6 +250,10 @@ func (d *decoder) decode(r io.Reader, configOnly, keepAllFrames bool) error {
 				return err
 			}
 
+			if !keepAllFrames && len(d.image) == 1 {
+				return nil
+			}
+
 		case sTrailer:
 			if len(d.image) == 0 {
 				return fmt.Errorf("gif: missing image data")

--- a/src/image/gif/reader_test.go
+++ b/src/image/gif/reader_test.go
@@ -379,7 +379,7 @@ func TestLoopCount(t *testing.T) {
 
 func TestUnexpectedEOF(t *testing.T) {
 	for i := len(testGIF) - 1; i >= 0; i-- {
-		_, err := Decode(bytes.NewReader(testGIF[:i]))
+		_, err := DecodeAll(bytes.NewReader(testGIF[:i]))
 		if err == errNotEnough {
 			continue
 		}


### PR DESCRIPTION
The existing decode() method offers the ability to keep just one
frame of the GIF image, however it will read and decompress all
subsequent frames regardless.

Fixes #41142