### PR TITLE
runtime: add missing //go:nosplit for Windows context methods

### DIFF
--- a/src/runtime/defs_windows_386.go
+++ b/src/runtime/defs_windows_386.go
@@ -46,14 +46,20 @@ type context struct {
 	extendedregisters [512]uint8
 }
 
+//go:nosplit
 func (c *context) ip() uintptr { return uintptr(c.eip) }
+//go:nosplit
 func (c *context) sp() uintptr { return uintptr(c.esp) }
 
 // 386 does not have link register, so this returns 0.
+//go:nosplit
 func (c *context) lr() uintptr      { return 0 }
+//go:nosplit
 func (c *context) set_lr(x uintptr) {}
 
+//go:nosplit
 func (c *context) set_ip(x uintptr) { c.eip = uint32(x) }
+//go:nosplit
 func (c *context) set_sp(x uintptr) { c.esp = uint32(x) }
 
 func dumpregs(r *context) {

--- a/src/runtime/defs_windows_amd64.go
+++ b/src/runtime/defs_windows_amd64.go
@@ -60,14 +60,20 @@ type context struct {
 	lastexceptionfromrip uint64
 }
 
+//go:nosplit
 func (c *context) ip() uintptr { return uintptr(c.rip) }
+//go:nosplit
 func (c *context) sp() uintptr { return uintptr(c.rsp) }
 
 // AMD64 does not have link register, so this returns 0.
+//go:nosplit
 func (c *context) lr() uintptr      { return 0 }
+//go:nosplit
 func (c *context) set_lr(x uintptr) {}
 
+//go:nosplit
 func (c *context) set_ip(x uintptr) { c.rip = uint64(x) }
+//go:nosplit
 func (c *context) set_sp(x uintptr) { c.rsp = uint64(x) }
 
 func dumpregs(r *context) {

--- a/src/runtime/defs_windows_arm.go
+++ b/src/runtime/defs_windows_arm.go
@@ -50,12 +50,18 @@ type context struct {
 	padding2 [2]uint32
 }
 
+//go:nosplit
 func (c *context) ip() uintptr { return uintptr(c.pc) }
+//go:nosplit
 func (c *context) sp() uintptr { return uintptr(c.spr) }
+//go:nosplit
 func (c *context) lr() uintptr { return uintptr(c.lrr) }
 
+//go:nosplit
 func (c *context) set_ip(x uintptr) { c.pc = uint32(x) }
+//go:nosplit
 func (c *context) set_sp(x uintptr) { c.spr = uint32(x) }
+//go:nosplit
 func (c *context) set_lr(x uintptr) { c.lrr = uint32(x) }
 
 func dumpregs(r *context) {

--- a/src/runtime/defs_windows_arm64.go
+++ b/src/runtime/defs_windows_arm64.go
@@ -33,12 +33,18 @@ type context struct {
 	wvr          [2]uint64
 }
 
+//go:nosplit
 func (c *context) ip() uintptr { return uintptr(c.pc) }
+//go:nosplit
 func (c *context) sp() uintptr { return uintptr(c.xsp) }
+//go:nosplit
 func (c *context) lr() uintptr { return uintptr(c.x[30]) }
 
+//go:nosplit
 func (c *context) set_ip(x uintptr) { c.pc = uint64(x) }
+//go:nosplit
 func (c *context) set_sp(x uintptr) { c.xsp = uint64(x) }
+//go:nosplit
 func (c *context) set_lr(x uintptr) { c.x[30] = uint64(x) }
 
 func dumpregs(r *context) {


### PR DESCRIPTION
Avoid calling morestack when we handling exceptions.


