### PR TITLE
cmd/go: add missing parenthesis in a call to "PrintVersion"

### DIFF
--- a/src/cmd/go/testdata/script/work_prune.txt
+++ b/src/cmd/go/testdata/script/work_prune.txt
@@ -59,7 +59,7 @@ package b
 import "example.com/q"
 
 func TestB() {
-	q.PrintVersion
+	q.PrintVersion()
 }
 -- p/go.mod --
 module example.com/p


### PR DESCRIPTION
For #45713