### PR TITLE
cmd/buildid: reject rewriting legacy buildids

### DIFF
--- a/src/cmd/buildid/buildid.go
+++ b/src/cmd/buildid/buildid.go
@@ -53,6 +53,11 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// <= go 1.7 doesn't embed the contentID or actionID, so no slash is present
+	if !strings.Contains(id, "/") {
+		log.Fatalf("%s: build ID is a legacy format...binary too old for this tool", file)
+	}
+
 	newID := id[:strings.LastIndex(id, "/")] + "/" + buildid.HashToString(hash)
 	if len(newID) != len(id) {
 		log.Fatalf("%s: build ID length mismatch %q vs %q", file, id, newID)


### PR DESCRIPTION
This resolves legacy go binaries crashing the buildid tool when the -w flag is specified.

Fixes #50809