### PR TITLE
cmd/doc: generate docs for generic functions that return []T

### DIFF
--- a/src/go/doc/reader.go
+++ b/src/go/doc/reader.go
@@ -430,7 +430,10 @@ func (r *reader) readFunc(fun *ast.FuncDecl) {
 					// A type parameter is not a defined type.
 					continue
 				}
-				if t := r.lookupType(n); t != nil {
+				if t := r.lookupType(n); t != nil && t.decl != nil {
+					// Only types with Decl are counted
+					// Types of generic functions have nil declaration,
+					// should be associated on top-level
 					typ = t
 					numResultTypes++
 					if numResultTypes > 1 {


### PR DESCRIPTION
The current godoc can parse generic functions that return slice []T,
but will delete them afterwards, due to empty declaration of type T.

This change lets generic functions be top-level functions instead of 
type-T associated functions, making them appear in godoc output.

Fixes #48485 
