### PR TITLE
time/format: add 24 hour Kitchen format for non AM/PM

### DIFF
--- a/src/time/format.go
+++ b/src/time/format.go
@@ -101,6 +101,7 @@ const (
 	RFC3339     = "2006-01-02T15:04:05Z07:00"
 	RFC3339Nano = "2006-01-02T15:04:05.999999999Z07:00"
 	Kitchen     = "3:04PM"
+	Kitchen24   = "15:04"
 	// Handy time stamps.
 	Stamp      = "Jan _2 15:04:05"
 	StampMilli = "Jan _2 15:04:05.000"


### PR DESCRIPTION
Short and sweet request to add `Kitchen24` to the time formats.
Looks a lot more common than regular `time.Kitchen` across a sample of repos.