### PR TITLE
go/token: improve the performance of IsKeyword

### DIFF
--- a/src/go/token/token_test.go
+++ b/src/go/token/token_test.go
@@ -31,3 +31,68 @@ func TestIsIdentifier(t *testing.T) {
 		})
 	}
 }
+
+func TestIsKeyword(t *testing.T) {
+	for i := keyword_beg + 1; i < keyword_end; i++ {
+		tok, ok := isKeyword(tokens[i])
+		if !ok {
+			t.Errorf("want true, keyword is %q", tokens[i])
+			return
+		}
+		if tok != i {
+			t.Errorf("want equal, have: %d, want: %d", tok, i)
+			return
+		}
+	}
+	_, ok := isKeyword("foo")
+	if ok {
+		t.Errorf("want false, keyword is %q", "foo")
+		return
+	}
+}
+
+func BenchmarkIsKeyword(b *testing.B) {
+	keywords := tokens[keyword_beg+1 : keyword_end]
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < len(keywords); j++ {
+			IsKeyword(keywords[j])
+		}
+	}
+}
+
+func BenchmarkLookup(b *testing.B) {
+	keywords := tokens[keyword_beg+1 : keyword_end]
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < len(keywords); j++ {
+			Lookup(keywords[j])
+		}
+	}
+}
+
+func BenchmarkIsKeyword_WithNonKeywords(b *testing.B) {
+	keywords := make([]string, 0, keyword_end-(keyword_beg+1))
+	for i := keyword_beg + 1; i < keyword_end; i++ {
+		keywords = append(keywords, tokens[i]+"z")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < len(keywords); j++ {
+			IsKeyword(keywords[j])
+		}
+	}
+}
+
+func BenchmarkLookup_WithNonKeywords(b *testing.B) {
+	keywords := make([]string, 0, keyword_end-(keyword_beg+1))
+	for i := keyword_beg + 1; i < keyword_end; i++ {
+		keywords = append(keywords, tokens[i]+"z")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < len(keywords); j++ {
+			Lookup(keywords[j])
+		}
+	}
+}


### PR DESCRIPTION
This implementation is not perfect, but there is still a little performance improvement:

The current implementation is not the most efficient. 
Obviously, there is a high probability that we need to compare twice, and we can continue to optimize the hash function.

name                          old time/op  new time/op  delta
IsKeyword-12                   261ns ± 1%   112ns ± 0%  -57.05%  (p=0.000 n=9+9)
Lookup-12                      259ns ± 2%   113ns ± 3%  -56.28%  (p=0.000 n=7+9)
IsKeyword_WithNonKeywords-12   359ns ± 3%    84ns ± 6%  -76.50%  (p=0.000 n=8+10)
Lookup_WithNonKeywords-12      353ns ± 1%    81ns ± 1%  -77.19%  (p=0.000 n=8+10)


