### PR TITLE
doc: add illegal octal over 255 example

### DIFF
--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -529,6 +529,7 @@ escaped_char     = `\` ( "a" | "b" | "f" | "n" | "r" | "t" | "v" | `\` | "'" | `
 'aa'         // illegal: too many characters
 '\xa'        // illegal: too few hexadecimal digits
 '\0'         // illegal: too few octal digits
+'\400'       // illegal: octal value over 255
 '\uDFFF'     // illegal: surrogate half
 '\U00110000' // illegal: invalid Unicode code point
 </pre>


### PR DESCRIPTION
Octal values over 255, like \400 or \777, are illegal.  It wasn't clear if the expected behavior was a compile error, encoding the value as two characters, or if the value would be capped at 255.  

This example explicitly shows that octal values over 255 are illegal.