### PR TITLE
Unify "unreachable" panic messages

### DIFF
--- a/src/cmd/cgo/gcc.go
+++ b/src/cmd/cgo/gcc.go
@@ -2017,7 +2017,7 @@ func (p *Package) gccDebug(stdin []byte, nnames int) (d *dwarf.Data, ints []int6
 		return d, ints, floats, strs
 	}
 	fatalf("cannot parse gcc output %s as ELF, Mach-O, PE, XCOFF object", gccTmp())
-	panic("not reached")
+	panic("unreachable")
 }
 
 // gccDefines runs gcc -E -dM -xc - over the C program stdin

--- a/src/cmd/compile/internal/ssagen/ssa.go
+++ b/src/cmd/compile/internal/ssagen/ssa.go
@@ -244,7 +244,7 @@ func abiForFunc(fn *ir.Func, abi0, abi1 *abi.ABIConfig) *abi.ABIConfig {
 			return abi1
 		}
 		base.Fatalf("function %v has unknown ABI %v", fn, fn.ABI)
-		panic("not reachable")
+		panic("unreachable")
 	}
 
 	a := abi0

--- a/src/cmd/vendor/github.com/ianlancetaylor/demangle/demangle.go
+++ b/src/cmd/vendor/github.com/ianlancetaylor/demangle/demangle.go
@@ -923,7 +923,7 @@ func (st *state) operatorName(inExpression bool) (AST, int) {
 		return &Operator{Name: op.name}, op.args
 	} else {
 		st.failEarlier("unrecognized operator code", 2)
-		panic("not reached")
+		panic("unreachable")
 	}
 }
 
@@ -1079,7 +1079,7 @@ func (st *state) specialName() AST {
 			return &Special{Prefix: "TLS wrapper function for ", Val: n}
 		default:
 			st.fail("unrecognized special T name code")
-			panic("not reached")
+			panic("unreachable")
 		}
 	} else {
 		st.checkChar('G')
@@ -1122,7 +1122,7 @@ func (st *state) specialName() AST {
 			return st.javaResource()
 		default:
 			st.fail("unrecognized special G name code")
-			panic("not reached")
+			panic("unreachable")
 		}
 	}
 }
@@ -2180,7 +2180,7 @@ func (st *state) expression() AST {
 
 		default:
 			st.fail(fmt.Sprintf("unsupported number of operator arguments: %d", args))
-			panic("not reached")
+			panic("unreachable")
 		}
 	}
 }

--- a/src/cmd/vendor/golang.org/x/tools/go/analysis/internal/analysisflags/flags.go
+++ b/src/cmd/vendor/golang.org/x/tools/go/analysis/internal/analysisflags/flags.go
@@ -287,7 +287,7 @@ func (ts *triState) String() string {
 	case setFalse:
 		return "false"
 	}
-	panic("not reached")
+	panic("unreachable")
 }
 
 func (ts triState) IsBoolFlag() bool {

--- a/src/math/cmplx/pow.go
+++ b/src/math/cmplx/pow.go
@@ -63,7 +63,7 @@ func Pow(x, y complex128) complex128 {
 		case r > 0:
 			return 0
 		}
-		panic("not reached")
+		panic("unreachable")
 	}
 	modulus := Abs(x)
 	if modulus == 0 {

--- a/src/runtime/mheap.go
+++ b/src/runtime/mheap.go
@@ -1924,7 +1924,7 @@ func freeSpecial(s *special, p unsafe.Pointer, size uintptr) {
 		// The creator frees these.
 	default:
 		throw("bad special kind")
-		panic("not reached")
+		panic("unreachable")
 	}
 }
 

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -931,7 +931,7 @@ func castogscanstatus(gp *g, oldval, newval uint32) bool {
 	}
 	print("runtime: castogscanstatus oldval=", hex(oldval), " newval=", hex(newval), "\n")
 	throw("castogscanstatus")
-	panic("not reached")
+	panic("unreachable")
 }
 
 // If asked to move to or from a Gscanstatus this will throw. Use the castogscanstatus

--- a/src/runtime/syscall_windows_test.go
+++ b/src/runtime/syscall_windows_test.go
@@ -960,7 +960,7 @@ func removeOneCPU(mask uintptr) (uintptr, error) {
 		}
 
 	}
-	panic("not reached")
+	panic("unreachable")
 }
 
 func resumeChildThread(kernel32 *syscall.DLL, childpid int) error {

--- a/src/runtime/testdata/testprog/deadlock.go
+++ b/src/runtime/testdata/testprog/deadlock.go
@@ -43,12 +43,12 @@ func init() {
 
 func SimpleDeadlock() {
 	select {}
-	panic("not reached")
+	panic("unreachable")
 }
 
 func InitDeadlock() {
 	select {}
-	panic("not reached")
+	panic("unreachable")
 }
 
 func LockedDeadlock() {

--- a/src/text/template/exec.go
+++ b/src/text/template/exec.go
@@ -486,7 +486,7 @@ func (s *state) evalCommand(dot reflect.Value, cmd *parse.CommandNode, final ref
 		return reflect.ValueOf(word.Text)
 	}
 	s.errorf("can't evaluate command %q", firstWord)
-	panic("not reached")
+	panic("unreachable")
 }
 
 // idealConstant is called to return the value of a number in a context where
@@ -657,7 +657,7 @@ func (s *state) evalField(dot reflect.Value, fieldName string, node parse.Node, 
 		}
 	}
 	s.errorf("can't evaluate field %s in type %s", fieldName, typ)
-	panic("not reached")
+	panic("unreachable")
 }
 
 var (
@@ -832,7 +832,7 @@ func (s *state) evalArg(dot reflect.Value, typ reflect.Type, n parse.Node) refle
 		return s.evalUnsignedInteger(typ, n)
 	}
 	s.errorf("can't handle %s for arg of type %s", n, typ)
-	panic("not reached")
+	panic("unreachable")
 }
 
 func (s *state) evalBool(typ reflect.Type, n parse.Node) reflect.Value {
@@ -843,7 +843,7 @@ func (s *state) evalBool(typ reflect.Type, n parse.Node) reflect.Value {
 		return value
 	}
 	s.errorf("expected bool; found %s", n)
-	panic("not reached")
+	panic("unreachable")
 }
 
 func (s *state) evalString(typ reflect.Type, n parse.Node) reflect.Value {
@@ -854,7 +854,7 @@ func (s *state) evalString(typ reflect.Type, n parse.Node) reflect.Value {
 		return value
 	}
 	s.errorf("expected string; found %s", n)
-	panic("not reached")
+	panic("unreachable")
 }
 
 func (s *state) evalInteger(typ reflect.Type, n parse.Node) reflect.Value {
@@ -865,7 +865,7 @@ func (s *state) evalInteger(typ reflect.Type, n parse.Node) reflect.Value {
 		return value
 	}
 	s.errorf("expected integer; found %s", n)
-	panic("not reached")
+	panic("unreachable")
 }
 
 func (s *state) evalUnsignedInteger(typ reflect.Type, n parse.Node) reflect.Value {
@@ -876,7 +876,7 @@ func (s *state) evalUnsignedInteger(typ reflect.Type, n parse.Node) reflect.Valu
 		return value
 	}
 	s.errorf("expected unsigned integer; found %s", n)
-	panic("not reached")
+	panic("unreachable")
 }
 
 func (s *state) evalFloat(typ reflect.Type, n parse.Node) reflect.Value {
@@ -887,7 +887,7 @@ func (s *state) evalFloat(typ reflect.Type, n parse.Node) reflect.Value {
 		return value
 	}
 	s.errorf("expected float; found %s", n)
-	panic("not reached")
+	panic("unreachable")
 }
 
 func (s *state) evalComplex(typ reflect.Type, n parse.Node) reflect.Value {
@@ -897,7 +897,7 @@ func (s *state) evalComplex(typ reflect.Type, n parse.Node) reflect.Value {
 		return value
 	}
 	s.errorf("expected complex; found %s", n)
-	panic("not reached")
+	panic("unreachable")
 }
 
 func (s *state) evalEmptyInterface(dot reflect.Value, n parse.Node) reflect.Value {
@@ -924,7 +924,7 @@ func (s *state) evalEmptyInterface(dot reflect.Value, n parse.Node) reflect.Valu
 		return s.evalPipeline(dot, n)
 	}
 	s.errorf("can't handle assignment of %s to empty interface argument", n)
-	panic("not reached")
+	panic("unreachable")
 }
 
 // indirect returns the item at the end of indirection, and a bool to indicate

--- a/test/typeswitch1.go
+++ b/test/typeswitch1.go
@@ -39,7 +39,7 @@ func whatis(x interface{}) string {
 	case nil:
 		return fmt.Sprint("nil ", xx)
 	}
-	panic("not reached")
+	panic("unreachable")
 }
 
 func whatis1(x interface{}) string {
@@ -58,7 +58,7 @@ func whatis1(x interface{}) string {
 	case nil:
 		return fmt.Sprint("nil ", xx)
 	}
-	panic("not reached")
+	panic("unreachable")
 }
 
 func check(x interface{}, s string) {


### PR DESCRIPTION
Existing code occasionally uses "not reached" or "not reachable"
when panicking. Use "unreachable" as the panic message instead,
since it is already most commonly used.