### PR TITLE
encoding/xml: fix 'unsupported type' error on interface{} attributes

### DIFF
--- a/src/encoding/xml/marshal.go
+++ b/src/encoding/xml/marshal.go
@@ -555,6 +555,15 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 
 // marshalAttr marshals an attribute with the given name and value, adding to start.Attr.
 func (p *printer) marshalAttr(start *StartElement, name Name, val reflect.Value) error {
+	// Dereference or skip nil pointer, interface values.
+	switch val.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+	}
+
 	if val.CanInterface() && val.Type().Implements(marshalerAttrType) {
 		attr, err := val.Interface().(MarshalerAttr).MarshalXMLAttr(name)
 		if err != nil {
@@ -599,15 +608,6 @@ func (p *printer) marshalAttr(start *StartElement, name Name, val reflect.Value)
 			start.Attr = append(start.Attr, Attr{name, string(text)})
 			return nil
 		}
-	}
-
-	// Dereference or skip nil pointer, interface values.
-	switch val.Kind() {
-	case reflect.Pointer, reflect.Interface:
-		if val.IsNil() {
-			return nil
-		}
-		val = val.Elem()
 	}
 
 	// Walk slices.

--- a/src/encoding/xml/marshal_test.go
+++ b/src/encoding/xml/marshal_test.go
@@ -343,6 +343,10 @@ type MarshalerStruct struct {
 	Foo MyMarshalerAttrTest `xml:",attr"`
 }
 
+type IMarshalerStruct struct {
+	Foo interface{} `xml:",attr"`
+}
+
 type InnerStruct struct {
 	XMLName Name `xml:"testns outer"`
 }
@@ -1251,6 +1255,11 @@ var marshalTests = []struct {
 	{
 		ExpectXML: `<MarshalerStruct Foo="hello world"></MarshalerStruct>`,
 		Value:     &MarshalerStruct{},
+	},
+	{
+		ExpectXML:   `<IMarshalerStruct Foo="hello world"></IMarshalerStruct>`,
+		Value:       &IMarshalerStruct{Foo: &MyMarshalerAttrTest{}},
+		MarshalOnly: true,
 	},
 	{
 		ExpectXML: `<outer xmlns="testns" int="10"></outer>`,


### PR DESCRIPTION
When given interface value that is actually a type implementing
`encoding.TextMarshaler` or `xml.MarshalerAttr`, `marshalAttr` would return an
`unsupported type` error. The cause of this is that pointer and interface values
are dereferences after checking if the supported interfaces are implemented.

Solve this by moving the dereference of the pointer and interface values to the
start of the function, and update the test cases to test for this situation.

Fixes #48624
