### PR TITLE
html/template: Tree is only updated after Execute() is called

### DIFF
--- a/src/html/template/template.go
+++ b/src/html/template/template.go
@@ -25,7 +25,7 @@ type Template struct {
 	// we need to keep our version of the name space and the underlying
 	// template's in sync.
 	text *template.Template
-	// The underlying template's parse tree, updated to be HTML-safe.
+	// The underlying template's parse tree, updated to be HTML-safe after the first execution.
 	Tree       *parse.Tree
 	*nameSpace // common to all associated templates
 }


### PR DESCRIPTION
The current comment "The underlying template's parse tree, updated to be HTML-safe."
at https://pkg.go.dev/html/template#Template is not correct

Fixes #43064