### PR TITLE
runtime: fix typo

### DIFF
--- a/src/runtime/symtab.go
+++ b/src/runtime/symtab.go
@@ -408,7 +408,7 @@ type pcHeader struct {
 
 // moduledata records information about the layout of the executable
 // image. It is written by the linker. Any changes here must be
-// matched changes to the code in cmd/internal/ld/symtab.go:symtab.
+// matched changes to the code in cmd/link/internal/ld/symtab.go:symtab.
 // moduledata is stored in statically allocated non-pointer memory;
 // none of the pointers here are visible to the garbage collector.
 type moduledata struct {


### PR DESCRIPTION
filepath change from cmd/internal/ld/symtab.go to cmd/link/internal/ld/symtab.go