### PR TITLE
crypto/tls: fix a testing deadlock that occurs on a TLS protocol error

### DIFF
--- a/src/crypto/tls/handshake_server_test.go
+++ b/src/crypto/tls/handshake_server_test.go
@@ -200,7 +200,6 @@ func TestRenegotiationExtension(t *testing.T) {
 		n, err := c.Read(buf)
 		if err != nil {
 			t.Errorf("Server read returned error: %s", err)
-			return
 		}
 		c.Close()
 		bufChan <- buf[:n]


### PR DESCRIPTION
A Go routine was, on an error, returning without sending a message on its
signaling channel, so the main program was blocking forever waiting for
a message that was never sent. Found while breaking crypto/tls.

