### PR TITLE
reflect: update Type.Kind func doc

### DIFF
--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -98,6 +98,7 @@ type Type interface {
 	String() string
 
 	// Kind returns the specific kind of this type.
+	// If called by nil, will panic.
 	Kind() Kind
 
 	// Implements reports whether the type implements the interface type u.

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -98,7 +98,7 @@ type Type interface {
 	String() string
 
 	// Kind returns the specific kind of this type.
-	// If called by nil, will panic.
+	// If called by nil Type, will panic.
 	Kind() Kind
 
 	// Implements reports whether the type implements the interface type u.


### PR DESCRIPTION
In the reflect package, the Type.Kind func will panic if called by nil.
This PR updates the doc to make it clear.