### PR TITLE
syscall: Add double quotes if parameter contain special symbols

### DIFF
--- a/src/syscall/exec_windows.go
+++ b/src/syscall/exec_windows.go
@@ -106,7 +106,7 @@ func makeCmdLine(args []string) string {
 		if len(b) > 0 {
 			b = append(b, ' ')
 		}
-		b = appendEscapeArg(b, v)
+		b = append(b, v...)
 	}
 	return string(b)
 }

--- a/src/syscall/exec_windows.go
+++ b/src/syscall/exec_windows.go
@@ -48,7 +48,7 @@ func appendEscapeArg(b []byte, s string) []byte {
 	}
 
 	needsBackslash := false
-	hasSpace := false
+	needsQuote := false
 	for i := 0; i < len(s); i++ {
 		if !needsBackslash{
 			switch s[i] {
@@ -56,26 +56,26 @@ func appendEscapeArg(b []byte, s string) []byte {
 				needsBackslash = true
 			}
 		}
-		if !hasSpace{
+		if !needsQuote{
 			switch s[i] {
 			case ' ', '\t', '!','&', '(', ')', '[', ']', '{', '}', ';', '<', '>', '|':
-				hasSpace = true
+				needsQuote = true
 			}
 		}
 	}
 
-	if !needsBackslash && !hasSpace {
+	if !needsBackslash && !needsQuote {
 		// No special handling required; normal case.
 		return append(b, s...)
 	}
 	if !needsBackslash {
-		// hasSpace is true, so we need to quote the string.
+		// needsQuote is true, so we need to quote the string.
 		b = append(b, '"')
 		b = append(b, s...)
 		return append(b, '"')
 	}
 
-	if hasSpace {
+	if needsQuote {
 		b = append(b, '"')
 	}
 	slashes := 0
@@ -94,7 +94,7 @@ func appendEscapeArg(b []byte, s string) []byte {
 		}
 		b = append(b, c)
 	}
-	if hasSpace {
+	if needsQuote {
 		for ; slashes > 0; slashes-- {
 			b = append(b, '\\')
 		}

--- a/src/syscall/exec_windows.go
+++ b/src/syscall/exec_windows.go
@@ -50,11 +50,17 @@ func appendEscapeArg(b []byte, s string) []byte {
 	needsBackslash := false
 	hasSpace := false
 	for i := 0; i < len(s); i++ {
-		switch s[i] {
-		case '"', '\\':
-			needsBackslash = true
-		case ' ', '\t':
-			hasSpace = true
+		if !needsBackslash{
+			switch s[i] {
+			case '"', '\\':
+				needsBackslash = true
+			}
+		}
+		if !hasSpace{
+			switch s[i] {
+			case ' ', '\t', '!','&', '(', ')', '[', ']', '{', '}', ';', '<', '>', '|':
+				hasSpace = true
+			}
 		}
 	}
 
@@ -106,7 +112,7 @@ func makeCmdLine(args []string) string {
 		if len(b) > 0 {
 			b = append(b, ' ')
 		}
-		b = append(b, v...)
+		b = appendEscapeArg(b, v)
 	}
 	return string(b)
 }

--- a/src/syscall/exec_windows_test.go
+++ b/src/syscall/exec_windows_test.go
@@ -39,6 +39,7 @@ func TestEscapeArg(t *testing.T) {
 		{`\\.\C:\Windows\`, `\\.\C:\Windows\`},
 		{`\\server\share\file`, `\\server\share\file`},
 		{`\\newserver\tempshare\really.txt`, `\\newserver\tempshare\really.txt`},
+		{`http:\\www.xxx.com\?a=bb&c=dd&g=[]{}<>$%`, `"http:\\www.xxx.com\?a=bb&c=dd&g=[]{}<>$%"`},
 	}
 	for _, test := range tests {
 		if got := syscall.EscapeArg(test.input); got != test.output {


### PR DESCRIPTION
i want to run cmd:`test.exe "a&b&c"`

if i run exec.Command("./test.exe", '"a&b&c"'):
appendEscapeArg will change it to `test.exe \"a&b&c\"`

if i run exec.Command("./test.exe", "a&b&c")
appendEscapeArg will not change it: `test.exe a&b&c`
it shoule be `test.exe "a&b&c"`