### PR TITLE
src/fmt: misuse of different kind of ticks together is corrected

### DIFF
--- a/src/fmt/print.go
+++ b/src/fmt/print.go
@@ -55,7 +55,7 @@ type Formatter interface {
 }
 
 // Stringer is implemented by any value that has a String method,
-// which defines the ``native'' format for that value.
+// which defines the 'native' format for that value.
 // The String method is used to print values passed as an operand
 // to any format that accepts a string or to an unformatted printer
 // such as Print.


### PR DESCRIPTION
misuse of different kind of ticks together is corrected