### PR TITLE
math: add ARM64 Abs assembly implementation

### DIFF
--- a/src/math/abs.go
+++ b/src/math/abs.go
@@ -10,5 +10,12 @@ package math
 //	Abs(±Inf) = +Inf
 //	Abs(NaN) = NaN
 func Abs(x float64) float64 {
+	if haveArchAbs {
+		return archAbs(x)
+	}
+	return abs(x)
+}
+
+func abs(x float64) float64 {
 	return Float64frombits(Float64bits(x) &^ (1 << 63))
 }

--- a/src/math/abs_arm64.s
+++ b/src/math/abs_arm64.s
@@ -1,0 +1,12 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "textflag.h"
+
+// func archAbs(x float64) float64
+TEXT ·archAbs(SB), NOSPLIT, $0-16
+    FMOVD   x+0(FP), F0
+    FABSD   F0, F0
+    FMOVD   F0, ret+8(FP)
+    RET

--- a/src/math/abs_asm.go
+++ b/src/math/abs_asm.go
@@ -1,0 +1,12 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build arm64
+// +build arm64
+
+package math
+
+const haveArchAbs = true
+
+func archAbs(x float64) float64

--- a/src/math/abs_noasm.go
+++ b/src/math/abs_noasm.go
@@ -1,0 +1,14 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !arm64
+// +build !arm64
+
+package math
+
+const haveArchAbs = false
+
+func archAbs(x float64) float64 {
+	panic("not implemented")
+}

--- a/src/math/all_test.go
+++ b/src/math/all_test.go
@@ -3417,6 +3417,15 @@ func BenchmarkAbs(b *testing.B) {
 
 }
 
+func BenchmarkAbsGo(b *testing.B) {
+	x := 0.0
+	for i := 0; i < b.N; i++ {
+		x = AbsGo(absPos)
+	}
+	GlobalF = x
+
+}
+
 func BenchmarkDim(b *testing.B) {
 	x := 0.0
 	for i := 0; i < b.N; i++ {

--- a/src/math/export_test.go
+++ b/src/math/export_test.go
@@ -5,6 +5,7 @@
 package math
 
 // Export internal functions for testing.
+var AbsGo = abs
 var ExpGo = exp
 var Exp2Go = exp2
 var HypotGo = hypot


### PR DESCRIPTION
The benchmark which run on Apple Silicon M1 chip is listed as following.
BenchmarkAbs-8     	0.9488 ns/op    0 B/op	   0 allocs/op
BenchmarkAbsGo-8   	1.007 ns/op	    0 B/op	   0 allocs/op

Average time per iteration drops 5.78%
