### PR TITLE
net/http: add client option to retain the auth/cookie headers

### DIFF
--- a/src/net/http/client.go
+++ b/src/net/http/client.go
@@ -104,6 +104,10 @@ type Client struct {
 	// RoundTripper implementations should use the Request's Context
 	// for cancellation instead of implementing CancelRequest.
 	Timeout time.Duration
+
+	// RetainHeaders indicates whether to keep the auth/cookie headers when redirect across different primary domains.
+	// For example, if you want to retain the auth/cookie headers after redirecting from a.com to b.com, set it to true.
+	RetainHeaders bool
 }
 
 // DefaultClient is the default Client and is used by Get, Head, and Post.
@@ -797,9 +801,15 @@ func (c *Client) makeHeadersCopier(ireq *Request) func(*Request) {
 		}
 
 		// Copy the initial request's Header values
-		// (at least the safe ones).
-		for k, vv := range ireqhdr {
-			if shouldCopyHeaderOnRedirect(k, preq.URL, req.URL) {
+		// (at least the safe ones when Client.RetainHeaders is false).
+		if !c.RetainHeaders {
+			for k, vv := range ireqhdr {
+				if shouldCopyHeaderOnRedirect(k, preq.URL, req.URL) {
+					req.Header[k] = vv
+				}
+			}
+		} else {
+			for k, vv := range ireqhdr {
 				req.Header[k] = vv
 			}
 		}


### PR DESCRIPTION
I added an option attribute RetainHeaders to the client struct, it indicates whether to keep the auth/cookie headers(Authorization, Www-Authenticate, Cookie, Cookie2 in function shouldCopyHeaderOnRedirect) when redirect across different primary domains.

For example, if you want to retain the auth/cookie headers after redirecting from a.com to b.com, set it to true.

In fact, this is just needed when the system migrates to a new primary domain name and is compatible with downstream applications (redirection is configured), especially for some interfaces that require secure header parameters, such as oauth2 / token, these headers cannot be discarded.