### PR TITLE
cmd/go: prevent fatal when working in a git repo with no commit

### DIFF
--- a/src/cmd/go/testdata/script/build_v_git_repository_empty.txt
+++ b/src/cmd/go/testdata/script/build_v_git_repository_empty.txt
@@ -1,0 +1,18 @@
+[!exec:git] skip
+
+exec git init
+exec git config user.email gopher@golang.org
+exec git config user.name 'J.R. Gopher'
+
+go build -v
+stderr example.com/test
+! stderr fatal
+
+-- go.mod --
+module example.com/test
+
+go 1.18
+-- main.go --
+package main
+
+func main() {}


### PR DESCRIPTION
Use git rev-list instead of git show to prevent misleading error
in the user's console when working with an empty repository with
no commits.

Fixes #52263
