### PR TITLE
cmd/internal/sys: allow c-shared buildmode on ios

### DIFF
--- a/src/cmd/internal/sys/supported.go
+++ b/src/cmd/internal/sys/supported.go
@@ -109,6 +109,7 @@ func BuildModeSupported(compiler, buildmode, goos, goarch string) bool {
 			"android/amd64", "android/arm", "android/arm64", "android/386",
 			"freebsd/amd64",
 			"darwin/amd64", "darwin/arm64",
+			"ios/amd64", "ios/arm64",
 			"windows/amd64", "windows/386", "windows/arm64":
 			return true
 		}


### PR DESCRIPTION
This mode seems to work just fine, and could already be accessed via
`GOOS=darwin` with `-tags ios`.