### PR TITLE
encoding/base32: decoder output depends on chunking of underlying reader

### DIFF
--- a/src/encoding/base32/base32_test.go
+++ b/src/encoding/base32/base32_test.go
@@ -91,7 +91,7 @@ func TestEncoderBuffering(t *testing.T) {
 func TestDecode(t *testing.T) {
 	for _, p := range pairs {
 		dbuf := make([]byte, StdEncoding.DecodedLen(len(p.encoded)))
-		count, _, end, err := StdEncoding.decode(dbuf, []byte(p.encoded))
+		count, end, err := StdEncoding.decode(dbuf, []byte(p.encoded))
 		testEqual(t, "Decode(%q) = error %v, want %v", p.encoded, err, error(nil))
 		testEqual(t, "Decode(%q) = length %v, want %v", p.encoded, count, len(p.decoded))
 		if len(p.encoded) > 0 {
@@ -644,18 +644,18 @@ func TestBufferedDecodingPadding(t *testing.T) {
 		{[]string{
 			"I4======",
 			"N4======",
-		}, "illegal base32 data at input byte 2"},
+		}, "illegal base32 data at input byte 0"},
 
 		{[]string{
 			"I4======",
 			"========",
-		}, "illegal base32 data at input byte 2"},
+		}, "illegal base32 data at input byte 0"},
 
 		{[]string{
 			"I4I4I4I4",
 			"I4======",
 			"I4======",
-		}, "illegal base32 data at input byte 10"},
+		}, "illegal base32 data at input byte 0"},
 	}
 
 	for _, testcase := range testcases {

--- a/src/encoding/base32/base32_test.go
+++ b/src/encoding/base32/base32_test.go
@@ -672,9 +672,9 @@ func TestBufferedDecodingPadding(t *testing.T) {
 		_, err := io.ReadAll(decoder)
 
 		if err == nil && len(testcase.expectedError) != 0 {
-			t.Errorf("Expected %v, got nil error; case %+v", testcase.expectedError, testcase.chunks)
+			t.Errorf("case %q: got nil error, want %v", testcase.chunks, testcase.expectedError)
 		} else if err.Error() != testcase.expectedError {
-			t.Errorf("Expected %v, got %v; case %+v", testcase.expectedError, err, testcase.chunks)
+			t.Errorf("case %q: got %v, want %v", testcase.chunks, err, testcase.expectedError)
 		}
 	}
 }


### PR DESCRIPTION
After an analysis, I figured that a way to do it could be to check, after 
the call to readEncodedData whether the decoder already saw the end or not.

Fixes #38657