### PR TITLE
internal/cpu: Prefer XOR CX, CX over MOV 0, CX in xgetbv

### DIFF
--- a/src/internal/cpu/cpu_x86.s
+++ b/src/internal/cpu/cpu_x86.s
@@ -20,7 +20,7 @@ TEXT ·cpuid(SB), NOSPLIT, $0-24
 
 // func xgetbv() (eax, edx uint32)
 TEXT ·xgetbv(SB),NOSPLIT,$0-8
-	MOVL $0, CX
+	XORL CX, CX
 	XGETBV
 	MOVL AX, eax+0(FP)
 	MOVL DX, edx+4(FP)


### PR DESCRIPTION
This makes the code consistent with the gccgo implementation.