### PR TITLE
encoding/xml: allow mismatched `XMLName` / field metadata tag names

### DIFF
--- a/src/encoding/xml/marshal_test.go
+++ b/src/encoding/xml/marshal_test.go
@@ -2490,3 +2490,34 @@ func TestInvalidXMLName(t *testing.T) {
 		t.Errorf("error %q does not contain %q", err, want)
 	}
 }
+
+func TestMismatchedTagNames(t *testing.T) {
+	type InnerStruct struct {
+		XMLName Name   `xml:"innerStruct"`
+		Name    string `xml:"name"`
+	}
+
+	type Outer struct {
+		XMLName Name         `xml:"outer"`
+		Inner   *InnerStruct `xml:"inner"`
+	}
+
+	dec := NewDecoder(strings.NewReader(`<?xml version="1.0"?>
+<outer>
+    <inner>
+        <name>foo</name>
+    </inner>
+</outer>"`))
+
+	holder := &Outer{}
+	if err := dec.Decode(holder); err != nil {
+		t.Errorf("Unexpected error: %q", err)
+	}
+	if holder == nil {
+		t.Error("Holder should be non-nil")
+	} else if holder.Inner == nil {
+		t.Error("Inner should be non-nil")
+	} else if holder.Inner.Name != "foo" {
+		t.Errorf("Expected name to be %q, but was %q", "foo", holder.Inner.Name)
+	}
+}

--- a/src/encoding/xml/read.go
+++ b/src/encoding/xml/read.go
@@ -423,9 +423,6 @@ func (d *Decoder) unmarshal(val reflect.Value, start *StartElement) error {
 		// Validate and assign element name.
 		if tinfo.xmlname != nil {
 			finfo := tinfo.xmlname
-			if finfo.name != "" && finfo.name != start.Name.Local {
-				return UnmarshalError("expected element type <" + finfo.name + "> but have <" + start.Name.Local + ">")
-			}
 			if finfo.xmlns != "" && finfo.xmlns != start.Name.Space {
 				e := "expected element <" + finfo.name + "> in name space " + finfo.xmlns + " but have "
 				if start.Name.Space == "" {

--- a/src/encoding/xml/typeinfo.go
+++ b/src/encoding/xml/typeinfo.go
@@ -211,17 +211,6 @@ func structFieldInfo(typ reflect.Type, f *reflect.StructField) (*fieldInfo, erro
 		finfo.parents = parents[:len(parents)-1]
 	}
 
-	// If the field type has an XMLName field, the names must match
-	// so that the behavior of both marshaling and unmarshaling
-	// is straightforward and unambiguous.
-	if finfo.flags&fElement != 0 {
-		ftyp := f.Type
-		xmlname := lookupXMLName(ftyp)
-		if xmlname != nil && xmlname.name != finfo.name {
-			return nil, fmt.Errorf("xml: name %q in tag of %s.%s conflicts with name %q in %s.XMLName",
-				finfo.name, typ, f.Name, xmlname.name, ftyp)
-		}
-	}
 	return finfo, nil
 }
 


### PR DESCRIPTION
Currently, if you have nested structs, where the inner struct’s
XMLName doesn’t match the outer struct’s field name metadata, such as:

	type InnerStruct struct {
		XMLName Name   `xml:"innerStruct"`
		Name	string `xml:"name"`
	}

	type Outer struct {
		XMLName Name		 `xml:"outer"`
		Inner	*InnerStruct `xml:"inner"`
	}

Then decoding XML produces an error:

    xml: name "inner" in tag of xml.Outer.Inner conflicts with name "innerStruct" in *xml.InnerStruct.XMLName

This causes issues when interacting with SOAP web services, whose
WSDLs are expressed with XSD.  XSD allows defining reusable types;
each of those types has a unique name.  That name MAY be the name of
the tag containing the struct’s data, but isn’t ALWAYS.  An
xsd:element may specify a different tag name to contain an XSD type’s
values.  An illustration of a real-world case where this happens is
hooklift/gowsdl#219.

This PR uses the big hammer of removing the tests and errors which
cause the issue.  I’m reasonably certain that the structFieldInfo()
changes are fine, but I feel less good about Decoder.unmarshal().
Ideally, that code would look at the field metadata of the containing
struct, then the XMLName of the destination struct.  I’m not familiar
with this code, but it looks like the parent element isn’t accessible
at the time when this check would need to happen, so I opted to remove
it instead.

fixes hooklift/gowsdl#219