### PR TITLE
[dev.fuzz] internal/fuzz: avoid corruption of minimized crashers

### DIFF
--- a/src/internal/fuzz/minimize_test.go
+++ b/src/internal/fuzz/minimize_test.go
@@ -50,13 +50,9 @@ func TestMinimizeInput(t *testing.T) {
 				}
 				if len(b) == 2 && b[0] == 1 && b[1] == 2 {
 					return nil
-				} else {
-					return fmt.Errorf("bad %v", e.Values[0])
 				}
-				if b[1] == 2 {
-					return fmt.Errorf("bad %v", e.Values[0])
-				}
-				return nil
+
+				return fmt.Errorf("bad %v", e.Values[0])
 			},
 			input:    []interface{}{[]byte{1, 2, 3, 4, 5}},
 			expected: []interface{}{[]byte{2, 3}},

--- a/src/internal/fuzz/minimize_test.go
+++ b/src/internal/fuzz/minimize_test.go
@@ -44,6 +44,25 @@ func TestMinimizeInput(t *testing.T) {
 		{
 			name: "ones_string",
 			fn: func(e CorpusEntry) error {
+				b := e.Values[0].([]byte)
+				if len(b) < 2 {
+					return nil
+				}
+				if len(b) == 2 && b[0] == 1 && b[1] == 2 {
+					return nil
+				} else {
+					return fmt.Errorf("bad %v", e.Values[0])
+				}
+				if int(b[len(b)-1]) == len(b) {
+					return fmt.Errorf("bad %v", e.Values[0])
+				}
+				return nil
+			},
+			input:    []interface{}{[]byte{1, 2, 3, 4, 5}},
+			expected: []interface{}{[]byte{2, 3}},
+		},
+		{
+			fn: func(e CorpusEntry) error {
 				b := e.Values[0].(string)
 				ones := 0
 				for _, v := range b {

--- a/src/internal/fuzz/minimize_test.go
+++ b/src/internal/fuzz/minimize_test.go
@@ -53,7 +53,7 @@ func TestMinimizeInput(t *testing.T) {
 				} else {
 					return fmt.Errorf("bad %v", e.Values[0])
 				}
-				if int(b[len(b)-1]) == len(b) {
+				if b[1] == 2 {
 					return fmt.Errorf("bad %v", e.Values[0])
 				}
 				return nil

--- a/src/internal/fuzz/worker.go
+++ b/src/internal/fuzz/worker.go
@@ -861,7 +861,7 @@ func (ws *workerServer) minimizeInput(ctx context.Context, vals []interface{}, c
 		case []byte:
 			switch prev.(type) {
 			case []byte:
-				vals[valI] = c
+				vals[valI] = append([]byte{}, c...)
 			case string:
 				vals[valI] = string(c)
 			default:


### PR DESCRIPTION
In workerServer.minimizeInput, the callback "tryMinimize" can receive
byte slices which will be modified after the callback returns. Similarly
to the case where the "candidate" is a string, make a copy of the byte
slice.

Fixes #47587