### PR TITLE
net/url: fix regex typo in comment in url.go

### DIFF
--- a/src/net/url/url.go
+++ b/src/net/url/url.go
@@ -428,7 +428,7 @@ func (u *Userinfo) String() string {
 }
 
 // Maybe rawURL is of the form scheme:path.
-// (Scheme must be [a-zA-Z][a-zA-Z0-9+-.]*)
+// (Scheme must be [a-zA-Z][a-zA-Z0-9+.-]*)
 // If so, return scheme, path; else return "", rawURL.
 func getScheme(rawURL string) (scheme, path string, err error) {
 	for i := 0; i < len(rawURL); i++ {


### PR DESCRIPTION
The original author almost certainly intended to match the literal dash
character '-' but ended up matching a range of other characters instead.