### PR TITLE
spec: fix typo in go_spec.html

### DIFF
--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -7926,7 +7926,7 @@ func Slice(ptr *ArbitraryType, len IntegerType) []ArbitraryType
 
 <!--
 These conversions also apply to type parameters with suitable core types.
-Determine if we can simply use core type insted of underlying type here,
+Determine if we can simply use core type instead of underlying type here,
 of if the general conversion rules take care of this.
 -->
 


### PR DESCRIPTION
insted -> instead
