### PR TITLE
time: update current time comment

### DIFF
--- a/src/time/sleep.go
+++ b/src/time/sleep.go
@@ -84,8 +84,6 @@ func (t *Timer) Stop() bool {
 // NewTimer creates a new Timer that will send
 // the current time on its channel after at least duration d.
 func NewTimer(d Duration) *Timer {
-	// Give the channel a 1-element time buffer
-	// to hold the current time.
 	c := make(chan Time, 1)
 	t := &Timer{
 		C: c,

--- a/src/time/sleep.go
+++ b/src/time/sleep.go
@@ -139,13 +139,12 @@ func (t *Timer) Reset(d Duration) bool {
 	return resetTimer(&t.r, w)
 }
 
-// sendTime sends the current time on c
+// sendTime Non-blocking send of current time on c.
+// Used in NewTimer, it cannot block anyway (buffer).
+// Used in NewTicker, dropping sends on the floor is
+// the desired behavior when the reader gets behind,
+// because the sends are periodic.
 func sendTime(c interface{}, seq uintptr) {
-	// Non-blocking send of current time on c.
-	// Used in NewTimer, it cannot block anyway (buffer).
-	// Used in NewTicker, dropping sends on the floor is
-	// the desired behavior when the reader gets behind,
-	// because the sends are periodic.
 	select {
 	case c.(chan Time) <- Now():
 	default:

--- a/src/time/sleep.go
+++ b/src/time/sleep.go
@@ -139,7 +139,7 @@ func (t *Timer) Reset(d Duration) bool {
 	return resetTimer(&t.r, w)
 }
 
-// sendTime Non-blocking send of current time on c.
+// sendTime does a non-blocking send of the current time on c.
 // Used in NewTimer, it cannot block anyway (buffer).
 // Used in NewTicker, dropping sends on the floor is
 // the desired behavior when the reader gets behind,

--- a/src/time/sleep.go
+++ b/src/time/sleep.go
@@ -84,6 +84,7 @@ func (t *Timer) Stop() bool {
 // NewTimer creates a new Timer that will send
 // the current time on its channel after at least duration d.
 func NewTimer(d Duration) *Timer {
+	// Give the channel a 1-element time buffer to hold the current time.
 	c := make(chan Time, 1)
 	t := &Timer{
 		C: c,
@@ -140,10 +141,8 @@ func (t *Timer) Reset(d Duration) bool {
 }
 
 // sendTime does a non-blocking send of the current time on c.
-// Used in NewTimer, it cannot block anyway (buffer).
-// Used in NewTicker, dropping sends on the floor is
-// the desired behavior when the reader gets behind,
-// because the sends are periodic.
+// Used in NewTimer and NewTicker, it will not block the Chan
+// buffer if c is not ready to receive.
 func sendTime(c interface{}, seq uintptr) {
 	select {
 	case c.(chan Time) <- Now():

--- a/src/time/sleep.go
+++ b/src/time/sleep.go
@@ -84,7 +84,8 @@ func (t *Timer) Stop() bool {
 // NewTimer creates a new Timer that will send
 // the current time on its channel after at least duration d.
 func NewTimer(d Duration) *Timer {
-	// Give the channel a 1-element time buffer to hold the current time.
+	// Give the channel a 1-element time buffer
+	// to hold the current time.
 	c := make(chan Time, 1)
 	t := &Timer{
 		C: c,

--- a/src/time/sleep.go
+++ b/src/time/sleep.go
@@ -140,8 +140,7 @@ func (t *Timer) Reset(d Duration) bool {
 }
 
 // sendTime does a non-blocking send of the current time on c.
-// Used in NewTimer and NewTicker, it will not block the Chan
-// buffer if c is not ready to receive.
+// This is used by NewTimer and NewTicker.
 func sendTime(c interface{}, seq uintptr) {
 	select {
 	case c.(chan Time) <- Now():

--- a/src/time/sleep.go
+++ b/src/time/sleep.go
@@ -139,8 +139,9 @@ func (t *Timer) Reset(d Duration) bool {
 	return resetTimer(&t.r, w)
 }
 
+// sendTime sends the current time on c
 func sendTime(c interface{}, seq uintptr) {
-	// Non-blocking send of time on c.
+	// Non-blocking send of current time on c.
 	// Used in NewTimer, it cannot block anyway (buffer).
 	// Used in NewTicker, dropping sends on the floor is
 	// the desired behavior when the reader gets behind,

--- a/src/time/sleep.go
+++ b/src/time/sleep.go
@@ -140,7 +140,6 @@ func (t *Timer) Reset(d Duration) bool {
 }
 
 // sendTime does a non-blocking send of the current time on c.
-// This is used by NewTimer and NewTicker.
 func sendTime(c interface{}, seq uintptr) {
 	select {
 	case c.(chan Time) <- Now():

--- a/src/time/tick.go
+++ b/src/time/tick.go
@@ -6,7 +6,7 @@ package time
 
 import "errors"
 
-// A Ticker holds a channel that delivers `ticks` of a clock
+// A Ticker holds a channel that delivers ``ticks'' of a clock
 // at intervals.
 type Ticker struct {
 	C <-chan Time // The channel on which the ticks are delivered.
@@ -14,9 +14,9 @@ type Ticker struct {
 }
 
 // NewTicker returns a new Ticker containing a channel that will send
-// the current time on the channel after each tick. The period of the ticks is
-// specified by the duration argument. The ticker will adjust the time
-// interval or drop ticks to make up for slow receivers.
+// the current time on the channel after each tick. The period of the
+// ticks is specified by the duration argument. The ticker will adjust
+// the time interval or drop ticks to make up for slow receivers.
 // The duration d must be greater than zero; if not, NewTicker will
 // panic. Stop the ticker to release associated resources.
 func NewTicker(d Duration) *Ticker {

--- a/src/time/tick.go
+++ b/src/time/tick.go
@@ -6,7 +6,7 @@ package time
 
 import "errors"
 
-// A Ticker holds a channel that delivers ``ticks'' of a clock
+// A Ticker holds a channel that delivers `ticks` of a clock
 // at intervals.
 type Ticker struct {
 	C <-chan Time // The channel on which the ticks are delivered.
@@ -14,7 +14,7 @@ type Ticker struct {
 }
 
 // NewTicker returns a new Ticker containing a channel that will send
-// the time on the channel after each tick. The period of the ticks is
+// the current time on the channel after each tick. The period of the ticks is
 // specified by the duration argument. The ticker will adjust the time
 // interval or drop ticks to make up for slow receivers.
 // The duration d must be greater than zero; if not, NewTicker will


### PR DESCRIPTION
In the time package, the ticker and timer both send
current time to channel C, so this PR update the comment
to understand them better.