### PR TITLE
crypto/ecdsa: Adjust entropy bounds

### DIFF
--- a/src/crypto/ecdsa/ecdsa.go
+++ b/src/crypto/ecdsa/ecdsa.go
@@ -200,10 +200,13 @@ var errZeroParam = errors.New("zero parameter")
 func Sign(rand io.Reader, priv *PrivateKey, hash []byte) (r, s *big.Int, err error) {
 	randutil.MaybeReadByte(rand)
 
-	// Get min(log2(q) / 2, 256) bits of entropy from rand.
-	entropylen := (priv.Curve.Params().BitSize + 7) / 16
-	if entropylen > 32 {
+	// Get min(max(log2(q), 256), 512) bits of entropy from rand.
+	entropylen := (priv.Curve.Params().BitSize + 7) / 8
+	if entropylen < 32 {
 		entropylen = 32
+	}
+	if entropylen > 64 {
+		entropylen = 64
 	}
 	entropy := make([]byte, entropylen)
 	_, err = io.ReadFull(rand, entropy)


### PR DESCRIPTION
Matching the entropy for an ECDSA signature to the ECDLP attack cost of the curve might make intuitive sense, but the birthday bound for a random function is Q(sqrt(N)), so we're matching a square root of a square root. For P-224 (ECDLP security of 112 bits), this doesn't yield a birthday bound of 112 bits, it yields a birthday bound of **56 bits**.

This patch changes the formula to produce roughly double the expected entropy (by changing the divisor from `16` to `8`), while requiring at least 256 bits. In case of weird cure support, this patch also caps the entropy at 512 bits. The variability between the two will mostly be observed with curves in between the two bounds (i.e. NIST P-384, which many users expect to offer a 192-bit security level anyway).

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
