### PR TITLE
go/token: fix File.AddLineColumnInfo logic

### DIFF
--- a/src/go/token/position.go
+++ b/src/go/token/position.go
@@ -245,7 +245,7 @@ func (f *File) AddLineInfo(offset int, filename string, line int) {
 // information for line directives such as //line filename:line:column.
 func (f *File) AddLineColumnInfo(offset int, filename string, line, column int) {
 	f.mutex.Lock()
-	if i := len(f.infos); i == 0 || f.infos[i-1].Offset < offset && offset < f.size {
+	if i := len(f.infos); (i == 0 || f.infos[i-1].Offset < offset) && offset < f.size {
 		f.infos = append(f.infos, lineInfo{offset, filename, line, column})
 	}
 	f.mutex.Unlock()

--- a/src/go/token/position_test.go
+++ b/src/go/token/position_test.go
@@ -7,6 +7,7 @@ package token
 import (
 	"fmt"
 	"math/rand"
+	"reflect"
 	"sync"
 	"testing"
 )
@@ -379,4 +380,98 @@ func TestRemoveFile(t *testing.T) {
 	checkPos(apos3, "-")
 	checkPos(bpos3, "fileB:1:4")
 	checkNumFiles(1)
+}
+
+func TestFileAddLineColumnInfo(t *testing.T) {
+	const (
+		filename = "test.go"
+		filesize = 100
+	)
+
+	tests := []struct {
+		name  string
+		infos []lineInfo
+		want  []lineInfo
+	}{
+		{
+			name: "normal",
+			infos: []lineInfo{
+				{Offset: 10, Filename: filename, Line: 2, Column: 1},
+				{Offset: 50, Filename: filename, Line: 3, Column: 1},
+				{Offset: 80, Filename: filename, Line: 4, Column: 2},
+			},
+			want: []lineInfo{
+				{Offset: 10, Filename: filename, Line: 2, Column: 1},
+				{Offset: 50, Filename: filename, Line: 3, Column: 1},
+				{Offset: 80, Filename: filename, Line: 4, Column: 2},
+			},
+		},
+		{
+			name: "offset1 == file size",
+			infos: []lineInfo{
+				{Offset: filesize, Filename: filename, Line: 2, Column: 1},
+			},
+			want: nil,
+		},
+		{
+			name: "offset1 > file size",
+			infos: []lineInfo{
+				{Offset: filesize + 1, Filename: filename, Line: 2, Column: 1},
+			},
+			want: nil,
+		},
+		{
+			name: "offset2 == file size",
+			infos: []lineInfo{
+				{Offset: 10, Filename: filename, Line: 2, Column: 1},
+				{Offset: filesize, Filename: filename, Line: 3, Column: 1},
+			},
+			want: []lineInfo{
+				{Offset: 10, Filename: filename, Line: 2, Column: 1},
+			},
+		},
+		{
+			name: "offset2 > file size",
+			infos: []lineInfo{
+				{Offset: 10, Filename: filename, Line: 2, Column: 1},
+				{Offset: filesize + 1, Filename: filename, Line: 3, Column: 1},
+			},
+			want: []lineInfo{
+				{Offset: 10, Filename: filename, Line: 2, Column: 1},
+			},
+		},
+		{
+			name: "offset2 == offset1",
+			infos: []lineInfo{
+				{Offset: 10, Filename: filename, Line: 2, Column: 1},
+				{Offset: 10, Filename: filename, Line: 3, Column: 1},
+			},
+			want: []lineInfo{
+				{Offset: 10, Filename: filename, Line: 2, Column: 1},
+			},
+		},
+		{
+			name: "offset2 < offset1",
+			infos: []lineInfo{
+				{Offset: 10, Filename: filename, Line: 2, Column: 1},
+				{Offset: 9, Filename: filename, Line: 3, Column: 1},
+			},
+			want: []lineInfo{
+				{Offset: 10, Filename: filename, Line: 2, Column: 1},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fs := NewFileSet()
+			f := fs.AddFile(filename, -1, filesize)
+			for _, info := range test.infos {
+				f.AddLineColumnInfo(info.Offset, info.Filename, info.Line, info.Column)
+			}
+			if !reflect.DeepEqual(f.infos, test.want) {
+				t.Errorf("\ngot %+v, \nwant %+v", f.infos, test.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
The offset of the line info should be smaller than the file size.
Otherwise, it should be ignored. 
Before the change, such an invalid line info won't be ignored when it's
the first one to add.