### PR TITLE
cmd/go: fix a typo in mod_lazy_new_import.txt

### DIFF
--- a/src/cmd/go/testdata/script/mod_lazy_new_import.txt
+++ b/src/cmd/go/testdata/script/mod_lazy_new_import.txt
@@ -7,7 +7,7 @@
 #     \
 #      ---- a/y (new) ---- c
 #
-# Where a/x and x/y are disjoint packages, but both contained in module a.
+# Where a/x and a/y are disjoint packages, but both contained in module a.
 #
 # The module dependency graph initially looks like:
 #


### PR DESCRIPTION
x/y -> a/y
