### PR TITLE
net/http: correctly show error types in transfer test

### DIFF
--- a/src/net/http/transfer_test.go
+++ b/src/net/http/transfer_test.go
@@ -267,7 +267,7 @@ func TestTransferWriterWriteBodyReaderTypes(t *testing.T) {
 				}
 
 				if tc.expectedReader != actualReader {
-					t.Fatalf("got reader %T want %T", actualReader, tc.expectedReader)
+					t.Fatalf("got reader %s want %s", actualReader, tc.expectedReader)
 				}
 			}
 


### PR DESCRIPTION
actualReader and tc.expectedReader are reflect.Type instances,
not the actual objects.