### PR TITLE
time: add AddDateX more attention to months then AddDate

### DIFF
--- a/src/time/time_test.go
+++ b/src/time/time_test.go
@@ -674,6 +674,27 @@ func TestAddDate(t *testing.T) {
 	}
 }
 
+var addDateXTests = []struct {
+	years, months, days int
+}{
+	{4, 6, 0},
+	{3, 18, 0},
+	{5, -6, 0},
+}
+
+func TestAddDateX(t *testing.T) {
+	t0 := Date(2021, 10, 31, 16, 8, 8, 0, UTC)
+	t1 := Date(2026, 4, 30, 16, 8, 8, 0, UTC)
+	for _, at := range addDateXTests {
+		time := t0.AddDateX(at.years, at.months, at.days)
+		if !time.Equal(t1) {
+			t.Errorf("AddDateX(%d, %d, %d) = %v, want %v",
+				at.years, at.months, at.days,
+				time, t1)
+		}
+	}
+}
+
 var daysInTests = []struct {
 	year, month, di int
 }{


### PR DESCRIPTION
AddDateX returns the time more attention to months then AddDate.
For example, AddDateX(0, 1, 0) applied to 2021-08-31
will returns 2021-09-30.
If the desired month does not have this day,
temporarily set the day as the maximum day of the desired month,
and then process the param days.

Fixes #31145
