### PR TITLE
os: explain ProccessState.Exited()  SIGKILL interaction

### DIFF
--- a/src/os/exec.go
+++ b/src/os/exec.go
@@ -148,7 +148,7 @@ func (p *ProcessState) SystemTime() time.Duration {
 	return p.systemTime()
 }
 
-// Exited reports whether the program has exited.
+// Exited reports whether the program has exited. (Note that if the program has been forcefully killed, Exited will return `false`)
 func (p *ProcessState) Exited() bool {
 	return p.exited()
 }

--- a/src/os/exec.go
+++ b/src/os/exec.go
@@ -148,7 +148,9 @@ func (p *ProcessState) SystemTime() time.Duration {
 	return p.systemTime()
 }
 
-// Exited reports whether the program has exited. (Note that if the program has been forcefully killed, Exited will return `false`)
+// Exited reports whether the program has exited.
+// On Unix systems this reports true if the program exited due to calling exit,
+// but false if the program terminated due to a signal.
 func (p *ProcessState) Exited() bool {
 	return p.exited()
 }


### PR DESCRIPTION
When a process is forcefully killed (for example, with SIGKILL on unix), its ProccessState.Exited() will return false.

