### PR TITLE
Use common error on `exec.LookPath`

### DIFF
--- a/src/os/exec/lp_unix.go
+++ b/src/os/exec/lp_unix.go
@@ -42,6 +42,9 @@ func LookPath(file string) (string, error) {
 		if err == nil {
 			return file, nil
 		}
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", &Error{file, ErrNotFound}
+		}
 		return "", &Error{file, err}
 	}
 	path := os.Getenv("PATH")


### PR DESCRIPTION
LookPath is already expected to return the common `exec.ErrNotFound` error, but it does not do that when it is called with a leading `/`.

This treats the error returned by `io/fs`, so it gets properly translated to the expected and common error for such not found scenarios.

This is to prevent workarounds like https://github.com/twpayne/chezmoi/pull/1608.