### PR TITLE
cmd/compile/internal/types2: more consistently print "check go.mod" if language version < 1.18

### DIFF
--- a/src/cmd/compile/internal/types2/resolver.go
+++ b/src/cmd/compile/internal/types2/resolver.go
@@ -413,7 +413,7 @@ func (check *Checker) collectObjects() {
 
 			case *syntax.TypeDecl:
 				if len(s.TParamList) != 0 && !check.allowVersion(pkg, 1, 18) {
-					check.softErrorf(s.TParamList[0], "type parameters require go1.18 or later")
+					check.versionErrorf(s.TParamList[0], "go1.18", "type parameter")
 				}
 				obj := NewTypeName(s.Name.Pos(), pkg, s.Name.Value, nil)
 				check.declarePkgObj(s.Name, obj, &declInfo{file: fileScope, tdecl: s})
@@ -458,7 +458,7 @@ func (check *Checker) collectObjects() {
 					check.recordDef(s.Name, obj)
 				}
 				if len(s.TParamList) != 0 && !check.allowVersion(pkg, 1, 18) && !hasTParamError {
-					check.softErrorf(s.TParamList[0], "type parameters require go1.18 or later")
+					check.versionErrorf(s.TParamList[0], "go1.18", "type parameter")
 				}
 				info := &declInfo{file: fileScope, fdecl: s}
 				// Methods are not package-level objects but we still track them in the

--- a/src/cmd/compile/internal/types2/testdata/fixedbugs/issue47818.go2
+++ b/src/cmd/compile/internal/types2/testdata/fixedbugs/issue47818.go2
@@ -8,13 +8,13 @@
 
 package go1_17
 
-type T[P /* ERROR type parameters require go1\.18 or later */ any /* ERROR undeclared name: any \(requires version go1\.18 or later\) */ ] struct{}
+type T[P /* ERROR type parameter requires go1\.18 or later */ any /* ERROR undeclared name: any \(requires version go1\.18 or later\) */ ] struct{}
 
 // for init (and main, but we're not in package main) we should only get one error
 func init[P /* ERROR func init must have no type parameters */ any /* ERROR undeclared name: any \(requires version go1\.18 or later\) */ ]()   {}
-func main[P /* ERROR type parameters require go1\.18 or later */ any /* ERROR undeclared name: any \(requires version go1\.18 or later\) */ ]() {}
+func main[P /* ERROR type parameter requires go1\.18 or later */ any /* ERROR undeclared name: any \(requires version go1\.18 or later\) */ ]() {}
 
-func f[P /* ERROR type parameters require go1\.18 or later */ any /* ERROR undeclared name: any \(requires version go1\.18 or later\) */ ](x P) {
+func f[P /* ERROR type parameter requires go1\.18 or later */ any /* ERROR undeclared name: any \(requires version go1\.18 or later\) */ ](x P) {
 	var _ T[ /* ERROR type instantiation requires go1\.18 or later */ int]
 	var _ (T[ /* ERROR type instantiation requires go1\.18 or later */ int])
 	_ = T[ /* ERROR type instantiation requires go1\.18 or later */ int]{}

--- a/test/fixedbugs/issue51531.go
+++ b/test/fixedbugs/issue51531.go
@@ -1,0 +1,13 @@
+// errorcheck -lang=go1.17
+
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package p
+
+type empty interface{}
+
+type Foo[T empty] int // ERROR "type parameter requires go1\.18 or later \(-lang was set to go1\.17; check go.mod\)"
+
+func Bar[T empty]() {} // ERROR "type parameter requires go1\.18 or later \(-lang was set to go1\.17; check go.mod\)"


### PR DESCRIPTION
If you attempt to instantiate a generic type or func and run 'go build'
with a language version < 1.18 in the 'go' directive inside the go.mod
file, cmd/compile emits a friendly message that includes the suggestion
to 'check go.mod':

    type instantiation requires go1.18 or later (-lang was set to go1.17; check go.mod)

However, if the code instead only declares a generic type or func
without instantiating, cmd/compile currently emits a less friendly
message:

    type parameters require go1.18 or later

With this CL, the error in that situation becomes:

    type parameter requires go1.18 or later (-lang was set to go1.17; check go.mod)

Within cmd/compile/internal/types2, it already calls check.versionErrorf
in a dozen or so places, including three existing calls to
check.versionErrorf within typeset.go (e.g., for embedding a constraint
interface).

This CL adds two more calls to check.versionErrorf, replacing calls to
check.softErrorf. Both check.versionErrorf and check.softErrorf call 
check.err(at, <string>, true) after massaging the string message.

Fixes #51531