### PR TITLE
go/token: slight performance improvement for IsIdentifier

### DIFF
--- a/src/go/token/token.go
+++ b/src/go/token/token.go
@@ -340,10 +340,13 @@ func IsKeyword(name string) bool {
 // is not a digit. Keywords are not identifiers.
 //
 func IsIdentifier(name string) bool {
+	if name == "" || IsKeyword(name) {
+		return false
+	}
 	for i, c := range name {
 		if !unicode.IsLetter(c) && c != '_' && (i == 0 || !unicode.IsDigit(c)) {
 			return false
 		}
 	}
-	return name != "" && !IsKeyword(name)
+	return true
 }


### PR DESCRIPTION
If name is empty or a keyword, we can skip the loop entirely.
Otherwise, we do the same amount of work as before.

Here is the benchmark result for go/parser:

name          old time/op    new time/op    delta
Parse-12        2.53ms ± 2%    2.47ms ± 1%  -2.38%  (p=0.000 n=9+10)
ParseOnly-12    1.97ms ± 1%    1.93ms ± 2%  -1.80%  (p=0.000 n=10+10)
Resolve-12       560µs ± 1%     558µs ± 1%    ~     (p=0.200 n=9+8)

name          old speed      new speed      delta
Parse-12      26.1MB/s ± 2%  26.8MB/s ± 1%  +2.44%  (p=0.000 n=9+10)
ParseOnly-12  33.6MB/s ± 1%  34.3MB/s ± 2%  +1.82%  (p=0.000 n=10+10)
Resolve-12     118MB/s ± 2%   119MB/s ± 1%    ~     (p=0.116 n=10+8)