### PR TITLE
net/http/httputil: allow MIME parameters when detecting SSE in ReverseProxy

### DIFF
--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"mime"
 	"net"
 	"net/http"
 	"net/http/internal/ascii"
@@ -412,7 +413,7 @@ func (p *ReverseProxy) flushInterval(res *http.Response) time.Duration {
 
 	// For Server-Sent Events responses, flush immediately.
 	// The MIME type is defined in https://www.w3.org/TR/eventsource/#text-event-stream
-	if resCT == "text/event-stream" {
+	if baseCT, _, _ := mime.ParseMediaType(resCT); baseCT == "text/event-stream" {
 		return -1 // negative means immediately
 	}
 

--- a/src/net/http/httputil/reverseproxy_test.go
+++ b/src/net/http/httputil/reverseproxy_test.go
@@ -1195,6 +1195,26 @@ func TestSelectFlushInterval(t *testing.T) {
 			want: -1,
 		},
 		{
+			name: "server-sent events with media-type parameters overrides non-zero",
+			res: &http.Response{
+				Header: http.Header{
+					"Content-Type": {"text/event-stream;charset=utf-8"},
+				},
+			},
+			p:    &ReverseProxy{FlushInterval: 123},
+			want: -1,
+		},
+		{
+			name: "server-sent events with media-type parameters overrides zero",
+			res: &http.Response{
+				Header: http.Header{
+					"Content-Type": {"text/event-stream;charset=utf-8"},
+				},
+			},
+			p:    &ReverseProxy{FlushInterval: 0},
+			want: -1,
+		},
+		{
 			name: "Content-Length: -1, overrides non-zero",
 			res: &http.Response{
 				ContentLength: -1,


### PR DESCRIPTION
This change allows httputil.ReverseProxy to detect SSE (server-sent events)
content when the response's Content-Type header includes MIME parameters,
such as "text/event-stream;charset=utf-8".

Prior to this change the value of the Content-Type header was compared
directly to the literal "text/event-stream". This caused a false-negative
which failed to set the FlushInterval correctly when MIME parameters were
present.