### PR TITLE
[dev.boringcrypto] crypto/tls: use correct config in TestBoringClientHello

### DIFF
--- a/src/crypto/tls/boring_test.go
+++ b/src/crypto/tls/boring_test.go
@@ -264,7 +264,7 @@ func TestBoringClientHello(t *testing.T) {
 	clientConfig.CipherSuites = allCipherSuites()
 	clientConfig.CurvePreferences = defaultCurvePreferences
 
-	go Client(c, testConfig).Handshake()
+	go Client(c, clientConfig).Handshake()
 	srv := Server(s, testConfig)
 	msg, err := srv.readHandshake()
 	if err != nil {


### PR DESCRIPTION
The existing implementation sets the ClientConfig to specific values to
check, but does not uses it in the actual testing. This commit make the
test to actually use it, which can be used to flag bugs in the future.