### PR TITLE
net/http: adjust a substring which matches "uninteresting" goroutine

### DIFF
--- a/src/net/http/main_test.go
+++ b/src/net/http/main_test.go
@@ -43,7 +43,7 @@ func interestingGoroutines() (gs []string) {
 			// These only show up with GOTRACEBACK=2; Issue 5005 (comment 28)
 			strings.Contains(stack, "runtime.goexit") ||
 			strings.Contains(stack, "created by runtime.gc") ||
-			strings.Contains(stack, "net/http_test.interestingGoroutines") ||
+			strings.Contains(stack, "interestingGoroutines") ||
 			strings.Contains(stack, "runtime.MHeap_Scavenger") {
 			continue
 		}


### PR DESCRIPTION
This change allows the check to pass unmodified under GopherJS, which
stack traces are formatted differently (due to being generated by
NodeJS). There are no other functions named `interestingGoroutines` in
the standard library, so it's very unlikely to create false negatives,
and will allow reduce the number of overlays GopherJS needs to maintain.