### PR TITLE
[dev.fuzz] cmd/go: 'go clean -fuzzcache' should not delete compiled files

### DIFF
--- a/src/cmd/go/internal/clean/clean.go
+++ b/src/cmd/go/internal/clean/clean.go
@@ -116,7 +116,7 @@ func runClean(ctx context.Context, cmd *base.Command, args []string) {
 	// or no other target (such as a cache) was requested to be cleaned.
 	cleanPkg := len(args) > 0 || cleanI || cleanR
 	if (!modload.Enabled() || modload.HasModRoot()) &&
-		!cleanCache && !cleanModcache && !cleanTestcache {
+		!cleanCache && !cleanModcache && !cleanTestcache && !cleanFuzzcache {
 		cleanPkg = true
 	}
 


### PR DESCRIPTION
This change adds -fuzzcache to the list of flags that prevents 'go clean'
from cleaning packages by default.

Fixes #47478
