### PR TITLE
spec: fix link for instantiations

### DIFF
--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -2883,7 +2883,7 @@ to use. This makes the receiver type parameters available to the method.
 
 <p>
 Syntactically, this type parameter declaration looks like an
-<a href="#Instantiantions">instantiation</a> of the receiver base type, except that
+<a href="#Instantiations">instantiation</a> of the receiver base type, except that
 the type arguments are the type parameters being declared, one for each type parameter
 of the receiver base type.
 The type parameter names do not need to match their corresponding parameter names in the


### PR DESCRIPTION
This change corrects the link `Instantiantions` to `Instantiations` in the spec.