### PR TITLE
go/doc: fix incorrect identifier parsing in comments

### DIFF
--- a/src/go/doc/comment/parse.go
+++ b/src/go/doc/comment/parse.go
@@ -1063,7 +1063,7 @@ func ident(s string) (id string, ok bool) {
 			}
 			break
 		}
-		r, nr := utf8.DecodeRuneInString(s)
+		r, nr := utf8.DecodeRuneInString(s[n:])
 		if unicode.IsLetter(r) {
 			n += nr
 			continue

--- a/src/go/doc/comment/parse_test.go
+++ b/src/go/doc/comment/parse_test.go
@@ -1,0 +1,12 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package comment
+
+import "testing"
+
+// See https://golang.org/issue/52353
+func Test52353(t *testing.T) {
+	ident("𫕐ﯯ")
+}


### PR DESCRIPTION
This code was trying to iterate codepoints, but didn't reslice the string,
so it was reading the first codepoint over and over, if the string length was
not a multiple of the first codepoint length, this would cause to overshoot
past the end of the string.

This was a latent bug introduced in CL 384265 but was revealed to
Ngolo-fuzzing in OSS-Fuzz in CL 397277.

Fixes #52353