### PR TITLE
encoding/hex: early BCE in Encode

### DIFF
--- a/src/encoding/hex/hex.go
+++ b/src/encoding/hex/hex.go
@@ -42,13 +42,18 @@ func EncodedLen(n int) int { return n * 2 }
 // of bytes written to dst, but this value is always EncodedLen(len(src)).
 // Encode implements hexadecimal encoding.
 func Encode(dst, src []byte) int {
+	if len(src) == 0 {
+		return 0
+	}
+	l := EncodedLen(len(src))
+	_ = dst[l-1] // BCE
 	j := 0
 	for _, v := range src {
 		dst[j] = hextable[v>>4]
 		dst[j+1] = hextable[v&0x0f]
 		j += 2
 	}
-	return len(src) * 2
+	return l
 }
 
 // ErrLength reports an attempt to decode an odd-length input


### PR DESCRIPTION
This leads to 1.11~1.04x improvement.
This has less impacts for bigger slices since the branch predictor spend
more time having learnt that slices should be in bound.

name             old time/op    new time/op    delta
Encode/256-12       262ns ± 3%     236ns ± 2%   -9.96%  (p=0.000 n=10+10)
Encode/1024-12      972ns ± 8%     909ns ± 3%     ~     (p=0.085 n=10+10)
Encode/4096-12     3.88µs ± 7%    3.62µs ± 2%   -6.69%  (p=0.000 n=10+10)
Encode/16384-12    15.3µs ± 7%    14.7µs ± 3%   -3.43%  (p=0.034 n=10+10)

name             old speed      new speed      delta
Encode/256-12     978MB/s ± 3%  1087MB/s ± 2%  +11.06%  (p=0.000 n=10+10)
Encode/1024-12   1.06GB/s ± 8%  1.13GB/s ± 3%     ~     (p=0.086 n=10+10)
Encode/4096-12   1.06GB/s ± 7%  1.13GB/s ± 2%   +6.99%  (p=0.000 n=10+10)
Encode/16384-12  1.07GB/s ± 7%  1.11GB/s ± 3%   +3.43%  (p=0.034 n=10+10)