### PR TITLE
cmd/vendor: fix typo in report.go

### DIFF
--- a/src/cmd/vendor/github.com/google/pprof/internal/report/report.go
+++ b/src/cmd/vendor/github.com/google/pprof/internal/report/report.go
@@ -293,7 +293,7 @@ func (rpt *Report) newGraph(nodes graph.NodeSet) *graph.Graph {
 	return graph.New(rpt.prof, gopt)
 }
 
-// printProto writes the incoming proto via thw writer w.
+// printProto writes the incoming proto via the writer w.
 // If the divide_by option has been specified, samples are scaled appropriately.
 func printProto(w io.Writer, rpt *Report) error {
 	p, o := rpt.prof, rpt.options


### PR DESCRIPTION
thw -> the
