### PR TITLE
math/rand: improve performance by adding rand.Int31n(n) into rand.Int63n(n)

### DIFF
--- a/src/math/rand/rand.go
+++ b/src/math/rand/rand.go
@@ -112,6 +112,9 @@ func (r *Rand) Int63n(n int64) int64 {
 	if n&(n-1) == 0 { // n is power of two, can mask
 		return r.Int63() & (n - 1)
 	}
+	if n<=1<<31-1{
+		return int64(Int31n(int32(n)))
+	}
 	max := int64((1 << 63) - 1 - (1<<63)%uint64(n))
 	v := r.Int63()
 	for v > max {


### PR DESCRIPTION
Int31n(n) is faster than Int63n(n) when 0<n<=1-31-1 . while we use Int63n(n) to generate a pseudo-random number in this scenario which 0<n and n<=1<<31-1,using Int31n(n) is more recommended.