### PR TITLE
time: return ENOENT instead of ERROR_PATH_NOT_FOUND in windows

### DIFF
--- a/src/time/sys_windows.go
+++ b/src/time/sys_windows.go
@@ -16,6 +16,7 @@ func interrupt() {
 func open(name string) (uintptr, error) {
 	fd, err := syscall.Open(name, syscall.O_RDONLY, 0)
 	if err != nil {
+		//This condition solves issue 50248 (https://github.com/golang/go/issues/50248)
 		if err == syscall.ERROR_PATH_NOT_FOUND {
 			err = syscall.ENOENT
 		}

--- a/src/time/sys_windows.go
+++ b/src/time/sys_windows.go
@@ -16,7 +16,7 @@ func interrupt() {
 func open(name string) (uintptr, error) {
 	fd, err := syscall.Open(name, syscall.O_RDONLY, 0)
 	if err != nil {
-		//This condition solves issue 50248 (https://github.com/golang/go/issues/50248)
+		// This condition solves issue https://go.dev/issue/50248
 		if err == syscall.ERROR_PATH_NOT_FOUND {
 			err = syscall.ENOENT
 		}

--- a/src/time/sys_windows.go
+++ b/src/time/sys_windows.go
@@ -16,6 +16,9 @@ func interrupt() {
 func open(name string) (uintptr, error) {
 	fd, err := syscall.Open(name, syscall.O_RDONLY, 0)
 	if err != nil {
+		if err == syscall.ERROR_PATH_NOT_FOUND {
+			err = syscall.ENOENT
+		}
 		return 0, err
 	}
 	return uintptr(fd), nil


### PR DESCRIPTION
When using windows some users got a weird error (File not found) when the timezone database is not found. It happens because some methods in the time package don't treat ERROR_PATH_NOT_FOUND and ENOTDIR. To solve it was added a conversion to ENOTENT error.

Fixes #50248