### PR TITLE
os: look up hostname from PATH in test

### DIFF
--- a/src/os/os_test.go
+++ b/src/os/os_test.go
@@ -1699,16 +1699,21 @@ func runBinHostname(t *testing.T) string {
 		t.Fatal(err)
 	}
 	defer r.Close()
-	const path = "/bin/hostname"
+
+	path, err := osexec.LookPath("hostname")
+	if err != nil {
+		if errors.Is(err, osexec.ErrNotFound) {
+			t.Skip("skipping test; test requires hostname but it does not exist")
+		}
+		t.Fatal(err)
+	}
+
 	argv := []string{"hostname"}
 	if runtime.GOOS == "aix" {
 		argv = []string{"hostname", "-s"}
 	}
 	p, err := StartProcess(path, argv, &ProcAttr{Files: []*File{nil, w, Stderr}})
 	if err != nil {
-		if _, err := Stat(path); IsNotExist(err) {
-			t.Skipf("skipping test; test requires %s but it does not exist", path)
-		}
 		t.Fatal(err)
 	}
 	w.Close()


### PR DESCRIPTION
When running TestHostname, the location of the hostname binary
is hardcoded as /bin/hostname. However, on some systems the actual
location is /usr/bin/hostname.

Change this behaviour to perform a lookup for hostname in PATH,
and skip the test when it cannot be found there.

Fixes #52402