### PR TITLE
net/http: improve documentation of a Client request

### DIFF
--- a/src/net/http/doc.go
+++ b/src/net/http/doc.go
@@ -14,7 +14,7 @@ Get, Head, Post, and PostForm make HTTP (or HTTPS) requests:
 	resp, err := http.PostForm("http://example.com/form",
 		url.Values{"key": {"Value"}, "id": {"123"}})
 
-The client must close the response body when finished with it:
+The client must read and close the response body when finished with it:
 
 	resp, err := http.Get("http://example.com/")
 	if err != nil {


### PR DESCRIPTION
The documentation of Client.Do is clear, that the it is not enough
to close the responce body. It als has to be read.

The existing first description of this case only said, that it has
to be closed.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.
