### PR TITLE
cmd/link: specify -Wl,-z params as documented

### DIFF
--- a/src/cmd/link/internal/ld/lib.go
+++ b/src/cmd/link/internal/ld/lib.go
@@ -1463,12 +1463,12 @@ func (ctxt *Link) hostlink() {
 		// We force all symbol resolution to be done at program startup
 		// because lazy PLT resolution can use large amounts of stack at
 		// times we cannot allow it to do so.
-		argv = append(argv, "-Wl,-znow")
+		argv = append(argv, "-Wl,-z,now")
 
 		// Do not let the host linker generate COPY relocations. These
 		// can move symbols out of sections that rely on stable offsets
 		// from the beginning of the section (like sym.STYPE).
-		argv = append(argv, "-Wl,-znocopyreloc")
+		argv = append(argv, "-Wl,-z,nocopyreloc")
 
 		if buildcfg.GOOS == "android" {
 			// Use lld to avoid errors from default linker (issue #38838)


### PR DESCRIPTION
Both GNU and LLVM linkers de facto accept `-zPARAM`, and Go sometimes
does it. Inconsistently: there are more uses of `-z PARAM` than
`-zPARAM`:

    $ git grep -E -- '-Wl,-z[^,]' master | wc -l
    4
    $ git grep -E -- '-Wl,-z,' master | wc -l
    7

However, not adding a space between `-z` and the param is not
documented:

llvm-13:

    $ man ld.lld-13 | grep -E -A1 -w -- "^ +-z"
         -z option
                 Linker option extensions.


gnu ld:

    $ man ld | grep -E -A1 -w -- "^ +-z"
           -z keyword
               The recognized keywords are:
    --
           -z defs
               Report unresolved symbol references from regular object files.  This is done even if the linker is creating a non-symbolic
    --
           -z muldefs
               Normally when a symbol is defined multiple times, the linker will report a fatal error. These options allow multiple definitions
    --
           -z
           --imagic

... and thus should be avoided.

`zig cc`, when used as the C compiler (`CC="zig cc" go build ...`), will
bark, because `zig cc` accepts only `-z PARAM`, as documented.

Closes ziglang/zig#11669