### PR TITLE
cmd/compile: fix stack growing algorithm

### DIFF
--- a/src/runtime/stack.go
+++ b/src/runtime/stack.go
@@ -1064,7 +1064,7 @@ func newstack() {
 	// recheck the bounds on return.)
 	if f := findfunc(gp.sched.pc); f.valid() {
 		max := uintptr(funcMaxSPDelta(f))
-		for newsize-gp.sched.sp < max+_StackGuard {
+		for newsize-(gp.stack.hi-gp.sched.sp) < max+_StackGuard {
 			newsize *= 2
 		}
 	}

--- a/src/runtime/stack.go
+++ b/src/runtime/stack.go
@@ -1064,7 +1064,9 @@ func newstack() {
 	// recheck the bounds on return.)
 	if f := findfunc(gp.sched.pc); f.valid() {
 		max := uintptr(funcMaxSPDelta(f))
-		for newsize-(gp.stack.hi-gp.sched.sp) < max+_StackGuard {
+		needed := max + _StackGuard
+		used := gp.stack.hi - gp.sched.sp
+		for newsize-used < needed {
 			newsize *= 2
 		}
 	}


### PR DESCRIPTION
The current stack growing implementation looks not right.
Specially, the line runtime/stack.go#L1068 never gets executed,
which causes many unnecessary copystack calls.

This PR is trying to correct the implementation.
As I'm not familiar with the code, the fix is just a guess. 
