### PR TITLE
crypto/x509: optimize the performance of checkSignature

### DIFF
--- a/src/crypto/x509/x509.go
+++ b/src/crypto/x509/x509.go
@@ -823,6 +823,7 @@ func checkSignature(algo SignatureAlgorithm, signed, signature []byte, publicKey
 		if details.algo == algo {
 			hashType = details.hash
 			pubKeyAlgo = details.pubKeyAlgo
+			break
 		}
 	}
 


### PR DESCRIPTION
The loop should be terminated immediately when `algo` has been found

Fixes #52955
