### PR TITLE
cmd/internal/obj/riscv: simplify addition with constant

### DIFF
--- a/test/codegen/arithmetic.go
+++ b/test/codegen/arithmetic.go
@@ -575,3 +575,11 @@ func constantFold3(i, j int) int {
 	r := (5 * i) * (6 * j)
 	return r
 }
+
+func addConst(i int64) (int64, int64) {
+	// riscv64:`ADDI`,-`LUI`
+	a := i + 3001
+	// riscv64:`LUI`,`ADDIW`
+	b := i + 5009
+	return a, b
+}


### PR DESCRIPTION
This CL simplifies riscv addition (add r, imm) to
(ADDI (ADDI r, imm/2), imm-imm/2) if imm is in specific ranges.
(-4096 <= imm <= -2049 or 2048 <= imm <= 4094)

There is little impact to the go1 benchmark, while the total
size of pkg/linux_riscv64 decreased by about 11KB.