### PR TITLE
net: improve error handling in dnsclient_unix.go

### DIFF
--- a/src/net/dnsclient_unix.go
+++ b/src/net/dnsclient_unix.go
@@ -57,11 +57,14 @@ func newRequest(q dnsmessage.Question) (id uint16, udpReq, tcpReq []byte, err er
 		return 0, nil, nil, err
 	}
 	tcpReq, err = b.Finish()
+	if err != nil {
+		return 0, nil, nil, err
+	}
 	udpReq = tcpReq[2:]
 	l := len(tcpReq) - 2
 	tcpReq[0] = byte(l >> 8)
 	tcpReq[1] = byte(l)
-	return id, udpReq, tcpReq, err
+	return id, udpReq, tcpReq, nil
 }
 
 func checkResponse(reqID uint16, reqQues dnsmessage.Question, respHdr dnsmessage.Header, respQues dnsmessage.Question) bool {


### PR DESCRIPTION
In the file net/dnsclient_unix.go in the function newRequest
error handling is missing after calling b.Finish(). If
the implementation of dnsmessage.Builder.Finish changes
it is theoretically possible that the missing error handling
introduces a nil pointer exception.

Fixes #50946