### PR TITLE
cmd/go: remove mercurial from bitbucket vcs options

### DIFF
--- a/src/cmd/go/internal/vcs/vcs.go
+++ b/src/cmd/go/internal/vcs/vcs.go
@@ -1437,8 +1437,9 @@ var vcsPaths = []*vcsPath{
 	{
 		pathPrefix: "bitbucket.org",
 		regexp:     lazyregexp.New(`^(?P<root>bitbucket\.org/(?P<bitname>[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+))(/[A-Za-z0-9_.\-]+)*$`),
+		vcs:        "git",
 		repo:       "https://{root}",
-		check:      bitbucketVCS,
+		check:      noVCSSuffix,
 	},
 
 	// IBM DevOps Services (JazzHub)
@@ -1508,56 +1509,6 @@ func noVCSSuffix(match map[string]string) error {
 		}
 	}
 	return nil
-}
-
-// bitbucketVCS determines the version control system for a
-// Bitbucket repository, by using the Bitbucket API.
-func bitbucketVCS(match map[string]string) error {
-	if err := noVCSSuffix(match); err != nil {
-		return err
-	}
-
-	var resp struct {
-		SCM string `json:"scm"`
-	}
-	url := &urlpkg.URL{
-		Scheme:   "https",
-		Host:     "api.bitbucket.org",
-		Path:     expand(match, "/2.0/repositories/{bitname}"),
-		RawQuery: "fields=scm",
-	}
-	data, err := web.GetBytes(url)
-	if err != nil {
-		if httpErr, ok := err.(*web.HTTPError); ok && httpErr.StatusCode == 403 {
-			// this may be a private repository. If so, attempt to determine which
-			// VCS it uses. See issue 5375.
-			root := match["root"]
-			for _, vcs := range []string{"git", "hg"} {
-				if vcsByCmd(vcs).Ping("https", root) == nil {
-					resp.SCM = vcs
-					break
-				}
-			}
-		}
-
-		if resp.SCM == "" {
-			return err
-		}
-	} else {
-		if err := json.Unmarshal(data, &resp); err != nil {
-			return fmt.Errorf("decoding %s: %v", url, err)
-		}
-	}
-
-	if vcsByCmd(resp.SCM) != nil {
-		match["vcs"] = resp.SCM
-		if resp.SCM == "git" {
-			match["repo"] += ".git"
-		}
-		return nil
-	}
-
-	return fmt.Errorf("unable to detect version control system for bitbucket.org/ path")
 }
 
 // launchpadVCS solves the ambiguity for "lp.net/project/foo". In this case,

--- a/src/cmd/go/internal/vcs/vcs.go
+++ b/src/cmd/go/internal/vcs/vcs.go
@@ -6,7 +6,6 @@ package vcs
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	exec "internal/execabs"

--- a/src/cmd/go/internal/vcs/vcs_test.go
+++ b/src/cmd/go/internal/vcs/vcs_test.go
@@ -5,7 +5,6 @@
 package vcs
 
 import (
-	"cmd/go/internal/web"
 	"errors"
 	"fmt"
 	"internal/testenv"
@@ -13,6 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"cmd/go/internal/web"
 )
 
 func init() {

--- a/src/cmd/go/internal/vcs/vcs_test.go
+++ b/src/cmd/go/internal/vcs/vcs_test.go
@@ -5,6 +5,7 @@
 package vcs
 
 import (
+	"cmd/go/internal/web"
 	"errors"
 	"fmt"
 	"internal/testenv"
@@ -12,8 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"cmd/go/internal/web"
 )
 
 func init() {
@@ -182,6 +181,13 @@ func TestRepoRootForImportPath(t *testing.T) {
 		{
 			"chiselapp.com/user/kyle/fossilgg",
 			nil,
+		},
+		{
+			"bitbucket.org/workspace/pkgname",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://bitbucket.org/workspace/pkgname",
+			},
 		},
 	}
 


### PR DESCRIPTION
Mercurial was deprecated as of July 1, 2020 as per https://bitbucket.org/blog/sunsetting-mercurial-support-in-bitbucket
