### PR TITLE
encoding/gob: use reflect.Value.MapRange for map iteration

### DIFF
--- a/src/encoding/gob/encode.go
+++ b/src/encoding/gob/encode.go
@@ -368,7 +368,7 @@ func (enc *Encoder) encodeMap(b *encBuffer, mv reflect.Value, keyOp, elemOp encO
 	state := enc.newEncoderState(b)
 	state.fieldnum = -1
 	state.sendZero = true
-	state.encodeInt(int64(mv.Len()))
+	state.encodeUint(uint64(mv.Len()))
 	iter := mv.MapRange()
 	for iter.Next() {
 		encodeReflectValue(state, iter.Key(), keyOp, keyIndir)

--- a/src/encoding/gob/encode.go
+++ b/src/encoding/gob/encode.go
@@ -368,11 +368,11 @@ func (enc *Encoder) encodeMap(b *encBuffer, mv reflect.Value, keyOp, elemOp encO
 	state := enc.newEncoderState(b)
 	state.fieldnum = -1
 	state.sendZero = true
-	keys := mv.MapKeys()
-	state.encodeUint(uint64(len(keys)))
-	for _, key := range keys {
-		encodeReflectValue(state, key, keyOp, keyIndir)
-		encodeReflectValue(state, mv.MapIndex(key), elemOp, elemIndir)
+	state.encodeInt(int64(mv.Len()))
+	iter := mv.MapRange()
+	for iter.Next() {
+		encodeReflectValue(state, iter.Key(), keyOp, keyIndir)
+		encodeReflectValue(state, iter.Value(), elemOp, elemIndir)
 	}
 	enc.freeEncoderState(state)
 }


### PR DESCRIPTION
This change will reduce memory usage and improve performance by eliminating unnecessary map iteration for making key slice.