### PR TITLE
io: fix for LimitedReader sentinel when N == stream length

### DIFF
--- a/src/io/io.go
+++ b/src/io/io.go
@@ -469,7 +469,11 @@ type LimitedReader struct {
 }
 
 func (l *LimitedReader) Read(p []byte) (n int, err error) {
-	if l.N <= 0 {
+	if l.N == 0 {
+		l.N--
+		n, err = l.R.Read(p[:0])
+		return
+	} else if l.N < 0 {
 		err := l.Err
 		if err == nil {
 			err = EOF

--- a/src/io/limited_reader_test.go
+++ b/src/io/limited_reader_test.go
@@ -1,0 +1,58 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package io_test
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func testLimitedReader(t *testing.T, data, limit int) {
+	if data < 0 {
+		return
+	}
+	sample := strings.Repeat("a", data)
+	r := strings.NewReader(sample)
+	sentinel := errors.New("reached read limit")
+	lr := &io.LimitedReader{R: r, N: int64(limit), Err: sentinel}
+
+	var buf strings.Builder
+	_, err := io.Copy(&buf, lr)
+	wantlen := limit
+	wanterr := sentinel
+	if limit >= data {
+		wanterr = nil
+		wantlen = data
+	}
+	if wantlen < 0 {
+		wantlen = 0
+	}
+
+	if s := buf.String(); len(s) != wantlen {
+		t.Fatalf("want len %d; got %d", wantlen, len(s))
+	}
+	if err != wanterr {
+		t.Fatalf("want err %v; got %v", wanterr, err)
+	}
+}
+
+func TestLimitedReader(t *testing.T) {
+	for _, tc := range [][2]int{
+		{0, -1},
+		{0, 0},
+		{0, 5},
+		{5, -1},
+		{5, 4},
+		{5, 5},
+		{5, 6},
+		{15_000, 14_999},
+		{15_000, 15_000},
+		{15_000, 15_001},
+	} {
+		testLimitedReader(t, tc[0], tc[1])
+	}
+}


### PR DESCRIPTION
@rogpeppe found a bug. See https://github.com/golang/go/issues/51115#issuecomment-1125017083

Fixes #51115
