### PR TITLE
encoding/json: fix unmarshal null array will not change the original value

### DIFF
--- a/src/encoding/json/decode.go
+++ b/src/encoding/json/decode.go
@@ -907,7 +907,7 @@ func (d *decodeState) literalStore(item []byte, v reflect.Value, fromQuoted bool
 			break
 		}
 		switch v.Kind() {
-		case reflect.Interface, reflect.Ptr, reflect.Map, reflect.Slice:
+		case reflect.Interface, reflect.Ptr, reflect.Map, reflect.Slice, reflect.Array:
 			v.Set(reflect.Zero(v.Type()))
 			// otherwise, ignore null for primitives/string
 		}

--- a/src/encoding/json/decode_test.go
+++ b/src/encoding/json/decode_test.go
@@ -1880,11 +1880,9 @@ func TestUnmarshalNulls(t *testing.T) {
 	if nulls.Slice != nil {
 		t.Errorf("Unmarshal of null did not clear nulls.Slice")
 	}
-
-	if reflect.DeepEqual(nulls.Array, [1]string{}) {
+	if !reflect.DeepEqual(nulls.Array, [1]string{}) {
 		t.Errorf("Unmarshal of null did not clear nulls.Array")
 	}
-
 	if nulls.Interface != nil {
 		t.Errorf("Unmarshal of null did not clear nulls.Interface")
 	}

--- a/src/encoding/json/decode_test.go
+++ b/src/encoding/json/decode_test.go
@@ -1768,6 +1768,7 @@ type NullTest struct {
 	PBool     *bool
 	Map       map[string]string
 	Slice     []string
+	Array     [1]string
 	Interface interface{}
 
 	PRaw    *RawMessage
@@ -1812,6 +1813,7 @@ func TestUnmarshalNulls(t *testing.T) {
 				"PBool": null,
 				"Map": null,
 				"Slice": null,
+				"Array": null,
 				"Interface": null,
 				"PRaw": null,
 				"PTime": null,
@@ -1844,6 +1846,7 @@ func TestUnmarshalNulls(t *testing.T) {
 		PBool:     new(bool),
 		Map:       map[string]string{},
 		Slice:     []string{},
+		Array:     [1]string{"123"},
 		Interface: new(MustNotUnmarshalJSON),
 		PRaw:      new(RawMessage),
 		PTime:     new(time.Time),
@@ -1877,6 +1880,11 @@ func TestUnmarshalNulls(t *testing.T) {
 	if nulls.Slice != nil {
 		t.Errorf("Unmarshal of null did not clear nulls.Slice")
 	}
+
+	if reflect.DeepEqual(nulls.Array, [1]string{}) {
+		t.Errorf("Unmarshal of null did not clear nulls.Array")
+	}
+
 	if nulls.Interface != nil {
 		t.Errorf("Unmarshal of null did not clear nulls.Interface")
 	}


### PR DESCRIPTION
The problem is `Unmarshal` `null`  will not reset array to zero value.
```
v := [2]int64{1, 2}
json.Unmarshal([]byte(`null`), &v) // [1, 2]
```