### PR TITLE
internal/cpu: fix cpu cacheLineSize for arm64 darwin(a.k.a. M1)

### DIFF
--- a/src/internal/cpu/cpu_arm64.go
+++ b/src/internal/cpu/cpu_arm64.go
@@ -4,7 +4,10 @@
 
 package cpu
 
-const CacheLinePadSize = 64
+// CacheLinePadSize is used to prevent false sharing of cache lines.
+// We choose 128 because Apple Silicon, a.k.a. M1, has 128-byte cache line size.
+// It doesn't cost much and is much more future-proof.
+const CacheLinePadSize = 128
 
 func doinit() {
 	options = []option{


### PR DESCRIPTION
The existing value for M1 is 64, which is the same as other arm64 cpus.
But the correct cacheLineSize for M1 should be 128, which can be
verified using the following command:

$ sysctl -a hw | grep cachelinesize
hw.cachelinesize: 128

Fixes #53075