### PR TITLE
net/http: add a RoundTripperFunc helper

### DIFF
--- a/src/net/http/client.go
+++ b/src/net/http/client.go
@@ -166,6 +166,17 @@ func refererForURL(lastReq, newReq *url.URL) string {
 	return referer
 }
 
+// The RoundTripperFunc type is an adapter to allow the use of
+// ordinary functions as RoundTripper. If f is a function
+// with the appropriate signature, RoundTripperFunc(f) is a
+// RoundTripper that calls f.
+type RoundTripperFunc func(*Request) (*Response, error)
+
+// RoundTrip calls f(r).
+func (f RoundTripperFunc) RoundTrip(r *Request) (*Response, error) {
+	return f(r)
+}
+
 // didTimeout is non-nil only if err != nil.
 func (c *Client) send(req *Request, deadline time.Time) (resp *Response, didTimeout func() bool, err error) {
 	if c.Jar != nil {

--- a/src/net/http/client_test.go
+++ b/src/net/http/client_test.go
@@ -85,6 +85,28 @@ func TestClient(t *testing.T) {
 	}
 }
 
+func TestRoundTripperFunc(t *testing.T) {
+	client := Client{
+		Transport: RoundTripperFunc(func(r *Request) (*Response, error) {
+			if r == nil {
+				t.Errorf("Nil request passed")
+			} else {
+				if r.URL == nil || r.URL.String() != "http://some.example.com/path" {
+					t.Errorf("Incorrect forwarded request URL: %v", r.URL)
+				}
+			}
+			return &Response{StatusCode: StatusOK}, nil
+		}),
+	}
+	response, err := client.Get("http://some.example.com/path")
+	if err != nil {
+		t.Errorf("Incorrect error returned: %v", err)
+	}
+	if response == nil || response.StatusCode != StatusOK {
+		t.Errorf("Incorrect response returned %v", response)
+	}
+}
+
 func TestClientHead_h1(t *testing.T) { testClientHead(t, h1Mode) }
 func TestClientHead_h2(t *testing.T) { testClientHead(t, h2Mode) }
 


### PR DESCRIPTION
Inspired from the useful http.HandlerFunc, add a http.RoundTripperFunc
to simplify writing stateless and stand-alone RoundTrippers.

Such a helper is particularily interesting when developing and testing
HTTP clients, as it allows to simply embbed in the test the call and the
relevant checks.

Change-Id: Ie825d95e58e321711d5a86243abbbd0479c44d44

