### PR TITLE
cmd/go: improve err msg when vendors dir is missing but required

### DIFF
--- a/src/cmd/go/internal/modload/vendor.go
+++ b/src/cmd/go/internal/modload/vendor.go
@@ -44,7 +44,7 @@ func readVendorList(mainModule module.Version) {
 		vendorMeta = make(map[module.Version]vendorMetadata)
 		data, err := os.ReadFile(filepath.Join(MainModules.ModRoot(mainModule), "vendor/modules.txt"))
 		if err != nil {
-			if !errors.Is(err, fs.ErrNotExist) {
+			if errors.Is(err, fs.ErrNotExist) {
 				base.Fatalf("go: %s", err)
 			}
 			return

--- a/src/cmd/go/testdata/script/mod_ambiguous_import.txt
+++ b/src/cmd/go/testdata/script/mod_ambiguous_import.txt
@@ -46,3 +46,4 @@ module example.com/a/x
 go 1.14
 -- $WORK/ax/x.go --
 package x
+-- $WORK/vendor/modules.txt --

--- a/src/cmd/go/testdata/script/mod_convert_vendor_json.txt
+++ b/src/cmd/go/testdata/script/mod_convert_vendor_json.txt
@@ -10,6 +10,7 @@ stderr '\s*cd \.\. && go mod init'
 # The command we suggested should succeed.
 cd ..
 go mod init
+go mod vendor
 go list -m
 stdout '^m$'
 

--- a/src/cmd/go/testdata/script/mod_convert_vendor_manifest.txt
+++ b/src/cmd/go/testdata/script/mod_convert_vendor_manifest.txt
@@ -10,6 +10,7 @@ stderr '\s*cd \.\. && go mod init'
 # The command we suggested should succeed.
 cd ..
 go mod init
+go mod vendor
 go list -m
 stdout '^m$'
 

--- a/src/cmd/go/testdata/script/mod_std_vendor.txt
+++ b/src/cmd/go/testdata/script/mod_std_vendor.txt
@@ -21,8 +21,8 @@ stdout ^vendor/golang.org/x/crypto # dep of .TestImports
 cd broken
 ! go build -mod=readonly
 stderr 'disabled by -mod=readonly'
-! go build -mod=vendor
-stderr 'cannot find package'
+! go build
+stderr 'no required module provides package'
 stderr 'hpack'
 
 # ...even if they explicitly use the "cmd/vendor/" or "vendor/" prefix.

--- a/src/cmd/go/testdata/script/test_vendor.txt
+++ b/src/cmd/go/testdata/script/test_vendor.txt
@@ -7,8 +7,15 @@ stdout TestMsgExternal
 
 # In module mode, they cannot.
 env GO111MODULE=on
-! go test -mod=vendor
+! go test
 stderr 'undefined: strings.Msg'
+
+# The vendor/modules.txt has to exist if -mod=vendor is enabled
+env GOFLAGS=-mod=vendor
+! go fmt ./...
+stderr 'vendor/modules.txt: no such file or directory'
+env GOFLAGS=
+go fmt ./...
 
 -- vend/hello/go.mod --
 module vend/hello


### PR DESCRIPTION
The existing implementation is producing log.Fatalf err message but
that codepath is never touched, because the conditional statement
is wrong.

Fixes #53007
