### PR TITLE
net/http: fix zombie connection leaked

### DIFF
--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -968,6 +968,9 @@ func (c *conn) readRequest(ctx context.Context) (w *response, err error) {
 	t0 := time.Now()
 	if d := c.server.readHeaderTimeout(); d > 0 {
 		hdrDeadline = t0.Add(d)
+	} else {
+		const headerTimeout = 30 * time.Second
+		hdrDeadline = t0.Add(headerTimeout)
 	}
 	if d := c.server.ReadTimeout; d > 0 {
 		wholeReqDeadline = t0.Add(d)
@@ -1993,7 +1996,6 @@ func (c *conn) serve(ctx context.Context) {
 				return
 			}
 		}
-		c.rwc.SetReadDeadline(time.Time{})
 	}
 }
 


### PR DESCRIPTION
When `Server.IdleTimeout` is not zero and after the first request, the client sends part of the data of a full request, and the data is no less than 4 bytes, the idle timeout which has been set will be reset to zero here and would never close the conn:
https://github.com/golang/go/blob/master/src/net/http/server.go#L1996

Fixes https://github.com/golang/go/issues/51614
