### PR TITLE
cmd/go/internal/test: clarify `-count` default

### DIFF
--- a/src/cmd/go/internal/test/test.go
+++ b/src/cmd/go/internal/test/test.go
@@ -208,7 +208,7 @@ control the execution of any test:
 	    (for example, -benchtime 100x).
 
 	-count n
-	    Run each test and benchmark n times (default 1).
+	    Run each test and benchmark n times (default 1 unless cached).
 	    If -cpu is set, run n times for each GOMAXPROCS value.
 	    Examples are always run once.
 


### PR DESCRIPTION
Count default is only 1 when the test is not cached. 
If the test is cached it will not rerun the test. 

This documentation causes confusion because the only way to run tests without cache is to use `-count=1`. According to the documentation as is `-count=1` should have no effect. Changing this CLI documentation to clarify the behavior.

ref: https://github.com/golang/go/issues/39056?ts=4#issuecomment-631688012
resolves: https://github.com/golang/go/issues/39056
