### PR TITLE
database/sql: use `asString` to reduce logic

### DIFF
--- a/src/database/sql/convert.go
+++ b/src/database/sql/convert.go
@@ -466,8 +466,8 @@ func convertAssignRows(dest, src any, rows *Rows) error {
 		if src == nil {
 			return fmt.Errorf("converting NULL to %s is unsupported", dv.Kind())
 		}
-		v := src.(type)
-		if v == string || v == []byte {
+		switch v := src.(type) {
+		case string, []byte:
 			dv.SetString(asString(v))
 			return nil
 		}

--- a/src/database/sql/convert.go
+++ b/src/database/sql/convert.go
@@ -466,12 +466,9 @@ func convertAssignRows(dest, src any, rows *Rows) error {
 		if src == nil {
 			return fmt.Errorf("converting NULL to %s is unsupported", dv.Kind())
 		}
-		switch v := src.(type) {
-		case string:
-			dv.SetString(v)
-			return nil
-		case []byte:
-			dv.SetString(string(v))
+		v := src.(type)
+		if v == string || v == []byte {
+			dv.SetString(asString(v))
 			return nil
 		}
 	}


### PR DESCRIPTION
Use the function `asString` to convert the type to string and keep a single
return (not two as it was in the case)

change function `convertAssignRows`