### PR TITLE
net/http: guarantee that the Transport dial functions are respected in js/wasm

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1015,6 +1015,7 @@ Nathan Youngman <git@nathany.com>
 Nathaniel Cook <nvcook42@gmail.com>
 Naveen Kumar Sangi <naveenkumarsangi@protonmail.com>
 Neelesh Chandola <neelesh.c98@gmail.com>
+Neil Alexander <neilalexander@neilalexander.dev>
 Neil Lyons <nwjlyons@googlemail.com>
 Netflix, Inc.
 Neuman Vong <neuman.vong@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1812,6 +1812,7 @@ Naveen Kumar Sangi <naveenkumarsangi@protonmail.com>
 Neeilan Selvalingam <neeilan96@gmail.com>
 Neelesh Chandola <neelesh.c98@gmail.com>
 Nehal J Wani <nehaljw.kkd1@gmail.com>
+Neil Alexander <neilalexander@neilalexander.dev>
 Neil Lyons <nwjlyons@googlemail.com>
 Neuman Vong <neuman.vong@gmail.com>
 Neven Sajko <nsajko@gmail.com>

--- a/src/net/http/roundtrip_js.go
+++ b/src/net/http/roundtrip_js.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build js && wasm
 // +build js,wasm
 
 package http

--- a/src/net/http/roundtrip_js.go
+++ b/src/net/http/roundtrip_js.go
@@ -42,7 +42,7 @@ const jsFetchRedirect = "js.fetch:redirect"
 
 // jsFetchMissing will be true if the Fetch API is not present in
 // the browser globals.
-var jsFetchMissing = !js.Global().Get("fetch").IsUndefined()
+var jsFetchMissing = js.Global().Get("fetch").IsUndefined()
 
 // RoundTrip implements the RoundTripper interface using the WHATWG Fetch API.
 func (t *Transport) RoundTrip(req *Request) (*Response, error) {

--- a/src/net/http/roundtrip_js.go
+++ b/src/net/http/roundtrip_js.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build js && wasm
 // +build js,wasm
 
 package http
@@ -41,7 +40,9 @@ const jsFetchCreds = "js.fetch:credentials"
 // Reference: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters
 const jsFetchRedirect = "js.fetch:redirect"
 
-var useFakeNetwork = js.Global().Get("fetch").IsUndefined()
+// jsFetchMissing will be true if the Fetch API is not present in
+// the browser globals.
+var jsFetchMissing = !js.Global().Get("fetch").IsUndefined()
 
 // RoundTrip implements the RoundTripper interface using the WHATWG Fetch API.
 func (t *Transport) RoundTrip(req *Request) (*Response, error) {
@@ -49,15 +50,9 @@ func (t *Transport) RoundTrip(req *Request) (*Response, error) {
 	// DialTLSContext functions are set, they will be used to set up the connections.
 	// If they aren't set then the documented contract is to use Dial or DialTLS, even
 	// though they are deprecated. Therefore, if any of these are set, we should obey
-	// the contract and dial using the regular round-trip instead. Otherwise we will
-	// end up calling the browser Fetch API unexpectedly.
-	if t.Dial != nil || t.DialContext != nil || t.DialTLS != nil || t.DialTLSContext != nil {
-		useFakeNetwork = true
-	}
-
-	// If the browser Fetch API is unavailable, or the above conditions are met, then
-	// we will lean on fake networking to set up the connection.
-	if useFakeNetwork {
+	// the contract and dial using the regular round-trip instead. Otherwise, we'll try
+	// to fall back on the Fetch API, unless it's not available.
+	if t.Dial != nil || t.DialContext != nil || t.DialTLS != nil || t.DialTLSContext != nil || jsFetchMissing {
 		return t.roundTrip(req)
 	}
 

--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -35,24 +35,6 @@ import (
 	"golang.org/x/net/http/httpproxy"
 )
 
-// DefaultTransport is the default implementation of Transport and is
-// used by DefaultClient. It establishes network connections as needed
-// and caches them for reuse by subsequent calls. It uses HTTP proxies
-// as directed by the $HTTP_PROXY and $NO_PROXY (or $http_proxy and
-// $no_proxy) environment variables.
-var DefaultTransport RoundTripper = &Transport{
-	Proxy: ProxyFromEnvironment,
-	DialContext: (&net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-	}).DialContext,
-	ForceAttemptHTTP2:     true,
-	MaxIdleConns:          100,
-	IdleConnTimeout:       90 * time.Second,
-	TLSHandshakeTimeout:   10 * time.Second,
-	ExpectContinueTimeout: 1 * time.Second,
-}
-
 // DefaultMaxIdleConnsPerHost is the default value of Transport's
 // MaxIdleConnsPerHost.
 const DefaultMaxIdleConnsPerHost = 2

--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -35,10 +35,6 @@ import (
 	"golang.org/x/net/http/httpproxy"
 )
 
-// DefaultMaxIdleConnsPerHost is the default value of Transport's
-// MaxIdleConnsPerHost.
-const DefaultMaxIdleConnsPerHost = 2
-
 // DefaultTransport is the default implementation of Transport and is
 // used by DefaultClient. It establishes network connections as needed
 // and caches them for reuse by subsequent calls. It uses HTTP proxies
@@ -53,6 +49,10 @@ var DefaultTransport RoundTripper = &Transport{
 	TLSHandshakeTimeout:   10 * time.Second,
 	ExpectContinueTimeout: 1 * time.Second,
 }
+
+// DefaultMaxIdleConnsPerHost is the default value of Transport's
+// MaxIdleConnsPerHost.
+const DefaultMaxIdleConnsPerHost = 2
 
 // Transport is an implementation of RoundTripper that supports HTTP,
 // HTTPS, and HTTP proxies (for either HTTP or HTTPS with CONNECT).

--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -46,7 +46,7 @@ const DefaultMaxIdleConnsPerHost = 2
 // $no_proxy) environment variables.
 var DefaultTransport RoundTripper = &Transport{
 	Proxy:                 ProxyFromEnvironment,
-	DialContext:           defaultTransportDialer(),
+	DialContext:           defaultTransportDialContext(),
 	ForceAttemptHTTP2:     true,
 	MaxIdleConns:          100,
 	IdleConnTimeout:       90 * time.Second,

--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -41,8 +41,11 @@ import (
 // as directed by the $HTTP_PROXY and $NO_PROXY (or $http_proxy and
 // $no_proxy) environment variables.
 var DefaultTransport RoundTripper = &Transport{
-	Proxy:                 ProxyFromEnvironment,
-	DialContext:           defaultTransportDialContext(),
+	Proxy: ProxyFromEnvironment,
+	DialContext: defaultTransportDialContext(&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}),
 	ForceAttemptHTTP2:     true,
 	MaxIdleConns:          100,
 	IdleConnTimeout:       90 * time.Second,

--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -39,6 +39,21 @@ import (
 // MaxIdleConnsPerHost.
 const DefaultMaxIdleConnsPerHost = 2
 
+// DefaultTransport is the default implementation of Transport and is
+// used by DefaultClient. It establishes network connections as needed
+// and caches them for reuse by subsequent calls. It uses HTTP proxies
+// as directed by the $HTTP_PROXY and $NO_PROXY (or $http_proxy and
+// $no_proxy) environment variables.
+var DefaultTransport RoundTripper = &Transport{
+	Proxy:                 ProxyFromEnvironment,
+	DialContext:           defaultTransportDialer(),
+	ForceAttemptHTTP2:     true,
+	MaxIdleConns:          100,
+	IdleConnTimeout:       90 * time.Second,
+	TLSHandshakeTimeout:   10 * time.Second,
+	ExpectContinueTimeout: 1 * time.Second,
+}
+
 // Transport is an implementation of RoundTripper that supports HTTP,
 // HTTPS, and HTTP proxies (for either HTTP or HTTPS with CONNECT).
 //

--- a/src/net/http/transport_default_js.go
+++ b/src/net/http/transport_default_js.go
@@ -1,0 +1,26 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build js && wasm
+// +build js,wasm
+
+package http
+
+import (
+	"time"
+)
+
+// DefaultTransport is the default implementation of Transport and is
+// used by DefaultClient. It uses HTTP proxies as directed by the
+// $HTTP_PROXY and $NO_PROXY (or $http_proxy and $no_proxy) environment
+// variables. No default dialer is specified as the Fetch API will be
+// used in RoundTrip if not specified.
+var DefaultTransport RoundTripper = &Transport{
+	Proxy:                 ProxyFromEnvironment,
+	ForceAttemptHTTP2:     true,
+	MaxIdleConns:          100,
+	IdleConnTimeout:       90 * time.Second,
+	TLSHandshakeTimeout:   10 * time.Second,
+	ExpectContinueTimeout: 1 * time.Second,
+}

--- a/src/net/http/transport_default_js.go
+++ b/src/net/http/transport_default_js.go
@@ -12,6 +12,6 @@ import (
 	"net"
 )
 
-func defaultTransportDialContext() func(context.Context, string, string) (net.Conn, error) {
+func defaultTransportDialContext(dialer *net.Dialer) func(context.Context, string, string) (net.Conn, error) {
 	return nil
 }

--- a/src/net/http/transport_default_js.go
+++ b/src/net/http/transport_default_js.go
@@ -7,20 +7,8 @@
 
 package http
 
-import (
-	"time"
-)
+import "net"
 
-// DefaultTransport is the default implementation of Transport and is
-// used by DefaultClient. It uses HTTP proxies as directed by the
-// $HTTP_PROXY and $NO_PROXY (or $http_proxy and $no_proxy) environment
-// variables. No default dialer is specified as the Fetch API will be
-// used in RoundTrip if not specified.
-var DefaultTransport RoundTripper = &Transport{
-	Proxy:                 ProxyFromEnvironment,
-	ForceAttemptHTTP2:     true,
-	MaxIdleConns:          100,
-	IdleConnTimeout:       90 * time.Second,
-	TLSHandshakeTimeout:   10 * time.Second,
-	ExpectContinueTimeout: 1 * time.Second,
+func defaultTransportDialer() *net.Dialer {
+	return nil
 }

--- a/src/net/http/transport_default_js.go
+++ b/src/net/http/transport_default_js.go
@@ -7,8 +7,11 @@
 
 package http
 
-import "net"
+import (
+	"context"
+	"net"
+)
 
-func defaultTransportDialer() *net.Dialer {
+func defaultTransportDialContext() func(context.Context, string, string) (net.Conn, error) {
 	return nil
 }

--- a/src/net/http/transport_default_other.go
+++ b/src/net/http/transport_default_other.go
@@ -1,0 +1,31 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !js || !wasm
+// +build !js !wasm
+
+package http
+
+import (
+	"net"
+	"time"
+)
+
+// DefaultTransport is the default implementation of Transport and is
+// used by DefaultClient. It establishes network connections as needed
+// and caches them for reuse by subsequent calls. It uses HTTP proxies
+// as directed by the $HTTP_PROXY and $NO_PROXY (or $http_proxy and
+// $no_proxy) environment variables.
+var DefaultTransport RoundTripper = &Transport{
+	Proxy: ProxyFromEnvironment,
+	DialContext: (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).DialContext,
+	ForceAttemptHTTP2:     true,
+	MaxIdleConns:          100,
+	IdleConnTimeout:       90 * time.Second,
+	TLSHandshakeTimeout:   10 * time.Second,
+	ExpectContinueTimeout: 1 * time.Second,
+}

--- a/src/net/http/transport_default_other.go
+++ b/src/net/http/transport_default_other.go
@@ -2,30 +2,21 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !js || !wasm
+//go:build !(js && wasm)
 // +build !js !wasm
 
 package http
 
 import (
+	"context"
 	"net"
 	"time"
 )
 
-// DefaultTransport is the default implementation of Transport and is
-// used by DefaultClient. It establishes network connections as needed
-// and caches them for reuse by subsequent calls. It uses HTTP proxies
-// as directed by the $HTTP_PROXY and $NO_PROXY (or $http_proxy and
-// $no_proxy) environment variables.
-var DefaultTransport RoundTripper = &Transport{
-	Proxy: ProxyFromEnvironment,
-	DialContext: (&net.Dialer{
+func defaultTransportDialer() func(context.Context, string, string) (net.Conn, error) {
+	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
-	}).DialContext,
-	ForceAttemptHTTP2:     true,
-	MaxIdleConns:          100,
-	IdleConnTimeout:       90 * time.Second,
-	TLSHandshakeTimeout:   10 * time.Second,
-	ExpectContinueTimeout: 1 * time.Second,
+	}
+	return dialer.DialContext
 }

--- a/src/net/http/transport_default_other.go
+++ b/src/net/http/transport_default_other.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-func defaultTransportDialer() func(context.Context, string, string) (net.Conn, error) {
+func defaultTransportDialContext() func(context.Context, string, string) (net.Conn, error) {
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,

--- a/src/net/http/transport_default_other.go
+++ b/src/net/http/transport_default_other.go
@@ -10,13 +10,8 @@ package http
 import (
 	"context"
 	"net"
-	"time"
 )
 
-func defaultTransportDialContext() func(context.Context, string, string) (net.Conn, error) {
-	dialer := &net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-	}
+func defaultTransportDialContext(dialer *net.Dialer) func(context.Context, string, string) (net.Conn, error) {
 	return dialer.DialContext
 }


### PR DESCRIPTION
The net/http package has a documented contract that if DialContext, DialDLSContext, Dial or DialTLS are specified in an instance of Transport, that they will be used to set up the connection. If they are not specified, then a reasonable fallback is made (e.g. using the net package).

This is ordinarily true, except for when compiling for the js/wasm target, where the browser's Fetch API is preferred in all cases (except for when it is undefined/unavailable) and therefore the dial functions are all ignored. As a result, the http.Transport implementation under js/wasm doesn't meet that contract.

This PR updates the RoundTrip behaviour of http.Transport so that if DialContext, DialTLSContext, Dial or DialTLS are specified, they are used as expected. The Fetch API will be used as a fallback if they are not specified.

Fixes #27495