### PR TITLE
runtime: add missing //go:nosplit for efaceOf

### DIFF
--- a/src/runtime/runtime2.go
+++ b/src/runtime/runtime2.go
@@ -209,6 +209,7 @@ type eface struct {
 	data  unsafe.Pointer
 }
 
+//go:nosplit
 func efaceOf(ep *any) *eface {
 	return (*eface)(unsafe.Pointer(ep))
 }


### PR DESCRIPTION
This fix prevents additional stack checking code from being
generated on func efaceOf to avoid unexpected growth of stack
in child process.

Fixes #48967