### PR TITLE
link: add .eh_frame section for amd64/arm64 ELF binaries

### DIFF
--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -2513,6 +2513,11 @@ func (b *Builder) compilerCmd(compiler []string, incdir, workdir string) []strin
 		a = append(a, "-Qunused-arguments")
 	}
 
+	// add eh_frame generation
+	if b.gccSupportsFlag(compiler, "-funwind-tables") {
+		a = append(a, "-funwind-tables")
+	}
+
 	// disable word wrapping in error messages
 	a = append(a, "-fmessage-length=0")
 

--- a/src/cmd/link/internal/amd64/l.go
+++ b/src/cmd/link/internal/amd64/l.go
@@ -40,4 +40,5 @@ const (
 const (
 	dwarfRegSP = 7
 	dwarfRegLR = 16
+	dwarfRegBP = 6
 )

--- a/src/cmd/link/internal/amd64/obj.go
+++ b/src/cmd/link/internal/amd64/obj.go
@@ -45,6 +45,7 @@ func Init() (*sys.Arch, ld.Arch) {
 		Minalign:   minAlign,
 		Dwarfregsp: dwarfRegSP,
 		Dwarfreglr: dwarfRegLR,
+		Dwarfregbp: dwarfRegBP,
 		// 0xCC is INT $3 - breakpoint instruction
 		CodePad: []byte{0xCC},
 

--- a/src/cmd/link/internal/arm64/asm.go
+++ b/src/cmd/link/internal/arm64/asm.go
@@ -486,7 +486,16 @@ func elfreloc1(ctxt *ld.Link, out *ld.OutBuf, ldr *loader.Loader, s loader.Sym, 
 			return false
 		}
 		out.Write64(uint64(elf.R_AARCH64_CALL26) | uint64(elfsym)<<32)
-
+	case objabi.R_PCREL:
+                if siz == 4 {
+                        if ldr.SymType(r.Xsym) == sym.SDYNIMPORT && ldr.SymElfType(r.Xsym) == elf.STT_FUNC {
+                                panic("not managed")
+                        } else {
+                                out.Write64(uint64(elf.R_AARCH64_PREL32) | uint64(elfsym)<<32)
+                        }
+                } else {
+                        return false
+                }
 	}
 	out.Write64(uint64(r.Xadd))
 
@@ -578,6 +587,9 @@ func machoreloc1(arch *sys.Arch, out *ld.OutBuf, ldr *loader.Loader, s loader.Sy
 		}
 		v |= 1 << 24 // pc-relative bit
 		v |= ld.MACHO_ARM64_RELOC_GOT_LOAD_PAGE21 << 28
+	 case objabi.R_PCREL:
+                v |= 1 << 24 // pc-relative bit
+                v |= ld.MACHO_X86_64_RELOC_SIGNED << 28
 	}
 
 	switch siz {

--- a/src/cmd/link/internal/arm64/l.go
+++ b/src/cmd/link/internal/arm64/l.go
@@ -71,4 +71,5 @@ const (
 const (
 	dwarfRegSP = 31
 	dwarfRegLR = 30
+	dwarfRegBP = 29
 )

--- a/src/cmd/link/internal/arm64/obj.go
+++ b/src/cmd/link/internal/arm64/obj.go
@@ -45,6 +45,7 @@ func Init() (*sys.Arch, ld.Arch) {
 		Minalign:   minAlign,
 		Dwarfregsp: dwarfRegSP,
 		Dwarfreglr: dwarfRegLR,
+		Dwarfregbp: dwarfRegBP,
 		TrampLimit: 0x7c00000, // 26-bit signed offset * 4, leave room for PLT etc.
 
 		Adddynrel:        adddynrel,

--- a/src/cmd/link/internal/ld/dwarf.go
+++ b/src/cmd/link/internal/ld/dwarf.go
@@ -1514,6 +1514,13 @@ func (d *dwctxt) writeframes(fs loader.Sym) dwarfSecInfo {
 }
 
 func (d *dwctxt) writeehframes(fs loader.Sym) dwarfSecInfo {
+	if (d.arch.Family != sys.ARM64) && (d.arch.Family != sys.AMD64) {
+	return dwarfSecInfo{syms: []loader.Sym{fs}}
+	}
+	if (!d.linkctxt.IsELF) {
+		return dwarfSecInfo{syms: []loader.Sym{fs}}
+	}
+
 	fsd := dwSym(fs)
 	fsu := d.ldr.MakeSymbolUpdater(fs)
 	fsu.SetType(sym.SDWARFSECT)

--- a/src/cmd/link/internal/ld/lib.go
+++ b/src/cmd/link/internal/ld/lib.go
@@ -182,6 +182,7 @@ type Arch struct {
 	Minalign   int
 	Dwarfregsp int
 	Dwarfreglr int
+	Dwarfregbp int
 
 	// Threshold of total text size, used for trampoline insertion. If the total
 	// text size is smaller than TrampLimit, we won't need to insert trampolines.
@@ -1466,6 +1467,11 @@ func (ctxt *Link) hostlink() {
 	const unusedArguments = "-Qunused-arguments"
 	if linkerFlagSupported(ctxt.Arch, argv[0], altLinker, unusedArguments) {
 		argv = append(argv, unusedArguments)
+	}
+
+	const ehframeHdrArgument = "-Wl,--eh-frame-hdr"
+	if linkerFlagSupported(ctxt.Arch, argv[0], altLinker, ehframeHdrArgument) {
+		argv = append(argv, ehframeHdrArgument)
 	}
 
 	const compressDWARF = "-Wl,--compress-debug-sections=zlib-gnu"

--- a/src/cmd/link/internal/x86/l.go
+++ b/src/cmd/link/internal/x86/l.go
@@ -40,4 +40,5 @@ const (
 const (
 	dwarfRegSP = 4
 	dwarfRegLR = 8
+	dwarfRegBP = 5
 )

--- a/src/cmd/link/internal/x86/obj.go
+++ b/src/cmd/link/internal/x86/obj.go
@@ -45,6 +45,7 @@ func Init() (*sys.Arch, ld.Arch) {
 		Minalign:   minAlign,
 		Dwarfregsp: dwarfRegSP,
 		Dwarfreglr: dwarfRegLR,
+		Dwarfregbp: dwarfRegBP,
 		// 0xCC is INT $3 - breakpoint instruction
 		CodePad: []byte{0xCC},
 


### PR DESCRIPTION
Fixes #47166

For ELF binaries, add dwarf .eh_frame section with specific dwarf opcodes for runtime.asmcgocall.
When using cgo, this is needed to have a complete backtrace when the C code crashes ; otherwise, the backtrace stops at runtime.asmcgocall. This is due to the fact that runtime.asmcgocall switches the stack (Go stack <-> system stack).

The dwarf opcode for runtime.asmcgocall might probably be optimized.

Please note, even if the initial problem was on Android, this fixes should work on the other platforms supporting ELF binaries (tested successfully on Linux/amd64).