### PR TITLE
strings: adding micro-optimization for TrimSpace

### DIFF
--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -884,7 +884,8 @@ func TrimSpace(s string) string {
 	for ; stop > start; stop-- {
 		c := s[stop-1]
 		if c >= utf8.RuneSelf {
-			return TrimFunc(s[start:stop], unicode.IsSpace)
+			// start has been already trimmed above, should trim end only
+			return TrimRightFunc(s[start:stop], unicode.IsSpace)
 		}
 		if asciiSpace[c] == 0 {
 			break


### PR DESCRIPTION
replace for string's end trimming TrimFunc -> TrimRightFunc

strings.TrimSpace string's end trimming should use more specific TrimRightFunc instead of common TrimFunc (because start has already trimmed before)