### PR TITLE
runtime: allow TestCtrlHandler to run in ConPTY

### DIFF
--- a/src/runtime/signal_windows_test.go
+++ b/src/runtime/signal_windows_test.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -112,18 +111,6 @@ func TestCtrlHandler(t *testing.T) {
 		cmd.Process.Kill()
 		cmd.Wait()
 	}()
-
-	// wait for child to be ready to receive signals
-	if line, err := outReader.ReadString('\n'); err != nil {
-		t.Fatalf("could not read stdout: %v", err)
-	} else if strings.TrimSpace(line) != "ready" {
-		t.Fatalf("unexpected message: %s", line)
-	}
-
-	// gracefully kill pid, this closes the command window
-	if err := exec.Command("taskkill.exe", "/pid", strconv.Itoa(cmd.Process.Pid)).Run(); err != nil {
-		t.Fatalf("failed to kill: %v", err)
-	}
 
 	// check child received, handled SIGTERM
 	if line, err := outReader.ReadString('\n'); err != nil {

--- a/src/runtime/testdata/testwinsignal/main.go
+++ b/src/runtime/testdata/testwinsignal/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/signal"
@@ -10,6 +11,11 @@ import (
 )
 
 func main() {
+	go func() {
+		io.Copy(io.Discard, os.Stdin)
+		log.Fatal("stdin is closed; terminating")
+	}()
+
 	// register to receive all signals
 	c := make(chan os.Signal, 1)
 	signal.Notify(c)
@@ -31,15 +37,9 @@ func main() {
 		log.Fatal("post message failed: ", err)
 	}
 
-	// check if we receive syscall.SIGTERM
-	select {
-	case sig := <-c:
-		// prentend to take some time handling the signal
-		time.Sleep(time.Second)
-		// print signal name, "terminated" makes the test succeed
-		fmt.Println(sig)
-
-	case <-time.After(time.Second):
-		log.Fatal("timed out waiting for signal")
-	}
+	sig := <-c
+	// pretend to take some time handling the signal
+	time.Sleep(time.Second)
+	// print signal name, "terminated" makes the test succeed
+	fmt.Println(sig)
 }

--- a/src/runtime/testdata/testwinsignal/main.go
+++ b/src/runtime/testdata/testwinsignal/main.go
@@ -11,6 +11,8 @@ import (
 )
 
 func main() {
+	// ensure that this process terminates when the test times out,
+	// even if the expected signal never arrives
 	go func() {
 		io.Copy(io.Discard, os.Stdin)
 		log.Fatal("stdin is closed; terminating")

--- a/src/runtime/testdata/testwinsignal/main.go
+++ b/src/runtime/testdata/testwinsignal/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 )
 
@@ -11,7 +13,21 @@ func main() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c)
 
-	fmt.Println("ready")
+	kernel32 := syscall.NewLazyDLL("kernel32.dll")
+	getConsoleWindow := kernel32.NewProc("GetConsoleWindow")
+	hwnd, _, err := getConsoleWindow.Call()
+	if hwnd == 0 {
+		log.Fatal("no associated console: ", err)
+	}
+
+	const _WM_CLOSE = 0x0010
+	user32 := syscall.NewLazyDLL("user32.dll")
+	postMessage := user32.NewProc("PostMessageW")
+	ok, _, err := postMessage.Call(hwnd, _WM_CLOSE, 0, 0)
+	if ok == 0 {
+		log.Fatal("post message failed: ", err)
+	}
+
 	sig := <-c
 
 	time.Sleep(time.Second)

--- a/src/runtime/testdata/testwinsignal/main.go
+++ b/src/runtime/testdata/testwinsignal/main.go
@@ -11,18 +11,18 @@ import (
 )
 
 func main() {
-	// ensure that this process terminates when the test times out,
-	// even if the expected signal never arrives
+	// Ensure that this process terminates when the test times out,
+	// even if the expected signal never arrives.
 	go func() {
 		io.Copy(io.Discard, os.Stdin)
 		log.Fatal("stdin is closed; terminating")
 	}()
 
-	// register to receive all signals
+	// Register to receive all signals.
 	c := make(chan os.Signal, 1)
 	signal.Notify(c)
 
-	// get console window handle
+	// Get console window handle.
 	kernel32 := syscall.NewLazyDLL("kernel32.dll")
 	getConsoleWindow := kernel32.NewProc("GetConsoleWindow")
 	hwnd, _, err := getConsoleWindow.Call()
@@ -30,7 +30,7 @@ func main() {
 		log.Fatal("no associated console: ", err)
 	}
 
-	// close console window
+	// Send message to close the console window.
 	const _WM_CLOSE = 0x0010
 	user32 := syscall.NewLazyDLL("user32.dll")
 	postMessage := user32.NewProc("PostMessageW")
@@ -40,8 +40,14 @@ func main() {
 	}
 
 	sig := <-c
-	// pretend to take some time handling the signal
+
+	// Allow some time for the handler to complete if it's going to.
+	//
+	// (In https://go.dev/issue/41884 the handler returned immediately,
+	// which caused Windows to terminate the program before the goroutine
+	// that received the SIGTERM had a chance to actually clean up.)
 	time.Sleep(time.Second)
-	// print signal name, "terminated" makes the test succeed
+
+	// Print the signal's name: "terminated" makes the test succeed.
 	fmt.Println(sig)
 }


### PR DESCRIPTION
Fixes #51602. Previous test would not run in a pseudo-console (ConPTY).

New test avoids taskkill entirely by having the child request its own
console window be closed.

Verified that this runs locally (within a real console), over SSH
(within a pseudo-console), and that it breaks if #41884 were reverted.