### PR TITLE
cmd/compile: fold constants found by prove

### DIFF
--- a/test/codegen/comparisons.go
+++ b/test/codegen/comparisons.go
@@ -161,7 +161,7 @@ func CmpZero4(a int64, ptr *int) {
 	}
 }
 
-func CmpToZero(a, b, d int32, e, f int64) int32 {
+func CmpToZero(a, b, d int32, e, f int64, deOptC0, deOptC1 bool) int32 {
 	// arm:`TST`,-`AND`
 	// arm64:`TSTW`,-`AND`
 	// 386:`TESTL`,-`ANDL`
@@ -201,13 +201,17 @@ func CmpToZero(a, b, d int32, e, f int64) int32 {
 	} else if c4 {
 		return 5
 	} else if c5 {
-		return b + d
+		return 6
 	} else if c6 {
-		return a & d
-	} else if c7 {
 		return 7
+	} else if c7 {
+		return 9
 	} else if c8 {
-		return 8
+		return 10
+	} else if deOptC0 {
+		return b + d
+	} else if deOptC1 {
+		return a & d
 	} else {
 		return 0
 	}

--- a/test/prove_constant_folding.go
+++ b/test/prove_constant_folding.go
@@ -1,0 +1,32 @@
+// +build amd64
+// errorcheck -0 -d=ssa/prove/debug=2
+
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+func f0i(x int) int {
+  if x == 20 {
+    return x // ERROR "Proved.+is constant 20$"
+  }
+
+  if (x + 20) == 20 {
+    return x + 5 // ERROR "Proved.+is constant 0$"
+  }
+
+  return x / 2
+}
+
+func f0u(x uint) uint {
+  if x == 20 {
+    return x // ERROR "Proved.+is constant 20$"
+  }
+
+  if (x + 20) == 20 {
+    return x + 5 // ERROR "Proved.+is constant 0$"
+  }
+
+  return x / 2
+}


### PR DESCRIPTION
It is hit ~70k times building go.
This make the go binary, 0.04% smaller.
I didn't included benchmarks because this is just constant foldings
and is hard to mesure objectively.

For example, this enable rewriting things like:
  if x == 20 {
    return x + 30 + z
  }

Into:
  if x == 20 {
    return 50 + z
  }

It's not just fixing programer's code,
the ssa generator generate code like this sometimes.
