### PR TITLE
hash/maphash: flush the buffer during Sum64

### DIFF
--- a/src/hash/maphash/maphash.go
+++ b/src/hash/maphash/maphash.go
@@ -181,11 +181,8 @@ func (h *Hash) Reset() {
 	h.n = 0
 }
 
-// precondition: buffer is full.
+// Updates the sum with the contents of the buffer.
 func (h *Hash) flush() {
-	if h.n != len(h.buf) {
-		panic("maphash: flush of partially full buffer")
-	}
 	h.initSeed()
 	h.state.s = rthash(&h.buf[0], h.n, h.state.s)
 	h.n = 0
@@ -199,8 +196,8 @@ func (h *Hash) flush() {
 // independently distributed, so it can be safely reduced
 // by using bit masking, shifting, or modular arithmetic.
 func (h *Hash) Sum64() uint64 {
-	h.initSeed()
-	return rthash(&h.buf[0], h.n, h.state.s)
+	h.flush()
+	return h.state.s
 }
 
 // MakeSeed returns a new random seed.

--- a/src/hash/maphash/maphash_test.go
+++ b/src/hash/maphash/maphash_test.go
@@ -218,87 +218,18 @@ func benchmarkSize(b *testing.B, size int) {
 	}
 }
 
-func benchmarkChunked(b *testing.B, size int, chunk int) {
-	h := &Hash{}
-	buf := make([]byte, size)
-	b.SetBytes(int64(size))
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		h.Reset()
-
-		start := 0
-
-		// Write and sum based on the chunk size
-		for end := chunk; end < size; end += chunk {
-			h.Write(buf[start:end])
-			h.Sum64()
-
-			start = end
-		}
-
-		// Write the remainder of the buffer
-		h.Write(buf[start:])
-		h.Sum64()
-	}
-}
-
-func benchmarkRepeat(b *testing.B, size int, times int) {
-	h := &Hash{}
-	buf := make([]byte, size)
-	b.SetBytes(int64(size))
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		h.Reset()
-		h.Write(buf)
-
-		for i := 0; i < times; i += 1 {
-			h.Sum64()
-		}
-	}
-}
-
 func BenchmarkHash8Bytes(b *testing.B) {
 	benchmarkSize(b, 8)
-}
-
-func BenchmarkHash8BytesRepeat(b *testing.B) {
-	benchmarkRepeat(b, 8, 8)
 }
 
 func BenchmarkHash320Bytes(b *testing.B) {
 	benchmarkSize(b, 320)
 }
 
-func BenchmarkHash320BytesRepeat(b *testing.B) {
-	benchmarkRepeat(b, 320, 8)
-}
-
-func BenchmarkHash320BytesChunked(b *testing.B) {
-	benchmarkChunked(b, 320, 100)
-}
-
 func BenchmarkHash1K(b *testing.B) {
 	benchmarkSize(b, 1024)
 }
 
-func BenchmarkHash1KRepeat(b *testing.B) {
-	benchmarkRepeat(b, 1024, 8)
-}
-
-func BenchmarkHash1KChunked(b *testing.B) {
-	benchmarkChunked(b, 1024, 100)
-}
-
 func BenchmarkHash8K(b *testing.B) {
 	benchmarkSize(b, 8192)
-}
-
-func BenchmarkHash8KRepeat(b *testing.B) {
-	benchmarkRepeat(b, 8192, 8)
-}
-
-func BenchmarkHash8KChunked(b *testing.B) {
-	benchmarkChunked(b, 8192, 100)
 }

--- a/src/hash/maphash/maphash_test.go
+++ b/src/hash/maphash/maphash_test.go
@@ -218,18 +218,87 @@ func benchmarkSize(b *testing.B, size int) {
 	}
 }
 
+func benchmarkChunked(b *testing.B, size int, chunk int) {
+	h := &Hash{}
+	buf := make([]byte, size)
+	b.SetBytes(int64(size))
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		h.Reset()
+
+		start := 0
+
+		// Write and sum based on the chunk size
+		for end := chunk; end < size; end += chunk {
+			h.Write(buf[start:end])
+			h.Sum64()
+
+			start = end
+		}
+
+		// Write the remainder of the buffer
+		h.Write(buf[start:])
+		h.Sum64()
+	}
+}
+
+func benchmarkRepeat(b *testing.B, size int, times int) {
+	h := &Hash{}
+	buf := make([]byte, size)
+	b.SetBytes(int64(size))
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		h.Reset()
+		h.Write(buf)
+
+		for i := 0; i < times; i += 1 {
+			h.Sum64()
+		}
+	}
+}
+
 func BenchmarkHash8Bytes(b *testing.B) {
 	benchmarkSize(b, 8)
+}
+
+func BenchmarkHash8BytesRepeat(b *testing.B) {
+	benchmarkRepeat(b, 8, 8)
 }
 
 func BenchmarkHash320Bytes(b *testing.B) {
 	benchmarkSize(b, 320)
 }
 
+func BenchmarkHash320BytesRepeat(b *testing.B) {
+	benchmarkRepeat(b, 320, 8)
+}
+
+func BenchmarkHash320BytesChunked(b *testing.B) {
+	benchmarkChunked(b, 320, 100)
+}
+
 func BenchmarkHash1K(b *testing.B) {
 	benchmarkSize(b, 1024)
 }
 
+func BenchmarkHash1KRepeat(b *testing.B) {
+	benchmarkRepeat(b, 1024, 8)
+}
+
+func BenchmarkHash1KChunked(b *testing.B) {
+	benchmarkChunked(b, 1024, 100)
+}
+
 func BenchmarkHash8K(b *testing.B) {
 	benchmarkSize(b, 8192)
+}
+
+func BenchmarkHash8KRepeat(b *testing.B) {
+	benchmarkRepeat(b, 8192, 8)
+}
+
+func BenchmarkHash8KChunked(b *testing.B) {
+	benchmarkChunked(b, 8192, 100)
 }


### PR DESCRIPTION
Multiple calls to Sum64() will recompute the hash for any 
contents in the 128 byte buffer, resulting in worse performance.
This change saves the updated hash state by calling flush().

My application computes a running hash, repeating `WriteString()` and `Sum64()` calls. Currently, bytes within the buffer are fed into `rthash` on each `Sum64()` call and the resulting state is discarded. This means the next `Sum64()` call will rehash those bytes, continuing until the buffer is filled and flushed.

Writing and hashing 100 bytes at a time, 1k total:
```
before:         	 5441156	       217.3 ns/op	4711.47 MB/s
after:          	 7531274	       155.9 ns/op	6569.08 MB/s
```

In addition, my application would call `Sum64()` without actually writing any new data. Currently, bytes in the buffer are rehashed each time. My work-around is to cache the sum myself, repopulating it each time new data is written to the hash. This is kind of annoying and almost completely defeats the purpose of the buffer.

Hashing 1k bytes, then calling Sum64() 8 times:
```
before:          	 8607100	       138.2 ns/op	7408.88 MB/s
after:           	12039759	       107.4 ns/op	9536.97 MB/s
```

1024 is actually a multiple of 128, so you would think there would be no data in the buffer and thus no performance hit. However the last 128 bytes actually gets copied to the buffer, which seems completely unnecessary. [This](https://cs.opensource.google/go/go/+/refs/tags/go1.17.6:src/hash/maphash/maphash.go;l=118) should be changed to `>=`.

And finally the original benchmark, hashing 1k bytes, then calling Sum64():
```
before:                 	13830176	        85.37 ns/op	11994.99 MB/s
after:                  	13324110	        86.77 ns/op	11801.60 MB/s
```