### PR TITLE
syscall: change default flag for utimensat to AT_SYMLINK_NOFOLLOW on linux

### DIFF
--- a/src/syscall/syscall_linux.go
+++ b/src/syscall/syscall_linux.go
@@ -204,7 +204,7 @@ func UtimesNano(path string, ts []Timespec) (err error) {
 	if len(ts) != 2 {
 		return EINVAL
 	}
-	err = utimensat(_AT_FDCWD, path, (*[2]Timespec)(unsafe.Pointer(&ts[0])), 0)
+	err = utimensat(_AT_FDCWD, path, (*[2]Timespec)(unsafe.Pointer(&ts[0])), _AT_SYMLINK_NOFOLLOW)
 	if err != ENOSYS {
 		return err
 	}


### PR DESCRIPTION
The default behavior for utimensat is following links to the real file, this makes it impossible to change the timestamp of a symbol link itself in golang. This code changes the behavior of syscall.UtimesNano on symbol link on linux, and do not follow links anymore. This way, the timestamp for the real file could be changed after following the link, and the link file cloud be changed directly.  
