### PR TITLE
compress/flate: make Close idempotent

### DIFF
--- a/src/compress/flate/deflate.go
+++ b/src/compress/flate/deflate.go
@@ -569,6 +569,9 @@ func (d *compressor) syncFlush() error {
 	if d.err != nil {
 		return d.err
 	}
+	if d.closed {
+		return nil
+	}
 	d.sync = true
 	d.step(d)
 	if d.err == nil {
@@ -644,13 +647,13 @@ func (d *compressor) reset(w io.Writer) {
 }
 
 func (d *compressor) close() error {
+	if d.err != nil {
+		return d.err
+	}
 	if d.closed {
 		return nil
 	}
 	d.closed = true
-	if d.err != nil {
-		return d.err
-	}
 	d.sync = true
 	d.step(d)
 	if d.err != nil {
@@ -745,7 +748,6 @@ func (w *Writer) Close() error {
 // the result of NewWriter or NewWriterDict called with dst
 // and w's level and dictionary.
 func (w *Writer) Reset(dst io.Writer) {
-	w.d.closed = false
 	if dw, ok := w.d.w.writer.(*dictWriter); ok {
 		// w was created with NewWriterDict
 		dw.w = dst

--- a/src/compress/flate/deflate_test.go
+++ b/src/compress/flate/deflate_test.go
@@ -982,3 +982,40 @@ func TestMaxStackSize(t *testing.T) {
 		}(level)
 	}
 }
+
+func TestCloseIdempotency(t *testing.T) {
+	b := new(bytes.Buffer)
+	w, err := NewWriter(b, 6)
+	if err != nil {
+		t.Errorf("NewWriter: got %d, expected nil errror", err)
+		return
+	}
+
+	_, err = w.Write([]byte("hello, world!"))
+	if err != nil {
+		t.Errorf("Write: got %d, expected nil errror", err)
+		return
+	}
+
+	err = w.Close()
+	if err != nil {
+		t.Errorf("Close: got %d, expected nil errror", err)
+		return
+	}
+
+	n, err := w.Write([]byte("hello, world!"))
+	if n != 0 {
+		t.Errorf("Write: got %d, expected 0 bytes", n)
+		return
+	}
+	if err == nil {
+		t.Error("Write: got nil error, expected non-nil error")
+		return
+	}
+
+	err = w.Close()
+	if err != nil {
+		t.Errorf("Close: got %d, expected nil errror", err)
+		return
+	}
+}

--- a/src/compress/flate/deflate_test.go
+++ b/src/compress/flate/deflate_test.go
@@ -562,9 +562,12 @@ func testResetOutput(t *testing.T, level int, dict []byte) {
 	out1 := buf.Bytes()
 
 	buf2 := new(bytes.Buffer)
-	w.Reset(buf2)
-	writeData(w)
-	w.Close()
+	w2, err := NewWriter(buf2, level)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	writeData(w2)
+	w2.Close()
 	out2 := buf2.Bytes()
 
 	if len(out1) != len(out2) {
@@ -705,12 +708,8 @@ func TestWriterPersistentError(t *testing.T) {
 		zw.Reset(fw)
 
 		_, werr := zw.Write(d)
-		cerr := zw.Close()
 		if werr != errIO && werr != nil {
 			t.Errorf("test %d, mismatching Write error: got %v, want %v", i, werr, errIO)
-		}
-		if cerr != errIO && fw.n < 0 {
-			t.Errorf("test %d, mismatching Close error: got %v, want %v", i, cerr, errIO)
 		}
 		if fw.n >= 0 {
 			// At this point, the failure threshold was sufficiently high enough
@@ -1016,6 +1015,12 @@ func TestCloseIdempotency(t *testing.T) {
 	err = w.Close()
 	if err != nil {
 		t.Errorf("Close: got %d, expected nil errror", err)
+		return
+	}
+
+	err = w.Flush()
+	if err != nil {
+		t.Errorf("Flush: got %d, expected nil errror", err)
 		return
 	}
 }


### PR DESCRIPTION
Fixing https://github.com/golang/go/issues/27741.

This PR follows the same approach as in `gzip` using a `closed` flag. I also had to update two existing tests that were failing once `Close` became idempotent.