### PR TITLE
runtime: fix breakpoint in ppc64x

### DIFF
--- a/src/runtime/asm_ppc64x.s
+++ b/src/runtime/asm_ppc64x.s
@@ -106,7 +106,7 @@ DATA	runtime·mainPC+0(SB)/8,$runtime·main<ABIInternal>(SB)
 GLOBL	runtime·mainPC(SB),RODATA,$8
 
 TEXT runtime·breakpoint(SB),NOSPLIT|NOFRAME,$0-0
-	MOVD	R0, 0(R0) // TODO: TD
+	TW	$31, R0, R0
 	RET
 
 TEXT runtime·asminit(SB),NOSPLIT|NOFRAME,$0-0


### PR DESCRIPTION
Currently runtime.Breakpoint generates a SIGSEGV in ppc64.
The solution is an unconditional trap similar to what clang and gcc do. It is documented in the section C.6 of the ABI Book 3.
    
Fixes #52101