### PR TITLE
go/internal/load: fix bad error message for local imports in module mode

### DIFF
--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -754,6 +754,8 @@ func loadImport(ctx context.Context, opts PackageOpts, pre *preload, path, srcDi
 		var err error
 		if path == "." {
 			err = ImportErrorf(path, "%s: cannot import current directory", path)
+		} else if build.IsLocalImport(path) {
+			err = ImportErrorf(path, "%s: relative import not supported", path)
 		} else {
 			err = ImportErrorf(path, "local import %q in non-local package", path)
 		}

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -752,10 +752,10 @@ func loadImport(ctx context.Context, opts PackageOpts, pre *preload, path, srcDi
 	if p.Internal.Local && parent != nil && !parent.Internal.Local {
 		perr := *p
 		var err error
-		if path == "." {
+		if cfg.ModulesEnabled {
+			err = ImportErrorf(path, "local import %q not supported in module mode", path)
+		} else if path == "." {
 			err = ImportErrorf(path, "%s: cannot import current directory", path)
-		} else if build.IsLocalImport(path) {
-			err = ImportErrorf(path, "%s: relative import not supported", path)
 		} else {
 			err = ImportErrorf(path, "local import %q in non-local package", path)
 		}

--- a/src/cmd/go/testdata/script/build_relative_import_not_supported.txt
+++ b/src/cmd/go/testdata/script/build_relative_import_not_supported.txt
@@ -1,0 +1,17 @@
+! go build
+stderr 'main.go:4:2: ./foo: relative import not supported'
+
+-- foo/foo.go --
+package foo
+-- go.mod --
+module example.com/m
+
+go 1.17
+-- main.go --
+package main
+
+import (
+	_ "./foo"
+)
+
+func main() {}

--- a/src/cmd/go/testdata/script/build_relative_import_not_supported.txt
+++ b/src/cmd/go/testdata/script/build_relative_import_not_supported.txt
@@ -1,5 +1,5 @@
 ! go build
-stderr 'main.go:4:2: ./foo: relative import not supported'
+stderr 'main.go:4:2: local import "./foo" not supported in module mode'
 
 -- foo/foo.go --
 package foo

--- a/src/cmd/go/testdata/script/build_relative_import_not_supported.txt
+++ b/src/cmd/go/testdata/script/build_relative_import_not_supported.txt
@@ -1,5 +1,5 @@
 ! go build
-stderr 'main.go:4:2: local import "./foo" not supported in module mode'
+stderr 'main.go:4:2: local import "./foo" not supported in module mode$'
 
 -- foo/foo.go --
 package foo

--- a/src/cmd/go/testdata/script/build_relative_import_not_supported_in_go_path_mode.txt
+++ b/src/cmd/go/testdata/script/build_relative_import_not_supported_in_go_path_mode.txt
@@ -1,0 +1,11 @@
+env GO111MODULE=off
+
+! go build
+stderr 'cannot find package "\." in:\n\t.WORK/gopath/src/foo'
+
+-- main.go --
+package main
+
+import _ "./foo"
+
+func main() {}

--- a/src/cmd/go/testdata/script/build_relative_import_not_supported_in_go_path_mode.txt
+++ b/src/cmd/go/testdata/script/build_relative_import_not_supported_in_go_path_mode.txt
@@ -1,11 +1,27 @@
 env GO111MODULE=off
 
-! go build
-stderr 'cannot find package "\." in:\n\t.WORK/gopath/src/foo'
+# Control case: in GOPATH mode,
+# a/a.go can import package "./b" using a relative path.
+go build a/a.go
+! stderr .
 
--- main.go --
-package main
+# package "a" itself cannot import "./b": "a" has a non-local
+# import path, so its imports must also have non-local import paths.
+! go build a
+stderr '^a[/\\]a.go:3:8: local import "./b" in non-local package$'
 
-import _ "./foo"
+# package "c" imports itself, which is not allowed.
+! go build c
+stderr '^c[/\\]c.go:3:8: .: cannot import current directory$'
 
-func main() {}
+
+-- a/a.go --
+package a
+
+import _ "./b"
+-- a/b/b.go --
+package b
+-- c/c.go --
+package c
+
+import _ "."


### PR DESCRIPTION
In module mode, if an import statement refers to a relative path it is
currently supposed to fail with relative import not supported
However, we seem to be missing test coverage for that error message,
and the actual error that is printed for that case is substantially different

Fixes #47088