### PR TITLE
cmd/objfile: adding parsing of elf symbol type and binding

### DIFF
--- a/src/cmd/internal/objfile/objfile.go
+++ b/src/cmd/internal/objfile/objfile.go
@@ -37,12 +37,13 @@ type Entry struct {
 
 // A Sym is a symbol defined in an executable file.
 type Sym struct {
-	Name   string  // symbol name
-	Addr   uint64  // virtual address of symbol
-	Size   int64   // size in bytes
-	Code   rune    // nm code (T for text, D for data, and so on)
-	Type   string  // XXX?
-	Relocs []Reloc // in increasing Addr order
+	Name    string  // symbol name
+	Addr    uint64  // virtual address of symbol
+	Size    int64   // size in bytes
+	Code    rune    // nm code (T for text, D for data, and so on)
+	Type    string  // calculated from s.Info, (((unsigned int) x) & 0xf)
+	Binding string  // same but ((x) >> 4) both converted to string
+	Relocs  []Reloc // in increasing Addr order
 }
 
 type Reloc struct {


### PR DESCRIPTION
This change modifies go to include a symbol.Type and symbol.Binding that can (after some discussion) be added to the `go tool objdump` command. Currently, if you parse a list of symbols ([]syms) the Type will always be undefined, and this is because we needed to parse the byte value of s.Info into both a type and binding.  

There is some background and context in the thread here! https://twitter.com/vsoch/status/1437575705328439304. I might have instead done these values to be an enum to be useful elsewhere, but since it's defined as a string I didn't want to modify the current API and chose the current (fairly simple) implementation. Some resources:

 - [The ELF pdf](https://refspecs.linuxfoundation.org/elf/elf.pdf#%5B%7B%22num%22%3A109%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C-55%2C797%2C0%5D) (see 1.18 for Symbol binding/type calculations) 
 - The same in the elf.h source code https://github.com/torvalds/linux/blob/d0ee23f9d78be5531c4b055ea424ed0b489dfe9b/include/uapi/linux/elf.h#L132

If this was intended to be skipped and you see no value in added the type and binding to the objdump output, please close this PR and let me know. If you also think  it could be useful to have, could you tell me how you like the format specified?  I'd also be interested to ask if there are future plans for a more publicly exposed API for parsing binaries?  

And apologies if I've done any of this wrong - this is my first PR to go. Thank you!