### PR TITLE
debug/buildinfo: avoid nil defererence for invalid XCOFF

### DIFF
--- a/src/debug/buildinfo/buildinfo.go
+++ b/src/debug/buildinfo/buildinfo.go
@@ -393,5 +393,8 @@ func (x *xcoffExe) ReadData(addr, size uint64) ([]byte, error) {
 }
 
 func (x *xcoffExe) DataStart() uint64 {
-	return x.f.SectionByType(xcoff.STYP_DATA).VirtualAddress
+	if s := x.f.SectionByType(xcoff.STYP_DATA); s != nil {
+		return s.VirtualAddress
+	}
+	return 0
 }


### PR DESCRIPTION
I've made it return 0 following what the other DataStart implementation
do when they do not found the section.

Fixes #52718