### PR TITLE
net/http: remove Content-Encoding in writeNotModified

### DIFF
--- a/src/net/http/fs.go
+++ b/src/net/http/fs.go
@@ -541,6 +541,7 @@ func writeNotModified(w ResponseWriter) {
 	h := w.Header()
 	delete(h, "Content-Type")
 	delete(h, "Content-Length")
+	delete(h, "Content-Encoding")
 	if h.Get("Etag") != "" {
 		delete(h, "Last-Modified")
 	}

--- a/src/net/http/fs_test.go
+++ b/src/net/http/fs_test.go
@@ -606,8 +606,9 @@ func testServeFileNotModified(t *testing.T, h2 bool) {
 	if g, e := resp.StatusCode, StatusNotModified; g != e {
 		t.Errorf("status mismatch: got %d, want %d", g, e)
 	}
-	if g, e := resp.ContentLength, int64(-1); g != e {
-		t.Errorf("Content-Length mismatch: got %d, want %d", g, e)
+	// HTTP1 transport sets ContentLength to 0.
+	if g, e1, e2 := resp.ContentLength, int64(-1), int64(0); g != e1 && g != e2 {
+		t.Errorf("Content-Length mismatch: got %d, want %d or %d", g, e1, e2)
 	}
 	if resp.Header.Get("Content-Type") != "" {
 		t.Errorf("Content-Type present, but it should not be")

--- a/src/net/http/fs_test.go
+++ b/src/net/http/fs_test.go
@@ -596,6 +596,9 @@ func testServeFileNotModified(t *testing.T, h2 bool) {
 		t.Fatal(err)
 	}
 	resp.Body.Close()
+	if g, e := resp.StatusCode, StatusNotModified; g != e {
+		t.Errorf("status mismatch: got %d, want %d", g, e)
+	}
 	if g, e := resp.ContentLength, int64(-1); g != e {
 		t.Errorf("Content-Length mismatch: got %d, want %d", g, e)
 	}

--- a/src/net/http/fs_test.go
+++ b/src/net/http/fs_test.go
@@ -595,7 +595,14 @@ func testServeFileNotModified(t *testing.T, h2 bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	b, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
+	if err != nil {
+		t.Fatal("reading Body:", err)
+	}
+	if len(b) != 0 {
+		t.Errorf("non-empty body")
+	}
 	if g, e := resp.StatusCode, StatusNotModified; g != e {
 		t.Errorf("status mismatch: got %d, want %d", g, e)
 	}


### PR DESCRIPTION
Additional header to remove if set before calling http.ServeContent.

The API of ServeContent is that one should set Content-Encoding before calling it, if the content is encoded (e.g., compressed). But then, if content has not been modified, that header should be removed, according to RFC 7232 section 4.1.