### PR TITLE
runtime/cgo: fix signature of crosscall_amd64 in comment

### DIFF
--- a/src/runtime/cgo/gcc_amd64.S
+++ b/src/runtime/cgo/gcc_amd64.S
@@ -12,7 +12,7 @@
 #endif
 
 /*
- * void crosscall_amd64(void (*fn)(void))
+ * void crosscall_amd64(void (*fn)(void), void (*setg_gcc)(void*), void *g)
  *
  * Calling into the 6c tool chain, where all registers are caller save.
  * Called from standard x86-64 ABI, where %rbx, %rbp, %r12-%r15


### PR DESCRIPTION
In commit 63de211014, crosscall_amd64() was changed to recieve 3
arguments, but the commet was not updated.