### PR TITLE
cmd: replace `git.io` in the message

### DIFF
--- a/src/cmd/vendor/github.com/google/pprof/internal/report/report.go
+++ b/src/cmd/vendor/github.com/google/pprof/internal/report/report.go
@@ -1215,7 +1215,7 @@ func reportLabels(rpt *Report, g *graph.Graph, origCount, droppedNodes, droppedE
 	// Help new users understand the graph.
 	// A new line is intentionally added here to better show this message.
 	if fullHeaders {
-		label = append(label, "\nSee https://git.io/JfYMW for how to read the graph")
+		label = append(label, "\nSee https://github.com/google/pprof/blob/master/doc/README.md#interpreting-the-callgraph for how to read the graph")
 	}
 
 	return label


### PR DESCRIPTION
Replace the `git.io` link with its actual URL.


x-ref: https://github.blog/changelog/2022-04-25-git-io-deprecation/
