### PR TITLE
misc/wasm: wasm_exec.js to work inside node

### DIFF
--- a/misc/wasm/wasm_exec.js
+++ b/misc/wasm/wasm_exec.js
@@ -11,6 +11,31 @@
 		return err;
 	};
 
+	const isRunningInsideNode = () => {
+		return process && process.release && process.release.name && process.release.name === "node"
+	}
+
+	if (isRunningInsideNode()) {
+		globalThis.require = require;
+		globalThis.fs = require("fs");
+		globalThis.TextEncoder = require("util").TextEncoder;
+		globalThis.TextDecoder = require("util").TextDecoder;
+
+		globalThis.performance = {
+			now() {
+				const [sec, nsec] = process.hrtime();
+				return sec * 1000 + nsec / 1000000;
+			},
+		};
+
+		const crypto = require("crypto");
+		globalThis.crypto = {
+			getRandomValues(b) {
+				crypto.randomFillSync(b);
+			},
+		};
+	}
+
 	if (!globalThis.fs) {
 		let outputBuf = "";
 		globalThis.fs = {
@@ -550,5 +575,9 @@
 				return event.result;
 			};
 		}
+	}
+
+	if (isRunningInsideNode()) {
+		module.exports.Go = globalThis.Go
 	}
 })();

--- a/misc/wasm/wasm_exec_node.js
+++ b/misc/wasm/wasm_exec_node.js
@@ -9,25 +9,6 @@ if (process.argv.length < 3) {
 	process.exit(1);
 }
 
-globalThis.require = require;
-globalThis.fs = require("fs");
-globalThis.TextEncoder = require("util").TextEncoder;
-globalThis.TextDecoder = require("util").TextDecoder;
-
-globalThis.performance = {
-	now() {
-		const [sec, nsec] = process.hrtime();
-		return sec * 1000 + nsec / 1000000;
-	},
-};
-
-const crypto = require("crypto");
-globalThis.crypto = {
-	getRandomValues(b) {
-		crypto.randomFillSync(b);
-	},
-};
-
 require("./wasm_exec");
 
 const go = new Go();


### PR DESCRIPTION
Addressing #53128

Currently one can use the `wasm_exec.js` to run a Go WASM file as `node wasm_exec.js something.wasm`, and use it in the web to load a WASM file. Yet, there is no way to use it inside of the node to run Go WASMs there. This PR makes `wasm_exec.js` to be leaded inside of node and return the `Go` class as follows:
```js
const { Go } = require("./wasm_exec.js")
// and rest is just like the web...
```