### PR TITLE
net/http: clarify TimeoutHandler buffer writes to memory

### DIFF
--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -3281,8 +3281,9 @@ func (srv *Server) onceSetNextProtoDefaults() {
 // After such a timeout, writes by h to its ResponseWriter will return
 // ErrHandlerTimeout.
 //
-// TimeoutHandler supports the Pusher interface but does not support
-// the Hijacker or Flusher interfaces.
+// TimeoutHandler buffers all Handler writes to memory.
+// It supports the Pusher interface but does not support the Hijacker
+// or Flusher interfaces.
 func TimeoutHandler(h Handler, dt time.Duration, msg string) Handler {
 	return &timeoutHandler{
 		handler: h,

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -3274,14 +3274,14 @@ func (srv *Server) onceSetNextProtoDefaults() {
 
 // TimeoutHandler returns a Handler that runs h with the given time limit.
 //
-// The new Handler calls h.ServeHTTP to handle each request, but if a
-// call runs for longer than its time limit, the handler responds with
+// The new Handler calls h.ServeHTTP to handle each request, but buffers
+// all writes to the ResponseWriter until the call returns. If a call
+// runs for longer than its time limit, the handler responds with
 // a 503 Service Unavailable error and the given message in its body.
 // (If msg is empty, a suitable default message will be sent.)
 // After such a timeout, writes by h to its ResponseWriter will return
 // ErrHandlerTimeout.
 //
-// TimeoutHandler buffers all Handler writes to memory.
 // It supports the Pusher interface but does not support the Hijacker
 // or Flusher interfaces.
 func TimeoutHandler(h Handler, dt time.Duration, msg string) Handler {


### PR DESCRIPTION
Clarify that TimeoutHandler middleware buffers all writes
to an in-memory buffer.

Fixes #47899
