### PR TITLE
crypto/cipher: use AEAD.NonceSize to make nonce in the example

### DIFF
--- a/src/crypto/cipher/example_test.go
+++ b/src/crypto/cipher/example_test.go
@@ -29,14 +29,14 @@ func ExampleNewGCM_encrypt() {
 		panic(err.Error())
 	}
 
-	// Never use more than 2^32 random nonces with a given key because of the risk of a repeat.
-	nonce := make([]byte, 12)
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
 		panic(err.Error())
 	}
 
-	aesgcm, err := cipher.NewGCM(block)
-	if err != nil {
+	// Never use more than 2^32 random nonces with a given key because of the risk of a repeat.
+	nonce := make([]byte, aesgcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		panic(err.Error())
 	}
 


### PR DESCRIPTION
The existing example uses hard-coded constant to make nonce buffer.
Using AEAD.NonceSize makes it a more portable and appropriate example.

Fixes: #48372