### PR TITLE
doc/go1.18.html: fix a typo

### DIFF
--- a/doc/go1.18.html
+++ b/doc/go1.18.html
@@ -98,7 +98,7 @@ Do not send CLs removing the interior tags from such phrases.
 <p><!-- https://golang.org/issue/43566 -->
   <code>gofmt</code> now reads and formats input files concurrently, with a
   memory limit proportional to <code>GOMAXPROCS</code>. On a machine with
-  multiple CPUs, gofmt should now be significantly faster.
+  multiple CPUs, <code>gofmt</code> should now be significantly faster.
 </p>
 
 


### PR DESCRIPTION
gofmt -> <code>gofmt</code>