### PR TITLE
list 'e.next' points to nil - Dev.boringcrypto.go1.16

### DIFF
--- a/src/container/list/list.go
+++ b/src/container/list/list.go
@@ -93,7 +93,9 @@ func (l *List) insert(e, at *Element) *Element {
 	e.prev = at
 	e.next = at.next
 	e.prev.next = e
-	e.next.prev = e
+	if e.next != nil {
+		e.next.prev = e
+	}
 	e.list = l
 	l.len++
 	return e

--- a/src/container/list/list.go
+++ b/src/container/list/list.go
@@ -94,7 +94,7 @@ func (l *List) insert(e, at *Element) *Element {
 	e.next = at.next
 	e.prev.next = e
 	if e.next != nil {
-		e.next.prev = e
+		e.next.prev=e
 	}
 	e.list = l
 	l.len++


### PR DESCRIPTION
When 'at.next' points to nil, it causes e.next.prev to refer to an empty address; which is judged to be e.next.prev, and when the element after e points to nil, e.next.prev is no longer assigned.
