### PR TITLE
runtime: ensure the fixalloc object size is valid

### DIFF
--- a/src/runtime/mfixalloc.go
+++ b/src/runtime/mfixalloc.go
@@ -47,10 +47,17 @@ type mlink struct {
 	next *mlink
 }
 
+func maxUintptr(a, b uintptr) uintptr {
+	if a > b {
+		return a
+	}
+	return b
+}
+
 // Initialize f to allocate objects of the given size,
 // using the allocator to obtain chunks of memory.
 func (f *fixalloc) init(size uintptr, first func(arg, p unsafe.Pointer), arg unsafe.Pointer, stat *sysMemStat) {
-	f.size = size
+	f.size = maxUintptr(size, unsafe.Sizeof(mlink{}))
 	f.first = first
 	f.arg = arg
 	f.list = nil
@@ -77,7 +84,8 @@ func (f *fixalloc) alloc() unsafe.Pointer {
 		return v
 	}
 	if uintptr(f.nchunk) < f.size {
-		f.chunk = uintptr(persistentalloc(_FixAllocChunk, 0, f.stat))
+		chunksz := maxUintptr(f.size, _FixAllocChunk)
+		f.chunk = uintptr(persistentalloc(chunksz, 0, f.stat))
 		f.nchunk = _FixAllocChunk
 	}
 

--- a/src/runtime/mfixalloc.go
+++ b/src/runtime/mfixalloc.go
@@ -86,7 +86,7 @@ func (f *fixalloc) alloc() unsafe.Pointer {
 	if uintptr(f.nchunk) < f.size {
 		chunksz := maxUintptr(f.size, _FixAllocChunk)
 		f.chunk = uintptr(persistentalloc(chunksz, 0, f.stat))
-		f.nchunk = _FixAllocChunk
+		f.nchunk = uint32(chunksz)
 	}
 
 	v := unsafe.Pointer(f.chunk)

--- a/src/runtime/mfixalloc.go
+++ b/src/runtime/mfixalloc.go
@@ -85,7 +85,7 @@ func (f *fixalloc) alloc() unsafe.Pointer {
 	}
 	if uintptr(f.nchunk) < f.size {
 		f.chunk = uintptr(persistentalloc(_FixAllocChunk, 0, f.stat))
-		f.nchunk = f._FixAllocChunk
+		f.nchunk = _FixAllocChunk
 	}
 
 	v := unsafe.Pointer(f.chunk)


### PR DESCRIPTION
Usually, fixalloc is used to allocate small, persistent and reuseable
objects. The size is typically between range [sizeof(mlink), _FixAllocChunk].

It's rare for being out of the range. But if it did happen, we got a
hard-to-discover memory corruption. This commit prevents that situation by limiting object's size.