### PR TITLE
os/env: Getenv add defaultValue

### DIFF
--- a/src/os/env.go
+++ b/src/os/env.go
@@ -96,12 +96,21 @@ func getShellName(s string) (string, int) {
 }
 
 // Getenv retrieves the value of the environment variable named by the key.
-// It returns the value, which will be empty if the variable is not present.
+// It returns the value, if there is a value on env, otherwise it will return
+// from defaultValue first args, if defaultValue not exist, return empty string.
 // To distinguish between an empty value and an unset value, use LookupEnv.
-func Getenv(key string) string {
+func Getenv(key string, defaultValue ...string) string {
 	testlog.Getenv(key)
 	v, _ := syscall.Getenv(key)
-	return v
+	if v != "" {
+		return v
+	}
+	
+	if len(defaultValue) > 0 {
+		return defaultValue[0]
+	}
+	
+ 	return ""
 }
 
 // LookupEnv retrieves the value of the environment variable named


### PR DESCRIPTION
```go
os.Getenv("MONGO_URI", "mongodb://127.0.0.1:3306")
```

reason: 

1. Python has it, and It's really useful
2. this changes will not break old code (but may make it more tight in the future)