### PR TITLE
math/big: add Copy function to *big.Int

### DIFF
--- a/src/math/big/int.go
+++ b/src/math/big/int.go
@@ -1216,3 +1216,8 @@ func (z *Int) Sqrt(x *Int) *Int {
 	z.abs = z.abs.sqrt(x.abs)
 	return z
 }
+
+// Copy returns a copy of [z].
+func (z *Int) Copy() *Int {
+	return new(Int).Set(z)
+}


### PR DESCRIPTION
This PR adds a Copy function to `*big.Int` in the package `math/big/`