### PR TITLE
cmd/go/internal/load: prevent calling ImportErrorf when the err is *module.InvalidPathError

### DIFF
--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -1857,12 +1857,26 @@ func (p *Package) load(ctx context.Context, opts PackageOpts, path string, stk *
 	if other := foldPath[fold]; other == "" {
 		foldPath[fold] = p.ImportPath
 	} else if other != p.ImportPath {
-		setError(ImportErrorf(p.ImportPath, "case-insensitive import collision: %q and %q", p.ImportPath, other))
+		// It is unnecessary to set an ImportPathError when the error is already
+		// a module.InvalidPathError.
+		// Beside, ImportErrorf may panic when the import path is invalid.
+		// See https://golang.org/issue/49137
+		var invalidPathErr *module.InvalidPathError
+		if !errors.As(err, &invalidPathErr) {
+			setError(ImportErrorf(p.ImportPath, "case-insensitive import collision: %q and %q", p.ImportPath, other))
+		}
 		return
 	}
 
 	if !SafeArg(p.ImportPath) {
-		setError(ImportErrorf(p.ImportPath, "invalid import path %q", p.ImportPath))
+		// It is unnecessary to set an ImportPathError when the error is already
+		// a module.InvalidPathError.
+		// Beside, ImportErrorf may panic when the import path is invalid.
+		// See https://golang.org/issue/49137
+		var invalidPathErr *module.InvalidPathError
+		if !errors.As(err, &invalidPathErr) {
+			setError(ImportErrorf(p.ImportPath, "invalid import path %q", p.ImportPath))
+		}
 		return
 	}
 

--- a/src/cmd/go/testdata/script/load_invalid_import_path.txt
+++ b/src/cmd/go/testdata/script/load_invalid_import_path.txt
@@ -1,0 +1,14 @@
+# Tests issue 49137. The following commands should not panic any way.
+
+! go list '"a"'
+stderr 'malformed import path "\\"a\\"": invalid char ''"'''
+
+! go build '' -ldflags='-X "main.Tags="'
+stderr 'malformed import path "-ldflags=-X \\"main.Tags=\\"": leading dash'
+
+-- go.mod --
+module m
+
+go 1.16
+-- main.go --
+package main

--- a/src/cmd/go/testdata/script/load_invalid_import_path.txt
+++ b/src/cmd/go/testdata/script/load_invalid_import_path.txt
@@ -1,10 +1,10 @@
 # Tests issue 49137. The following commands should not panic any way.
 
 ! go list '"a"'
-stderr 'malformed import path "\\"a\\"": invalid char ''"'''
+stderr '^malformed import path "\\"a\\"": invalid char ''"''$'
 
 ! go build '' -ldflags='-X "main.Tags="'
-stderr 'malformed import path "-ldflags=-X \\"main.Tags=\\"": leading dash'
+stderr '^malformed import path "-ldflags=-X \\"main.Tags=\\"": leading dash$'
 
 -- go.mod --
 module m


### PR DESCRIPTION
1. The call of setError is unnecessary bacause setError do nothing when
p.Error is not nil.
2. The call of ImportErrorf may panic in this situation
(double quotes appear in the import path).

Fixes #49137
