### PR TITLE
runtime: fix stack split at bad time when fuzzing

### DIFF
--- a/src/runtime/libfuzzer.go
+++ b/src/runtime/libfuzzer.go
@@ -15,41 +15,53 @@ func libfuzzerCall4(fn *byte, fakePC uintptr, s1, s2 unsafe.Pointer, result uint
 // Keep in sync with the definition of ret_sled in src/runtime/libfuzzer_amd64.s
 const retSledSize = 512
 
+// In libFuzzer mode, the compiler inserts calls to libfuzzerTraceCmpN and libfuzzerTraceConstCmpN
+// (where N can be 1, 2, 4, or 8) for encountered integer comparisons in the code to be instrumented.
+// This may result in these functions having callers that are nosplit. That is why they must be nosplit.
+//
+//go:nosplit
 func libfuzzerTraceCmp1(arg0, arg1 uint8, fakePC int) {
 	fakePC = fakePC % retSledSize
 	libfuzzerCallTraceIntCmp(&__sanitizer_cov_trace_cmp1, uintptr(arg0), uintptr(arg1), uintptr(fakePC))
 }
 
+//go:nosplit
 func libfuzzerTraceCmp2(arg0, arg1 uint16, fakePC int) {
 	fakePC = fakePC % retSledSize
 	libfuzzerCallTraceIntCmp(&__sanitizer_cov_trace_cmp2, uintptr(arg0), uintptr(arg1), uintptr(fakePC))
 }
 
+//go:nosplit
 func libfuzzerTraceCmp4(arg0, arg1 uint32, fakePC int) {
 	fakePC = fakePC % retSledSize
 	libfuzzerCallTraceIntCmp(&__sanitizer_cov_trace_cmp4, uintptr(arg0), uintptr(arg1), uintptr(fakePC))
 }
 
+//go:nosplit
 func libfuzzerTraceCmp8(arg0, arg1 uint64, fakePC int) {
 	fakePC = fakePC % retSledSize
 	libfuzzerCallTraceIntCmp(&__sanitizer_cov_trace_cmp8, uintptr(arg0), uintptr(arg1), uintptr(fakePC))
 }
 
+//go:nosplit
 func libfuzzerTraceConstCmp1(arg0, arg1 uint8, fakePC int) {
 	fakePC = fakePC % retSledSize
 	libfuzzerCallTraceIntCmp(&__sanitizer_cov_trace_const_cmp1, uintptr(arg0), uintptr(arg1), uintptr(fakePC))
 }
 
+//go:nosplit
 func libfuzzerTraceConstCmp2(arg0, arg1 uint16, fakePC int) {
 	fakePC = fakePC % retSledSize
 	libfuzzerCallTraceIntCmp(&__sanitizer_cov_trace_const_cmp2, uintptr(arg0), uintptr(arg1), uintptr(fakePC))
 }
 
+//go:nosplit
 func libfuzzerTraceConstCmp4(arg0, arg1 uint32, fakePC int) {
 	fakePC = fakePC % retSledSize
 	libfuzzerCallTraceIntCmp(&__sanitizer_cov_trace_const_cmp4, uintptr(arg0), uintptr(arg1), uintptr(fakePC))
 }
 
+//go:nosplit
 func libfuzzerTraceConstCmp8(arg0, arg1 uint64, fakePC int) {
 	fakePC = fakePC % retSledSize
 	libfuzzerCallTraceIntCmp(&__sanitizer_cov_trace_const_cmp8, uintptr(arg0), uintptr(arg1), uintptr(fakePC))


### PR DESCRIPTION
Fix #53190