### PR TITLE
io: NopCloser forward WriterTo implementations if the reader supports it

### DIFF
--- a/src/io/io_test.go
+++ b/src/io/io_test.go
@@ -471,3 +471,24 @@ func TestCopyLargeWriter(t *testing.T) {
 		t.Errorf("Copy error: got %v, want %v", err, want)
 	}
 }
+
+func TestNopCloserWriterToForwarding(t *testing.T) {
+	for _, tc := range [...]struct {
+		Name string
+		r    Reader
+	}{
+		{"not a WriterTo", Reader(nil)},
+		{"a WriterTo", struct {
+			Reader
+			WriterTo
+		}{}},
+	} {
+		nc := NopCloser(tc.r)
+
+		_, expected := tc.r.(WriterTo)
+		_, got := nc.(WriterTo)
+		if expected != got {
+			t.Errorf("NopCloser incorrectly forwards WriterTo for %s, got %t want %t", tc.Name, got, expected)
+		}
+	}
+}


### PR DESCRIPTION
This patch also include related fixes to net/http.

io_test.go don't test reading or WritingTo of the because the logic is simple.
NopCloser didn't even had direct tests before.

Fixes #51566