### PR TITLE
mime: add .ico to builtin types

### DIFF
--- a/src/mime/type.go
+++ b/src/mime/type.go
@@ -63,6 +63,7 @@ var builtinTypesLower = map[string]string{
 	".gif":  "image/gif",
 	".htm":  "text/html; charset=utf-8",
 	".html": "text/html; charset=utf-8",
+	".ico":  "image/x-icon",
 	".jpeg": "image/jpeg",
 	".jpg":  "image/jpeg",
 	".js":   "text/javascript; charset=utf-8",


### PR DESCRIPTION
Dear go maintainer.

I added the *.ico* extension as *image/x-icon" to the *builtinTypesLower* map on the *mime* package.

I think this fits as a trivial change and did not open an issue.

There's a discussion about this mime type: some say it is `image/vnd.microsoft.icon` but I've heard the most used is `image/x-icon`, so I decided to use the latter.

This is the first time I try to contribute to `go`, I hope this PR is correct.