### PR TITLE
encoding/gob: marshal maps using reflect.Value.MapRange

### DIFF
--- a/src/encoding/gob/encode.go
+++ b/src/encoding/gob/encode.go
@@ -368,11 +368,11 @@ func (enc *Encoder) encodeMap(b *encBuffer, mv reflect.Value, keyOp, elemOp encO
 	state := enc.newEncoderState(b)
 	state.fieldnum = -1
 	state.sendZero = true
-	keys := mv.MapKeys()
-	state.encodeUint(uint64(len(keys)))
-	for _, key := range keys {
-		encodeReflectValue(state, key, keyOp, keyIndir)
-		encodeReflectValue(state, mv.MapIndex(key), elemOp, elemIndir)
+	state.encodeUint(uint64(mv.Len()))
+	mi := mv.MapRange()
+	for mi.Next() {
+		encodeReflectValue(state, mi.Key(), keyOp, keyIndir)
+		encodeReflectValue(state, mi.Value(), elemOp, elemIndir)
 	}
 	enc.freeEncoderState(state)
 }

--- a/src/encoding/gob/encoder_test.go
+++ b/src/encoding/gob/encoder_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"math"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -1156,7 +1157,11 @@ func TestDecodeErrorMultipleTypes(t *testing.T) {
 
 // Issue 24075
 func TestMarshalFloatMap(t *testing.T) {
-	var m = map[float64]string{math.NaN(): "NaN"}
+	var m = map[float64]string{
+		math.NaN(): "a",
+		math.NaN(): "b",
+		math.NaN(): "c",
+	}
 
 	var b bytes.Buffer
 	enc := NewEncoder(&b)
@@ -1174,12 +1179,26 @@ func TestMarshalFloatMap(t *testing.T) {
 	}
 
 	// NaN cannot compare
-	for k, v := range result {
-		if fmt.Sprintf("%v", k) != "NaN" {
-			t.Fatalf("decoder fail: %v", k)
+
+	readMap := func(m map[float64]string) ([]uint64, []string) {
+		var (
+			mk = []uint64{}
+			mv = []string{}
+		)
+		for k, v := range m {
+			mk = append(mk, math.Float64bits(k)) // conversion NaN to a uint64
+			mv = append(mv, v)
 		}
-		if v != "NaN" {
-			t.Fatalf("decoder fail: %v", v)
-		}
+		sort.Slice(mk, func(i, j int) bool {
+			return mk[i] < mk[j]
+		})
+		sort.Strings(mv)
+		return mk, mv
+	}
+	mk, mv := readMap(m)
+	resultk, resultv := readMap(result)
+
+	if !reflect.DeepEqual(mk, resultk) || !reflect.DeepEqual(mv, resultv) {
+		t.Fatalf("decoder fail: \n %v %v \n %v %v", mk, mv, resultk, resultv)
 	}
 }


### PR DESCRIPTION
golang.org/cl/33572 added a map iterator.

use the reflect.Value.MapRange to fix map keys that contain a NaN

Fixes #24075