### PR TITLE
net/http: mention io.Seeker requirement in FS documentation

### DIFF
--- a/src/net/http/fs.go
+++ b/src/net/http/fs.go
@@ -815,6 +815,7 @@ func (f ioFile) Readdir(count int) ([]fs.FileInfo, error) {
 
 // FS converts fsys to a FileSystem implementation,
 // for use with FileServer and NewFileTransport.
+// The files provided by fsys must implement io.Seeker.
 func FS(fsys fs.FS) FileSystem {
 	return ioFS{fsys}
 }


### PR DESCRIPTION
Both FileServer and NewFileTransport can try to seek a file, specifically
when MIME type sniffing is performed. This can be somewhat surprising to an
implementer of an fs.FS, as their filesystem will appear to work until a
user tries to access a file with an unrecognized extension (which requires
type sniffing and therefore seeking). With FileServer, this results in a
"seeker can't seek" message, which is not very clear for the developer.

The issue arises because fs.FS does not require Seek, while http.FileSystem
does. Therefore, this change adds a line to the documentation of net/http's
adapter function mentioning the requirement.