### PR TITLE
doc/go_spec.html: update type identity example

### DIFF
--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -1880,7 +1880,7 @@ A4, func(int, float64) *[]string, and A5
 B0 and C0
 D0[int, string] and E0
 []int and []int
-struct{ a, b *T5 } and struct{ a, b *T5 }
+struct{ a, b *B5 } and struct{ a, b *B5 }
 func(x int, y float64) *[]string, func(int, float64) (result *[]string), and A5
 </pre>
 


### PR DESCRIPTION
In the Type identity section, the example provides various types as givens. 

The example refers to the type *T5, but it is not provided in the givens. 

I am assuming this was a typo, and was meant to refer to *A1 or *B1.
*B1 seems to be in alignment with the rest of the provided examples.