### PR TITLE
net/http: return ErrNoCookie from Request.Cookie when name is ""

### DIFF
--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -418,6 +418,9 @@ var ErrNoCookie = errors.New("http: named cookie not present")
 // If multiple cookies match the given name, only one cookie will
 // be returned.
 func (r *Request) Cookie(name string) (*Cookie, error) {
+	if name == "" {
+		return nil, ErrNoCookie
+	}
 	for _, c := range readCookies(r.Header, name) {
 		return c, nil
 	}


### PR DESCRIPTION
Request.Cookie(name string) will return the first cookie
when cookie name is "". Since readCookies in
file net/http/cookie.go at line 247 return all cookies
when second parameter is a empty string.
    
To fix it, Return ErrNoCookie from Request.Cookie(""),
instead of the first cookie in the request.
    
Fixes #53181