### PR TITLE
cmd/go: add `go mod update` command

### DIFF
--- a/src/cmd/go/internal/modcmd/mod.go
+++ b/src/cmd/go/internal/modcmd/mod.go
@@ -26,6 +26,7 @@ See 'go help modules' for an overview of module functionality.
 		cmdGraph,
 		cmdInit,
 		cmdTidy,
+		cmdUpdate,
 		cmdVendor,
 		cmdVerify,
 		cmdWhy,

--- a/src/cmd/go/internal/modcmd/update.go
+++ b/src/cmd/go/internal/modcmd/update.go
@@ -1,0 +1,16 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package modcmd
+
+import (
+	"cmd/go/internal/modget"
+)
+
+var cmdUpdate = modget.CmdGet
+
+func init() {
+	cmdUpdate.UsageLine = "go mod update [-t] [-u] [-v] [build flags] [packages]"
+	cmdUpdate.Run = modget.RunGet
+}

--- a/src/cmd/go/internal/modget/get.go
+++ b/src/cmd/go/internal/modget/get.go
@@ -248,11 +248,11 @@ func (v *upgradeFlag) String() string { return "" }
 
 func init() {
 	work.AddBuildFlags(CmdGet, work.OmitModFlag)
-	CmdGet.Run = runGet // break init loop
+	CmdGet.Run = RunGet // break init loop
 	CmdGet.Flag.Var(&getU, "u", "")
 }
 
-func runGet(ctx context.Context, cmd *base.Command, args []string) {
+func RunGet(ctx context.Context, cmd *base.Command, args []string) {
 	switch getU.version {
 	case "", "upgrade", "patch":
 		// ok


### PR DESCRIPTION
This change adds an 'update' command to 'go mod' for updating module dependencies.

Fixes #44726

New help output!

```
$ go help mod
Go mod provides access to operations on modules.

Note that support for modules is built into all the go commands,
not just 'go mod'. For example, day-to-day adding, removing, upgrading,
and downgrading of dependencies should be done using 'go get'.
See 'go help modules' for an overview of module functionality.

Usage:

        go mod <command> [arguments]

The commands are:

        download    download modules to local cache
        edit        edit go.mod from tools or scripts
        graph       print module requirement graph
        init        initialize new module in current directory
        tidy        add missing and remove unused modules
        update      add dependencies to current module and install them
        vendor      make vendored copy of dependencies
        verify      verify dependencies have expected content
        why         explain why packages or modules are needed

Use "go help mod <command>" for more information about a command.
```

This is my first contribution so if I messed anything up, please let me know!