### PR TITLE
cmd/dist: add build mode support regression test for issue #43571

### DIFF
--- a/src/cmd/dist/buildmode_test.go
+++ b/src/cmd/dist/buildmode_test.go
@@ -1,0 +1,55 @@
+//go:build go1.14
+// +build go1.14
+
+package main
+
+import (
+	"cmd/internal/sys"
+	"runtime"
+	"testing"
+)
+
+var osList = []string{"aix", "android", "darwin", "dragonfly", "freebsd",
+	"hurd", "illumos", "ios", "js", "linux", "nacl", "netbsd",
+	"openbsd", "plan9", "solaris", "windows", "zos"}
+
+var archList = []string{
+	"386", "amd64", "amd64p32", "arm", "armbe", "arm64", "arm64be",
+	"loong64", "mips", "mipsle", "mips64", "mips64le", "mips64p32",
+	"mips64p32le", "ppc", "ppc64", "ppc64le", "riscv", "riscv64",
+	"s390", "s390x", "sparc", "sparc64", "wasm"}
+
+var buildmodeList = []string{
+	"archive", "c-archive", "c-shared", "default", "shared", "exe", "pie",
+	"plugin"}
+
+func TestBuildModeSupported(t *testing.T) {
+	// Regression test for issue #43571. Checks that
+	// (*cmd/dist.tester).supportedBuildmode and
+	// cmd/internal/sys.BuildModeSupported are in sync.
+	tester := &tester{} // none of the contents are actually used
+	actualGoos := goos
+	actualGoarch := goarch
+	actualGohostos := gohostos
+	gc := runtime.Compiler
+	for _, os := range osList {
+		for _, arch := range archList {
+			for _, buildmode := range buildmodeList {
+				goos = os
+				goarch = arch
+				gohostos = os
+				testerResult := tester.supportedBuildmode(buildmode)
+				sysResult := sys.BuildModeSupported(gc, buildmode, os, arch)
+				if testerResult != sysResult {
+					t.Errorf("Build mode mismatch for %s-%s %s:\n"+
+						"tester.supportedBuildmode: %t\n"+
+						"sys.BuildModeSupported: %t", os, arch, buildmode,
+						testerResult, sysResult)
+				}
+			}
+		}
+	}
+	goos = actualGoos
+	goarch = actualGoarch
+	gohostos = actualGohostos
+}

--- a/src/cmd/dist/test.go
+++ b/src/cmd/dist/test.go
@@ -1085,25 +1085,16 @@ func (t *tester) internalLinkPIE() bool {
 func (t *tester) supportedBuildmode(mode string) bool {
 	pair := goos + "-" + goarch
 	switch mode {
+	case "archive":
+		return true
 	case "c-archive":
-		if !t.extLink() {
-			return false
-		}
-		switch pair {
-		case "aix-ppc64",
-			"darwin-amd64", "darwin-arm64", "ios-arm64",
-			"linux-amd64", "linux-386", "linux-ppc64le", "linux-riscv64", "linux-s390x",
-			"freebsd-amd64",
-			"windows-amd64", "windows-386":
-			return true
-		}
-		return false
+		return pair != "linux-ppc64"
 	case "c-shared":
 		switch pair {
 		case "linux-386", "linux-amd64", "linux-arm", "linux-arm64", "linux-ppc64le", "linux-riscv64", "linux-s390x",
 			"darwin-amd64", "darwin-arm64",
 			"freebsd-amd64",
-			"android-arm", "android-arm64", "android-386",
+			"android-amd64", "android-arm", "android-arm64", "android-386",
 			"windows-amd64", "windows-386", "windows-arm64":
 			return true
 		}
@@ -1122,17 +1113,26 @@ func (t *tester) supportedBuildmode(mode string) bool {
 			return true
 		case "freebsd-amd64":
 			return true
+		case "android-386", "android-amd64", "android-arm", "android-arm64":
+			return true
 		}
 		return false
+	case "default":
+		return true
+	case "exe":
+		return true
 	case "pie":
 		switch pair {
-		case "aix/ppc64",
-			"linux-386", "linux-amd64", "linux-arm", "linux-arm64", "linux-ppc64le", "linux-riscv64", "linux-s390x",
+		case "linux-386", "linux-amd64", "linux-arm", "linux-arm64", "linux-ppc64le", "linux-riscv64", "linux-s390x",
 			"android-amd64", "android-arm", "android-arm64", "android-386":
 			return true
 		case "darwin-amd64", "darwin-arm64":
 			return true
 		case "windows-amd64", "windows-386", "windows-arm":
+			return true
+		case "freebsd-amd64", "ios-amd64", "ios-arm64":
+			return true
+		case "aix-ppc64":
 			return true
 		}
 		return false


### PR DESCRIPTION
Hiya! 
Issue #43571 pointed out there are several duplicates of a supported build mode check, namely in cmd/internal/sys.BuildModeSupported and (*cmd/dist.tester).supportedBuildmode. Since dist has to build with 1.4, it can't simply check with sys.BuildModeSupported, so this adds a test to ensure that both have uniform behavior for supported platforms. Several platforms did not match as expected, so I had to make some changes to cmd/dist/test.go to bring it in line.