### PR TITLE
cmd/dist: support embedding of toolchain rev by envvar

### DIFF
--- a/src/cmd/dist/build.go
+++ b/src/cmd/dist/build.go
@@ -343,6 +343,17 @@ func branchtag(branch string) (tag string, precise bool) {
 
 // findgoversion determines the Go version to use in the version string.
 func findgoversion() string {
+	// If the magic envvar `GOLANG_TOOLCHAIN_REV` is set, use that git
+	// revision. Git checkouts are not reproducible. This allows users
+	// to build a compiler reproducibly from a context by feeding the
+	// appropriate hash to the build system.
+	if rev := os.Getenv("GOLANG_TOOLCHAIN_REV"); rev != "" {
+		if len(rev) > 10 {
+			rev = rev[:10]
+		}
+		return rev
+	}
+
 	// The $GOROOT/VERSION file takes priority, for distributions
 	// without the source repo.
 	path := pathf("%s/VERSION", goroot)


### PR DESCRIPTION
Git checkouts are not byte-for-byte reproducible and the exact hash of
them can drift as git's moods change. This patch enables users of
deterministic build systems such as Nix or Guix to build an exact
revision of Go from the git repo directly by feeding the proper hash
into the build system with the envvar GOLANG_TOOLCHAIN_REV.

This should only be used as a last resort (such as when the source
directory is immutable, like in the nix-build context).

This is a port of https://github.com/tailscale/go/commit/6785c6aa7b55f795ece47b2ee775cd3feb58b29e.
