### PR TITLE
runtime: avoid unnecessary zeroing of spans for mallocs that don't needzero

### DIFF
--- a/src/runtime/mcache.go
+++ b/src/runtime/mcache.go
@@ -143,7 +143,7 @@ func getMCache() *mcache {
 //
 // Must run in a non-preemptible context since otherwise the owner of
 // c could change.
-func (c *mcache) refill(spc spanClass) {
+func (c *mcache) refill(spc spanClass, needzero bool) {
 	// Return the current cached span to the central lists.
 	s := c.alloc[spc]
 
@@ -159,7 +159,7 @@ func (c *mcache) refill(spc spanClass) {
 	}
 
 	// Get a new cached span from the central lists.
-	s = mheap_.central[spc].mcentral.cacheSpan()
+	s = mheap_.central[spc].mcentral.cacheSpan(needzero)
 	if s == nil {
 		throw("out of memory")
 	}

--- a/src/runtime/mcentral.go
+++ b/src/runtime/mcentral.go
@@ -76,7 +76,7 @@ func (c *mcentral) fullSwept(sweepgen uint32) *spanSet {
 }
 
 // Allocate a span to use in an mcache.
-func (c *mcentral) cacheSpan() *mspan {
+func (c *mcentral) cacheSpan(needzero bool) *mspan {
 	// Deduct credit for this span allocation and sweep if necessary.
 	spanBytes := uintptr(class_to_allocnpages[c.spanclass.sizeclass()]) * _PageSize
 	deductSweepCredit(spanBytes, 0)
@@ -158,7 +158,7 @@ func (c *mcentral) cacheSpan() *mspan {
 	}
 
 	// We failed to get a span from the mcentral so get one from mheap.
-	s = c.grow()
+	s = c.grow(needzero)
 	if s == nil {
 		return nil
 	}
@@ -234,11 +234,11 @@ func (c *mcentral) uncacheSpan(s *mspan) {
 }
 
 // grow allocates a new empty span from the heap and initializes it for c's size class.
-func (c *mcentral) grow() *mspan {
+func (c *mcentral) grow(needzero bool) *mspan {
 	npages := uintptr(class_to_allocnpages[c.spanclass.sizeclass()])
 	size := uintptr(class_to_size[c.spanclass.sizeclass()])
 
-	s, _ := mheap_.alloc(npages, c.spanclass, true)
+	s, _ := mheap_.alloc(npages, c.spanclass, needzero)
 	if s == nil {
 		return nil
 	}

--- a/src/runtime/mheap.go
+++ b/src/runtime/mheap.go
@@ -920,8 +920,8 @@ func (h *mheap) alloc(npages uintptr, spanclass spanClass, needzero bool) (*mspa
 	if needzero && !isZeroed {
 		memclrNoHeapPointers(unsafe.Pointer(s.base()), s.npages<<_PageShift)
 		isZeroed = true
+		s.needzero = 0
 	}
-	s.needzero = 0
 	return s, isZeroed
 }
 


### PR DESCRIPTION
In the current implementation, if the allocation size not larger than 32768
and no free mspans are available, the calls like mallocgc(*, *, false) might
call the (*mcentral).grow method eventaully. The calling route:

  mallocgc -> (*mcache).nextFree -> (*mcache).refill -> (*mcentral).cacheSpan -> (*mcentral).grow -> (*mheap).alloc

The (*mcentral).grow method always passes a true needzero
argument to the (*mheap).alloc method. This causes the
memclrNoHeapPointers function is very probably called in that method,
even if a false needzero argument is passed to the initial mallocgc
function. The callers of the mallocgc function will fill the memory again,
which makes the call to memclrNoHeapPointers unnecessary.

This PR tries to avoid this unnecessary call in the (*mheap).alloc method.

name                             old time/op  new time/op  delta
MakeSliceCopy/mallocmove/Byte-4  79.9ns ± 1%  68.2ns ± 3%  -14.64%  (p=0.000 n=8+9)
MakeSliceCopy/mallocmove/Int-4   81.4ns ± 4%  69.2ns ± 4%  -14.98%  (p=0.000 n=10+10)
MakeSliceCopy/mallocmove/Ptr-4    166ns ±23%   158ns ± 5%     ~     (p=0.481 n=10+10)
MakeSliceCopy/makecopy/Byte-4    84.8ns ±11%  71.3ns ± 7%  -15.98%  (p=0.000 n=9+10)
MakeSliceCopy/makecopy/Int-4     84.5ns ± 8%  70.3ns ± 3%  -16.76%  (p=0.000 n=9+9)
MakeSliceCopy/makecopy/Ptr-4      159ns ± 3%   156ns ± 3%     ~     (p=0.051 n=9+10)
MakeSliceCopy/nilappend/Byte-4   93.0ns ± 2%  77.1ns ± 3%  -17.10%  (p=0.000 n=10+9)
MakeSliceCopy/nilappend/Int-4    94.1ns ± 2%  77.4ns ± 3%  -17.72%  (p=0.000 n=10+10)
MakeSliceCopy/nilappend/Ptr-4     176ns ± 2%   170ns ± 1%   -3.64%  (p=0.000 n=10+8)
MakeSlice/Byte-4                 16.6ns ± 1%  16.0ns ± 0%   -3.83%  (p=0.000 n=10+9)
MakeSlice/Int16-4                19.9ns ± 1%  19.1ns ± 1%   -3.97%  (p=0.000 n=9+10)
MakeSlice/Int-4                  31.6ns ± 1%  31.0ns ± 1%   -1.78%  (p=0.000 n=10+9)
MakeSlice/Ptr-4                  84.6ns ± 1%  80.9ns ± 1%   -4.45%  (p=0.000 n=10+9)
MakeSlice/Struct/24-4            46.5ns ± 2%  46.3ns ± 2%     ~     (p=0.436 n=10+10)
MakeSlice/Struct/32-4            52.9ns ± 2%  52.9ns ± 3%     ~     (p=1.000 n=10+10)
MakeSlice/Struct/40-4            59.6ns ± 0%  59.8ns ± 3%     ~     (p=0.549 n=9+10)
GrowSlice/Byte-4                 34.3ns ± 1%  33.0ns ± 0%   -3.88%  (p=0.000 n=9+8)
GrowSlice/Int16-4                42.4ns ± 1%  40.4ns ± 1%   -4.61%  (p=0.000 n=10+9)
GrowSlice/Int-4                  57.3ns ± 2%  49.9ns ± 2%  -12.90%  (p=0.000 n=10+10)
GrowSlice/Ptr-4                   119ns ± 1%   117ns ± 1%   -2.28%  (p=0.000 n=10+10)
GrowSlice/Struct/24-4            98.9ns ± 3%  83.8ns ± 0%  -15.31%  (p=0.000 n=10+8)
GrowSlice/Struct/32-4             107ns ± 3%    91ns ± 1%  -14.54%  (p=0.000 n=10+10)
GrowSlice/Struct/40-4             137ns ± 1%   117ns ± 2%  -14.68%  (p=0.000 n=8+9)
ExtendSlice/IntSlice-4           43.8ns ± 2%  44.1ns ± 1%   +0.69%  (p=0.045 n=10+10)
ExtendSlice/PointerSlice-4       94.6ns ± 0%  91.0ns ± 1%   -3.89%  (p=0.000 n=9+10)
ExtendSlice/NoGrow-4             3.37ns ± 0%  3.39ns ± 1%   +0.44%  (p=0.027 n=10+10)
Append-4                         14.7ns ± 5%  14.8ns ± 5%     ~     (p=0.810 n=10+10)
AppendGrowByte-4                 2.02ms ± 0%  2.03ms ± 3%     ~     (p=0.447 n=9+10)
AppendGrowString-4               77.4ms ± 4%  77.8ms ± 3%     ~     (p=0.356 n=10+9)
AppendSlice/1Bytes-4             3.70ns ± 1%  3.69ns ± 0%     ~     (p=0.357 n=9+8)
AppendSlice/4Bytes-4             3.00ns ± 0%  3.01ns ± 1%     ~     (p=0.984 n=9+10)
AppendSlice/7Bytes-4             3.38ns ± 1%  3.38ns ± 1%     ~     (p=0.670 n=10+10)
AppendSlice/8Bytes-4             3.39ns ± 1%  3.38ns ± 1%   -0.39%  (p=0.008 n=10+9)
AppendSlice/15Bytes-4            4.13ns ± 0%  4.13ns ± 1%     ~     (p=0.765 n=10+9)
AppendSlice/16Bytes-4            4.14ns ± 1%  4.13ns ± 0%     ~     (p=0.078 n=10+10)
AppendSlice/32Bytes-4            4.14ns ± 0%  4.12ns ± 1%   -0.34%  (p=0.022 n=9+9)
AppendSliceLarge/1024Bytes-4      283ns ± 2%   254ns ± 1%  -10.18%  (p=0.000 n=9+8)
AppendSliceLarge/4096Bytes-4     1.02µs ± 3%  0.97µs ± 2%   -5.11%  (p=0.000 n=10+9)
AppendSliceLarge/16384Bytes-4    3.75µs ± 3%  3.41µs ± 3%   -8.88%  (p=0.000 n=10+10)
AppendSliceLarge/65536Bytes-4    12.0µs ± 2%  11.9µs ± 1%   -1.37%  (p=0.011 n=10+10)
AppendSliceLarge/262144Bytes-4   49.2µs ± 5%  52.4µs ± 5%   +6.48%  (p=0.003 n=10+10)
AppendSliceLarge/1048576Bytes-4   149µs ± 5%   143µs ± 6%   -4.24%  (p=0.000 n=10+10)
AppendStr/1Bytes-4               3.72ns ± 1%  3.69ns ± 1%   -0.78%  (p=0.001 n=9+10)
AppendStr/4Bytes-4               3.10ns ± 1%  3.07ns ± 1%   -0.79%  (p=0.001 n=10+10)
AppendStr/8Bytes-4               3.57ns ± 1%  3.55ns ± 0%   -0.35%  (p=0.029 n=10+10)
AppendStr/16Bytes-4              4.14ns ± 1%  5.15ns ± 1%  +24.54%  (p=0.000 n=10+10)
AppendStr/32Bytes-4              4.13ns ± 1%  4.14ns ± 1%     ~     (p=0.363 n=10+10)
AppendSpecialCase-4              25.1ns ± 4%  25.7ns ± 0%     ~     (p=0.381 n=5+2)
