### PR TITLE
time: re-add space-padded day of year to docs

### DIFF
--- a/src/time/format.go
+++ b/src/time/format.go
@@ -74,7 +74,7 @@ import "errors"
 // for compatibility with fixed-width Unix time formats. A leading zero represents
 // a zero-padded value.
 //
-// The formats  and 002 are space-padded and zero-padded
+// The formats __2 and 002 are space-padded and zero-padded
 // three-character day of year; there is no unpadded day of year format.
 //
 // A comma or decimal point followed by one or more zeros represents


### PR DESCRIPTION
CL 320252 reworked the time docs, but accidentally deleted the format __2
from the sentence describing the three-character day of year component.