### PR TITLE
math/big: Support string numbers in Int.UnmarshalJSON

### DIFF
--- a/src/math/big/intmarsh.go
+++ b/src/math/big/intmarsh.go
@@ -73,8 +73,12 @@ func (x *Int) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (z *Int) UnmarshalJSON(text []byte) error {
 	// Ignore null, like in the main JSON package.
-	if string(text) == "null" {
+	if string(text) == "null" || string(text) == `""` {
 		return nil
+	}
+	// Unmarshal string number.
+	if len(text) > 2 && text[0] == '"' && text[len(text)-1] == '"' {
+		return z.UnmarshalText(text[1 : len(text)-1])
 	}
 	return z.UnmarshalText(text)
 }


### PR DESCRIPTION
Fixes #49525

This PR adds support to unmarshal json numbers in string format (e.g. `{"val":"123456789"}`) to `big.Int`.

