### PR TITLE
doc/go1.18: fix grammar error

### DIFF
--- a/doc/go1.18.html
+++ b/doc/go1.18.html
@@ -84,7 +84,7 @@ Do not send CLs removing the interior tags from such phrases.
   <li>
     The new
     <a href="/ref/spec#Predeclared_identifiers">predeclared identifier</a>
-    <code>comparable</code> is an interface the denotes the set of all types which can be
+    <code>comparable</code> is an interface that denotes the set of all types which can be
     compared using <code>==</code> or <code>!=</code>. It may only be used as (or embedded in)
     a type constraint.
   </li>


### PR DESCRIPTION
sed 's/the/that/g'

