### PR TITLE
cmd/{compile,link}: add .debug_efacetyeps section

### DIFF
--- a/src/cmd/compile/internal/walk/convert.go
+++ b/src/cmd/compile/internal/walk/convert.go
@@ -5,6 +5,7 @@
 package walk
 
 import (
+	"cmd/internal/obj"
 	"encoding/binary"
 	"go/constant"
 
@@ -47,6 +48,13 @@ func walkConvInterface(n *ir.ConvExpr, init *ir.Nodes) ir.Node {
 	if !fromType.IsInterface() && !ir.IsBlank(ir.CurFunc.Nname) {
 		// skip unnamed functions (func _())
 		reflectdata.MarkTypeUsedInInterface(fromType, ir.CurFunc.LSym)
+	}
+
+	if toType.IsEmptyInterface() {
+		fromTypeLsym := reflectdata.TypeLinksym(fromType)
+		if fromTypeLsym != nil {
+			fromTypeLsym.Set(obj.AttrUsedInEface, true)
+		}
 	}
 
 	if !fromType.IsInterface() {

--- a/src/cmd/internal/goobj/objfile.go
+++ b/src/cmd/internal/goobj/objfile.go
@@ -305,6 +305,7 @@ const (
 	SymFlagUsedInIface = 1 << iota
 	SymFlagItab
 	SymFlagDict
+	SymFlagUsedInEface
 )
 
 // Returns the length of the name of the symbol.
@@ -333,6 +334,7 @@ func (s *Sym) NoSplit() bool       { return s.Flag()&SymFlagNoSplit != 0 }
 func (s *Sym) ReflectMethod() bool { return s.Flag()&SymFlagReflectMethod != 0 }
 func (s *Sym) IsGoType() bool      { return s.Flag()&SymFlagGoType != 0 }
 func (s *Sym) UsedInIface() bool   { return s.Flag2()&SymFlagUsedInIface != 0 }
+func (s *Sym) UsedInEface() bool   { return s.Flag2()&SymFlagUsedInEface != 0 }
 func (s *Sym) IsItab() bool        { return s.Flag2()&SymFlagItab != 0 }
 func (s *Sym) IsDict() bool        { return s.Flag2()&SymFlagDict != 0 }
 

--- a/src/cmd/internal/obj/link.go
+++ b/src/cmd/internal/obj/link.go
@@ -693,6 +693,10 @@ const (
 	// Used by the linker to determine what methods can be pruned.
 	AttrUsedInIface
 
+	// Only applied on type descriptor symbols, UsedInEface indicates this type is
+	// converted to an empty interface.
+	AttrUsedInEface
+
 	// ContentAddressable indicates this is a content-addressable symbol.
 	AttrContentAddressable
 
@@ -725,6 +729,7 @@ func (a *Attribute) Static() bool             { return a.load()&AttrStatic != 0 
 func (a *Attribute) WasInlined() bool         { return a.load()&AttrWasInlined != 0 }
 func (a *Attribute) Indexed() bool            { return a.load()&AttrIndexed != 0 }
 func (a *Attribute) UsedInIface() bool        { return a.load()&AttrUsedInIface != 0 }
+func (a *Attribute) UsedInEface() bool        { return a.load()&AttrUsedInEface != 0 }
 func (a *Attribute) ContentAddressable() bool { return a.load()&AttrContentAddressable != 0 }
 func (a *Attribute) ABIWrapper() bool         { return a.load()&AttrABIWrapper != 0 }
 

--- a/src/cmd/internal/obj/objfile.go
+++ b/src/cmd/internal/obj/objfile.go
@@ -337,6 +337,9 @@ func (w *writer) Sym(s *LSym) {
 	if s.UsedInIface() {
 		flag2 |= goobj.SymFlagUsedInIface
 	}
+	if s.UsedInEface() {
+		flag2 |= goobj.SymFlagUsedInEface
+	}
 	if strings.HasPrefix(s.Name, "go.itab.") && s.Type == objabi.SRODATA {
 		flag2 |= goobj.SymFlagItab
 	}

--- a/src/cmd/link/internal/ld/dwarf.go
+++ b/src/cmd/link/internal/ld/dwarf.go
@@ -2035,6 +2035,7 @@ func (d *dwctxt) dwarfGenerateDebugSyms() {
 	lineSym := mkSecSym(".debug_line")
 	rangesSym := mkSecSym(".debug_ranges")
 	infoSym := mkSecSym(".debug_info")
+	efacetypesSym := d.ldr.Lookup(".debug_efacetypes", 0)
 
 	// Create the section objects
 	lineSec := dwarfSecInfo{syms: []loader.Sym{lineSym}}
@@ -2042,6 +2043,7 @@ func (d *dwctxt) dwarfGenerateDebugSyms() {
 	rangesSec := dwarfSecInfo{syms: []loader.Sym{rangesSym}}
 	frameSec := dwarfSecInfo{syms: []loader.Sym{frameSym}}
 	infoSec := dwarfSecInfo{syms: []loader.Sym{infoSym}}
+	efacetypesSec := dwarfSecInfo{syms: []loader.Sym{efacetypesSym}}
 
 	// Create any new symbols that will be needed during the
 	// parallel portion below.
@@ -2112,6 +2114,9 @@ func (d *dwctxt) dwarfGenerateDebugSyms() {
 		dwarfp = append(dwarfp, locSec)
 	}
 	dwarfp = append(dwarfp, rangesSec)
+	if d.linkctxt.efaceTypes {
+		dwarfp = append(dwarfp, efacetypesSec)
+	}
 
 	// Check to make sure we haven't listed any symbols more than once
 	// in the info section. This used to be done by setting and
@@ -2154,7 +2159,7 @@ func dwarfaddshstrings(ctxt *Link, shstrtab *loader.SymbolBuilder) {
 		return
 	}
 
-	secs := []string{"abbrev", "frame", "info", "loc", "line", "gdb_scripts", "ranges"}
+	secs := []string{"abbrev", "frame", "info", "loc", "line", "gdb_scripts", "ranges", "efacetypes"}
 	for _, sec := range secs {
 		shstrtab.Addstring(".debug_" + sec)
 		if ctxt.IsExternal() {

--- a/src/cmd/link/internal/ld/efacetypes.go
+++ b/src/cmd/link/internal/ld/efacetypes.go
@@ -1,0 +1,38 @@
+package ld
+
+import (
+	"cmd/internal/objabi"
+	"cmd/link/internal/loader"
+	"cmd/link/internal/sym"
+)
+
+func (ctxt *Link) efacetypes() {
+	if !ctxt.efaceTypes {
+		return
+	}
+
+	ldr := ctxt.loader
+	var efacetypes []loader.Sym
+
+	for s := loader.Sym(1); s < loader.Sym(ldr.NSym()); s++ {
+		if ldr.AttrReachable(s) && ldr.AttrUsedInEface(s) {
+			efacetypes = append(efacetypes, s)
+		}
+	}
+
+	et := ldr.CreateSymForUpdate(".debug_efacetypes", 0)
+	et.SetType(sym.SDWARFSECT)
+	et.SetReachable(true)
+	et.SetSize(int64(ctxt.Arch.PtrSize * len(efacetypes)))
+	et.Grow(et.Size())
+
+	relocs := et.AddRelocs(len(efacetypes))
+
+	for i, s := range efacetypes {
+		r := relocs.At(i)
+		r.SetSym(s)
+		r.SetOff(int32(i * ctxt.Arch.PtrSize))
+		r.SetSiz(uint8(ctxt.Arch.PtrSize))
+		r.SetType(objabi.R_ADDR)
+	}
+}

--- a/src/cmd/link/internal/ld/link.go
+++ b/src/cmd/link/internal/ld/link.go
@@ -66,6 +66,8 @@ type Link struct {
 
 	compressDWARF bool
 
+	efaceTypes bool
+
 	Libdir       []string
 	Library      []*sym.Library
 	LibraryByPkg map[string]*sym.Library

--- a/src/cmd/link/internal/ld/main.go
+++ b/src/cmd/link/internal/ld/main.go
@@ -137,6 +137,7 @@ func Main(arch *sys.Arch, theArch Arch) {
 	flag.Var(&ctxt.LinkMode, "linkmode", "set link `mode`")
 	flag.Var(&ctxt.BuildMode, "buildmode", "set build `mode`")
 	flag.BoolVar(&ctxt.compressDWARF, "compressdwarf", true, "compress DWARF if possible")
+	flag.BoolVar(&ctxt.efaceTypes, "efacetypes", false, "generate debug eface types section")
 	objabi.Flagfn1("B", "add an ELF NT_GNU_BUILD_ID `note` when using ELF", addbuildinfo)
 	objabi.Flagfn1("L", "add specified `directory` to library path", func(a string) { Lflag(ctxt, a) })
 	objabi.AddVersionFlag() // -V
@@ -307,6 +308,8 @@ func Main(arch *sys.Arch, theArch Arch) {
 	ctxt.textaddress()
 	bench.Start("typelink")
 	ctxt.typelink()
+	bench.Start("efacetypes")
+	ctxt.efacetypes()
 	bench.Start("buildinfo")
 	ctxt.buildinfo()
 	bench.Start("pclntab")


### PR DESCRIPTION
This commit introduces a new .debug_efacetypes section which contains
addresses of types that are converted to empty interfaces.
This section provides information required for binary optimization tools
(like llvm-bolt) for correct parsing of those structures to keep them
in a consistent state after optimizer tool performs relocations of
binary blocks.

DO NOT REVIEW
DO NOT MERGE