### PR TITLE
database/sql: add SetMaxBadConnRetries

### DIFF
--- a/src/database/sql/sql_test.go
+++ b/src/database/sql/sql_test.go
@@ -2660,6 +2660,9 @@ func TestManyErrBadConn(t *testing.T) {
 			f(db)
 		}
 
+		var maxBadConnRetries = 2
+		db.SetMaxBadConnRetries(maxBadConnRetries)
+
 		nconn := maxBadConnRetries + 1
 		db.SetMaxIdleConns(nconn)
 		db.SetMaxOpenConns(nconn)

--- a/src/database/sql/sql_test.go
+++ b/src/database/sql/sql_test.go
@@ -2790,6 +2790,14 @@ func TestManyErrBadConn(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// set maxBadConnRetries to 0 should raise error
+	db = manyErrBadConnSetup()
+	db.SetMaxBadConnRetries(0)
+	rows, err = db.Query("SELECT|people|age,name|")
+	if !errors.Is(err, driver.ErrBadConn) {
+		t.Fatal(err)
+	}
 }
 
 // Issue 34775: Ensure that a Tx cannot commit after a rollback.


### PR DESCRIPTION
Add the ability to sets the number of maximum retries if the driver returns driver.ErrBadConn.

This can allow us to skip retry those long running SQL queries killed by db server.

Fixes #52886