### PR TITLE
net/http: add Request.SetContext

### DIFF
--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -341,6 +341,15 @@ func (r *Request) Context() context.Context {
 	return context.Background()
 }
 
+// SetContext sets the request's context value without clone r.
+// The provided ctx must be non-nil.
+func (r *Request) SetContext(ctx context.Context) {
+	if ctx == nil {
+		panic("nil context")
+	}
+	r.ctx = ctx
+}
+
 // WithContext returns a shallow copy of r with its context changed
 // to ctx. The provided ctx must be non-nil.
 //


### PR DESCRIPTION
I wrote an async-io lib [nbio](https://github.com/lesismal/nbio) to avoid using one or more goroutines per connection.
Then we save lots of goroutines, reduce lots of memory usage and avoid stw, so we have mostly solved the `1000k` problem which is still a difficult job for `net/http`.
Here is some comparison: https://github.com/golang/go/issues/15735#issuecomment-917435376

In [nbio](https://github.com/lesismal/nbio), I implemented async-streaming-parser for http(and either tls and websocket) which set values of `http.Request`'s fields and manage `http.Request` by sync.Pool. I want to set the `http.Request`'s context value, but it's not a public field and both of the two methods(WithContext and NewRequestWithContext) provided in net/http make a copy and do not manage the struct by a pool. I want to create the `http.Request` myself and set the value but not make a copy.