### PR TITLE
encoding/json: calculate correct SyntaxError.Offset in the stream

### DIFF
--- a/src/encoding/json/decode_test.go
+++ b/src/encoding/json/decode_test.go
@@ -452,6 +452,8 @@ var unmarshalTests = []unmarshalTest{
 	{in: `{"X": "foo", "Y"}`, err: &SyntaxError{"invalid character '}' after object key", 17}},
 	{in: `[1, 2, 3+]`, err: &SyntaxError{"invalid character '+' after array element", 9}},
 	{in: `{"X":12x}`, err: &SyntaxError{"invalid character 'x' after object key:value pair", 8}, useNumber: true},
+	{in: ``, err: &SyntaxError{msg: "unexpected end of JSON input", Offset: 0}},
+	{in: ` `, err: &SyntaxError{msg: "unexpected end of JSON input", Offset: 1}},
 	{in: `[2, 3`, err: &SyntaxError{msg: "unexpected end of JSON input", Offset: 5}},
 	{in: `{"F3": -}`, ptr: new(V), out: V{F3: Number("-")}, err: &SyntaxError{msg: "invalid character '}' in numeric literal", Offset: 9}},
 
@@ -1084,6 +1086,11 @@ func equalError(a, b error) bool {
 	}
 	if b == nil {
 		return a == nil
+	}
+	ase, aok := a.(*SyntaxError)
+	bse, bok := b.(*SyntaxError)
+	if aok || bok {
+		return aok && bok && *ase == *bse
 	}
 	return a.Error() == b.Error()
 }

--- a/src/encoding/json/scanner_test.go
+++ b/src/encoding/json/scanner_test.go
@@ -178,18 +178,20 @@ func TestIndentBig(t *testing.T) {
 	}
 }
 
-type indentErrorTest struct {
+type errorTest struct {
 	in  string
 	err error
 }
 
-var indentErrorTests = []indentErrorTest{
+var errorTests = []errorTest{
 	{`{"X": "foo", "Y"}`, &SyntaxError{"invalid character '}' after object key", 17}},
 	{`{"X": "foo" "Y": "bar"}`, &SyntaxError{"invalid character '\"' after object key:value pair", 13}},
+	{``, &SyntaxError{"unexpected end of JSON input", 0}},
+	{`  [  `, &SyntaxError{"unexpected end of JSON input", 5}},
 }
 
 func TestIndentErrors(t *testing.T) {
-	for i, tt := range indentErrorTests {
+	for i, tt := range errorTests {
 		slice := make([]uint8, 0)
 		buf := bytes.NewBuffer(slice)
 		if err := Indent(buf, []uint8(tt.in), "", ""); err != nil {
@@ -197,6 +199,17 @@ func TestIndentErrors(t *testing.T) {
 				t.Errorf("#%d: Indent: %#v", i, err)
 				continue
 			}
+		}
+	}
+}
+
+func TestCompactErrors(t *testing.T) {
+	for i, tt := range errorTests {
+		var buf bytes.Buffer
+		err := Compact(&buf, []byte(tt.in))
+		if !reflect.DeepEqual(err, tt.err) {
+			t.Errorf("#%d: Compact: expected %#v, got: %#v", i, tt.err, err)
+			continue
 		}
 	}
 }

--- a/src/encoding/json/stream.go
+++ b/src/encoding/json/stream.go
@@ -99,13 +99,8 @@ Input:
 		// Look in the buffer for a new value.
 		for ; scanp < len(dec.buf); scanp++ {
 			c := dec.buf[scanp]
-			dec.scan.bytes++
 			switch dec.scan.step(&dec.scan, c) {
 			case scanEnd:
-				// scanEnd is delayed one byte so we decrement
-				// the scanner bytes count by 1 to ensure that
-				// this value is correct in the next call of Decode.
-				dec.scan.bytes--
 				break Input
 			case scanEndObject, scanEndArray:
 				// scanEnd is delayed one byte.
@@ -116,8 +111,8 @@ Input:
 					break Input
 				}
 			case scanError:
-				dec.err = dec.scan.err
-				return 0, dec.scan.err
+				dec.err = &SyntaxError{msg: dec.scan.errMsg, Offset: dec.scanned + int64(scanp) + 1}
+				return 0, dec.err
 			}
 		}
 

--- a/src/encoding/json/stream_test.go
+++ b/src/encoding/json/stream_test.go
@@ -397,10 +397,14 @@ var tokenStreamCases = []tokenStreamCase{
 	}},
 	{json: `{ "\a" }`, expTokens: []interface{}{
 		Delim('{'),
-		&SyntaxError{"invalid character 'a' in string escape code", 3},
+		&SyntaxError{"invalid character 'a' in string escape code", 5},
 	}},
 	{json: ` \a`, expTokens: []interface{}{
-		&SyntaxError{"invalid character '\\\\' looking for beginning of value", 1},
+		&SyntaxError{"invalid character '\\\\' looking for beginning of value", 2},
+	}},
+	{json: `{ } [] nil`, expTokens: []interface{}{
+		Delim('{'), Delim('}'), Delim('['), Delim(']'),
+		&SyntaxError{"invalid character 'i' in literal null (expecting 'u')", 9},
 	}},
 }
 


### PR DESCRIPTION
Stream decoder does not count whitespaces, empty objects and arrays
in syntax error offset. This change removes offset tracking from the
scanner and relies on the calling code to provide the correct value.

Fixes #44811, #34543
