### PR TITLE
src/runtime/internal/math: improve if expression for MulUintptr function

### DIFF
--- a/src/runtime/internal/math/math.go
+++ b/src/runtime/internal/math/math.go
@@ -11,7 +11,7 @@ const MaxUintptr = ^uintptr(0)
 // MulUintptr returns a * b and whether the multiplication overflowed.
 // On supported platforms this is an intrinsic lowered by the compiler.
 func MulUintptr(a, b uintptr) (uintptr, bool) {
-	if a|b < 1<<(4*sys.PtrSize) || a == 0 {
+	if a == 0 || b == 0 || a|b < 1<<(4*sys.PtrSize) {
 		return a * b, false
 	}
 	overflow := b > MaxUintptr/a


### PR DESCRIPTION
Using Short-circuit evaluation and add parameter b judgment to make MulUintptr function run faster.

The Short-circuit evaluation is described at https://en.wikipedia.org/wiki/Short-circuit_evaluation