### PR TITLE
time: add doc comment about tzdata package

### DIFF
--- a/src/time/zoneinfo.go
+++ b/src/time/zoneinfo.go
@@ -637,6 +637,9 @@ var zoneinfoOnce sync.Once
 // named by the ZONEINFO environment variable, if any, then looks in
 // known installation locations on Unix systems,
 // and finally looks in $GOROOT/lib/time/zoneinfo.zip.
+// If the time/tzdata package is imported, LoadLocation will load
+// the time zone database from that package if it could not be
+// loaded from any other location.
 func LoadLocation(name string) (*Location, error) {
 	if name == "" || name == "UTC" {
 		return UTC, nil

--- a/src/time/zoneinfo.go
+++ b/src/time/zoneinfo.go
@@ -635,7 +635,7 @@ var zoneinfoOnce sync.Once
 // locations in order:
 //
 // - the directory or uncompressed zip file named by the ZONEINFO environment variable
-// - pn a Unix system, the system standard installation location
+// - on a Unix system, the system standard installation location
 // - $GOROOT/lib/time/zoneinfo.zip
 // - the time/tzdata package, if it was imported
 func LoadLocation(name string) (*Location, error) {

--- a/src/time/zoneinfo.go
+++ b/src/time/zoneinfo.go
@@ -636,7 +636,7 @@ var zoneinfoOnce sync.Once
 // LoadLocation looks in the directory or uncompressed zip file
 // named by the ZONEINFO environment variable, if any, then looks in
 // known installation locations on Unix systems,
-// and finally looks in $GOROOT/lib/time/zoneinfo.zip.
+// and looks in $GOROOT/lib/time/zoneinfo.zip.
 // If the time/tzdata package is imported, LoadLocation will load
 // the time zone database from that package if it could not be
 // loaded from any other location.

--- a/src/time/zoneinfo.go
+++ b/src/time/zoneinfo.go
@@ -631,15 +631,13 @@ var zoneinfoOnce sync.Once
 // Otherwise, the name is taken to be a location name corresponding to a file
 // in the IANA Time Zone database, such as "America/New_York".
 //
-// The time zone database needed by LoadLocation may not be
-// present on all systems, especially non-Unix systems.
-// LoadLocation looks in the directory or uncompressed zip file
-// named by the ZONEINFO environment variable, if any, then looks in
-// known installation locations on Unix systems,
-// and looks in $GOROOT/lib/time/zoneinfo.zip.
-// If the time/tzdata package is imported, LoadLocation will load
-// the time zone database from that package if it could not be
-// loaded from any other location.
+// LoadLocation looks for the IANA Time Zone database in the following
+// locations in order:
+//
+// - the directory or uncompressed zip file named by the ZONEINFO environment variable
+// - pn a Unix system, the system standard installation location
+// - $GOROOT/lib/time/zoneinfo.zip
+// - the time/tzdata package, if it was imported
 func LoadLocation(name string) (*Location, error) {
 	if name == "" || name == "UTC" {
 		return UTC, nil


### PR DESCRIPTION
Add doc comment about the time/tzdata package to the time.LoadLocation
function. The time.LoadLocation function was changed in Go 1.15 to add an extra
source that it considers for the time zone database. That location is the
time/tzdata package. It is not easy to discover this behavior because the
documentation for the time package doesn't mention it in the discussion on the
time.LoadLocation function when discussing the different sources. It would be helpful to
describe all possible sources that time.LoadLocation considers when loading the
time zone database, and so I think it would be worthwhile to mention
time/tzdata.
