### PR TITLE
testing: update benchmark name output

### DIFF
--- a/src/testing/benchmark.go
+++ b/src/testing/benchmark.go
@@ -494,7 +494,7 @@ func (r BenchmarkResult) MemString() string {
 // benchmarkName returns full name of benchmark including procs suffix.
 func benchmarkName(name string, n int) string {
 	if n != 1 {
-		return fmt.Sprintf("%s-%d", name, n)
+		return fmt.Sprintf("%s-%d(procs)", name, n)
 	}
 	return name
 }


### PR DESCRIPTION
Currently, the benchmark test output is like this:
```
goos: darwin
goarch: amd64
pkg: project/path
cpu: vendor info
BenchmarkWithSlice
BenchmarkWithSlice-12             	461047779	         2.609 ns/op
PASS

Process finished with the exit code 0
```

The benchmark name suffix `-12` is a little confusing, so this PR
update the output to understand it better.