### PR TITLE
net: fix receiver names are different

### DIFF
--- a/src/net/dnsclient.go
+++ b/src/net/dnsclient.go
@@ -165,39 +165,39 @@ func (s byPriorityWeight) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
 // shuffleByWeight shuffles SRV records by weight using the algorithm
 // described in RFC 2782.
-func (addrs byPriorityWeight) shuffleByWeight() {
+func (s byPriorityWeight) shuffleByWeight() {
 	sum := 0
-	for _, addr := range addrs {
+	for _, addr := range s {
 		sum += int(addr.Weight)
 	}
-	for sum > 0 && len(addrs) > 1 {
-		s := 0
+	for sum > 0 && len(s) > 1 {
+		w := 0
 		n := randIntn(sum)
-		for i := range addrs {
-			s += int(addrs[i].Weight)
-			if s > n {
+		for i := range s {
+			w += int(s[i].Weight)
+			if w > n {
 				if i > 0 {
-					addrs[0], addrs[i] = addrs[i], addrs[0]
+					s[0], s[i] = s[i], s[0]
 				}
 				break
 			}
 		}
-		sum -= int(addrs[0].Weight)
-		addrs = addrs[1:]
+		sum -= int(s[0].Weight)
+		s = s[1:]
 	}
 }
 
 // sort reorders SRV records as specified in RFC 2782.
-func (addrs byPriorityWeight) sort() {
-	sort.Sort(addrs)
+func (s byPriorityWeight) sort() {
+	sort.Sort(s)
 	i := 0
-	for j := 1; j < len(addrs); j++ {
-		if addrs[i].Priority != addrs[j].Priority {
-			addrs[i:j].shuffleByWeight()
+	for j := 1; j < len(s); j++ {
+		if s[i].Priority != s[j].Priority {
+			s[i:j].shuffleByWeight()
 			i = j
 		}
 	}
-	addrs[i:].shuffleByWeight()
+	s[i:].shuffleByWeight()
 }
 
 // An MX represents a single DNS MX record.

--- a/src/net/dnsclient_unix.go
+++ b/src/net/dnsclient_unix.go
@@ -474,7 +474,7 @@ func avoidDNS(name string) bool {
 }
 
 // nameList returns a list of names for sequential DNS queries.
-func (conf *dnsConfig) nameList(name string) []string {
+func (c *dnsConfig) nameList(name string) []string {
 	if avoidDNS(name) {
 		return nil
 	}
@@ -491,18 +491,18 @@ func (conf *dnsConfig) nameList(name string) []string {
 		return []string{name}
 	}
 
-	hasNdots := count(name, '.') >= conf.ndots
+	hasNdots := count(name, '.') >= c.ndots
 	name += "."
 	l++
 
 	// Build list of search choices.
-	names := make([]string, 0, 1+len(conf.search))
+	names := make([]string, 0, 1+len(c.search))
 	// If name has enough dots, try unsuffixed first.
 	if hasNdots {
 		names = append(names, name)
 	}
 	// Try suffixes that are not too long (see isDomainName).
-	for _, suffix := range conf.search {
+	for _, suffix := range c.search {
 		if l+len(suffix) <= 254 {
 			names = append(names, name+suffix)
 		}

--- a/src/net/http/fcgi/fcgi.go
+++ b/src/net/http/fcgi/fcgi.go
@@ -136,8 +136,8 @@ func (rec *record) read(r io.Reader) (err error) {
 	return nil
 }
 
-func (r *record) content() []byte {
-	return r.buf[:r.h.ContentLength]
+func (rec *record) content() []byte {
+	return rec.buf[:rec.h.ContentLength]
 }
 
 // writeRecord writes and sends a single record.

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -616,9 +616,9 @@ func (w *response) ReadFrom(src io.Reader) (n int64, err error) {
 const debugServerConnections = false
 
 // Create new connection from rwc.
-func (srv *Server) newConn(rwc net.Conn) *conn {
+func (s *Server) newConn(rwc net.Conn) *conn {
 	c := &conn{
-		server: srv,
+		server: s,
 		rwc:    rwc,
 	}
 	if debugServerConnections {
@@ -860,15 +860,15 @@ func putBufioWriter(bw *bufio.Writer) {
 // This can be overridden by setting Server.MaxHeaderBytes.
 const DefaultMaxHeaderBytes = 1 << 20 // 1 MB
 
-func (srv *Server) maxHeaderBytes() int {
-	if srv.MaxHeaderBytes > 0 {
-		return srv.MaxHeaderBytes
+func (s *Server) maxHeaderBytes() int {
+	if s.MaxHeaderBytes > 0 {
+		return s.MaxHeaderBytes
 	}
 	return DefaultMaxHeaderBytes
 }
 
-func (srv *Server) initialReadLimitSize() int64 {
-	return int64(srv.maxHeaderBytes()) + 4096 // bufio slop
+func (s *Server) initialReadLimitSize() int64 {
+	return int64(s.maxHeaderBytes()) + 4096 // bufio slop
 }
 
 // tlsHandshakeTimeout returns the time limit permitted for the TLS
@@ -876,12 +876,12 @@ func (srv *Server) initialReadLimitSize() int64 {
 //
 // It returns the minimum of any positive ReadHeaderTimeout,
 // ReadTimeout, or WriteTimeout.
-func (srv *Server) tlsHandshakeTimeout() time.Duration {
+func (s *Server) tlsHandshakeTimeout() time.Duration {
 	var ret time.Duration
 	for _, v := range [...]time.Duration{
-		srv.ReadHeaderTimeout,
-		srv.ReadTimeout,
-		srv.WriteTimeout,
+		s.ReadHeaderTimeout,
+		s.ReadTimeout,
+		s.WriteTimeout,
 	} {
 		if v <= 0 {
 			continue
@@ -2726,15 +2726,15 @@ func (s *Server) closeDoneChanLocked() {
 //
 // Close returns any error returned from closing the Server's
 // underlying Listener(s).
-func (srv *Server) Close() error {
-	srv.inShutdown.setTrue()
-	srv.mu.Lock()
-	defer srv.mu.Unlock()
-	srv.closeDoneChanLocked()
-	err := srv.closeListenersLocked()
-	for c := range srv.activeConn {
+func (s *Server) Close() error {
+	s.inShutdown.setTrue()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closeDoneChanLocked()
+	err := s.closeListenersLocked()
+	for c := range s.activeConn {
 		c.rwc.Close()
-		delete(srv.activeConn, c)
+		delete(s.activeConn, c)
 	}
 	return err
 }
@@ -2768,16 +2768,16 @@ const shutdownPollIntervalMax = 500 * time.Millisecond
 //
 // Once Shutdown has been called on a server, it may not be reused;
 // future calls to methods such as Serve will return ErrServerClosed.
-func (srv *Server) Shutdown(ctx context.Context) error {
-	srv.inShutdown.setTrue()
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.inShutdown.setTrue()
 
-	srv.mu.Lock()
-	lnerr := srv.closeListenersLocked()
-	srv.closeDoneChanLocked()
-	for _, f := range srv.onShutdown {
+	s.mu.Lock()
+	lnerr := s.closeListenersLocked()
+	s.closeDoneChanLocked()
+	for _, f := range s.onShutdown {
 		go f()
 	}
-	srv.mu.Unlock()
+	s.mu.Unlock()
 
 	pollIntervalBase := time.Millisecond
 	nextPollInterval := func() time.Duration {
@@ -2794,7 +2794,7 @@ func (srv *Server) Shutdown(ctx context.Context) error {
 	timer := time.NewTimer(nextPollInterval())
 	defer timer.Stop()
 	for {
-		if srv.closeIdleConns() && srv.numListeners() == 0 {
+		if s.closeIdleConns() && s.numListeners() == 0 {
 			return lnerr
 		}
 		select {
@@ -2811,10 +2811,10 @@ func (srv *Server) Shutdown(ctx context.Context) error {
 // undergone ALPN protocol upgrade or that have been hijacked.
 // This function should start protocol-specific graceful shutdown,
 // but should not wait for shutdown to complete.
-func (srv *Server) RegisterOnShutdown(f func()) {
-	srv.mu.Lock()
-	srv.onShutdown = append(srv.onShutdown, f)
-	srv.mu.Unlock()
+func (s *Server) RegisterOnShutdown(f func()) {
+	s.mu.Lock()
+	s.onShutdown = append(s.onShutdown, f)
+	s.mu.Unlock()
 }
 
 func (s *Server) numListeners() int {
@@ -2978,11 +2978,11 @@ func AllowQuerySemicolons(h Handler) Handler {
 //
 // ListenAndServe always returns a non-nil error. After Shutdown or Close,
 // the returned error is ErrServerClosed.
-func (srv *Server) ListenAndServe() error {
-	if srv.shuttingDown() {
+func (s *Server) ListenAndServe() error {
+	if s.shuttingDown() {
 		return ErrServerClosed
 	}
-	addr := srv.Addr
+	addr := s.Addr
 	if addr == "" {
 		addr = ":http"
 	}
@@ -2990,15 +2990,15 @@ func (srv *Server) ListenAndServe() error {
 	if err != nil {
 		return err
 	}
-	return srv.Serve(ln)
+	return s.Serve(ln)
 }
 
 var testHookServerServe func(*Server, net.Listener) // used if non-nil
 
 // shouldDoServeHTTP2 reports whether Server.Serve should configure
 // automatic HTTP/2. (which sets up the srv.TLSNextProto map)
-func (srv *Server) shouldConfigureHTTP2ForServe() bool {
-	if srv.TLSConfig == nil {
+func (s *Server) shouldConfigureHTTP2ForServe() bool {
+	if s.TLSConfig == nil {
 		// Compatibility with Go 1.6:
 		// If there's no TLSConfig, it's possible that the user just
 		// didn't set it on the http.Server, but did pass it to
@@ -3014,7 +3014,7 @@ func (srv *Server) shouldConfigureHTTP2ForServe() bool {
 	// passed this tls.Config to tls.NewListener. And if they did,
 	// it's too late anyway to fix it. It would only be potentially racy.
 	// See Issue 15908.
-	return strSliceContains(srv.TLSConfig.NextProtos, http2NextProtoTLS)
+	return strSliceContains(s.TLSConfig.NextProtos, http2NextProtoTLS)
 }
 
 // ErrServerClosed is returned by the Server's Serve, ServeTLS, ListenAndServe,
@@ -3031,27 +3031,27 @@ var ErrServerClosed = errors.New("http: Server closed")
 //
 // Serve always returns a non-nil error and closes l.
 // After Shutdown or Close, the returned error is ErrServerClosed.
-func (srv *Server) Serve(l net.Listener) error {
+func (s *Server) Serve(l net.Listener) error {
 	if fn := testHookServerServe; fn != nil {
-		fn(srv, l) // call hook with unwrapped listener
+		fn(s, l) // call hook with unwrapped listener
 	}
 
 	origListener := l
 	l = &onceCloseListener{Listener: l}
 	defer l.Close()
 
-	if err := srv.setupHTTP2_Serve(); err != nil {
+	if err := s.setupHTTP2_Serve(); err != nil {
 		return err
 	}
 
-	if !srv.trackListener(&l, true) {
+	if !s.trackListener(&l, true) {
 		return ErrServerClosed
 	}
-	defer srv.trackListener(&l, false)
+	defer s.trackListener(&l, false)
 
 	baseCtx := context.Background()
-	if srv.BaseContext != nil {
-		baseCtx = srv.BaseContext(origListener)
+	if s.BaseContext != nil {
+		baseCtx = s.BaseContext(origListener)
 		if baseCtx == nil {
 			panic("BaseContext returned a nil context")
 		}
@@ -3059,12 +3059,12 @@ func (srv *Server) Serve(l net.Listener) error {
 
 	var tempDelay time.Duration // how long to sleep on accept failure
 
-	ctx := context.WithValue(baseCtx, ServerContextKey, srv)
+	ctx := context.WithValue(baseCtx, ServerContextKey, s)
 	for {
 		rw, err := l.Accept()
 		if err != nil {
 			select {
-			case <-srv.getDoneChan():
+			case <-s.getDoneChan():
 				return ErrServerClosed
 			default:
 			}
@@ -3077,21 +3077,21 @@ func (srv *Server) Serve(l net.Listener) error {
 				if max := 1 * time.Second; tempDelay > max {
 					tempDelay = max
 				}
-				srv.logf("http: Accept error: %v; retrying in %v", err, tempDelay)
+				s.logf("http: Accept error: %v; retrying in %v", err, tempDelay)
 				time.Sleep(tempDelay)
 				continue
 			}
 			return err
 		}
 		connCtx := ctx
-		if cc := srv.ConnContext; cc != nil {
+		if cc := s.ConnContext; cc != nil {
 			connCtx = cc(connCtx, rw)
 			if connCtx == nil {
 				panic("ConnContext returned nil")
 			}
 		}
 		tempDelay = 0
-		c := srv.newConn(rw)
+		c := s.newConn(rw)
 		c.setState(c.rwc, StateNew, runHooks) // before Serve can return
 		go c.serve(connCtx)
 	}
@@ -3110,14 +3110,14 @@ func (srv *Server) Serve(l net.Listener) error {
 //
 // ServeTLS always returns a non-nil error. After Shutdown or Close, the
 // returned error is ErrServerClosed.
-func (srv *Server) ServeTLS(l net.Listener, certFile, keyFile string) error {
+func (s *Server) ServeTLS(l net.Listener, certFile, keyFile string) error {
 	// Setup HTTP/2 before srv.Serve, to initialize srv.TLSConfig
 	// before we clone it and create the TLS Listener.
-	if err := srv.setupHTTP2_ServeTLS(); err != nil {
+	if err := s.setupHTTP2_ServeTLS(); err != nil {
 		return err
 	}
 
-	config := cloneTLSConfig(srv.TLSConfig)
+	config := cloneTLSConfig(s.TLSConfig)
 	if !strSliceContains(config.NextProtos, "http/1.1") {
 		config.NextProtos = append(config.NextProtos, "http/1.1")
 	}
@@ -3133,7 +3133,7 @@ func (srv *Server) ServeTLS(l net.Listener, certFile, keyFile string) error {
 	}
 
 	tlsListener := tls.NewListener(l, config)
-	return srv.Serve(tlsListener)
+	return s.Serve(tlsListener)
 }
 
 // trackListener adds or removes a net.Listener to the set of tracked
@@ -3202,15 +3202,15 @@ func (s *Server) shuttingDown() bool {
 // By default, keep-alives are always enabled. Only very
 // resource-constrained environments or servers in the process of
 // shutting down should disable them.
-func (srv *Server) SetKeepAlivesEnabled(v bool) {
+func (s *Server) SetKeepAlivesEnabled(v bool) {
 	if v {
-		atomic.StoreInt32(&srv.disableKeepAlives, 0)
+		atomic.StoreInt32(&s.disableKeepAlives, 0)
 		return
 	}
-	atomic.StoreInt32(&srv.disableKeepAlives, 1)
+	atomic.StoreInt32(&s.disableKeepAlives, 1)
 
 	// Close idle HTTP/1 conns:
-	srv.closeIdleConns()
+	s.closeIdleConns()
 
 	// TODO: Issue 26303: close HTTP/2 conns as soon as they become idle.
 }
@@ -3272,11 +3272,11 @@ func ListenAndServeTLS(addr, certFile, keyFile string, handler Handler) error {
 //
 // ListenAndServeTLS always returns a non-nil error. After Shutdown or
 // Close, the returned error is ErrServerClosed.
-func (srv *Server) ListenAndServeTLS(certFile, keyFile string) error {
-	if srv.shuttingDown() {
+func (s *Server) ListenAndServeTLS(certFile, keyFile string) error {
+	if s.shuttingDown() {
 		return ErrServerClosed
 	}
-	addr := srv.Addr
+	addr := s.Addr
 	if addr == "" {
 		addr = ":https"
 	}
@@ -3288,15 +3288,15 @@ func (srv *Server) ListenAndServeTLS(certFile, keyFile string) error {
 
 	defer ln.Close()
 
-	return srv.ServeTLS(ln, certFile, keyFile)
+	return s.ServeTLS(ln, certFile, keyFile)
 }
 
 // setupHTTP2_ServeTLS conditionally configures HTTP/2 on
 // srv and reports whether there was an error setting it up. If it is
 // not configured for policy reasons, nil is returned.
-func (srv *Server) setupHTTP2_ServeTLS() error {
-	srv.nextProtoOnce.Do(srv.onceSetNextProtoDefaults)
-	return srv.nextProtoErr
+func (s *Server) setupHTTP2_ServeTLS() error {
+	s.nextProtoOnce.Do(s.onceSetNextProtoDefaults)
+	return s.nextProtoErr
 }
 
 // setupHTTP2_Serve is called from (*Server).Serve and conditionally
@@ -3307,31 +3307,31 @@ func (srv *Server) setupHTTP2_ServeTLS() error {
 // The tests named TestTransportAutomaticHTTP2* and
 // TestConcurrentServerServe in server_test.go demonstrate some
 // of the supported use cases and motivations.
-func (srv *Server) setupHTTP2_Serve() error {
-	srv.nextProtoOnce.Do(srv.onceSetNextProtoDefaults_Serve)
-	return srv.nextProtoErr
+func (s *Server) setupHTTP2_Serve() error {
+	s.nextProtoOnce.Do(s.onceSetNextProtoDefaults_Serve)
+	return s.nextProtoErr
 }
 
-func (srv *Server) onceSetNextProtoDefaults_Serve() {
-	if srv.shouldConfigureHTTP2ForServe() {
-		srv.onceSetNextProtoDefaults()
+func (s *Server) onceSetNextProtoDefaults_Serve() {
+	if s.shouldConfigureHTTP2ForServe() {
+		s.onceSetNextProtoDefaults()
 	}
 }
 
 // onceSetNextProtoDefaults configures HTTP/2, if the user hasn't
 // configured otherwise. (by setting srv.TLSNextProto non-nil)
 // It must only be called via srv.nextProtoOnce (use srv.setupHTTP2_*).
-func (srv *Server) onceSetNextProtoDefaults() {
+func (s *Server) onceSetNextProtoDefaults() {
 	if omitBundledHTTP2 || godebug.Get("http2server") == "0" {
 		return
 	}
 	// Enable HTTP/2 by default if the user hasn't otherwise
 	// configured their TLSNextProto map.
-	if srv.TLSNextProto == nil {
+	if s.TLSNextProto == nil {
 		conf := &http2Server{
 			NewWriteScheduler: func() http2WriteScheduler { return http2NewPriorityWriteScheduler(nil) },
 		}
-		srv.nextProtoErr = http2ConfigureServer(srv, conf)
+		s.nextProtoErr = http2ConfigureServer(s, conf)
 	}
 }
 

--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -1512,20 +1512,20 @@ func (t *Transport) decConnsPerHost(key connectMethodKey) {
 // Add TLS to a persistent connection, i.e. negotiate a TLS session. If pconn is already a TLS
 // tunnel, this function establishes a nested TLS session inside the encrypted channel.
 // The remote endpoint's name may be overridden by TLSClientConfig.ServerName.
-func (pconn *persistConn) addTLS(ctx context.Context, name string, trace *httptrace.ClientTrace) error {
+func (pc *persistConn) addTLS(ctx context.Context, name string, trace *httptrace.ClientTrace) error {
 	// Initiate TLS and check remote host name against certificate.
-	cfg := cloneTLSConfig(pconn.t.TLSClientConfig)
+	cfg := cloneTLSConfig(pc.t.TLSClientConfig)
 	if cfg.ServerName == "" {
 		cfg.ServerName = name
 	}
-	if pconn.cacheKey.onlyH1 {
+	if pc.cacheKey.onlyH1 {
 		cfg.NextProtos = nil
 	}
-	plainConn := pconn.conn
+	plainConn := pc.conn
 	tlsConn := tls.Client(plainConn, cfg)
 	errc := make(chan error, 2)
 	var timer *time.Timer // for canceling TLS handshake
-	if d := pconn.t.TLSHandshakeTimeout; d != 0 {
+	if d := pc.t.TLSHandshakeTimeout; d != 0 {
 		timer = time.AfterFunc(d, func() {
 			errc <- tlsHandshakeTimeoutError{}
 		})
@@ -1551,8 +1551,8 @@ func (pconn *persistConn) addTLS(ctx context.Context, name string, trace *httptr
 	if trace != nil && trace.TLSHandshakeDone != nil {
 		trace.TLSHandshakeDone(cs, nil)
 	}
-	pconn.tlsState = &cs
-	pconn.conn = tlsConn
+	pc.tlsState = &cs
+	pc.conn = tlsConn
 	return nil
 }
 

--- a/src/net/listen_test.go
+++ b/src/net/listen_test.go
@@ -16,8 +16,8 @@ import (
 	"time"
 )
 
-func (ln *TCPListener) port() string {
-	_, port, err := SplitHostPort(ln.Addr().String())
+func (l *TCPListener) port() string {
+	_, port, err := SplitHostPort(l.Addr().String())
 	if err != nil {
 		return ""
 	}

--- a/src/net/netip/export_test.go
+++ b/src/net/netip/export_test.go
@@ -26,5 +26,5 @@ func IPv4(a, b, c, d uint8) Addr { return AddrFrom4([4]byte{a, b, c, d}) }
 
 var TestAppendToMarshal = testAppendToMarshal
 
-func (a Addr) IsZero() bool   { return a.isZero() }
+func (ip Addr) IsZero() bool  { return ip.isZero() }
 func (p Prefix) IsZero() bool { return p.isZero() }

--- a/src/net/tcpsock_plan9.go
+++ b/src/net/tcpsock_plan9.go
@@ -42,18 +42,18 @@ func (sd *sysDialer) doDialTCP(ctx context.Context, laddr, raddr *TCPAddr) (*TCP
 	return newTCPConn(fd), nil
 }
 
-func (ln *TCPListener) ok() bool { return ln != nil && ln.fd != nil && ln.fd.ctl != nil }
+func (l *TCPListener) ok() bool { return l != nil && l.fd != nil && l.fd.ctl != nil }
 
-func (ln *TCPListener) accept() (*TCPConn, error) {
-	fd, err := ln.fd.acceptPlan9()
+func (l *TCPListener) accept() (*TCPConn, error) {
+	fd, err := l.fd.acceptPlan9()
 	if err != nil {
 		return nil, err
 	}
 	tc := newTCPConn(fd)
-	if ln.lc.KeepAlive >= 0 {
+	if l.lc.KeepAlive >= 0 {
 		setKeepAlive(fd, true)
-		ka := ln.lc.KeepAlive
-		if ln.lc.KeepAlive == 0 {
+		ka := l.lc.KeepAlive
+		if l.lc.KeepAlive == 0 {
 			ka = defaultTCPKeepAlive
 		}
 		setKeepAlivePeriod(fd, ka)
@@ -61,22 +61,22 @@ func (ln *TCPListener) accept() (*TCPConn, error) {
 	return tc, nil
 }
 
-func (ln *TCPListener) close() error {
-	if err := ln.fd.pfd.Close(); err != nil {
+func (l *TCPListener) close() error {
+	if err := l.fd.pfd.Close(); err != nil {
 		return err
 	}
-	if _, err := ln.fd.ctl.WriteString("hangup"); err != nil {
-		ln.fd.ctl.Close()
+	if _, err := l.fd.ctl.WriteString("hangup"); err != nil {
+		l.fd.ctl.Close()
 		return err
 	}
-	if err := ln.fd.ctl.Close(); err != nil {
+	if err := l.fd.ctl.Close(); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (ln *TCPListener) file() (*os.File, error) {
-	f, err := ln.dup()
+func (l *TCPListener) file() (*os.File, error) {
+	f, err := l.dup()
 	if err != nil {
 		return nil, err
 	}

--- a/src/net/tcpsock_posix.go
+++ b/src/net/tcpsock_posix.go
@@ -133,18 +133,18 @@ func spuriousENOTAVAIL(err error) bool {
 	return err == syscall.EADDRNOTAVAIL
 }
 
-func (ln *TCPListener) ok() bool { return ln != nil && ln.fd != nil }
+func (l *TCPListener) ok() bool { return l != nil && l.fd != nil }
 
-func (ln *TCPListener) accept() (*TCPConn, error) {
-	fd, err := ln.fd.accept()
+func (l *TCPListener) accept() (*TCPConn, error) {
+	fd, err := l.fd.accept()
 	if err != nil {
 		return nil, err
 	}
 	tc := newTCPConn(fd)
-	if ln.lc.KeepAlive >= 0 {
+	if l.lc.KeepAlive >= 0 {
 		setKeepAlive(fd, true)
-		ka := ln.lc.KeepAlive
-		if ln.lc.KeepAlive == 0 {
+		ka := l.lc.KeepAlive
+		if l.lc.KeepAlive == 0 {
 			ka = defaultTCPKeepAlive
 		}
 		setKeepAlivePeriod(fd, ka)
@@ -152,12 +152,12 @@ func (ln *TCPListener) accept() (*TCPConn, error) {
 	return tc, nil
 }
 
-func (ln *TCPListener) close() error {
-	return ln.fd.Close()
+func (l *TCPListener) close() error {
+	return l.fd.Close()
 }
 
-func (ln *TCPListener) file() (*os.File, error) {
-	f, err := ln.fd.dup()
+func (l *TCPListener) file() (*os.File, error) {
+	f, err := l.fd.dup()
 	if err != nil {
 		return nil, err
 	}

--- a/src/net/unixsock.go
+++ b/src/net/unixsock.go
@@ -224,7 +224,7 @@ type UnixListener struct {
 	unlinkOnce sync.Once
 }
 
-func (ln *UnixListener) ok() bool { return ln != nil && ln.fd != nil }
+func (l *UnixListener) ok() bool { return l != nil && l.fd != nil }
 
 // SyscallConn returns a raw network connection.
 // This implements the syscall.Conn interface.

--- a/src/net/unixsock_plan9.go
+++ b/src/net/unixsock_plan9.go
@@ -30,15 +30,15 @@ func (sd *sysDialer) dialUnix(ctx context.Context, laddr, raddr *UnixAddr) (*Uni
 	return nil, syscall.EPLAN9
 }
 
-func (ln *UnixListener) accept() (*UnixConn, error) {
+func (l *UnixListener) accept() (*UnixConn, error) {
 	return nil, syscall.EPLAN9
 }
 
-func (ln *UnixListener) close() error {
+func (l *UnixListener) close() error {
 	return syscall.EPLAN9
 }
 
-func (ln *UnixListener) file() (*os.File, error) {
+func (l *UnixListener) file() (*os.File, error) {
 	return nil, syscall.EPLAN9
 }
 

--- a/src/net/unixsock_posix.go
+++ b/src/net/unixsock_posix.go
@@ -162,15 +162,15 @@ func (sd *sysDialer) dialUnix(ctx context.Context, laddr, raddr *UnixAddr) (*Uni
 	return newUnixConn(fd), nil
 }
 
-func (ln *UnixListener) accept() (*UnixConn, error) {
-	fd, err := ln.fd.accept()
+func (l *UnixListener) accept() (*UnixConn, error) {
+	fd, err := l.fd.accept()
 	if err != nil {
 		return nil, err
 	}
 	return newUnixConn(fd), nil
 }
 
-func (ln *UnixListener) close() error {
+func (l *UnixListener) close() error {
 	// The operating system doesn't clean up
 	// the file that announcing created, so
 	// we have to clean it up ourselves.
@@ -182,16 +182,16 @@ func (ln *UnixListener) close() error {
 	// sequence in ListenUnix. It's only non-Go
 	// programs that can mess us up.
 	// Even if there are racy calls to Close, we want to unlink only for the first one.
-	ln.unlinkOnce.Do(func() {
-		if ln.path[0] != '@' && ln.unlink {
-			syscall.Unlink(ln.path)
+	l.unlinkOnce.Do(func() {
+		if l.path[0] != '@' && l.unlink {
+			syscall.Unlink(l.path)
 		}
 	})
-	return ln.fd.Close()
+	return l.fd.Close()
 }
 
-func (ln *UnixListener) file() (*os.File, error) {
-	f, err := ln.fd.dup()
+func (l *UnixListener) file() (*os.File, error) {
+	f, err := l.fd.dup()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Keep the same receiver names, as prescribed in the [wiki](https://github.com/golang/go/wiki/CodeReviewComments#receiver-names).