### PR TITLE
all: fix spelling mistakes

### DIFF
--- a/src/cmd/compile/internal/noder/irgen.go
+++ b/src/cmd/compile/internal/noder/irgen.go
@@ -115,7 +115,7 @@ type dictInfo struct {
 	itabConvs []ir.Node
 
 	// Mapping from each shape type that substitutes a type param, to its
-	// type bound (which is also substitued with shapes if it is parameterized)
+	// type bound (which is also substituted with shapes if it is parameterized)
 	shapeToBound map[*types.Type]*types.Type
 
 	// For type switches on nonempty interfaces, a map from OTYPE entries of

--- a/src/internal/fuzz/sys_posix.go
+++ b/src/internal/fuzz/sys_posix.go
@@ -48,7 +48,7 @@ func (m *sharedMem) Close() error {
 	return nil
 }
 
-// setWorkerComm configures communciation channels on the cmd that will
+// setWorkerComm configures communication channels on the cmd that will
 // run a worker process.
 func setWorkerComm(cmd *exec.Cmd, comm workerComm) {
 	mem := <-comm.memMu

--- a/src/internal/fuzz/sys_windows.go
+++ b/src/internal/fuzz/sys_windows.go
@@ -86,7 +86,7 @@ func (m *sharedMem) Close() error {
 	return nil
 }
 
-// setWorkerComm configures communciation channels on the cmd that will
+// setWorkerComm configures communication channels on the cmd that will
 // run a worker process.
 func setWorkerComm(cmd *exec.Cmd, comm workerComm) {
 	mem := <-comm.memMu


### PR DESCRIPTION
Corrections were only made to comments and can be reproduced with the
following sed. 

sed -i 's/communciation/communication/g'  src/internal/fuzz/sys_windows.go
sed -i 's/communciation/communication/g'  src/internal/fuzz/sys_posix.go
sed -i 's/substitued/substituted/g'     src/cmd/compile/internal/noder/irgen.go