### PR TITLE
os: add examples for Mkdir and MkdirAll

### DIFF
--- a/src/os/example_test.go
+++ b/src/os/example_test.go
@@ -241,3 +241,25 @@ func ExampleWriteFile() {
 		log.Fatal(err)
 	}
 }
+
+func ExampleMkdir() {
+	err := os.Mkdir("testdir", 0750)
+	if err != nil && !os.IsExist(err) {
+		log.Fatal(err)
+	}
+	err = os.WriteFile("testdir/testfile.txt", []byte("Hello, Gophers!"), 0660)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func ExampleMkdirAll() {
+	err := os.MkdirAll("test/subdir", 0750)
+	if err != nil && !os.IsExist(err) {
+		log.Fatal(err)
+	}
+	err = os.WriteFile("test/subdir/testfile.txt", []byte("Hello, Gophers!"), 0660)
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
Provides example using value for the perm argument that matches the value set by the mkdir command on MacOS and Linux.