### PR TITLE
cmd/dist: support spaces and quotes in CC

### DIFF
--- a/src/cmd/dist/build.go
+++ b/src/cmd/dist/build.go
@@ -1631,7 +1631,13 @@ func checkCC() {
 	if !needCC() {
 		return
 	}
-	if output, err := exec.Command(defaultcc[""], "--help").CombinedOutput(); err != nil {
+	cc, err := quotedSplit(defaultcc[""])
+	if err != nil {
+		fatalf("split CC: %v", err)
+	}
+	var ccHelp = append(cc, "--help")
+
+	if output, err := exec.Command(ccHelp[0], ccHelp[1:]...).CombinedOutput(); err != nil {
 		outputHdr := ""
 		if len(output) > 0 {
 			outputHdr = "\nCommand output:\n\n"
@@ -1639,7 +1645,7 @@ func checkCC() {
 		fatalf("cannot invoke C compiler %q: %v\n\n"+
 			"Go needs a system C compiler for use with cgo.\n"+
 			"To set a C compiler, set CC=the-compiler.\n"+
-			"To disable cgo, set CGO_ENABLED=0.\n%s%s", defaultcc[""], err, outputHdr, output)
+			"To disable cgo, set CGO_ENABLED=0.\n%s%s", cc, err, outputHdr, output)
 	}
 }
 

--- a/src/cmd/dist/quoted.go
+++ b/src/cmd/dist/quoted.go
@@ -1,0 +1,49 @@
+package main
+
+import "fmt"
+
+// quotedSplit is a verbatim copy from cmd/internal/quoted.go:Split and its
+// dependencies (isSpaceByte). Since this package is built using the host's
+// Go compiler, it cannot use `cmd/internal/...`. We also don't want to export
+// it to all Go users.
+//
+// Please keep those in sync.
+func quotedSplit(s string) ([]string, error) {
+	// Split fields allowing '' or "" around elements.
+	// Quotes further inside the string do not count.
+	var f []string
+	for len(s) > 0 {
+		for len(s) > 0 && isSpaceByte(s[0]) {
+			s = s[1:]
+		}
+		if len(s) == 0 {
+			break
+		}
+		// Accepted quoted string. No unescaping inside.
+		if s[0] == '"' || s[0] == '\'' {
+			quote := s[0]
+			s = s[1:]
+			i := 0
+			for i < len(s) && s[i] != quote {
+				i++
+			}
+			if i >= len(s) {
+				return nil, fmt.Errorf("unterminated %c string", quote)
+			}
+			f = append(f, s[:i])
+			s = s[i+1:]
+			continue
+		}
+		i := 0
+		for i < len(s) && !isSpaceByte(s[i]) {
+			i++
+		}
+		f = append(f, s[:i])
+		s = s[i:]
+	}
+	return f, nil
+}
+
+func isSpaceByte(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}

--- a/src/cmd/internal/quoted/quoted.go
+++ b/src/cmd/internal/quoted/quoted.go
@@ -20,6 +20,8 @@ func isSpaceByte(c byte) bool {
 // allowing single or double quotes around elements.
 // There is no unescaping or other processing within
 // quoted fields.
+//
+// Keep in sync with cmd/dist/quoted.go
 func Split(s string) ([]string, error) {
 	// Split fields allowing '' or "" around elements.
 	// Quotes further inside the string do not count.


### PR DESCRIPTION
As of CL 334732 `go build` can accept `$CC` with spaces and quotes,
which lets us easily use `zig cc` as the C compiler, or easily pass
extra compiler parameters:

```
CC="zig cc" go build <...>
CC="clang-13 -v" go build <...>
CC="zig cc -Wl,--print-gc-sections" go build <...>
```

However, the same does not apply for building go itself:

```
$ CC="zig cc" ./make.bash
Building Go cmd/dist using /usr/local/go. (go1.18.2 linux/amd64)
go tool dist: cannot invoke C compiler "zig cc": exec: "zig cc": executable file not found in $PATH

Go needs a system C compiler for use with cgo.
To set a C compiler, set CC=the-compiler.
To disable cgo, set CGO_ENABLED=0.
```

With this change Go can be built directly with `zig cc` (the linker arg
will disappear with CL 405414):

```
$ CC="zig cc -Wl,--no-gc-sections" ./make.bash
Building Go cmd/dist using /usr/local/go. (go1.18.2 linux/amd64)
Building Go toolchain1 using /usr/local/go.
Building Go bootstrap cmd/go (go_bootstrap) using Go toolchain1.
Building Go toolchain2 using go_bootstrap and Go toolchain1.
Building Go toolchain3 using go_bootstrap and Go toolchain2.
Building packages and commands for linux/amd64.
---
Installed Go for linux/amd64 in /home/motiejus/code/go
Installed commands in /home/motiejus/code/go/bin
$ ../bin/go version
go version devel go1.19-811f1913a8 Thu May 19 09:44:49 2022 +0300 linux/amd64
```

Fixes #52990
