### PR TITLE
cmd/link: enable go plugin support for riscv64

### DIFF
--- a/src/cmd/dist/test.go
+++ b/src/cmd/dist/test.go
@@ -1115,7 +1115,7 @@ func (t *tester) supportedBuildmode(mode string) bool {
 		return false
 	case "plugin":
 		switch pair {
-		case "linux-386", "linux-amd64", "linux-arm", "linux-arm64", "linux-s390x", "linux-ppc64le":
+		case "linux-386", "linux-amd64", "linux-arm", "linux-arm64", "linux-riscv64", "linux-s390x", "linux-ppc64le":
 			return true
 		case "darwin-amd64", "darwin-arm64":
 			return true

--- a/src/cmd/internal/sys/supported.go
+++ b/src/cmd/internal/sys/supported.go
@@ -142,7 +142,7 @@ func BuildModeSupported(compiler, buildmode, goos, goarch string) bool {
 
 	case "plugin":
 		switch platform {
-		case "linux/amd64", "linux/arm", "linux/arm64", "linux/386", "linux/s390x", "linux/ppc64le",
+		case "linux/amd64", "linux/arm", "linux/arm64", "linux/riscv64", "linux/386", "linux/s390x", "linux/ppc64le",
 			"android/amd64", "android/arm", "android/arm64", "android/386",
 			"darwin/amd64", "darwin/arm64",
 			"freebsd/amd64":

--- a/src/cmd/link/internal/ld/config.go
+++ b/src/cmd/link/internal/ld/config.go
@@ -95,7 +95,7 @@ func (mode *BuildMode) Set(s string) error {
 		switch buildcfg.GOOS {
 		case "linux":
 			switch buildcfg.GOARCH {
-			case "386", "amd64", "arm", "arm64", "s390x", "ppc64le":
+			case "386", "amd64", "arm", "arm64", "riscv64", "s390x", "ppc64le":
 			default:
 				return badmode()
 			}


### PR DESCRIPTION
This change modifies Go to support buildmode: plugin on arch: riscv64.
It seems to be working fine, here are some build logs.

after fix, [finished](https://github.com/ClownpieceStripedAbyss/riscv/blob/235690f6ee60abfec92408ed895d68590c2afc45/after-fix.log#L1463)
before fix, [failed](https://github.com/ClownpieceStripedAbyss/riscv/blob/235690f6ee60abfec92408ed895d68590c2afc45/before-fix.log#L1051)