### PR TITLE
net/dns: Increase UDP response buffer to 1232 bytes

### DIFF
--- a/src/net/dnsclient_unix.go
+++ b/src/net/dnsclient_unix.go
@@ -82,7 +82,7 @@ func dnsPacketRoundTrip(c Conn, id uint16, query dnsmessage.Question, b []byte) 
 		return dnsmessage.Parser{}, dnsmessage.Header{}, err
 	}
 
-	b = make([]byte, 512) // see RFC 1035
+	b = make([]byte, 1232) // see RFC 6891, https://dnsflagday.net/2020/
 	for {
 		n, err := c.Read(b)
 		if err != nil {

--- a/src/net/dnsclient_unix_test.go
+++ b/src/net/dnsclient_unix_test.go
@@ -881,7 +881,7 @@ func (f *fakeDNSPacketConn) Close() error {
 func TestIgnoreDNSForgeries(t *testing.T) {
 	c, s := Pipe()
 	go func() {
-		b := make([]byte, 512)
+		b := make([]byte, 1232)
 		n, err := s.Read(b)
 		if err != nil {
 			t.Error(err)


### PR DESCRIPTION
This resolves #51127 in the near term by defaulting to a larger buffer
size. This is not a permanent fix or implementation of EDNS(0) or IETF
RFC6891 (https://datatracker.ietf.org/doc/html/rfc6891).

These changes should be reviewed by someone with more experience than I.

:)

Fixes #51127 
^ hotfix only.
