### PR TITLE
os/env: provide a way to get a default value if env variable is not present

### DIFF
--- a/src/os/env.go
+++ b/src/os/env.go
@@ -104,6 +104,16 @@ func Getenv(key string) string {
 	return v
 }
 
+// Getenv retrieves the value of the environment variable 
+// named by the key if key is present. Returns the defaultValue otherwise.
+func GetenvOrDefault(key string, defaultValue string) string {
+	v, ok := LookupEnv(key)
+	if !ok {
+		return defaultValue
+	}
+	return v
+}
+
 // LookupEnv retrieves the value of the environment variable named
 // by the key. If the variable is present in the environment the
 // value (which may be empty) is returned and the boolean is true.


### PR DESCRIPTION
This is useful when loading non-strings and we need to convert that same value to something else (usually int64), to avoid methods like strconv.ParseInt(...) from crashing if the string is empty, we can use this method to automally asign a default value (let's say zero or 123)