### PR TITLE
database/sql:fix SetConnMaxLifetime may not effect immediately

### DIFF
--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -1037,15 +1037,16 @@ func (db *DB) SetConnMaxIdleTime(d time.Duration) {
 	}
 	db.mu.Lock()
 	defer db.mu.Unlock()
-
+	
 	// Wake cleaner up when idle time is shortened.
-	if d > 0 && d < db.maxIdleTime && db.cleanerCh != nil {
+	maxIdleTime = db.maxIdleTime
+	db.maxIdleTime = d
+	if d > 0 && d < maxIdleTime && db.cleanerCh != nil {
 		select {
 		case db.cleanerCh <- struct{}{}:
 		default:
 		}
 	}
-	db.maxIdleTime = d
 	db.startCleanerLocked()
 }
 


### PR DESCRIPTION
when wake up the cleaner, `db.maxLifetime = d` may not be set. cleaner will determine to clean or not will the old maxLifetime