### PR TITLE
crypto: support ECDHE when ec_point_formats is missing in ClientHello

### DIFF
--- a/src/crypto/tls/handshake_server.go
+++ b/src/crypto/tls/handshake_server.go
@@ -314,7 +314,9 @@ func supportsECDHE(c *Config, supportedCurves []CurveID, supportedPoints []uint8
 		}
 	}
 
-	supportsPointFormat := false
+	// RFC 8422, Section 5.1.2
+	// If this extension is missing, it means that only the uncompressed point format is supported
+	supportsPointFormat := len(supportedPoints) == 0
 	for _, pointFormat := range supportedPoints {
 		if pointFormat == pointFormatUncompressed {
 			supportsPointFormat = true

--- a/src/crypto/tls/handshake_server_test.go
+++ b/src/crypto/tls/handshake_server_test.go
@@ -280,7 +280,7 @@ func TestTLS12OnlyCipherSuites(t *testing.T) {
 }
 
 func TestTLSPointFormats(t *testing.T) {
-	// Test that a Server returns the ec_point_format extension when ECC is
+	// Test that a Server returns the ec_point_formats extension when ECC is
 	// negotiated, and not returned on RSA handshake.
 	tests := []struct {
 		name                string
@@ -290,6 +290,7 @@ func TestTLSPointFormats(t *testing.T) {
 		wantSupportedPoints bool
 	}{
 		{"ECC", []uint16{TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA}, []CurveID{CurveP256}, []uint8{compressionNone}, true},
+		{"ECC without ec_point_formats", []uint16{TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA}, []CurveID{CurveP256}, []uint8{}, true},
 		{"RSA", []uint16{TLS_RSA_WITH_AES_256_GCM_SHA384}, nil, nil, false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
As describe in rfc8422 5.1.2, we will support ECDHE in the case client does not
include ec_point_formats extension in ClientHello extension. This make sure ECDHE
will work with (uncompressed point format is listed explicitly) or without extension.

rfc8422 5.1.2: https://datatracker.ietf.org/doc/html/rfc8422#section-5.1.2.

Fixes #49126