### PR TITLE
net/http: specifies origin of non 200 proxy status errors in the message

### DIFF
--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -1718,9 +1718,9 @@ func (t *Transport) dialConn(ctx context.Context, cm connectMethod) (pconn *pers
 			_, text, ok := strings.Cut(resp.Status, " ")
 			conn.Close()
 			if !ok {
-				return nil, errors.New("unknown status code")
+				return nil, errors.New("http: unknown status code (proxy)")
 			}
-			return nil, errors.New(text)
+			return nil, errors.New("http: " + text + " (proxy)")
 		}
 	}
 


### PR DESCRIPTION
Specifies the origin of non 200 proxy status errors in the message 

Example:
```
http: Forbidden (proxy)
```
instead of
```
Forbidden
```