### PR TITLE
cmd/go/internal/work: remove handler shared work state

### DIFF
--- a/src/cmd/go/internal/work/action.go
+++ b/src/cmd/go/internal/work/action.go
@@ -50,9 +50,7 @@ type Builder struct {
 	output    sync.Mutex
 	scriptDir string // current directory in printed script
 
-	exec      sync.Mutex
-	readySema chan bool
-	ready     actionQueue
+	exec sync.Mutex
 
 	id           sync.Mutex
 	toolIDCache  map[string]string // tool name -> tool ID


### PR DESCRIPTION
Removes the handler shared work state by communicating over two channels.
Ready queue is managed by the caller.