### PR TITLE
io: use errors.Is in reader and writer helpers

### DIFF
--- a/src/io/io.go
+++ b/src/io/io.go
@@ -333,7 +333,7 @@ func ReadAtLeast(r Reader, buf []byte, min int) (n int, err error) {
 	}
 	if n >= min {
 		err = nil
-	} else if n > 0 && err == EOF {
+	} else if n > 0 && errors.Is(err, EOF) {
 		err = ErrUnexpectedEOF
 	}
 	return
@@ -443,7 +443,7 @@ func copyBuffer(dst Writer, src Reader, buf []byte) (written int64, err error) {
 			}
 		}
 		if er != nil {
-			if er != EOF {
+			if !errors.Is(er, EOF) {
 				err = er
 			}
 			break
@@ -617,7 +617,7 @@ func (discard) ReadFrom(r Reader) (n int64, err error) {
 		n += int64(readSize)
 		if err != nil {
 			blackHolePool.Put(bufp)
-			if err == EOF {
+			if errors.Is(err, EOF) {
 				return n, nil
 			}
 			return
@@ -666,7 +666,7 @@ func ReadAll(r Reader) ([]byte, error) {
 		n, err := r.Read(b[len(b):cap(b)])
 		b = b[:len(b)+n]
 		if err != nil {
-			if err == EOF {
+			if errors.Is(err, EOF) {
 				err = nil
 			}
 			return b, err


### PR DESCRIPTION
This adds broad usage of errors.Is within io helper functions to make these helpers more resilient to implementations that choose to wrap errors. Currently, if an io.Reader wraps an io.EOF error in any way, helpers like io.ReadAll will not behave as expected, since they seem to expecting a naked EOF error to be returned.