### PR TITLE
runtime: add check before using arguments with -buildmode=c-archive and -buildmode=c-shared on non glibc systems such as musl/uclinux

### DIFF
--- a/misc/cgo/testcarchive/testdata/libgo/libgo.go
+++ b/misc/cgo/testcarchive/testdata/libgo/libgo.go
@@ -46,7 +46,11 @@ func DidMainRun() bool { return ranMain }
 
 //export CheckArgs
 func CheckArgs() {
-	if len(os.Args) != 3 || os.Args[1] != "arg1" || os.Args[2] != "arg2" {
+	// Dynamic linkers which supply the library initialization functions with the
+	// main program's argc / argc should have 3 args here, else they should have
+	// none.
+	valid := (len(os.Args) == 3 && os.Args[1] == "arg1" && os.Args[2] == "arg2") || (len(os.Args) == 0)
+	if !valid {
 		fmt.Printf("CheckArgs: want [_, arg1, arg2], got: %v\n", os.Args)
 		os.Exit(2)
 	}

--- a/src/runtime/cgo.go
+++ b/src/runtime/cgo.go
@@ -12,6 +12,7 @@ import "unsafe"
 
 //go:linkname _cgo_init _cgo_init
 //go:linkname _cgo_thread_start _cgo_thread_start
+//go:linkname _cgo_sys_lib_args_valid _cgo_sys_lib_args_valid
 //go:linkname _cgo_sys_thread_create _cgo_sys_thread_create
 //go:linkname _cgo_notify_runtime_init_done _cgo_notify_runtime_init_done
 //go:linkname _cgo_callers _cgo_callers
@@ -21,6 +22,7 @@ import "unsafe"
 var (
 	_cgo_init                     unsafe.Pointer
 	_cgo_thread_start             unsafe.Pointer
+	_cgo_sys_lib_args_valid       unsafe.Pointer
 	_cgo_sys_thread_create        unsafe.Pointer
 	_cgo_notify_runtime_init_done unsafe.Pointer
 	_cgo_callers                  unsafe.Pointer

--- a/src/runtime/cgo/callbacks.go
+++ b/src/runtime/cgo/callbacks.go
@@ -58,6 +58,14 @@ var _cgo_init = &x_cgo_init
 var x_cgo_thread_start byte
 var _cgo_thread_start = &x_cgo_thread_start
 
+// Determines if the argc / argv passed to the library initialization functions
+// are valid.
+//go:cgo_import_static x_cgo_sys_lib_args_valid
+//go:linkname x_cgo_sys_lib_args_valid x_cgo_sys_lib_args_valid
+//go:linkname _cgo_sys_lib_args_valid _cgo_sys_lib_args_valid
+var x_cgo_sys_lib_args_valid byte
+var _cgo_sys_lib_args_valid = &x_cgo_sys_lib_args_valid
+
 // Creates a new system thread without updating any Go state.
 //
 // This method is invoked during shared library loading to create a new OS

--- a/src/runtime/cgo/gcc_libinit.c
+++ b/src/runtime/cgo/gcc_libinit.c
@@ -7,6 +7,7 @@
 
 #include <pthread.h>
 #include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h> // strerror
@@ -20,6 +21,20 @@ static int runtime_init_done;
 
 // The context function, used when tracing back C calls into Go.
 static void (*cgo_context_function)(struct context_arg*);
+
+// Detect if using glibc
+int
+x_cgo_sys_lib_args_valid()
+{
+	// The ELF gABI doesn't require an argc / argv to be passed to the functions
+	// in the DT_INIT_ARRAY. However, glibc always does.
+	// Ignore uClibc masquerading as glibc.
+#if defined(__GLIBC__) && !defined(__UCLIBC__)
+	return 1;
+#else
+	return 0;
+#endif
+}
 
 void
 x_cgo_sys_thread_create(void* (*func)(void*), void* arg) {

--- a/src/runtime/cgo/gcc_libinit_windows.c
+++ b/src/runtime/cgo/gcc_libinit_windows.c
@@ -51,6 +51,11 @@ _cgo_maybe_run_preinit() {
 	 }
 }
 
+int
+x_cgo_sys_lib_args_valid() {
+	return 1;
+}
+
 void
 x_cgo_sys_thread_create(void (*func)(void*), void* arg) {
 	uintptr_t thandle;

--- a/src/runtime/runtime1.go
+++ b/src/runtime/runtime1.go
@@ -52,9 +52,27 @@ var (
 	argv **byte
 )
 
+// when using -buildmode=c-archive or -buildmode=c-shared on linux
+// we have to first make sure that glibc is being used or else
+// we cannot rely on argc/argv/auxv to be accurate
+func sysLibArgsValid() bool {
+	if _cgo_sys_lib_args_valid != nil {
+		ret := asmcgocall(_cgo_sys_lib_args_valid, nil)
+		if ret != 1 {
+			return false
+		}
+	}
+	return true
+}
+
 // nosplit for use in linux startup sysargs
 //go:nosplit
 func argv_index(argv **byte, i int32) *byte {
+	if islibrary || isarchive {
+		if !sysLibArgsValid() {
+			return nil
+		}
+	}
 	return *(**byte)(add(unsafe.Pointer(argv), uintptr(i)*goarch.PtrSize))
 }
 
@@ -68,6 +86,13 @@ func goargs() {
 	if GOOS == "windows" {
 		return
 	}
+
+	if islibrary || isarchive {
+		if !sysLibArgsValid() {
+			return
+		}
+	}
+
 	argslice = make([]string, argc)
 	for i := int32(0); i < argc; i++ {
 		argslice[i] = gostringnocopy(argv_index(argv, i))
@@ -75,6 +100,13 @@ func goargs() {
 }
 
 func goenvs_unix() {
+	if islibrary || isarchive {
+		if !sysLibArgsValid() {
+			envs = make([]string, 0)
+			return
+		}
+	}
+
 	// TODO(austin): ppc64 in dynamic linking mode doesn't
 	// guarantee env[] will immediately follow argv. Might cause
 	// problems.


### PR DESCRIPTION
This PR fixes using go .so and .a libraries with non glibc systems such as musl/uclinux when linking at compile time. This fix modifies the solution found here https://go-review.googlesource.com/c/go/+/37868

This fix does not fix the issues encountered when using dlopen on musl systems, I'm opening this PR in hopes of getting some help from the go team to fix this crippling issue using musl based systems.

Previous PR here -> https://github.com/golang/go/pull/47249

Tested with go 1.18 on 386/armv7/aarch64 with both libc and musl