### PR TITLE
cmd/internal/obj/riscv: fix illegal form of MOV instructions

### DIFF
--- a/src/cmd/asm/internal/asm/testdata/riscv64error.s
+++ b/src/cmd/asm/internal/asm/testdata/riscv64error.s
@@ -22,5 +22,9 @@ TEXT errors(SB),$0
 	MOVBU	X5, (X6)			// ERROR "unsupported unsigned store"
 	MOVHU	X5, (X6)			// ERROR "unsupported unsigned store"
 	MOVWU	X5, (X6)			// ERROR "unsupported unsigned store"
+	MOVF	F0, F1, F2			// ERROR "illegal MOV instruction"
+	MOVD	F0, F1, F2			// ERROR "illegal MOV instruction"
+	MOV	X10, X11, X12			// ERROR "illegal MOV instruction"
+	MOVW	X10, X11, X12			// ERROR "illegal MOV instruction"
 
 	RET

--- a/src/cmd/internal/obj/riscv/obj.go
+++ b/src/cmd/internal/obj/riscv/obj.go
@@ -1806,6 +1806,11 @@ func instructionsForMOV(p *obj.Prog) []*instruction {
 	ins := instructionForProg(p)
 	inss := []*instruction{ins}
 
+	if p.Reg != 0 {
+		p.Ctxt.Diag("%v: illegal MOV instruction", p)
+		return nil
+	}
+
 	switch {
 	case p.From.Type == obj.TYPE_CONST && p.To.Type == obj.TYPE_REG:
 		// Handle constant to register moves.


### PR DESCRIPTION
The MOV like instructions should only have two operands.