### PR TITLE
cmd/go: allow a package that ends with _test having an internal test package

### DIFF
--- a/src/cmd/go/testdata/script/test_issue45477.txt
+++ b/src/cmd/go/testdata/script/test_issue45477.txt
@@ -1,0 +1,12 @@
+[short] skip  # links and runs a test binary
+
+go test -v .
+
+-- go.mod --
+module example.com/pkg_test
+
+-- pkg.go --
+package pkg_test
+
+-- pkg_test.go --
+package pkg_test

--- a/src/go/build/build.go
+++ b/src/go/build/build.go
@@ -894,7 +894,7 @@ Found:
 
 		isTest := strings.HasSuffix(name, "_test.go")
 		isXTest := false
-		if isTest && strings.HasSuffix(pkg, "_test") {
+		if isTest && strings.HasSuffix(pkg, "_test") && p.Name != pkg {
 			isXTest = true
 			pkg = pkg[:len(pkg)-len("_test")]
 		}


### PR DESCRIPTION
Fixes #45477