### PR TITLE
runtime/mgc: add missing close of channel

### DIFF
--- a/src/runtime/mgc.go
+++ b/src/runtime/mgc.go
@@ -178,6 +178,7 @@ func gcenable() {
 	go bgscavenge(c)
 	<-c
 	<-c
+	close(c)
 	memstats.enablegc = true // now that runtime is initialized, GC is okay
 }
 


### PR DESCRIPTION
It seems we can close this channel after no use.