### PR TITLE
go/types: propagate conversion error reason if not assignable

### DIFF
--- a/src/go/types/conversions.go
+++ b/src/go/types/conversions.go
@@ -86,7 +86,7 @@ func (check *Checker) conversion(x *operand, T Type) {
 // exported API call, i.e., when all methods have been type-checked.
 func (x *operand) convertibleTo(check *Checker, T Type, reason *string) bool {
 	// "x is assignable to T"
-	if ok, _ := x.assignableTo(check, T, nil); ok {
+	if ok, _ := x.assignableTo(check, T, reason); ok {
 		return true
 	}
 


### PR DESCRIPTION
Prior to this change the code below would produce an error `cannot
convert (T literal) (value of type T) to I`:

```
type I interface{ Do() }
type T struct{}

var _ = I(T{})
```

After this change, the error is expanded to include `(missing method
Do)`, which is also what Go compiler outputs.

Fixes gopherjs/gopherjs#200.