### PR TITLE
net/mail: fix EOF error while reading header-only message

### DIFF
--- a/src/net/mail/message.go
+++ b/src/net/mail/message.go
@@ -54,7 +54,7 @@ func ReadMessage(r io.Reader) (msg *Message, err error) {
 	tp := textproto.NewReader(bufio.NewReader(r))
 
 	hdr, err := tp.ReadMIMEHeader()
-	if err != nil && err != io.EOF {
+	if err != nil && (err != io.EOF || len(hdr) == 0) {
 		return nil, err
 	}
 

--- a/src/net/mail/message.go
+++ b/src/net/mail/message.go
@@ -54,6 +54,13 @@ func ReadMessage(r io.Reader) (msg *Message, err error) {
 	tp := textproto.NewReader(bufio.NewReader(r))
 
 	hdr, err := tp.ReadMIMEHeader()
+	// Header-Only messages
+	if err == io.EOF && len(hdr) > 0 {
+		return &Message{
+			Header: Header(hdr),
+			Body:   tp.R,
+		}, nil
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/src/net/mail/message.go
+++ b/src/net/mail/message.go
@@ -54,14 +54,7 @@ func ReadMessage(r io.Reader) (msg *Message, err error) {
 	tp := textproto.NewReader(bufio.NewReader(r))
 
 	hdr, err := tp.ReadMIMEHeader()
-	// Header-Only messages
-	if err == io.EOF && len(hdr) > 0 {
-		return &Message{
-			Header: Header(hdr),
-			Body:   tp.R,
-		}, nil
-	}
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return nil, err
 	}
 

--- a/src/net/mail/message_test.go
+++ b/src/net/mail/message_test.go
@@ -47,8 +47,8 @@ Version: 1
 `,
 		header: Header{
 			"Feedback-Type": []string{"abuse"},
-			"User-Agent": []string{"SomeGenerator/1.0"},
-			"Version": []string{"1"},
+			"User-Agent":    []string{"SomeGenerator/1.0"},
+			"Version":       []string{"1"},
 		},
 		body: "",
 	},

--- a/src/net/mail/message_test.go
+++ b/src/net/mail/message_test.go
@@ -39,6 +39,19 @@ So, "Hello".
 		},
 		body: "This is a message just to say hello.\nSo, \"Hello\".\n",
 	},
+	{
+		// RFC 5965, Appendix B.1, a part of the multipart message (a header-only sub message)
+		in: `Feedback-Type: abuse
+User-Agent: SomeGenerator/1.0
+Version: 1
+`,
+		header: Header{
+			"Feedback-Type": []string{"abuse"},
+			"User-Agent": []string{"SomeGenerator/1.0"},
+			"Version": []string{"1"},
+		},
+		body: "",
+	},
 }
 
 func TestParsing(t *testing.T) {


### PR DESCRIPTION
Check if any header found in case of EOF to recognize header-only
messages and if so, return a Message with the found headers
and a body from the reader which is already empty.

Fixes #33823.