### PR TITLE
benchmark timeout when benchtime set too long 

### DIFF
--- a/src/testing/benchmark.go
+++ b/src/testing/benchmark.go
@@ -326,7 +326,13 @@ func (b *B) launch() {
 			// Run more iterations than we think we'll need (1.2x).
 			n += n / 5
 			// Don't grow too fast in case we had timing errors previously.
-			n = min(n, 100*last)
+			if n < 0 {
+				// If n < 0 (overflow int64), means need to be executed many times,
+				// Otherwise it is easy to time out.
+				n = max(n, 100*last)
+			} else {
+				n = min(n, 100*last)
+			}
 			// Be sure to run at least one more than last time.
 			n = max(n, last+1)
 			// Don't run more than 1e9 times. (This also keeps n in int range on 32 bit platforms.)


### PR DESCRIPTION
When benchmark function execute time is very short, set benchtime=5s / 10s / 20s is ok.
```
BenchmarkNewObject-2            1000000000               0.279 ns/op
```
But set benchtime=120s will execute time out.

```
*** Test killed with quit: ran too long (11m0s).
```

![image](https://user-images.githubusercontent.com/6935924/144583081-d8b4f059-d53b-46f2-88d0-658ed0566179.png)

1. benchtime short
The `B.n` maybe 1 , 100 , 10000, 1000000,  100000000, 100000000 and exist.

2. benchtime long
But set  benchtime=120s,  `n = goalns * prevIters / prevns` may be **overflow**(< 0) int64, and the `B.n` maybe 1, 100, 10000, 1000000, 100000000, 100000001, 100000002 .... and timeout.
