### PR TITLE
html/template: remove unused `mode` field on `Tree` struct

### DIFF
--- a/src/text/template/parse/parse.go
+++ b/src/text/template/parse/parse.go
@@ -32,7 +32,6 @@ type Tree struct {
 	treeSet    map[string]*Tree
 	actionLine int // line of left delim starting action
 	rangeDepth int
-	mode       Mode
 }
 
 // A mode value is a set of flags (or 0). Modes control parser behavior.


### PR DESCRIPTION
This changes Go, to remove this unused field on the `Tree` struct. Which seems to replaced by the non-private field `Mode`.