### PR TITLE
strings: limits allocation size for SplitN

### DIFF
--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -244,6 +244,9 @@ func genSplit(s, sep string, sepSave, n int) []string {
 		n = Count(s, sep) + 1
 	}
 
+	if n > len(s)+1 {
+		n = len(s) + 1
+	}
 	a := make([]string, n)
 	n--
 	i := 0

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"math/rand"
 	"reflect"
 	"strconv"
@@ -404,6 +405,7 @@ var splittests = []SplitTest{
 	{faces, "~", -1, []string{faces}},
 	{"1 2 3 4", " ", 3, []string{"1", "2", "3 4"}},
 	{"1 2", " ", 3, []string{"1", "2"}},
+	{"", "T", math.MaxInt / 4, []string{""}},
 }
 
 func TestSplit(t *testing.T) {


### PR DESCRIPTION
So that `strings.SplitN("", "T", int(144115188075855872))` does not panic.
