### PR TITLE
doc/go1.18: fix broken HTML in net/http.MaxBytesHandler

### DIFF
--- a/doc/go1.18.html
+++ b/doc/go1.18.html
@@ -728,7 +728,7 @@ Do not send CLs removing the interior tags from such phrases.
     <p><!-- CL 346569 -->
       The new
       <a href="/pkg/net/http#MaxBytesHandler"><code>MaxBytesHandler</code></a>
-      function creates a <code>Handler</p>code> that wraps its
+      function creates a <code>Handler</code> that wraps its
       <code>ResponseWriter</code> and <code>Request.Body</code> with a
       <a href="/pkg/net/http#MaxBytesReader"><code>MaxBytesReader</code></a>.
     </p>


### PR DESCRIPTION
For #47694

Sorry about that! I guess the autocompleter in VSCode auto-closed the paragraph and I didn't notice.