### PR TITLE
go/token: match the implementation of index selection with sort.Search

### DIFF
--- a/src/go/token/position.go
+++ b/src/go/token/position.go
@@ -540,7 +540,7 @@ func searchInts(a []int, x int) int {
 	// TODO(gri): Remove this when compilers have caught up.
 	i, j := 0, len(a)
 	for i < j {
-		h := i + (j-i)>>1 // avoid overflow when computing h
+		h := int(uint(i+j) >> 1) // avoid overflow when computing h
 		// i ≤ h < j
 		if a[h] <= x {
 			i = h + 1


### PR DESCRIPTION
name          old time/op    new time/op    delta
SearchInts-8    15.5ns ± 2%    13.7ns ± 4%  -11.87%  (p=0.008 n=5+5)

(see CL 36332 for the original change to sort.Search)
