### PR TITLE
cmd/compile: remove unused offset calculation in ssagen#rtcall

### DIFF
--- a/src/cmd/compile/internal/ssagen/ssa.go
+++ b/src/cmd/compile/internal/ssagen/ssa.go
@@ -5535,13 +5535,6 @@ func (s *state) rtcall(fn *obj.LSym, returns bool, results []*types.Type, args .
 	}
 	off = types.Rnd(off, int64(types.RegSize))
 
-	// Accumulate results types and offsets
-	offR := off
-	for _, t := range results {
-		offR = types.Rnd(offR, t.Alignment())
-		offR += t.Size()
-	}
-
 	// Issue call
 	var call *ssa.Value
 	aux := ssa.StaticAuxCall(fn, s.f.ABIDefault.ABIAnalyzeTypes(nil, callArgTypes, results))


### PR DESCRIPTION
This offR accumulation isn't used and some really similar code is done 
later in the Load results block.
