### PR TITLE
unicode/utf16: add RuneLen

### DIFF
--- a/api/next/44940.txt
+++ b/api/next/44940.txt
@@ -1,0 +1,1 @@
+pkg unicode/utf16, func RuneLen(int32) int #44940

--- a/src/unicode/utf16/utf16.go
+++ b/src/unicode/utf16/utf16.go
@@ -31,6 +31,19 @@ func IsSurrogate(r rune) bool {
 	return surr1 <= r && r < surr3
 }
 
+// RuneLen returns the number of 16-bit words required to encode the rune.
+// It returns -1 if the rune is not a valid value to encode in UTF-16.
+func RuneLen(r rune) int {
+	switch {
+	case 0 <= r && r < surr1, surr3 <= r && r < surrSelf:
+		return 1
+	case surrSelf <= r && r <= maxRune:
+		return 2
+	default:
+		return -1
+	}
+}
+
 // DecodeRune returns the UTF-16 decoding of a surrogate pair.
 // If the pair is not a valid UTF-16 surrogate pair, DecodeRune returns
 // the Unicode replacement code point U+FFFD.

--- a/src/unicode/utf16/utf16_test.go
+++ b/src/unicode/utf16/utf16_test.go
@@ -21,6 +21,31 @@ func TestConstants(t *testing.T) {
 	}
 }
 
+type runeLenTest struct {
+	r    rune
+	size int
+}
+
+var runelentests = []runeLenTest{
+	{0, 1},
+	{'e', 1},
+	{'é', 1},
+	{'😂', 2},
+	{0xD800, -1},
+	{0xDFFF, -1},
+	{MaxRune, 2},
+	{MaxRune + 1, -1},
+	{-1, -1},
+}
+
+func TestRuneLen(t *testing.T) {
+	for _, tt := range runelentests {
+		if size := RuneLen(tt.r); size != tt.size {
+			t.Errorf("RuneLen(%#U) = %d, want %d", tt.r, size, tt.size)
+		}
+	}
+}
+
 type encodeTest struct {
 	in  []rune
 	out []uint16


### PR DESCRIPTION
RuneLen returns the number of 16-bit words required to encode a rune.

Fixes #44940