### PR TITLE
cmd/go: enable fuzz testing for FreeBSD

### DIFF
--- a/src/cmd/internal/sys/supported.go
+++ b/src/cmd/internal/sys/supported.go
@@ -50,7 +50,7 @@ func ASanSupported(goos, goarch string) bool {
 // ('go test -fuzz=.').
 func FuzzSupported(goos, goarch string) bool {
 	switch goos {
-	case "darwin", "linux", "windows":
+	case "darwin", "freebsd", "linux", "windows":
 		return true
 	default:
 		return false

--- a/src/internal/fuzz/minimize_test.go
+++ b/src/internal/fuzz/minimize_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build darwin || linux || windows
+//go:build darwin || freebsd || linux || windows
 
 package fuzz
 

--- a/src/internal/fuzz/sys_posix.go
+++ b/src/internal/fuzz/sys_posix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build darwin || linux
+//go:build darwin || freebsd || linux
 
 package fuzz
 

--- a/src/internal/fuzz/sys_unimplemented.go
+++ b/src/internal/fuzz/sys_unimplemented.go
@@ -4,7 +4,7 @@
 
 // If you update this constraint, also update cmd/internal/sys.FuzzSupported.
 //
-//go:build !darwin && !linux && !windows
+//go:build !darwin && !freebsd && !linux && !windows
 
 package fuzz
 


### PR DESCRIPTION
Add "freebsd" to GOOS for which sys.FuzzSupported() returns true.

Fixes: #46554

