### PR TITLE
[dev.fuzz] internal/fuzz: always perform logical not on booleans when…

### DIFF
--- a/src/internal/fuzz/mutator.go
+++ b/src/internal/fuzz/mutator.go
@@ -88,9 +88,7 @@ func (m *mutator) mutate(vals []interface{}, maxBytes int) {
 	case float64:
 		vals[i] = m.mutateFloat(v, math.MaxFloat64)
 	case bool:
-		if m.rand(2) == 1 {
-			vals[i] = !v // 50% chance of flipping the bool
-		}
+		vals[i] = !v
 	case rune: // int32
 		vals[i] = rune(m.mutateInt(int64(v), math.MaxInt32))
 	case byte: // uint8


### PR DESCRIPTION
… mutating

Flip booleans when mutating rather than keeping the same value
50% of the time.

Updates #48291.
