### PR TITLE
reflect: fix Type to be implemented comparable

### DIFF
--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -215,6 +215,8 @@ type Type interface {
 	// It panics if the type's Kind is not Func.
 	// It panics if i is not in the range [0, NumOut()).
 	Out(i int) Type
+	
+	comparable
 
 	common() *rtype
 	uncommon() *uncommonType


### PR DESCRIPTION
The document for reflect.Type interface has described is comparable.

> Type values are comparable, such as with the == operator, so they can be used as map keys.

However, if I try to compare with a function using generics comparable, and I get a compilation error, so I implemented comparable to fix that.

https://go.dev/play/p/vPcBpD86rST?v=gotip