### PR TITLE
cpu: add HasSHA512 feature bit in ARM64

### DIFF
--- a/src/internal/cpu/cpu.go
+++ b/src/internal/cpu/cpu.go
@@ -61,6 +61,7 @@ var ARM64 struct {
 	HasPMULL     bool
 	HasSHA1      bool
 	HasSHA2      bool
+	HasSHA512    bool
 	HasCRC32     bool
 	HasATOMICS   bool
 	HasCPUID     bool

--- a/src/internal/cpu/cpu_arm64_darwin.go
+++ b/src/internal/cpu/cpu_arm64_darwin.go
@@ -10,6 +10,7 @@ package cpu
 func osInit() {
 	ARM64.HasATOMICS = sysctlEnabled([]byte("hw.optional.armv8_1_atomics\x00"))
 	ARM64.HasCRC32 = sysctlEnabled([]byte("hw.optional.armv8_crc32\x00"))
+	ARM64.HasSHA512 = sysctlEnabled([]byte("hw.optional.armv8_2_sha512\x00"))
 
 	// There are no hw.optional sysctl values for the below features on Mac OS 11.0
 	// to detect their supported state dynamically. Assume the CPU features that


### PR DESCRIPTION
Add HasSHA512 feature bit in ARM64 which allows us to check
if the running machine support SHA512 SIMD features.
