### PR TITLE
bufio: do not copy empty buffers while refilling

### DIFF
--- a/src/bufio/bufio.go
+++ b/src/bufio/bufio.go
@@ -92,7 +92,9 @@ var errNegativeRead = errors.New("bufio: reader returned negative count from Rea
 func (b *Reader) fill() {
 	// Slide existing data to beginning.
 	if b.r > 0 {
-		copy(b.buf, b.buf[b.r:b.w])
+		if b.r != b.w {
+			copy(b.buf, b.buf[b.r:b.w])
+		}
 		b.w -= b.r
 		b.r = 0
 	}


### PR DESCRIPTION
Avoid a copy in the `fill` function if the start and end cursors are at the same offset.