### PR TITLE
cmd/go/internal/modfetch: avoid leaking a lockedfile.File in case of write errors

### DIFF
--- a/src/cmd/go/internal/modfetch/fetch.go
+++ b/src/cmd/go/internal/modfetch/fetch.go
@@ -331,16 +331,14 @@ func hashZip(mod module.Version, zipfile, ziphashfile string) error {
 	if err != nil {
 		return err
 	}
+	// issue 50858: lockedfile.File leaked in case of write error
+	defer hf.Close()
 	if err := hf.Truncate(int64(len(hash))); err != nil {
 		return err
 	}
 	if _, err := hf.WriteAt([]byte(hash), 0); err != nil {
 		return err
 	}
-	if err := hf.Close(); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/src/cmd/go/internal/modfetch/fetch.go
+++ b/src/cmd/go/internal/modfetch/fetch.go
@@ -332,7 +332,7 @@ func hashZip(mod module.Version, zipfile, ziphashfile string) (err error) {
 		return err
 	}
 	defer func() {
-		if closeErr := hf.Close(); err != nil {
+		if closeErr := hf.Close(); err == nil && closeErr != nil {
 			err = closeErr
 		}
 	}()


### PR DESCRIPTION
The go modules download command has a method called hashZip which checks the
hash of a zipped directory versus an expected value, and then writes it out
to a file. In the event that the write operation is not successful, we do
not close the file, leading to it being leaked. This could happen if the
user runs out of disk space, causing the underlying OS write command to
return an error. Ultimately, this led to a panic in lockfile.OpenFile which
was invoked from a finalizer garbage collecting the leaked file. The result
was a stack trace that didn't show the call stack from where the write
operation actually failed.

Fixes #50858