### PR TITLE
cmd/cgo: dont override declared struct type

### DIFF
--- a/misc/cgo/test/testdata/issue52611.go
+++ b/misc/cgo/test/testdata/issue52611.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Go Authors. All rights reserved.
+// Copyright 2022 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/misc/cgo/test/testdata/issue52611.go
+++ b/misc/cgo/test/testdata/issue52611.go
@@ -1,0 +1,13 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Issue 52611: inconsistent compiler behaviour when compiling a C.struct.
+// No runtime test; just make sure it compiles.
+
+package cgotest
+
+import (
+	_ "cgotest/issue52611a"
+	_ "cgotest/issue52611b"
+)

--- a/misc/cgo/test/testdata/issue52611a/a.go
+++ b/misc/cgo/test/testdata/issue52611a/a.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Go Authors. All rights reserved.
+// Copyright 2022 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/misc/cgo/test/testdata/issue52611a/a.go
+++ b/misc/cgo/test/testdata/issue52611a/a.go
@@ -1,0 +1,16 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package issue52611a
+
+/*
+typedef struct Foo {
+    int X;
+} Foo;
+*/
+import "C"
+
+func GetX1(foo *C.struct_Foo) int32 {
+	return int32(foo.X)
+}

--- a/misc/cgo/test/testdata/issue52611a/b.go
+++ b/misc/cgo/test/testdata/issue52611a/b.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Go Authors. All rights reserved.
+// Copyright 2022 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/misc/cgo/test/testdata/issue52611a/b.go
+++ b/misc/cgo/test/testdata/issue52611a/b.go
@@ -1,0 +1,11 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package issue52611a
+
+import "C"
+
+func GetX2(foo *C.struct_Foo) int32 {
+	return int32(foo.X)
+}

--- a/misc/cgo/test/testdata/issue52611b/a.go
+++ b/misc/cgo/test/testdata/issue52611b/a.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Go Authors. All rights reserved.
+// Copyright 2022 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/misc/cgo/test/testdata/issue52611b/a.go
+++ b/misc/cgo/test/testdata/issue52611b/a.go
@@ -1,0 +1,11 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package issue52611b
+
+import "C"
+
+func GetX1(bar *C.struct_Bar) int32 {
+	return int32(bar.X)
+}

--- a/misc/cgo/test/testdata/issue52611b/b.go
+++ b/misc/cgo/test/testdata/issue52611b/b.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Go Authors. All rights reserved.
+// Copyright 2022 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/misc/cgo/test/testdata/issue52611b/b.go
+++ b/misc/cgo/test/testdata/issue52611b/b.go
@@ -1,0 +1,16 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package issue52611b
+
+/*
+typedef struct Bar {
+    int X;
+} Bar;
+*/
+import "C"
+
+func GetX2(bar *C.struct_Bar) int32 {
+	return int32(bar.X)
+}

--- a/src/cmd/cgo/gcc.go
+++ b/src/cmd/cgo/gcc.go
@@ -2512,6 +2512,11 @@ func (c *typeConv) loadType(dtype dwarf.Type, pos token.Pos, parent string) *Typ
 		t.Go = name // publish before recursive calls
 		goIdent[name.Name] = name
 		if dt.ByteSize < 0 {
+			// Don't override old type
+			if _, ok := typedef[name.Name]; ok {
+				break
+			}
+
 			// Size calculation in c.Struct/c.Opaque will die with size=-1 (unknown),
 			// so execute the basic things that the struct case would do
 			// other than try to determine a Go representation.


### PR DESCRIPTION
Fixes #52611