### PR TITLE
cmd/link: don't generate typedef DWARF entry for noalg.struct{...}

### DIFF
--- a/src/cmd/link/internal/ld/dwarf.go
+++ b/src/cmd/link/internal/ld/dwarf.go
@@ -471,6 +471,11 @@ func (d *dwctxt) dotypedef(parent *dwarf.DWDie, name string, def *dwarf.DWDie) *
 	if strings.HasPrefix(name, "struct {") {
 		return nil
 	}
+	// cmd/compile uses "noalg.struct {...}" as type name when hash and eq algorithm generation of
+	// this struct type is suppressed.
+	if strings.HasPrefix(name, "noalg.struct {") {
+		return nil
+	}
 	if strings.HasPrefix(name, "chan ") {
 		return nil
 	}


### PR DESCRIPTION
cmd/compile uses "noalg.struct {...}" as type name when hash and eq algorithm generation of this struct type is suppressed. This should be treated as normal struct type, that is, link shouldn't generate DW_TAG_typedef DIE for it.