### PR TITLE
net/http: trim cookie names

### DIFF
--- a/src/net/http/cookie.go
+++ b/src/net/http/cookie.go
@@ -70,6 +70,7 @@ func readSetCookies(h Header) []*Cookie {
 		}
 		parts[0] = textproto.TrimString(parts[0])
 		name, value, ok := strings.Cut(parts[0], "=")
+		name = textproto.TrimString(name)
 		if !ok {
 			continue
 		}
@@ -291,6 +292,7 @@ func readCookies(h Header, filter string) []*Cookie {
 				continue
 			}
 			name, val, _ := strings.Cut(part, "=")
+			name = textproto.TrimString(name)
 			if !isCookieNameValid(name) {
 				continue
 			}

--- a/src/net/http/cookie.go
+++ b/src/net/http/cookie.go
@@ -70,10 +70,10 @@ func readSetCookies(h Header) []*Cookie {
 		}
 		parts[0] = textproto.TrimString(parts[0])
 		name, value, ok := strings.Cut(parts[0], "=")
-		name = textproto.TrimString(name)
 		if !ok {
 			continue
 		}
+		name = textproto.TrimString(name)
 		if !isCookieNameValid(name) {
 			continue
 		}

--- a/src/net/http/cookie_test.go
+++ b/src/net/http/cookie_test.go
@@ -352,6 +352,10 @@ var readSetCookiesTests = []struct {
 		Header{"Set-Cookie": {`special-8=","`}},
 		[]*Cookie{{Name: "special-8", Value: ",", Raw: `special-8=","`}},
 	},
+	{
+		Header{"Set-Cookie": {`special-9 =","`}},
+		[]*Cookie{{Name: "special-9", Value: ",", Raw: `special-9 =","`}},
+	},
 
 	// TODO(bradfitz): users have reported seeing this in the
 	// wild, but do browsers handle it? RFC 6265 just says "don't

--- a/src/net/http/cookie_test.go
+++ b/src/net/http/cookie_test.go
@@ -352,6 +352,8 @@ var readSetCookiesTests = []struct {
 		Header{"Set-Cookie": {`special-8=","`}},
 		[]*Cookie{{Name: "special-8", Value: ",", Raw: `special-8=","`}},
 	},
+	// Make sure we can properly read back the Set-Cookie headers
+	// for names containing spaces:
 	{
 		Header{"Set-Cookie": {`special-9 =","`}},
 		[]*Cookie{{Name: "special-9", Value: ",", Raw: `special-9 =","`}},


### PR DESCRIPTION
The current implementation ignores cookies where the 
cookie name starts or ends with a space. For example,

name =value 

is ignored.

I have come across pages that send cookies in this weird format.
I tested with the latest versions of Firefox, Safari and Chrome, 
all of which accept cookies in this format. 

To do this, I remove leading and trailing spaces from the 
cookie name after cutting at '='.















