### PR TITLE
text/template: add the 'parent' keyword

### DIFF
--- a/src/text/template/exampleparent_test.go
+++ b/src/text/template/exampleparent_test.go
@@ -1,0 +1,78 @@
+package template_test
+
+import (
+	"log"
+	"os"
+	"text/template"
+)
+
+func ExampleTemplate_parent() {
+	const base_html = `<!DOCTYPE html>
+<html>
+	<head>
+		<title>{{block "title" .}}My website{{end}}</title>
+	</head>
+	<body>
+		<main>
+			{{- block "content" .}}{{end -}}
+		</main>
+		<footer>
+			{{- block "footer" .}}
+			<p>Thanks for visiting!</p>
+			{{- end}}
+		</footer>
+	</body>
+</html>
+
+`
+	base := template.Must(template.New("base.html").Parse(base_html))
+
+	const index_html = `{{define "content"}}<h1>Welcome!</h1>{{end}}`
+	index := template.Must(template.Must(base.Clone()).New("index.html").Parse(index_html))
+
+	{
+		err := index.ExecuteTemplate(os.Stdout, "base.html", nil)
+		if err != nil {
+			log.Println("executing template:", err)
+		}
+	}
+
+	const about_html = `{{define "title"}}{{template parent .}} - About{{end}}
+{{define "content"}}<h1>About us</h1>{{end}}`
+	about := template.Must(template.Must(base.Clone()).New("about.html").Parse(about_html))
+
+	{
+		err := about.ExecuteTemplate(os.Stdout, "base.html", nil)
+		if err != nil {
+			log.Println("executing template:", err)
+		}
+	}
+
+	// Output:
+	// <!DOCTYPE html>
+	// <html>
+	// 	<head>
+	// 		<title>My website</title>
+	// 	</head>
+	// 	<body>
+	// 		<main><h1>Welcome!</h1></main>
+	// 		<footer>
+	// 			<p>Thanks for visiting!</p>
+	// 		</footer>
+	// 	</body>
+	// </html>
+	//
+	// <!DOCTYPE html>
+	// <html>
+	// 	<head>
+	// 		<title>My website - About</title>
+	// 	</head>
+	// 	<body>
+	// 		<main><h1>About us</h1></main>
+	// 		<footer>
+	// 			<p>Thanks for visiting!</p>
+	// 		</footer>
+	// 	</body>
+	// </html>
+
+}

--- a/src/text/template/exampleparent_test.go
+++ b/src/text/template/exampleparent_test.go
@@ -29,7 +29,6 @@ func ExampleTemplate_parent() {
 
 	const index_html = `{{define "content"}}<h1>Welcome!</h1>{{end}}`
 	index := template.Must(template.Must(base.Clone()).New("index.html").Parse(index_html))
-
 	{
 		err := index.ExecuteTemplate(os.Stdout, "base.html", nil)
 		if err != nil {
@@ -40,7 +39,6 @@ func ExampleTemplate_parent() {
 	const about_html = `{{define "title"}}{{template parent .}} - About{{end}}
 {{define "content"}}<h1>About us</h1>{{end}}`
 	about := template.Must(template.Must(base.Clone()).New("about.html").Parse(about_html))
-
 	{
 		err := about.ExecuteTemplate(os.Stdout, "base.html", nil)
 		if err != nil {

--- a/src/text/template/exec.go
+++ b/src/text/template/exec.go
@@ -405,7 +405,7 @@ func (s *state) walkTemplate(dot reflect.Value, t *parse.TemplateNode) {
 	s.at(t)
 	scope := s.scope[t.Name]
 	if t.Parent {
-		scope += 1
+		scope++
 	}
 	s.scope[t.Name] = scope
 	tmpl := s.tmpl.LookupWithScope(t.Name, scope)
@@ -423,7 +423,11 @@ func (s *state) walkTemplate(dot reflect.Value, t *parse.TemplateNode) {
 	// No dynamic scoping: template invocations inherit no variables.
 	newState.vars = []variable{{"$", dot}}
 	newState.walk(dot, tmpl.Root)
-	newState.scope[t.Name] = scope - 1 // TODO: unclear if this makes sense here
+	scope--
+	if scope < 0 { // TODO logical bug
+		scope = 0
+	}
+	newState.scope[t.Name] = scope // TODO: unclear if this makes sense here
 }
 
 // Eval functions evaluate pipelines, commands, and their elements and extract

--- a/src/text/template/multi_test.go
+++ b/src/text/template/multi_test.go
@@ -71,12 +71,12 @@ func TestMultiParse(t *testing.T) {
 			continue
 		}
 		for i, name := range test.names {
-			tmpl, ok := template.tmpl[name]
+			tmpl, ok := template.tmpl[name] // TODO making this pass tests for now, turn into an accessor method
 			if !ok {
 				t.Errorf("%s: can't find template %q", test.name, name)
 				continue
 			}
-			result := tmpl.Root.String()
+			result := tmpl[0].Root.String() // TODO
 			if result != test.results[i] {
 				t.Errorf("%s=(%q): got\n\t%v\nexpected\n\t%v", test.name, test.input, result, test.results[i])
 			}
@@ -234,10 +234,10 @@ func TestClone(t *testing.T) {
 	}
 	// Verify that the clone is self-consistent.
 	for k, v := range clone.tmpl {
-		if k == clone.name && v.tmpl[k] != clone {
+		if k == clone.name && v[0].tmpl[k][0] != clone { // TODO making this pass tests for now
 			t.Error("clone does not contain root")
 		}
-		if v != v.tmpl[v.name] {
+		if v[0] != v[0].tmpl[v[0].name][0] { // TODO making this pass tests for now
 			t.Errorf("clone does not contain self for %q", k)
 		}
 	}

--- a/src/text/template/parent_test.go
+++ b/src/text/template/parent_test.go
@@ -1,0 +1,84 @@
+package template_test
+
+import (
+	"bytes"
+	"testing"
+	"text/template"
+)
+
+func TestParent(t *testing.T) {
+	parent, err := template.New("parent").Parse(`{{block "content" .}}parent{{end}}`)
+	if err != nil {
+		t.Fatalf("parsing parent template: %v", err)
+	}
+
+	var b bytes.Buffer
+	if err := parent.Execute(&b, nil); err != nil {
+		t.Fatalf("executing parent template: %v", err)
+	}
+	if b.String() != "parent" {
+		t.Errorf("want %q, got %q", "parent", b.String())
+	}
+
+	var child *template.Template
+	{
+		clone, err := parent.Clone()
+		if err != nil {
+			t.Fatalf("cloning parent: %v", err)
+		}
+
+		child, err = clone.Parse(`{{define "content"}}{{template parent}}child{{end}}`)
+		if err != nil {
+			t.Fatalf("parsing child template: %v", err)
+		}
+
+		b.Reset()
+		if err := child.Execute(&b, nil); err != nil {
+			t.Fatalf("executing child template: %v", err)
+		}
+		if b.String() != "parentchild" {
+			t.Errorf("want %q, got %q", "child", b.String())
+		}
+	}
+
+	{
+		clone, err := parent.Clone()
+		if err != nil {
+			t.Fatalf("cloning parent: %v", err)
+		}
+
+		child, err := clone.Parse(`{{define "content"}}{{template parent}}cloned child{{end}}`)
+		if err != nil {
+			t.Fatalf("parsing child template: %v", err)
+		}
+
+		b.Reset()
+		if err := child.Execute(&b, nil); err != nil {
+			t.Fatalf("executing child template: %v", err)
+		}
+		if b.String() != "parentcloned child" {
+			t.Errorf("want %q, got %q", "parentcloned child", b.String())
+		}
+	}
+
+	{
+		clone, err := child.Clone()
+		if err != nil {
+			t.Fatalf("cloning child: %v", err)
+		}
+
+		gc, err := clone.Parse(`{{define "content"}}{{template parent}}grandchild{{end}}`)
+		if err != nil {
+			t.Fatalf("parsing grandchild template: %v", err)
+		}
+
+		b.Reset()
+		if err := gc.Execute(&b, nil); err != nil {
+			t.Fatalf("executing grandchild template: %v", err)
+		}
+		if b.String() != "parentchildgrandchild" {
+			t.Errorf("want %q, got %q", "parentchildgrandchild", b.String())
+		}
+	}
+
+}

--- a/src/text/template/parse/lex.go
+++ b/src/text/template/parse/lex.go
@@ -68,6 +68,7 @@ const (
 	itemEnd      // end keyword
 	itemIf       // if keyword
 	itemNil      // the untyped nil constant, easiest to treat as a keyword
+	itemParent   // parent keyword
 	itemRange    // range keyword
 	itemTemplate // template keyword
 	itemWith     // with keyword
@@ -82,6 +83,7 @@ var key = map[string]itemType{
 	"if":       itemIf,
 	"range":    itemRange,
 	"nil":      itemNil,
+	"parent":   itemParent,
 	"template": itemTemplate,
 	"with":     itemWith,
 }

--- a/src/text/template/parse/lex_test.go
+++ b/src/text/template/parse/lex_test.go
@@ -40,6 +40,7 @@ var itemName = map[itemType]string{
 	itemIf:       "if",
 	itemEnd:      "end",
 	itemNil:      "nil",
+	itemParent:   "parent",
 	itemRange:    "range",
 	itemTemplate: "template",
 	itemWith:     "with",

--- a/src/text/template/parse/node.go
+++ b/src/text/template/parse/node.go
@@ -937,14 +937,15 @@ func (w *WithNode) Copy() Node {
 type TemplateNode struct {
 	NodeType
 	Pos
-	tr   *Tree
-	Line int       // The line number in the input. Deprecated: Kept for compatibility.
-	Name string    // The name of the template (unquoted).
-	Pipe *PipeNode // The command to evaluate as dot for the template.
+	tr     *Tree
+	Line   int       // The line number in the input. Deprecated: Kept for compatibility.
+	Name   string    // The name of the template (unquoted).
+	Parent bool      // Whether to lookup template of this name in parent scope.
+	Pipe   *PipeNode // The command to evaluate as dot for the template.
 }
 
-func (t *Tree) newTemplate(pos Pos, line int, name string, pipe *PipeNode) *TemplateNode {
-	return &TemplateNode{tr: t, NodeType: NodeTemplate, Pos: pos, Line: line, Name: name, Pipe: pipe}
+func (t *Tree) newTemplate(pos Pos, line int, name string, parent bool, pipe *PipeNode) *TemplateNode {
+	return &TemplateNode{tr: t, NodeType: NodeTemplate, Pos: pos, Line: line, Name: name, Parent: parent, Pipe: pipe}
 }
 
 func (t *TemplateNode) String() string {
@@ -968,5 +969,5 @@ func (t *TemplateNode) tree() *Tree {
 }
 
 func (t *TemplateNode) Copy() Node {
-	return t.tr.newTemplate(t.Pos, t.Line, t.Name, t.Pipe.CopyPipe())
+	return t.tr.newTemplate(t.Pos, t.Line, t.Name, t.Parent, t.Pipe.CopyPipe())
 }

--- a/src/text/template/parse/node.go
+++ b/src/text/template/parse/node.go
@@ -956,7 +956,11 @@ func (t *TemplateNode) String() string {
 
 func (t *TemplateNode) writeTo(sb *strings.Builder) {
 	sb.WriteString("{{template ")
-	sb.WriteString(strconv.Quote(t.Name))
+	if t.Parent {
+		sb.WriteString("parent")
+	} else {
+		sb.WriteString(strconv.Quote(t.Name))
+	}
 	if t.Pipe != nil {
 		sb.WriteByte(' ')
 		t.Pipe.writeTo(sb)

--- a/src/text/template/parse/parse.go
+++ b/src/text/template/parse/parse.go
@@ -160,7 +160,7 @@ func (t *Tree) ErrorContext(n Node) (location, context string) {
 // errorf formats the error and terminates processing.
 func (t *Tree) errorf(format string, args ...interface{}) {
 	t.Root = nil
-	format = fmt.Sprintf("\x1b[1;33mPAULDEV\x1b[0m template: %s:%d: %s", t.ParseName, t.token[0].line, format)
+	format = fmt.Sprintf("template: %s:%d: %s", t.ParseName, t.token[0].line, format)
 	panic(fmt.Errorf(format, args...))
 }
 
@@ -580,7 +580,7 @@ func (t *Tree) blockControl() Node {
 	block.add()
 	block.stopParse()
 
-	return t.newTemplate(token.pos, token.line, name, false, pipe) // TODO: support parent?
+	return t.newTemplate(token.pos, token.line, name, false, pipe)
 }
 
 // Template:
@@ -595,16 +595,15 @@ func (t *Tree) templateControl() Node {
 		parent bool
 	)
 	if token.typ == itemParent {
-		// If we encounter the `parent` keyword, then we assume the current
-		// definition we're in the midst of is an overriding of a previously
-		// defined template, and the author's intent is to execute that
-		// "parent" template as part of the "child".
+		// If we encounter the `parent` keyword, then we assume the template we're
+		// in the midst currently defining is overriding a previously defined
+		// template, and that the template author's intent is to execute that
+		// "parent" template as part of this "child" template.
 		//
-		// We know the name of the template currently being defined
-		// (overridden), so we augment the name with a flag to indicate to the
-		// execution step that it should lookup the "parent" template with that
-		// name.
-		//fmt.Printf("\x1b[1;31mTEMPLATE NAME: %q\x1b[0m\n", t.Name)
+		// We know the name of the template currently being defined (i.e., the one
+		// overriding a previous definition), so we set a flag to indicate to
+		// template execution that it should lookup the "parent" template with the
+		// same name.
 		name = t.Name
 		parent = true
 	} else {

--- a/src/text/template/parse/parse_test.go
+++ b/src/text/template/parse/parse_test.go
@@ -236,6 +236,8 @@ var parseTests = []parseTest{
 		`{{template "x"}}`},
 	{"template with arg", "{{template `x` .Y}}", noError,
 		`{{template "x" .Y}}`},
+	{"template with parent", "{{template parent .}}", noError,
+		`{{template parent .}}`},
 	{"with", "{{with .X}}hello{{end}}", noError,
 		`{{with .X}}"hello"{{end}}`},
 	{"with with else", "{{with .X}}hello{{else}}goodbye{{end}}", noError,

--- a/src/text/template/template.go
+++ b/src/text/template/template.go
@@ -209,7 +209,6 @@ func (t *Template) lookup(name string, scope int) *Template {
 	if scope >= len(t.tmpl[name]) {
 		return nil
 	}
-	//fmt.Printf("\x1b[1;35mname: %q\tscope: %d\tlen: %d\x1b[0m\n", name, scope, len(t.tmpl[name]))
 	return t.tmpl[name][scope] // TODO: invariant check: at least one
 }
 

--- a/src/text/template/template.go
+++ b/src/text/template/template.go
@@ -5,7 +5,6 @@
 package template
 
 import (
-	"fmt"
 	"reflect"
 	"sync"
 	"text/template/parse"
@@ -210,7 +209,7 @@ func (t *Template) lookup(name string, scope int) *Template {
 	if scope >= len(t.tmpl[name]) {
 		return nil
 	}
-	fmt.Printf("\x1b[1;35mname: %q\tscope: %d\tlen: %d\x1b[0m\n", name, scope, len(t.tmpl[name]))
+	//fmt.Printf("\x1b[1;35mname: %q\tscope: %d\tlen: %d\x1b[0m\n", name, scope, len(t.tmpl[name]))
 	return t.tmpl[name][scope] // TODO: invariant check: at least one
 }
 


### PR DESCRIPTION
Add the keyword `parent` to the text/template language. The keyword,
when used in place of a template name string in a template execution
node, causes execution of that template to refer to a previously-defined
template of the same name. In the context of template inheritance, this
allows child templates to access the contents of the parent template they
are overriding.

For example:

base template: `{{define "title"}Example.com{{end}}`

inheriting: `{{define "title"}}Welcome - {{template parent .}}{{end}}`

Would produce: `Welcome - Example.com`

Fixes #48266