### PR TITLE
os: don't check for IsExist in MkdirAll example

### DIFF
--- a/src/os/example_test.go
+++ b/src/os/example_test.go
@@ -255,7 +255,7 @@ func ExampleMkdir() {
 
 func ExampleMkdirAll() {
 	err := os.MkdirAll("test/subdir", 0750)
-	if err != nil && !os.IsExist(err) {
+	if err != nil {
 		log.Fatal(err)
 	}
 	err = os.WriteFile("test/subdir/testfile.txt", []byte("Hello, Gophers!"), 0660)


### PR DESCRIPTION
If a directory already exists, then MkdirAll returns nil. Therefore the
check with IsExist is not necessary.
