### PR TITLE
cmd/cgo: add line info for return statements

### DIFF
--- a/src/cmd/cgo/gcc.go
+++ b/src/cmd/cgo/gcc.go
@@ -812,6 +812,7 @@ func (p *Package) rewriteCall(f *File, call *Call) (string, bool) {
 
 	params := name.FuncType.Params
 	args := call.Call.Args
+	end := call.Call.End()
 
 	// Avoid a crash if the number of arguments doesn't match
 	// the number of parameters.
@@ -959,7 +960,7 @@ func (p *Package) rewriteCall(f *File, call *Call) (string, bool) {
 	if nu {
 		needsUnsafe = true
 	}
-	sb.WriteString(gofmtLine(m))
+	sb.WriteString(gofmtPos(m, end))
 
 	sb.WriteString("(")
 	for i := range params {


### PR DESCRIPTION
When calling a C function, line information will be
incorrect if the function call's closing parenthesis
is not on the same line as the last argument. We add
a comment with the line info for the return statement
to guide debuggers to the correct line.

Fixes #49839.