### PR TITLE
bytes: limit allocation in SplitN

### DIFF
--- a/src/bytes/bytes.go
+++ b/src/bytes/bytes.go
@@ -348,6 +348,9 @@ func genSplit(s, sep []byte, sepSave, n int) [][]byte {
 	if n < 0 {
 		n = Count(s, sep) + 1
 	}
+	if n > len(s)+1 {
+		n = len(s) + 1
+	}
 
 	a := make([][]byte, n)
 	n--

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -8,6 +8,7 @@ import (
 	. "bytes"
 	"fmt"
 	"internal/testenv"
+	"math"
 	"math/rand"
 	"reflect"
 	"strings"
@@ -723,6 +724,7 @@ var splittests = []SplitTest{
 	{"1 2", " ", 3, []string{"1", "2"}},
 	{"123", "", 2, []string{"1", "23"}},
 	{"123", "", 17, []string{"1", "2", "3"}},
+	{"bT", "T", math.MaxInt / 4, []string{"b", ""}},
 }
 
 func TestSplit(t *testing.T) {


### PR DESCRIPTION
So that bytes.SplitN("", "T", int(144115188075855872)) does not panic.