### PR TITLE
update go_spec documentation: fix casing typo

### DIFF
--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -52,7 +52,7 @@ operators, in increasing precedence:
 
 <p>
 Lower-case production names are used to identify lexical tokens.
-Non-terminals are in CamelCase. Lexical tokens are enclosed in
+Non-terminals are in PascalCase. Lexical tokens are enclosed in
 double quotes <code>""</code> or back quotes <code>``</code>.
 </p>
 


### PR DESCRIPTION
camelCase and PascalCase are different cases, but they are often confused
https://en.wikipedia.org/wiki/Naming_convention_(programming)#Examples_of_multiple-word_identifier_formats