### PR TITLE
runtime: check amd64 microarchitecture level at startup

### DIFF
--- a/src/runtime/asm_amd64.s
+++ b/src/runtime/asm_amd64.s
@@ -119,6 +119,17 @@ GLOBL bad_proc_msg<>(SB), RODATA, $78
 #endif
 
 #ifdef GOAMD64_v3
+#define NEED_V3_CHECK
+#endif
+
+// Excluding v4 checks on Darwin for now, see CL 285572.
+#ifdef GOAMD64_v4
+#ifdef GOOS_darwin
+#define NEED_V3_CHECK
+#endif
+#endif
+
+#ifdef NEED_V3_CHECK
 #define NEED_MAX_CPUID 0x80000001
 #define NEED_FEATURES_CX V3_FEATURES_CX
 #define NEED_EXT_FEATURES_CX V3_EXT_FEATURES_CX
@@ -127,11 +138,13 @@ GLOBL bad_proc_msg<>(SB), RODATA, $78
 #endif
 
 #ifdef GOAMD64_v4
+#ifndef GOOS_darwin
 #define NEED_MAX_CPUID 0x80000001
 #define NEED_FEATURES_CX V3_FEATURES_CX
 #define NEED_EXT_FEATURES_CX V3_EXT_FEATURES_CX
 #define NEED_EXT_FEATURES_BX V4_EXT_FEATURES_BX
 #define NEED_OS_SUPPORT_AX V4_OS_SUPPORT_AX
+#endif
 #endif
 
 TEXT runtime·rt0_go(SB),NOSPLIT|TOPFRAME,$0

--- a/src/runtime/asm_amd64.s
+++ b/src/runtime/asm_amd64.s
@@ -95,16 +95,16 @@ GLOBL bad_proc_msg<>(SB), RODATA, $78
 // Define a list of AMD64 microarchitecture level features
 // https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels
 
-                          // SSE3     SSSE3    CMPXCHNG16 SSE4.1    SSE4.2    POPCNT
-#define V2_FEATURES_CX      (1 << 0 | 1 << 9 | 1 << 13  | 1 << 19 | 1 << 20 | 1 << 23)
-                          // LAHF/SAHF
-#define V2_EXT_FEATURES_CX  (1 << 0)
-                                           // FMA       MOVBE     OSXSAVE   AVX       F16C
-#define V3_FEATURES_CX      (V2_FEATURES_CX | 1 << 12 | 1 << 22 | 1 << 27 | 1 << 28 | 1 << 29)
-                                               // ABM (FOR LZNCT)
-#define V3_EXT_FEATURES_CX  (V2_EXT_FEATURES_CX | 1 << 5)
-                          // BMI1     AVX2     BMI2
-#define V3_EXT_FEATURES_BX  (1 << 3 | 1 << 5 | 1 << 8)
+                     // SSE3     SSSE3    CMPXCHNG16 SSE4.1    SSE4.2    POPCNT
+#define V2_FEATURES_CX (1 << 0 | 1 << 9 | 1 << 13  | 1 << 19 | 1 << 20 | 1 << 23)
+                         // LAHF/SAHF
+#define V2_EXT_FEATURES_CX (1 << 0)
+                                      // FMA       MOVBE     OSXSAVE   AVX       F16C
+#define V3_FEATURES_CX (V2_FEATURES_CX | 1 << 12 | 1 << 22 | 1 << 27 | 1 << 28 | 1 << 29)
+                                              // ABM (FOR LZNCT)
+#define V3_EXT_FEATURES_CX (V2_EXT_FEATURES_CX | 1 << 5)
+                         // BMI1     AVX2     BMI2
+#define V3_EXT_FEATURES_BX (1 << 3 | 1 << 5 | 1 << 8)
                        // XMM      YMM
 #define V3_OS_SUPPORT_AX (1 << 1 | 1 << 2)
                                               // AVX512F   AVX512DQ  AVX512CD  AVX512BW  AVX512VL
@@ -147,6 +147,20 @@ GLOBL bad_proc_msg<>(SB), RODATA, $78
 #endif
 #endif
 
+#ifdef GOAMD64_v1
+#define SKIP_GOAMD64_CHECK
+#endif
+
+#ifndef GOAMD64_v1
+#ifndef GOAMD64_v2
+#ifndef GOAMD64_v3
+#ifndef GOAMD64_v4
+#define SKIP_GOAMD64_CHECK
+#endif
+#endif
+#endif
+#endif
+
 TEXT runtime·rt0_go(SB),NOSPLIT|TOPFRAME,$0
 	// copy arguments forward on an even stack
 	MOVQ	DI, AX		// argc
@@ -170,7 +184,7 @@ TEXT runtime·rt0_go(SB),NOSPLIT|TOPFRAME,$0
 	CPUID
 	MOVL	AX, SI
 	CMPL	AX, $0
-#ifdef GOAMD64_v1
+#ifdef SKIP_GOAMD64_CHECK
 	JE nocpuinfo
 #else
 	JNE	has_cpuinfo


### PR DESCRIPTION
Make Go runtime throw if it's been compiled to assume instruction
set extensions that aren't available on the CPU.
Updates #48506
