### PR TITLE
net, reflect, runtime, strconv, crypto/ed25519, test: Fix 7 typos in comment

### DIFF
--- a/src/crypto/ed25519/internal/edwards25519/tables.go
+++ b/src/crypto/ed25519/internal/edwards25519/tables.go
@@ -40,7 +40,7 @@ func (v *projLookupTable) FromP3(q *Point) {
 	for i := 0; i < 7; i++ {
 		// Compute (i+1)*Q as Q + i*Q and convert to a ProjCached
 		// This is needlessly complicated because the API has explicit
-		// recievers instead of creating stack objects and relying on RVO
+		// receivers instead of creating stack objects and relying on RVO
 		v.points[i+1].FromP3(tmpP3.fromP1xP1(tmpP1xP1.Add(q, &v.points[i])))
 	}
 }

--- a/src/net/lookup.go
+++ b/src/net/lookup.go
@@ -620,6 +620,6 @@ func (r *Resolver) LookupAddr(ctx context.Context, addr string) ([]string, error
 }
 
 // errMalformedDNSRecordsDetail is the DNSError detail which is returned when a Resolver.Lookup...
-// method recieves DNS records which contain invalid DNS names. This may be returned alongside
+// method receives DNS records which contain invalid DNS names. This may be returned alongside
 // results which have had the malformed records filtered out.
 var errMalformedDNSRecordsDetail = "DNS response contained records which contain invalid names"

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -931,7 +931,7 @@ func callMethod(ctxt *methodValue, frame unsafe.Pointer, retValid *bool, regs *a
 
 	// Deal with the receiver. It's guaranteed to only be one word in size.
 	if st := methodABI.call.steps[0]; st.kind == abiStepStack {
-		// Only copy the reciever to the stack if the ABI says so.
+		// Only copy the receiever to the stack if the ABI says so.
 		// Otherwise, it'll be in a register already.
 		storeRcvr(rcvr, methodFrame)
 	} else {

--- a/src/runtime/runtime2.go
+++ b/src/runtime/runtime2.go
@@ -652,7 +652,7 @@ type p struct {
 		// We need an explicit length here because this field is used
 		// in allocation codepaths where write barriers are not allowed,
 		// and eliminating the write barrier/keeping it eliminated from
-		// slice updates is tricky, moreso than just managing the length
+		// slice updates is tricky, more than just managing the length
 		// ourselves.
 		len int
 		buf [128]*mspan

--- a/src/runtime/traceback.go
+++ b/src/runtime/traceback.go
@@ -600,7 +600,7 @@ func printArgs(f funcInfo, argp unsafe.Pointer) {
 
 	print1 := func(off, sz uint8) {
 		x := readUnaligned64(add(argp, uintptr(off)))
-		// mask out irrelavant bits
+		// mask out irrelevant bits
 		if sz < 8 {
 			shift := 64 - sz*8
 			if sys.BigEndian {

--- a/src/strconv/ftoaryu.go
+++ b/src/strconv/ftoaryu.go
@@ -291,7 +291,7 @@ func ryuFtoaShortest(d *decimalSlice, mant uint64, exp int, flt *floatInfo) {
 	// Is it allowed to use 'du' as a result?
 	// It is always allowed when it is truncated, but also
 	// if it is exact and the original binary mantissa is even
-	// When disallowed, we can substract 1.
+	// When disallowed, we can subtract 1.
 	uok := !du0 || fracu > 0
 	if du0 && fracu == 0 {
 		uok = mant&1 == 0

--- a/test/typeparam/slices.go
+++ b/test/typeparam/slices.go
@@ -60,7 +60,7 @@ func _Equal[Elem comparable](s1, s2 []Elem) bool {
 	return true
 }
 
-// _EqualFn reports whether two slices are equal using a comparision
+// _EqualFn reports whether two slices are equal using a comparison
 // function on each element.
 func _EqualFn[Elem any](s1, s2 []Elem, eq func(Elem, Elem) bool) bool {
 	if len(s1) != len(s2) {


### PR DESCRIPTION
"comparision" is a misspelling of "comparison"
"irrelavant" is a misspelling of "irrelevant"
"moreso" is a misspelling of "more"
"reciever" is a misspelling of "receiver"
"recievers" is a misspelling of "receivers"
"recieves" is a misspelling of "receives"
"substract" is a misspelling of "subtract"