### PR TITLE
mime: skip globs2 entries that are not simple file extensions

### DIFF
--- a/src/mime/testdata/test.types.globs2
+++ b/src/mime/testdata/test.types.globs2
@@ -9,3 +9,6 @@
 50:text/plain:*,v
 50:application/x-trash:*~
 30:example/do-not-use:*.t4
+10:example/glob-question-mark:*.foo?ar
+10:example/glob-asterisk:*.foo*r
+10:example/glob-range:*.foo[1-3]

--- a/src/mime/type_unix.go
+++ b/src/mime/type_unix.go
@@ -40,7 +40,7 @@ func loadMimeGlobsFile(filename string) error {
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		// Each line should be of format: weight:mimetype:*.ext[:morefields...]
+		// Each line should be of format: weight:mimetype:glob[:morefields...]
 		fields := strings.Split(scanner.Text(), ":")
 		if len(fields) < 3 || len(fields[0]) < 1 || len(fields[2]) < 3 {
 			continue
@@ -49,6 +49,18 @@ func loadMimeGlobsFile(filename string) error {
 		}
 
 		extension := fields[2][1:]
+		if strings.ContainsAny(extension, "?*[") {
+			// Not a bare extension, but a glob. Ignore for now:
+			// - we do not have an implementation for this glob
+			//   syntax (translation to path/filepath.Match could
+			//   be possible)
+			// - support for globs with weight ordering would have
+			//   performance impact to all lookups to support the
+			//   rarely seen glob entries
+			// - trying to match glob metacharacters literally is
+			//   not useful
+			continue
+		}
 		if _, ok := mimeTypes.Load(extension); ok {
 			// We've already seen this extension.
 			// The file is in weight order, so we keep

--- a/src/mime/type_unix_test.go
+++ b/src/mime/type_unix_test.go
@@ -22,13 +22,16 @@ func initMimeUnixTest(t *testing.T) {
 func TestTypeByExtensionUNIX(t *testing.T) {
 	initMimeUnixTest(t)
 	typeTests := map[string]string{
-		".T1":  "application/test",
-		".t2":  "text/test; charset=utf-8",
-		".t3":  "document/test",
-		".t4":  "example/test",
-		".png": "image/png",
-		",v":   "",
-		"~":    "",
+		".T1":       "application/test",
+		".t2":       "text/test; charset=utf-8",
+		".t3":       "document/test",
+		".t4":       "example/test",
+		".png":      "image/png",
+		",v":        "",
+		"~":         "",
+		".foo?ar":   "",
+		".foo*r":    "",
+		".foo[1-3]": "",
 	}
 
 	for ext, want := range typeTests {


### PR DESCRIPTION
The entries in globs2 can be globs beyond simple *.ext ones. We support only simple extension based matching, so skip entries that do not represent them.