### PR TITLE
io: fix typo in TestMultiWriterSingleChainFlatten

### DIFF
--- a/src/io/multi_test.go
+++ b/src/io/multi_test.go
@@ -163,7 +163,7 @@ func TestMultiWriterSingleChainFlatten(t *testing.T) {
 	mw := w
 	// chain a bunch of multiWriters
 	for i := 0; i < 100; i++ {
-		mw = MultiWriter(w)
+		mw = MultiWriter(mw)
 	}
 
 	mw = MultiWriter(w, mw, w, mw)


### PR DESCRIPTION
This PR fix a typo in function TestMultiWriterSingleChainFlatten.

Compare between 'TestMultiReaderFlatten' and 'TestMultiWriterSingleChainFlatten', I guess that it should be 'mw' instead of 'w'.
