### PR TITLE
cmd/compile: correct comment: walkSwitch -> walkSelect

### DIFF
--- a/src/cmd/compile/internal/ir/stmt.go
+++ b/src/cmd/compile/internal/ir/stmt.go
@@ -338,7 +338,7 @@ type SelectStmt struct {
 	HasBreak bool
 
 	// TODO(rsc): Instead of recording here, replace with a block?
-	Compiled Nodes // compiled form, after walkSwitch
+	Compiled Nodes // compiled form, after walkSelect
 }
 
 func NewSelectStmt(pos src.XPos, cases []*CommClause) *SelectStmt {


### PR DESCRIPTION
fix typo