### PR TITLE
regexp: speed up onepass prefix check

### DIFF
--- a/src/regexp/exec.go
+++ b/src/regexp/exec.go
@@ -432,13 +432,13 @@ func (re *Regexp) doOnePass(ir io.RuneReader, ib []byte, is string, pos, ncap in
 	}
 
 	r, width = i.step(pos)
+	if r != endOfText {
+		r1, width1 = i.step(pos + width)
+	}
 	if pos == 0 {
 		flag = newLazyFlag(-1, r)
 	} else {
 		flag = i.context(pos)
-	}
-	if r != endOfText {
-		r1, width1 = i.step(pos + width)
 	}
 	for {
 		inst = re.onepass.Inst[pc]


### PR DESCRIPTION
Remove an unnecessary check that the first operation matches - we know
from compile-time that it is EmptyBeginText which will always match at
position 0.

This enables the call to i.hasPrefix to be done before unpacking the
instruction or the first two runes. If the prefix does not match we
go straight to return, and if it does match we need the runes after the
match, so in either case unpacking the runes was unnecessary.

Fixes #48891 

Modifying the regexp in BenchmarkAnchoredLiteralShortNonMatch to "^zbc(d|e).*$"
so it uses the onepass engine (see #48748), we get this improvement:

```
name                            old time/op    new time/op    delta
AnchoredLiteralShortNonMatch-8    29.8ns ± 5%    20.6ns ± 2%  -30.89%  (p=0.008 n=5+5)

name                            old alloc/op   new alloc/op   delta
AnchoredLiteralShortNonMatch-8     0.00B          0.00B          ~     (all equal)

name                            old allocs/op  new allocs/op  delta
AnchoredLiteralShortNonMatch-8      0.00           0.00          ~     (all equal)
```