### PR TITLE
internal/cpu,internal/bytealg: add SIMD prefix match for Index/amd64

### DIFF
--- a/src/internal/bytealg/bytealg.go
+++ b/src/internal/bytealg/bytealg.go
@@ -11,9 +11,11 @@ import (
 
 // Offsets into internal/cpu records for use in assembly.
 const (
-	offsetX86HasSSE42  = unsafe.Offsetof(cpu.X86.HasSSE42)
-	offsetX86HasAVX2   = unsafe.Offsetof(cpu.X86.HasAVX2)
-	offsetX86HasPOPCNT = unsafe.Offsetof(cpu.X86.HasPOPCNT)
+	offsetX86HasSSE42    = unsafe.Offsetof(cpu.X86.HasSSE42)
+	offsetX86HasAVX2     = unsafe.Offsetof(cpu.X86.HasAVX2)
+	offsetX86HasAVX512BW = unsafe.Offsetof(cpu.X86.HasAVX512BW)
+	offsetX86HasAVX512VL = unsafe.Offsetof(cpu.X86.HasAVX512VL)
+	offsetX86HasPOPCNT   = unsafe.Offsetof(cpu.X86.HasPOPCNT)
 
 	offsetS390xHasVX = unsafe.Offsetof(cpu.S390X.HasVX)
 

--- a/src/internal/bytealg/index_amd64_test.go
+++ b/src/internal/bytealg/index_amd64_test.go
@@ -1,0 +1,70 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bytealg_test
+
+import (
+	"internal/bytealg"
+	"internal/cpu"
+	"testing"
+)
+
+type BinOpTest struct {
+	a string
+	b string
+	i int
+}
+
+var indexTests = []BinOpTest{
+	{"012345ab", "ab", 6},
+	{"012345ab", "bc", -1},
+	// evex prefx match, needle =< 32
+	{"xxxxxxxxxxxxxxxxxxxx", "ab", -1},
+	{"xxxxxxxxxxxxxxabaaaa", "ab", 14},
+	{"abcxxxxxxxxxxxxxxxxx", "abc", 0},
+	{"xxxxxxxxxxxxxxxxxxxx", "abcd", -1},
+	{"abababababababababab", "abcd", -1},
+	{"abababababababxdabxd", "abcd", -1},
+	{"abxdabababababcdabxd", "abcd", 12},
+	{"abxdabababababddabcd", "abcd", 16},
+	{"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "ab", -1},
+	{"xabxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "ab", 1},
+	{"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "abcd", -1},
+	{"abababababababababababxxxxxxxxxxxxxxbaba", "abcd", -1},
+	{"ababababababxdabaabxdaxxxxxxxxxxxxxxabxd", "abcd", -1},
+	{"ababababababxdabaabcdaxxxxxxxxxxxxxxbaba", "abcd", 17},
+	{"ababababababxdabaabxdxxxxxxxxxxxxxxxabcd", "abcd", 36},
+	{"ababababababxdabaabxdxxxxxxxxxxxababcdcd", "abcd", 34},
+	{"ababababababxdabaabxdxxxxxxxxxxxxxabxdxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxababxdxx", "abcd", -1},
+	{"ababababababxdabaabxdxxxxxxxxxxxxxabcdxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxababxdxx", "abcd", 34},
+	// len(needle) = 32
+	{"ababeeeeeeexeeeeeeeeeeeeeeeeeeeecdxxxxxx", "abeeeeeeeeeeeeeeeeeeeeeeeeeeeecd", -1},
+	{"ababeeeeeeeeeeeeeeeeeeeeeeeeeeeecdxxxxxx", "abeeeeeeeeeeeeeeeeeeeeeeeeeeeecd", 2},
+	// evex prefix match, needle > 32
+	{"ababeeeeeeeeeeeeeexxeeeeeeeeeeeeeeecdxxxxxx", "abeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeecd", -1},
+	{"ababeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeecdxxxxxx", "abeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeecd", 2},
+	{"abxxxxxxabeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeecd", "abeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeecd", 8},
+	{"ababeeeeeeeeeeeeeexxeeeeeeeeeeeeeeecdxxxxxxxxxxxxxxxxxxxxxabeeeeeeeeeeeeeexxeeeeeeeeeeeeeeecd", "abeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeecd", -1},
+	{"ababeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeecdxxxxxxxxxxxxxxxxxxxxxabeeeeeeeeeeeeeexxeeeeeeeeeeeeeeecd", "abeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeecd", 2},
+	{"ababeeeeeeeeeeeeeexxeeeeeeeeeeeeeeecdxxxxxxxxxxxxxxxxxxxxxabeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeecd", "abeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeecd", 58},
+	{"ababeeeeeeeeeeeeeexxeeeeeeeeeeeeeeecdxxxxxxxxxxxxxxxxxxxxxabeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeecdx", "abeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeecd", 58},
+	{"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxabeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeecdxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "abeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeecd", 33},
+	// len(needle) = 63
+	{"xxxxabeeeeeeeeeeeeeeeeeeeeeexeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeecdxxx", "abeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeecd", -1},
+	{"xxxxabeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeecdxxx", "abeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeecd", 4},
+}
+
+func TestIndexSIMDPrefixMatch(t *testing.T) {
+	if cpu.X86.HasAVX512VL && cpu.X86.HasAVX512BW {
+		for _, test := range indexTests {
+			a := []byte(test.a)
+			b := []byte(test.b)
+			// Valid input length of b is [2, 63]
+			actual := bytealg.Index(a, b)
+			if actual != test.i {
+				t.Errorf("Index(%q,%q) = %v; want %v", a, b, actual, test.i)
+			}
+		}
+	}
+}

--- a/src/internal/cpu/cpu.go
+++ b/src/internal/cpu/cpu.go
@@ -29,6 +29,10 @@ var X86 struct {
 	HasADX       bool
 	HasAVX       bool
 	HasAVX2      bool
+	HasAVX512    bool
+	HasAVX512F   bool
+	HasAVX512BW  bool
+	HasAVX512VL  bool
 	HasBMI1      bool
 	HasBMI2      bool
 	HasERMS      bool

--- a/src/internal/cpu/cpu_darwin.go
+++ b/src/internal/cpu/cpu_darwin.go
@@ -1,0 +1,7 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cpu
+
+const GOOS = "darwin"

--- a/src/internal/cpu/cpu_other.go
+++ b/src/internal/cpu/cpu_other.go
@@ -1,0 +1,9 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !darwin
+
+package cpu
+
+const GOOS = ""


### PR DESCRIPTION
Add SIMD prefix matching for Index. The algorithm compare the prefix
of needle(first 2 byte) against haystack using SIMD; if match found,
compare with last byte to filter out unmatch tail quickly; if still
has candicates, do full match to determine the result. It requires
EVEX mask loading for data len < 32 (cpu features: AVX512VL + AVX512BW).
