### PR TITLE
runtime: make ncgocall a global counter

### DIFF
--- a/src/runtime/cgocall.go
+++ b/src/runtime/cgocall.go
@@ -110,6 +110,8 @@ func syscall_cgocaller(fn unsafe.Pointer, args ...uintptr) uintptr {
 	return as.retval
 }
 
+var ncgocall uint64 // number of cgo calls in total
+
 // Call from Go to C.
 //
 // This must be nosplit because it's used for syscalls on some
@@ -130,8 +132,8 @@ func cgocall(fn, arg unsafe.Pointer) int32 {
 		racereleasemerge(unsafe.Pointer(&racecgosync))
 	}
 
+	atomic.Xadd64(&ncgocall, 1)
 	mp := getg().m
-	mp.ncgocall++
 	mp.ncgo++
 
 	// Reset traceback.

--- a/src/runtime/cgocall.go
+++ b/src/runtime/cgocall.go
@@ -110,7 +110,7 @@ func syscall_cgocaller(fn unsafe.Pointer, args ...uintptr) uintptr {
 	return as.retval
 }
 
-var ncgocall uint64 // number of cgo calls in total
+var ncgocall uint64 // number of cgo calls in total for dead m
 
 // Call from Go to C.
 //
@@ -132,8 +132,8 @@ func cgocall(fn, arg unsafe.Pointer) int32 {
 		racereleasemerge(unsafe.Pointer(&racecgosync))
 	}
 
-	atomic.Xadd64(&ncgocall, 1)
 	mp := getg().m
+	mp.ncgocall++
 	mp.ncgo++
 
 	// Reset traceback.

--- a/src/runtime/debug.go
+++ b/src/runtime/debug.go
@@ -6,7 +6,7 @@ package runtime
 
 import (
 	"runtime/internal/atomic"
-	"unsafe"
+	_ "unsafe"
 )
 
 // GOMAXPROCS sets the maximum number of CPUs that can be executing
@@ -45,11 +45,7 @@ func NumCPU() int {
 
 // NumCgoCall returns the number of cgo calls made by the current process.
 func NumCgoCall() int64 {
-	var n int64
-	for mp := (*m)(atomic.Loadp(unsafe.Pointer(&allm))); mp != nil; mp = mp.alllink {
-		n += int64(mp.ncgocall)
-	}
-	return n
+	return int64(atomic.Load64(&ncgocall))
 }
 
 // NumGoroutine returns the number of goroutines that currently exist.

--- a/src/runtime/debug.go
+++ b/src/runtime/debug.go
@@ -6,7 +6,7 @@ package runtime
 
 import (
 	"runtime/internal/atomic"
-	_ "unsafe"
+	"unsafe"
 )
 
 // GOMAXPROCS sets the maximum number of CPUs that can be executing
@@ -45,7 +45,11 @@ func NumCPU() int {
 
 // NumCgoCall returns the number of cgo calls made by the current process.
 func NumCgoCall() int64 {
-	return int64(atomic.Load64(&ncgocall))
+	var n = int64(ncgocall)
+	for mp := (*m)(atomic.Loadp(unsafe.Pointer(&allm))); mp != nil; mp = mp.alllink {
+		n += int64(mp.ncgocall)
+	}
+	return n
 }
 
 // NumGoroutine returns the number of goroutines that currently exist.

--- a/src/runtime/debug.go
+++ b/src/runtime/debug.go
@@ -45,7 +45,7 @@ func NumCPU() int {
 
 // NumCgoCall returns the number of cgo calls made by the current process.
 func NumCgoCall() int64 {
-	var n = int64(ncgocall)
+	var n = int64(atomic.Load64(&ncgocall))
 	for mp := (*m)(atomic.Loadp(unsafe.Pointer(&allm))); mp != nil; mp = mp.alllink {
 		n += int64(mp.ncgocall)
 	}

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -1507,6 +1507,7 @@ func mexit(osStack bool) {
 	}
 	throw("m not found in allm")
 found:
+	ncgocall += m.ncgocall
 	if !osStack {
 		// Delay reaping m until it's done with the stack.
 		//

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -1507,7 +1507,6 @@ func mexit(osStack bool) {
 	}
 	throw("m not found in allm")
 found:
-	ncgocall += m.ncgocall
 	if !osStack {
 		// Delay reaping m until it's done with the stack.
 		//
@@ -1522,6 +1521,8 @@ found:
 		sched.freem = m
 	}
 	unlock(&sched.lock)
+
+	atomic.Xadd64(&ncgocall, int64(m.ncgocall))
 
 	// Release the P.
 	handoffp(releasep())

--- a/src/runtime/runtime2.go
+++ b/src/runtime/runtime2.go
@@ -541,7 +541,6 @@ type m struct {
 	fastrand      [2]uint32
 	needextram    bool
 	traceback     uint8
-	ncgocall      uint64      // number of cgo calls in total
 	ncgo          int32       // number of cgo calls currently in progress
 	cgoCallersUse uint32      // if non-zero, cgoCallers in use temporarily
 	cgoCallers    *cgoCallers // cgo traceback if crashing in cgo call

--- a/src/runtime/runtime2.go
+++ b/src/runtime/runtime2.go
@@ -541,6 +541,7 @@ type m struct {
 	fastrand      [2]uint32
 	needextram    bool
 	traceback     uint8
+	ncgocall      uint64      // number of cgo calls in total
 	ncgo          int32       // number of cgo calls currently in progress
 	cgoCallersUse uint32      // if non-zero, cgoCallers in use temporarily
 	cgoCallers    *cgoCallers // cgo traceback if crashing in cgo call


### PR DESCRIPTION
ncgocall was stored per M, runtime.NumCgoCall lost the counter when a M die.

Fixes #46789
