### PR TITLE
cmd/go: clean paths before checking same directory

### DIFF
--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2674,10 +2674,7 @@ func GoFilesPackage(ctx context.Context, opts PackageOpts, gofiles []string) *Pa
 		if fi.IsDir() {
 			base.Fatalf("%s is a directory, should be a Go file", file)
 		}
-		dir1, _ := filepath.Split(file)
-		if dir1 == "" {
-			dir1 = "./"
-		}
+		dir1 := filepath.Dir(file)
 		if dir == "" {
 			dir = dir1
 		} else if dir != dir1 {

--- a/src/cmd/go/testdata/script/run_dirs.txt
+++ b/src/cmd/go/testdata/script/run_dirs.txt
@@ -1,11 +1,21 @@
 cd rundir
 
 ! go run x.go sub/sub.go
-stderr 'named files must all be in one directory; have ./ and sub/'
+stderr 'named files must all be in one directory; have . and sub'
 ! go run sub/sub.go x.go
-stderr 'named files must all be in one directory; have sub/ and ./'
+stderr 'named files must all be in one directory; have sub and .'
+
+cd ../
+go run rundir/foo.go ./rundir/bar.go
+stderr 'hello world'
 
 -- rundir/sub/sub.go --
 package main
 -- rundir/x.go --
 package main
+-- rundir/foo.go --
+package main
+func main() { println(msg) }
+-- rundir/bar.go --
+package main
+const msg = "hello world"


### PR DESCRIPTION
Replace `filepath.Split`  with `filepath.Dir`. Clean paths before checking whether command line files are in same directory.

Fixes #47392
