### PR TITLE
crypto/tls: randomly generate ticket_age_add

### DIFF
--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -9,10 +9,12 @@ import (
 	"context"
 	"crypto"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/rsa"
 	"errors"
 	"hash"
 	"io"
+	"math/big"
 	"sync/atomic"
 	"time"
 )
@@ -744,6 +746,11 @@ func (hs *serverHandshakeStateTLS13) sendSessionTickets() error {
 		return err
 	}
 	m.lifetime = uint32(maxSessionTicketLifetime / time.Second)
+	ageAdd, err := rand.Int(rand.Reader, big.NewInt(4294967296)) // 2^32
+	if err != nil {
+		return err
+	}
+	m.ageAdd = uint32(ageAdd.Uint64())
 
 	if _, err := c.writeRecord(recordTypeHandshake, m.marshal()); err != nil {
 		return err


### PR DESCRIPTION
Currently, crypto/tls always sets `newSessionTicketMsgTLS13.ageAdd` to 0,
which makes it so that clients resuming a session can't obfuscate the
`obfusacted_ticket_age`. This violates the TLS 1.3 spec (RFC 8446, section
4.6.1), which says "The server MUST generate a fresh value for each
ticket it sends."

To fix this, it's enough to assign `ageAdd` a random value each time,
given that the `obfuscated_ticket_age` is not currently checked
server-side by crypto/tls.

Fixes #52814