### PR TITLE
Add padding to fix HITM issue across CPU sockets 

### DIFF
--- a/src/runtime/mheap.go
+++ b/src/runtime/mheap.go
@@ -134,6 +134,9 @@ type mheap struct {
 	// This is accessed atomically.
 	reclaimCredit uintptr
 
+	//add 64 bytes padding to seperate the data into different cacheline to fix HITM issue across CPU sockets
+	_ [8]uint64
+
 	// arenas is the heap arena map. It points to the metadata for
 	// the heap for every arena frame of the entire usable virtual
 	// address space.

--- a/src/runtime/mheap.go
+++ b/src/runtime/mheap.go
@@ -134,8 +134,8 @@ type mheap struct {
 	// This is accessed atomically.
 	reclaimCredit uintptr
 
-	//add 64 bytes padding to seperate the data into different cacheline to fix HITM issue across CPU sockets
-	_ [8]uint64
+	// Add padding to separate the data into different cacheline to fix HITM issue across CPU sockets.
+	_ cpu.CacheLinePad
 
 	// arenas is the heap arena map. It points to the metadata for
 	// the heap for every arena frame of the entire usable virtual


### PR DESCRIPTION
Runtime: Add padding to separate the data into different cache line to avoid HITM issue. Fix #47831.

I have run the benchmark of `test/bench/go1` in the root directory for overall comparison with cpu=1/N and sockets=2. The command is `go test -bench=. -count=5 -cpu=1`. Below is the result.

name                   old time/op    new time/op    delta
BinaryTree17              1.79s ± 2%     1.79s ± 1%    ~     (p=0.421 n=5+5)
Fannkuch11                2.15s ± 0%     2.15s ± 0%  -0.29%  (p=0.016 n=5+4)
FmtFprintfEmpty          26.3ns ± 1%    26.2ns ± 0%    ~     (p=0.151 n=5+5)
FmtFprintfString         46.6ns ± 0%    46.0ns ± 0%  -1.20%  (p=0.008 n=5+5)
FmtFprintfInt            53.6ns ± 0%    53.5ns ± 0%  -0.16%  (p=0.024 n=5+5)
FmtFprintfIntInt         84.4ns ± 0%    84.3ns ± 0%  -0.10%  (p=0.024 n=5+5)
FmtFprintfPrefixedInt    96.0ns ± 0%    95.8ns ± 0%  -0.20%  (p=0.008 n=5+5)
FmtFprintfFloat           138ns ± 0%     138ns ± 0%  -0.27%  (p=0.016 n=5+5)
FmtManyArgs               358ns ± 0%     357ns ± 0%  -0.24%  (p=0.008 n=5+5)
GobDecode                3.52ms ± 0%    3.53ms ± 1%    ~     (p=1.000 n=5+5)
GobEncode                2.64ms ± 0%    2.63ms ± 0%    ~     (p=0.151 n=5+5)
Gzip                      151ms ± 0%     150ms ± 0%  -0.26%  (p=0.032 n=5+5)
Gunzip                   22.6ms ± 0%    22.5ms ± 0%    ~     (p=0.056 n=5+5)
HTTPClientServer         28.5µs ± 0%    28.4µs ± 0%  -0.29%  (p=0.024 n=5+5)
JSONEncode               6.21ms ± 1%    6.19ms ± 1%    ~     (p=0.222 n=5+5)
JSONDecode               27.7ms ± 0%    27.6ms ± 0%    ~     (p=0.151 n=5+5)
Mandelbrot200            3.48ms ± 0%    3.47ms ± 0%  -0.26%  (p=0.008 n=5+5)
GoParse                  2.38ms ± 1%    2.35ms ± 1%    ~     (p=0.056 n=5+5)
RegexpMatchEasy0_32      43.1ns ± 0%    43.0ns ± 0%    ~     (p=0.143 n=5+5)
RegexpMatchEasy0_1K       129ns ± 0%     129ns ± 0%  -0.16%  (p=0.000 n=5+4)
RegexpMatchEasy1_32      38.5ns ± 1%    38.1ns ± 0%  -1.04%  (p=0.008 n=5+5)
RegexpMatchEasy1_1K       196ns ± 0%     195ns ± 0%    ~     (p=0.119 n=5+5)
RegexpMatchMedium_32      679ns ± 0%     678ns ± 0%    ~     (p=0.167 n=5+5)
RegexpMatchMedium_1K     20.8µs ± 0%    21.5µs ± 6%    ~     (p=0.690 n=5+5)
RegexpMatchHard_32       1.00µs ± 0%    1.01µs ± 0%    ~     (p=0.087 n=5+5)
RegexpMatchHard_1K       30.4µs ± 0%    30.6µs ± 0%  +0.72%  (p=0.008 n=5+5)
Revcomp                   311ms ± 0%     303ms ± 0%  -2.53%  (p=0.016 n=5+4)
Template                 37.8ms ± 0%    37.7ms ± 0%    ~     (p=0.310 n=5+5)
TimeParse                 163ns ± 0%     163ns ± 0%  -0.15%  (p=0.000 n=4+5)
TimeFormat                208ns ± 1%     208ns ± 1%    ~     (p=0.143 n=5+5)

name                   old speed      new speed      delta
GobDecode               218MB/s ± 0%   218MB/s ± 1%    ~     (p=1.000 n=5+5)
GobEncode               291MB/s ± 0%   292MB/s ± 0%    ~     (p=0.151 n=5+5)
Gzip                    129MB/s ± 0%   129MB/s ± 0%  +0.26%  (p=0.024 n=5+5)
Gunzip                  860MB/s ± 0%   861MB/s ± 0%    ~     (p=0.056 n=5+5)
JSONEncode              312MB/s ± 1%   314MB/s ± 1%    ~     (p=0.198 n=5+5)
JSONDecode             70.0MB/s ± 0%  70.2MB/s ± 0%    ~     (p=0.151 n=5+5)
GoParse                24.3MB/s ± 1%  24.6MB/s ± 1%    ~     (p=0.056 n=5+5)
RegexpMatchEasy0_32     743MB/s ± 0%   744MB/s ± 0%    ~     (p=0.151 n=5+5)
RegexpMatchEasy0_1K    7.94GB/s ± 0%  7.95GB/s ± 0%  +0.17%  (p=0.008 n=5+5)
RegexpMatchEasy1_32     832MB/s ± 1%   841MB/s ± 0%  +1.03%  (p=0.008 n=5+5)
RegexpMatchEasy1_1K    5.24GB/s ± 0%  5.25GB/s ± 0%    ~     (p=0.095 n=5+5)
RegexpMatchMedium_32   47.2MB/s ± 0%  47.2MB/s ± 0%    ~     (p=0.143 n=5+5)
RegexpMatchMedium_1K   49.2MB/s ± 0%  47.6MB/s ± 6%    ~     (p=0.651 n=5+5)
RegexpMatchHard_32     31.9MB/s ± 0%  31.8MB/s ± 0%    ~     (p=0.063 n=5+5)
RegexpMatchHard_1K     33.7MB/s ± 0%  33.5MB/s ± 0%  -0.72%  (p=0.008 n=5+5)
Revcomp                 818MB/s ± 0%   839MB/s ± 0%  +2.60%  (p=0.016 n=5+4)
Template               51.3MB/s ± 0%  51.4MB/s ± 0%    ~     (p=0.341 n=5+5)