### PR TITLE
math/big: don't force second arg to Jacobi and Int.ModSqrt to escape

### DIFF
--- a/src/math/big/int.go
+++ b/src/math/big/int.go
@@ -837,7 +837,7 @@ func (z *Int) ModInverse(g, n *Int) *Int {
 // The y argument must be an odd integer.
 func Jacobi(x, y *Int) int {
 	if len(y.abs) == 0 || y.abs[0]&1 == 0 {
-		panic(fmt.Sprintf("big: invalid 2nd argument to Int.Jacobi: need odd integer but got %s", y))
+		panic(fmt.Sprintf("big: invalid 2nd argument to Int.Jacobi: need odd integer but got %s", y.String()))
 	}
 
 	// We use the formulation described in chapter 2, section 2.4,


### PR DESCRIPTION
This CL updates big.Jacobi to avoid forcing its y argument to escape
to the heap. The argument was escaping because it was being passed
through an empty interface to fmt.Sprintf during an assertion failure.
As a result, callers of Jacobi and Int.ModSqrt (which calls Jacobi)
could not keep this value on the stack.

Noticed when working on https://github.com/cockroachdb/apd/pull/103.