### PR TITLE
pprof: support limit the max number for dumping goroutines.

### DIFF
--- a/api/next.txt
+++ b/api/next.txt
@@ -1,0 +1,1 @@
+pkg runtime/pprof, func SetMaxDumpGoroutineNum(int)


### PR DESCRIPTION
pprof may take too much time when there are many goroutines.
The new SetMaxDumpGoroutineNum API set the max goroutine number for dumping.