### PR TITLE
net/http: support bufio.Reader body retries

### DIFF
--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -902,6 +902,7 @@ func NewRequestWithContext(ctx context.Context, method, url string, body io.Read
 				return io.NopCloser(r), nil
 			}
 		case *bytes.Reader:
+		case *bufio.Reader:
 			req.ContentLength = int64(v.Len())
 			snapshot := *v
 			req.GetBody = func() (io.ReadCloser, error) {

--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -903,6 +903,7 @@ func NewRequestWithContext(ctx context.Context, method, url string, body io.Read
 			}
 		case *bytes.Reader:
 		case *bufio.Reader:
+		case *io.LimitedReader:
 			req.ContentLength = int64(v.Len())
 			snapshot := *v
 			req.GetBody = func() (io.ReadCloser, error) {


### PR DESCRIPTION
Enable requests with a body of type `bufio.Reader` to be retried successfully.