### PR TITLE
cmd/cover: print out the coverage HTML file unconditionally

### DIFF
--- a/src/cmd/cover/html.go
+++ b/src/cmd/cover/html.go
@@ -83,9 +83,8 @@ func htmlOutput(profile, outfile string) error {
 	}
 
 	if outfile == "" {
-		if !browser.Open("file://" + out.Name()) {
-			fmt.Fprintf(os.Stderr, "HTML output written to %s\n", out.Name())
-		}
+		fmt.Fprintf(os.Stderr, "HTML output written to %s\n", out.Name())
+		browser.Open("file://" + out.Name())
 	}
 
 	return nil


### PR DESCRIPTION
Even if `go tool cover` is able to open a browser window, it's still nice to print out the HTML file location so we can reopen it manually later.
