### PR TITLE
cmd/go/internal/mvs: Delete redundant searching  for maximum version when building minimal requirement list

### DIFF
--- a/src/cmd/go/internal/mvs/mvs.go
+++ b/src/cmd/go/internal/mvs/mvs.go
@@ -194,6 +194,11 @@ func Req(mainModule module.Version, base []string, reqs Reqs) ([]module.Version,
 	// that list came from a previous operation that paged
 	// in all the requirements, so there's no I/O to overlap now.
 
+	max := map[string]string{}
+	for _, m := range list {
+		max[m.Path] = m.Version
+	}
+
 	// Compute postorder, cache requirements.
 	var postorder []module.Version
 	reqCache := map[module.Version][]module.Version{}
@@ -235,14 +240,6 @@ func Req(mainModule module.Version, base []string, reqs Reqs) ([]module.Version,
 			walk(m1)
 		}
 		return nil
-	}
-	max := map[string]string{}
-	for _, m := range list {
-		if v, ok := max[m.Path]; ok {
-			max[m.Path] = reqs.Max(m.Version, v)
-		} else {
-			max[m.Path] = m.Version
-		}
 	}
 	// First walk the base modules that must be listed.
 	var min []module.Version


### PR DESCRIPTION
mvs.Req performs an unnecessary search for the maximum version when building minimal requirement list. Someone may be confused when reading this piece of code. The comment of the BuildList function also states that the build list contains the maximum version of each module. We just need to create a maximum version cache that maps from path to version, in the beginning of the Req function body.
