### PR TITLE
debug/elf: read section contents incrementally in Section.Data()

### DIFF
--- a/src/debug/elf/file.go
+++ b/src/debug/elf/file.go
@@ -102,9 +102,7 @@ type Section struct {
 // Even if the section is stored compressed in the ELF file,
 // Data returns uncompressed data.
 func (s *Section) Data() ([]byte, error) {
-	dat := make([]byte, s.Size)
-	n, err := io.ReadFull(s.Open(), dat)
-	return dat[0:n], err
+	return io.ReadAll(s.Open())
 }
 
 // stringTable reads and returns the string table given by the


### PR DESCRIPTION
io.ReadAll() ensures that memory is allocated on demand, as more
data is read from the input file. This avoids allocating arbitrary
amounts of memory upfront which can never be used because there is
not enough input data in the underlying file.

Fixes #45599
