### PR TITLE
runtime: do not alloc never used tail bytes in fixalloc

### DIFF
--- a/src/runtime/mfixalloc.go
+++ b/src/runtime/mfixalloc.go
@@ -30,8 +30,8 @@ type fixalloc struct {
 	arg    unsafe.Pointer
 	list   *mlink
 	chunk  uintptr // use uintptr instead of unsafe.Pointer to avoid write barriers
-	nchunk uint32
-	nalloc uint32
+	nchunk uint32  // bytes remaining in current chunk
+	nalloc uint32  // size of new chunks in bytes
 	inuse  uintptr // in-use bytes now
 	stat   *sysMemStat
 	zero   bool // zero allocations
@@ -57,7 +57,7 @@ func (f *fixalloc) init(size uintptr, first func(arg, p unsafe.Pointer), arg uns
 	f.list = nil
 	f.chunk = 0
 	f.nchunk = 0
-	f.nalloc = uint32(_FixAllocChunk / f.size * f.size)
+	f.nalloc = uint32(_FixAllocChunk / size * size) // Round _FixAllocChunk down to an exact multiple of size to eliminate tail waste
 	f.inuse = 0
 	f.stat = stat
 	f.zero = true


### PR DESCRIPTION
Currently, the '_FixAllocChunk % fixalloc.size' tail bytes
will never be used when allocing from persistentalloc.

Wasted bytes on darwin/amd64:
  _FixAllocChunk % mheap_.spanalloc.size             = 64
  _FixAllocChunk % mheap_.cachealloc.size            = 784
  _FixAllocChunk % mheap_.specialfinalizeralloc.size = 16
  _FixAllocChunk % mheap_.specialprofilealloc.size   = 16
  _FixAllocChunk % mheap_.specialReachableAlloc.size = 16
  _FixAllocChunk % mheap_.arenaHintAlloc.size        = 16

After this commit, fixalloc alloc '_FixAllocChunk / fixalloc.size'
objects exactly with zero waste. Sizeof(fixalloc{}) is unchanged.