### PR TITLE
compile: name X1 as RA under RISC-V in comment, other than LR

### DIFF
--- a/src/cmd/compile/internal/riscv64/ssa.go
+++ b/src/cmd/compile/internal/riscv64/ssa.go
@@ -18,7 +18,7 @@ import (
 // ssaRegToReg maps ssa register numbers to obj register numbers.
 var ssaRegToReg = []int16{
 	riscv.REG_X0,
-	// X1 (LR): unused
+	// X1 (ra): unused
 	riscv.REG_X2,
 	riscv.REG_X3,
 	riscv.REG_X4,


### PR DESCRIPTION
Ref: https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#general-registers

This commit does not modify any working code, it only alter one line of comment to enhance readability.

For lower case `ra` other than `RA`: the RISC-V Assembly Manual defined register names as lowercase.