### PR TITLE
strings: smarter growth of temporal buffer and avoid copying on return

### DIFF
--- a/src/strings/replace.go
+++ b/src/strings/replace.go
@@ -387,7 +387,7 @@ func makeSingleStringReplacer(pattern string, value string) *singleStringReplace
 }
 
 func (r *singleStringReplacer) Replace(s string) string {
-	buf := Builder{}
+	var buf Builder
 	i, matched := 0, false
 	for {
 		match := r.finder.next(s[i:])

--- a/src/strings/replace.go
+++ b/src/strings/replace.go
@@ -387,7 +387,7 @@ func makeSingleStringReplacer(pattern string, value string) *singleStringReplace
 }
 
 func (r *singleStringReplacer) Replace(s string) string {
-	var buf []byte
+	buf := Builder{}
 	i, matched := 0, false
 	for {
 		match := r.finder.next(s[i:])
@@ -395,15 +395,16 @@ func (r *singleStringReplacer) Replace(s string) string {
 			break
 		}
 		matched = true
-		buf = append(buf, s[i:i+match]...)
-		buf = append(buf, r.value...)
+		buf.Grow(match + len(r.value))
+		buf.WriteString(s[i : i+match])
+		buf.WriteString(r.value)
 		i += match + len(r.finder.pattern)
 	}
 	if !matched {
 		return s
 	}
-	buf = append(buf, s[i:]...)
-	return string(buf)
+	buf.WriteString(s[i:])
+	return buf.String()
 }
 
 func (r *singleStringReplacer) WriteString(w io.Writer, s string) (n int, err error) {


### PR DESCRIPTION
The implementation for single strings had two optimization opportunities:
1. Grow the temporary buffer by known size before appending.
2. Avoid a full copy of the result since the underlying buffer won't be mutated afterward.
Both things were leveraged by using a Builder instead of a byte slice.

Relevant benchmark results:

        name           old time/op    new time/op    delta
        SingleMatch-8    32.0µs ± 3%    26.1µs ± 3%  -18.41%  (p=0.000 n=9+10)
        
        name           old speed      new speed      delta
        SingleMatch-8   469MB/s ± 3%   574MB/s ± 3%  +22.56%  (p=0.000 n=9+10)
        
        name           old alloc/op   new alloc/op   delta
        SingleMatch-8    81.3kB ± 0%    49.0kB ± 0%  -39.67%  (p=0.000 n=10+10)
        
        name           old allocs/op  new allocs/op  delta
        SingleMatch-8      19.0 ± 0%      11.0 ± 0%  -42.11%  (p=0.000 n=10+10)

