### PR TITLE
main: add keyboard navigation to coverage reports

### DIFF
--- a/src/cmd/cover/html.go
+++ b/src/cmd/cover/html.go
@@ -301,6 +301,18 @@ const tmplHTML = `
 		if (!visible) {
 			select("file0");
 		}
+		
+		document.addEventListener("keydown", evt => {
+                        if (evt.key === "ArrowLeft" && files.selectedIndex > 0) {
+				files.selectedIndex--
+                        }
+
+                        if (evt.key === "ArrowRight" && files.selectedIndex < (files.childElementCount - 1)) {
+                                files.selectedIndex++;
+                        }
+
+                        onChange()
+                })
 	})();
 	</script>
 </html>


### PR DESCRIPTION
this commit adds simple keyboard navigation.
left arrow moves to previous file, right arrow moves to next file.
