### PR TITLE
image/gif: typo in type blockReader struct docs

### DIFF
--- a/src/image/gif/reader.go
+++ b/src/image/gif/reader.go
@@ -116,7 +116,7 @@ type decoder struct {
 // consumed when checking that the blockReader is exhausted.
 //
 // To avoid the allocation of a bufio.Reader for the lzw Reader, blockReader
-// implements io.ReadByte and buffers blocks into the decoder's "tmp" buffer.
+// implements io.ByteReader and buffers blocks into the decoder's "tmp" buffer.
 type blockReader struct {
 	d    *decoder
 	i, j uint8 // d.tmp[i:j] contains the buffered bytes


### PR DESCRIPTION
Fix typo
close #46967