### PR TITLE
cmd/go: cache coverage profile with tests

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -1800,8 +1800,9 @@
 //
 // The rule for a match in the cache is that the run involves the same
 // test binary and the flags on the command line come entirely from a
-// restricted set of 'cacheable' test flags, defined as -benchtime, -cpu,
-// -list, -parallel, -run, -short, -timeout, -failfast, and -v.
+// restricted set of 'cacheable' test flags, defined as -benchtime, -cover,
+// -covermode, -coverprofile, -cpu, -list, -parallel, -run, -short, -timeout,
+// -failfast, -v, -vet and -outputdir.
 // If a run of go test has any test or non-test flags outside this set,
 // the result is not cached. To disable test caching, use any test flag
 // or argument other than the cacheable flags. The idiomatic way to disable

--- a/src/cmd/go/go_test.go
+++ b/src/cmd/go/go_test.go
@@ -2448,9 +2448,9 @@ func TestCacheCoverage(t *testing.T) {
 }
 
 func TestCacheCoverageProfile(t *testing.T) {
-	tooSlow(t)
+	tooSlow(t, "links and runs a test binary multiple times with coverage enabled")
 
-	if godebug.Get("gocacheverify") == "1" {
+	if gocacheverify.Value() == "1" {
 		t.Skip("GODEBUG gocacheverify")
 	}
 

--- a/src/cmd/go/internal/test/cover.go
+++ b/src/cmd/go/internal/test/cover.go
@@ -44,10 +44,9 @@ func initCoverProfile() {
 }
 
 // mergeCoverProfile merges file into the profile stored in testCoverProfile.
-// It prints any errors it encounters to ew.
-func mergeCoverProfile(ew io.Writer, file string) {
+func mergeCoverProfile(file string) error {
 	if coverMerge.f == nil {
-		return
+		return nil
 	}
 	coverMerge.Lock()
 	defer coverMerge.Unlock()
@@ -57,22 +56,22 @@ func mergeCoverProfile(ew io.Writer, file string) {
 	r, err := os.Open(file)
 	if err != nil {
 		// Test did not create profile, which is OK.
-		return
+		return nil
 	}
 	defer r.Close()
 
 	n, err := io.ReadFull(r, buf)
 	if n == 0 {
-		return
+		return nil
 	}
 	if err != nil || string(buf) != expect {
-		fmt.Fprintf(ew, "error: test wrote malformed coverage profile %s.\n", file)
-		return
+		return fmt.Errorf("error: test wrote malformed coverage profile %s.\n", file)
 	}
 	_, err = io.Copy(coverMerge.f, r)
 	if err != nil {
-		fmt.Fprintf(ew, "error: saving coverage profile: %v\n", err)
+		return fmt.Errorf("saving coverage profile: %v\n", err)
 	}
+	return nil
 }
 
 func closeCoverProfile() {

--- a/src/cmd/go/internal/test/cover.go
+++ b/src/cmd/go/internal/test/cover.go
@@ -67,7 +67,7 @@ func mergeCoverProfile(file string) error {
 		return nil
 	}
 	if err != nil || string(buf) != expect {
-		return fmt.Errorf("error: test wrote malformed coverage profile %s.\n", file)
+		return fmt.Errorf("test wrote malformed coverage profile %s", file)
 	}
 	m, err := io.Copy(coverMerge.f, r)
 	if err != nil {

--- a/src/cmd/go/internal/test/test.go
+++ b/src/cmd/go/internal/test/test.go
@@ -1430,6 +1430,7 @@ func (r *runTestActor) Act(b *work.Builder, ctx context.Context, a *work.Action)
 	t := fmt.Sprintf("%.3fs", time.Since(t0).Seconds())
 
 	if coverErr := mergeCoverProfile(tempCoverProfile); coverErr != nil {
+		// TODO: consider whether an error to merge cover profiles should fail the test.
 		fmt.Fprintf(cmd.Stdout, "error: %v\n", coverErr)
 	}
 
@@ -1679,6 +1680,7 @@ func (c *runCache) tryCacheWithID(b *work.Builder, a *work.Action, id string) bo
 			return false
 		}
 		if err := mergeCoverProfile(f); err != nil {
+			// TODO: consider whether an error to merge cover profiles should fail the test.
 			if cache.DebugTest {
 				fmt.Fprintf(os.Stderr, "testcache: %s: test coverage profile not merged: %v\n", a.Package.ImportPath, err)
 			}

--- a/src/cmd/go/internal/test/test.go
+++ b/src/cmd/go/internal/test/test.go
@@ -1672,7 +1672,7 @@ func (c *runCache) tryCacheWithID(b *work.Builder, a *work.Action, id string) bo
 		// The cached coverprofile has the same expiration time as the
 		// test result it corresponds to. That time is already checked
 		// above, so we can ignore the entry returned by GetFile here.
-		f, _, err := cache.Default().GetFile(testCoverProfileKey(testID, testInputsID))
+		f, _, err := cache.GetFile(cache.Default(), testCoverProfileKey(testID, testInputsID))
 		if err != nil {
 			if cache.DebugTest {
 				fmt.Fprintf(os.Stderr, "testcache: %s: test coverage profile not found: %v\n", a.Package.ImportPath, err)
@@ -1881,7 +1881,7 @@ func (c *runCache) saveOutput(a *work.Action, coverprofileFile string) {
 			fmt.Fprintf(os.Stderr, "testcache: %s: save test ID %x => input ID %x => %x\n", a.Package.ImportPath, c.id1, testInputsID, testAndInputKey(c.id1, testInputsID))
 		}
 		cache.PutNoVerify(cache.Default(), c.id1, bytes.NewReader(testlog))
-		cache.PutNoVerify(testAndInputKey(cache.Default(), c.id1, testInputsID), bytes.NewReader(a.TestOutput.Bytes()))
+		cache.PutNoVerify(cache.Default(), testAndInputKey(c.id1, testInputsID), bytes.NewReader(a.TestOutput.Bytes()))
 		saveCoverProfile(c.id1)
 	}
 	if c.id2 != (cache.ActionID{}) {

--- a/src/cmd/go/internal/test/test.go
+++ b/src/cmd/go/internal/test/test.go
@@ -1668,8 +1668,9 @@ func (c *runCache) tryCacheWithID(b *work.Builder, a *work.Action, id string) bo
 
 	// Write coverage data to profile.
 	if cfg.BuildCover {
-		// coverprofile cache expiration time should be coupled with the test data above, so
-		// the entry can be ignored.
+		// The cached coverprofile has the same expiration time as the
+		// test result it corresponds to. That time is already checked
+		// above, so we can ignore the entry returned by GetFile here.
 		f, _, err := cache.Default().GetFile(testCoverProfileKey(testID, testInputsID))
 		if err != nil {
 			if cache.DebugTest {


### PR DESCRIPTION
This CL stores coverage profile data in the GOCACHE under the
'coverprofile' subkey alongside tests. This makes tests which use
coverage profiles cacheable. The values of the -coverprofile and
-outputdir flags are not included in the cache key to allow cached
profile data to be written to any output file.

Fixes #23565
