### PR TITLE
cmd/compile: new inline heuristic for struct compares

### DIFF
--- a/src/cmd/compile/internal/compare/compare.go
+++ b/src/cmd/compile/internal/compare/compare.go
@@ -172,8 +172,8 @@ func EqStruct(t *types.Type, np, nq ir.Node) []ir.Node {
 		}
 
 		cost, size, next := eqStructFieldCost(t, i)
-		if cost <= 2 {
-			// Two or fewer fields: use plain field equality.
+		if cost <= 4 {
+			// Cost of 4 or less: use plain field equality.
 			s := fields[i:next]
 			for _, f := range s {
 				and(eqfield(np, nq, ir.OEQ, f.Sym))

--- a/src/cmd/compile/internal/compare/compare.go
+++ b/src/cmd/compile/internal/compare/compare.go
@@ -96,7 +96,7 @@ func EqStructCost(t *types.Type) int64 {
 			continue
 		}
 
-		n, _, next := eqStructFieldCost(t, f, i)
+		n, _, next := eqStructFieldCost(t, i)
 
 		cost += n
 		i = next
@@ -105,15 +105,16 @@ func EqStructCost(t *types.Type) int64 {
 	return cost
 }
 
-func eqStructFieldCost(t *types.Type, f *types.Field, i int) (int64, int64, int) {
+func eqStructFieldCost(t *types.Type, i int) (int64, int64, int) {
 	var (
-		cost       = int64(0)
-		regSize    = int64(types.RegSize)
-		size, next = Memrun(t, i)
+		cost    = int64(0)
+		regSize = int64(types.RegSize)
 	)
 
+	size, next := Memrun(t, i)
+
 	if base.Ctxt.Arch.CanMergeLoads && size%regSize == 0 {
-		cost += size / int64(types.RegSize)
+		cost += size / regSize
 	} else if next == i+1 {
 		cost++
 	}

--- a/src/cmd/compile/internal/compare/compare.go
+++ b/src/cmd/compile/internal/compare/compare.go
@@ -125,7 +125,7 @@ func eqStructFieldCost(t *types.Type, i int) (int64, int64, int) {
 // EqStruct compares two structs np and nq for equality.
 // It works by building a list of boolean conditions to satisfy.
 // Conditions must be evaluated in the returned order and
-// properly short circuited by the caller.
+// properly short-circuited by the caller.
 func EqStruct(t *types.Type, np, nq ir.Node) []ir.Node {
 	// The conditions are a list-of-lists. Conditions are reorderable
 	// within each inner list. The outer lists must be evaluated in order.
@@ -171,10 +171,10 @@ func EqStruct(t *types.Type, np, nq ir.Node) []ir.Node {
 			continue
 		}
 
-		cost, size, next := eqStructFieldCost(t, f, i)
-		s := fields[i:next]
+		cost, size, next := eqStructFieldCost(t, i)
 		if cost <= 2 {
 			// Two or fewer fields: use plain field equality.
+			s := fields[i:next]
 			for _, f := range s {
 				and(eqfield(np, nq, ir.OEQ, f.Sym))
 			}

--- a/src/cmd/compile/internal/compare/compare.go
+++ b/src/cmd/compile/internal/compare/compare.go
@@ -106,13 +106,11 @@ func EqStructCost(t *types.Type) int64 {
 }
 
 // eqStructFieldCost returns the cost of an equality comparison of two struct fields.
-// t is the parent struct type, and i is the index of the first field in the run.
-// next is the index just after the end of the run.
-// The cost is determined using an algorithm which takes into consideration
-// the size of the registers in the current architecture and the size of the
-// memory-only fields in the struct.
-// The return values are the cost of the comparison, the size of the memory run, and the index
-// just after the end of the memory run.
+// t is the parent struct type, and i is the index of the field in the parent struct type.
+// eqStructFieldCost may compute the cost of several adjacent fields at once. It returns
+// the cost, the size of the set of fields it computed the cost for (in bytes), and the
+// index of the first field not part of the set of fields for which the cost
+// has already been calculated.
 func eqStructFieldCost(t *types.Type, i int) (int64, int64, int) {
 	var (
 		cost    = int64(0)

--- a/src/cmd/compile/internal/compare/compare_test.go
+++ b/src/cmd/compile/internal/compare/compare_test.go
@@ -25,7 +25,7 @@ func init() {
 		sym.Def = obj
 		return obj
 	})
-	base.Ctxt = &obj.Link{Arch: &obj.LinkArch{Arch: &sys.Arch{Alignment: 1}}}
+	base.Ctxt = &obj.Link{Arch: &obj.LinkArch{Arch: &sys.Arch{Alignment: 1, CanMergeLoads: true}}}
 }
 
 func TestEqStructCost(t *testing.T) {
@@ -127,7 +127,7 @@ func TestEqStructCost(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			want := tc.cost
-			actual := EqStructCost(tc.tfn(), true)
+			actual := EqStructCost(tc.tfn())
 			if actual != want {
 				t.Errorf("EqStructCost(%v) = %d, want %d", tc.tfn, actual, want)
 			}

--- a/src/cmd/compile/internal/compare/compare_test.go
+++ b/src/cmd/compile/internal/compare/compare_test.go
@@ -1,0 +1,116 @@
+package compare
+
+import (
+	"cmd/compile/internal/base"
+	"cmd/compile/internal/ir"
+	"cmd/compile/internal/types"
+	"cmd/internal/obj"
+	"cmd/internal/src"
+	"cmd/internal/sys"
+	"testing"
+)
+
+type typefn func() *types.Type
+
+func init() {
+	// These are the few constants that need to be initialized in order to use
+	// the types package without using the typecheck package by calling
+	// typecheck.InitUniverse() (the normal way to initialize the types package).
+	types.PtrSize = 8
+	types.RegSize = 8
+	types.MaxWidth = 1 << 50
+	types.InitTypes(func(sym *types.Sym, typ *types.Type) types.Object {
+		obj := ir.NewDeclNameAt(src.NoXPos, ir.OTYPE, sym)
+		obj.SetType(typ)
+		sym.Def = obj
+		return obj
+	})
+	base.Ctxt = &obj.Link{Arch: &obj.LinkArch{Arch: &sys.Arch{Alignment: 1}}}
+}
+
+func TestEqStructCost(t *testing.T) {
+	newByteField := func(parent *types.Type, offset int64) *types.Field {
+		f := types.NewField(src.XPos{}, parent.Sym(), types.ByteType)
+		f.Offset = offset
+		return f
+	}
+	newIntField := func(parent *types.Type, offset int64, kind types.Kind) *types.Field {
+		f := types.NewField(src.XPos{}, parent.Sym(), types.Types[kind])
+		f.Offset = offset
+		return f
+	}
+	tt := []struct {
+		name string
+		cost int64
+		tfn  typefn
+	}{
+		{"struct without fields", 0,
+			func() *types.Type {
+				return types.NewStruct(types.NewPkg("main", ""), []*types.Field{})
+			}},
+		{"struct with 1 byte field", 1,
+			func() *types.Type {
+				parent := types.NewStruct(types.NewPkg("main", ""), []*types.Field{})
+				fields := []*types.Field{
+					newByteField(parent, 0),
+				}
+				parent.SetFields(fields)
+				return parent
+			},
+		},
+		{"struct with 8 byte fields", 1,
+			func() *types.Type {
+				parent := types.NewStruct(types.NewPkg("main", ""), []*types.Field{})
+				fields := make([]*types.Field, 8)
+				for i := range fields {
+					fields[i] = newByteField(parent, int64(i))
+				}
+				parent.SetFields(fields)
+				return parent
+			},
+		},
+		{"struct with 16 byte fields", 2,
+			func() *types.Type {
+				parent := types.NewStruct(types.NewPkg("main", ""), []*types.Field{})
+				fields := make([]*types.Field, 16)
+				for i := range fields {
+					fields[i] = newByteField(parent, int64(i))
+				}
+				parent.SetFields(fields)
+				return parent
+			},
+		},
+		{"struct with 2 int32 fields", 1,
+			func() *types.Type {
+				parent := types.NewStruct(types.NewPkg("main", ""), []*types.Field{})
+				fields := make([]*types.Field, 2)
+				for i := range fields {
+					fields[i] = newIntField(parent, int64(i*4), types.TINT32)
+				}
+				parent.SetFields(fields)
+				return parent
+			},
+		},
+		{"struct with 2 int32 fields and 1 int64", 2,
+			func() *types.Type {
+				parent := types.NewStruct(types.NewPkg("main", ""), []*types.Field{})
+				fields := make([]*types.Field, 3)
+				fields[0] = newIntField(parent, int64(0), types.TINT32)
+				fields[1] = newIntField(parent, int64(4), types.TINT32)
+				fields[2] = newIntField(parent, int64(8), types.TINT64)
+				parent.SetFields(fields)
+				return parent
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			want := tc.cost
+			actual := EqStructCost(tc.tfn(), true)
+			if actual != want {
+				t.Errorf("EqStructCost(%v) = %d, want %d", tc.tfn, actual, want)
+			}
+		})
+	}
+}

--- a/src/cmd/compile/internal/compare/compare_test.go
+++ b/src/cmd/compile/internal/compare/compare_test.go
@@ -34,7 +34,7 @@ func TestEqStructCost(t *testing.T) {
 		f.Offset = offset
 		return f
 	}
-	newIntField := func(parent *types.Type, offset int64, kind types.Kind) *types.Field {
+	newField := func(parent *types.Type, offset int64, kind types.Kind) *types.Field {
 		f := types.NewField(src.XPos{}, parent.Sym(), types.Types[kind])
 		f.Offset = offset
 		return f
@@ -85,7 +85,7 @@ func TestEqStructCost(t *testing.T) {
 				parent := types.NewStruct(types.NewPkg("main", ""), []*types.Field{})
 				fields := make([]*types.Field, 2)
 				for i := range fields {
-					fields[i] = newIntField(parent, int64(i*4), types.TINT32)
+					fields[i] = newField(parent, int64(i*4), types.TINT32)
 				}
 				parent.SetFields(fields)
 				return parent
@@ -95,9 +95,29 @@ func TestEqStructCost(t *testing.T) {
 			func() *types.Type {
 				parent := types.NewStruct(types.NewPkg("main", ""), []*types.Field{})
 				fields := make([]*types.Field, 3)
-				fields[0] = newIntField(parent, int64(0), types.TINT32)
-				fields[1] = newIntField(parent, int64(4), types.TINT32)
-				fields[2] = newIntField(parent, int64(8), types.TINT64)
+				fields[0] = newField(parent, int64(0), types.TINT32)
+				fields[1] = newField(parent, int64(4), types.TINT32)
+				fields[2] = newField(parent, int64(8), types.TINT64)
+				parent.SetFields(fields)
+				return parent
+			},
+		},
+		{"struct with 1 int field and 1 string", 3,
+			func() *types.Type {
+				parent := types.NewStruct(types.NewPkg("main", ""), []*types.Field{})
+				fields := make([]*types.Field, 2)
+				fields[0] = newField(parent, int64(0), types.TINT64)
+				fields[1] = newField(parent, int64(8), types.TSTRING)
+				parent.SetFields(fields)
+				return parent
+			},
+		},
+		{"struct with 2 strings", 4,
+			func() *types.Type {
+				parent := types.NewStruct(types.NewPkg("main", ""), []*types.Field{})
+				fields := make([]*types.Field, 2)
+				fields[0] = newField(parent, int64(0), types.TSTRING)
+				fields[1] = newField(parent, int64(8), types.TSTRING)
 				parent.SetFields(fields)
 				return parent
 			},

--- a/src/cmd/compile/internal/compare/compare_test.go
+++ b/src/cmd/compile/internal/compare/compare_test.go
@@ -80,6 +80,17 @@ func TestEqStructCost(t *testing.T) {
 				return parent
 			},
 		},
+		{"struct with 32 byte fields", 4,
+			func() *types.Type {
+				parent := types.NewStruct(types.NewPkg("main", ""), []*types.Field{})
+				fields := make([]*types.Field, 32)
+				for i := range fields {
+					fields[i] = newByteField(parent, int64(i))
+				}
+				parent.SetFields(fields)
+				return parent
+			},
+		},
 		{"struct with 2 int32 fields", 1,
 			func() *types.Type {
 				parent := types.NewStruct(types.NewPkg("main", ""), []*types.Field{})

--- a/src/cmd/compile/internal/compare/compare_test.go
+++ b/src/cmd/compile/internal/compare/compare_test.go
@@ -29,8 +29,8 @@ func TestEqStructCost(t *testing.T) {
 		f.Offset = offset
 		return f
 	}
-	newUint16ArrayField := func(parent *types.Type, offset int64, len int64) *types.Field {
-		f := types.NewField(src.XPos{}, parent.Sym(), types.NewArray(types.Types[types.TUINT16], len))
+	newArrayField := func(parent *types.Type, offset int64, len int64, kind types.Kind) *types.Field {
+		f := types.NewField(src.XPos{}, parent.Sym(), types.NewArray(types.Types[kind], len))
 		// Call Type.Size here to force the size calculation to be done. If not done here the size returned later is incorrect.
 		f.Type.Size()
 		f.Offset = offset
@@ -140,7 +140,17 @@ func TestEqStructCost(t *testing.T) {
 			func() *types.Type {
 				parent := types.NewStruct(types.NewPkg("main", ""), []*types.Field{})
 				fields := []*types.Field{
-					newUint16ArrayField(parent, 0, 101),
+					newArrayField(parent, 0, 101, types.TUINT16),
+				}
+				parent.SetFields(fields)
+				return parent
+			},
+		},
+		{"struct with string array field", 4, 4,
+			func() *types.Type {
+				parent := types.NewStruct(types.NewPkg("main", ""), []*types.Field{})
+				fields := []*types.Field{
+					newArrayField(parent, 0, 2, types.TSTRING),
 				}
 				parent.SetFields(fields)
 				return parent

--- a/src/cmd/compile/internal/reflectdata/alg_test.go
+++ b/src/cmd/compile/internal/reflectdata/alg_test.go
@@ -74,3 +74,17 @@ func BenchmarkEqArrayOfFloats1024(b *testing.B) {
 		_ = a == c
 	}
 }
+
+type T1 struct {
+	a [8]byte
+}
+
+func BenchmarkEqStruct(b *testing.B) {
+	x, y := T1{}, T1{}
+	x.a = [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	y.a = [8]byte{2, 3, 4, 5, 6, 7, 8, 9}
+
+	for i := 0; i < b.N; i++ {
+		_ = x == y
+	}
+}

--- a/src/cmd/compile/internal/reflectdata/alg_test.go
+++ b/src/cmd/compile/internal/reflectdata/alg_test.go
@@ -75,7 +75,7 @@ func BenchmarkEqArrayOfFloats1024(b *testing.B) {
 	}
 }
 
-const size = 32
+const size = 16
 
 type T1 struct {
 	a [size]byte

--- a/src/cmd/compile/internal/reflectdata/alg_test.go
+++ b/src/cmd/compile/internal/reflectdata/alg_test.go
@@ -75,16 +75,21 @@ func BenchmarkEqArrayOfFloats1024(b *testing.B) {
 	}
 }
 
+const size = 32
+
 type T1 struct {
-	a [8]byte
+	a [size]byte
 }
 
 func BenchmarkEqStruct(b *testing.B) {
 	x, y := T1{}, T1{}
-	x.a = [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
-	y.a = [8]byte{2, 3, 4, 5, 6, 7, 8, 9}
+	x.a = [size]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	y.a = [size]byte{2, 3, 4, 5, 6, 7, 8, 9}
 
 	for i := 0; i < b.N; i++ {
-		_ = x == y
+		f := x == y
+		if f {
+			println("hello")
+		}
 	}
 }

--- a/src/cmd/compile/internal/types/type.go
+++ b/src/cmd/compile/internal/types/type.go
@@ -625,7 +625,6 @@ func NewArray(elem *Type, bound int64) *Type {
 	}
 	t := newType(TARRAY)
 	t.extra = &Array{Elem: elem, Bound: bound}
-	t.width = elem.Size() * bound
 	t.SetNotInHeap(elem.NotInHeap())
 	if elem.HasTParam() {
 		t.SetHasTParam(true)

--- a/src/cmd/compile/internal/types/type.go
+++ b/src/cmd/compile/internal/types/type.go
@@ -625,6 +625,7 @@ func NewArray(elem *Type, bound int64) *Type {
 	}
 	t := newType(TARRAY)
 	t.extra = &Array{Elem: elem, Bound: bound}
+	t.width = elem.Size() * bound
 	t.SetNotInHeap(elem.NotInHeap())
 	if elem.HasTParam() {
 		t.SetHasTParam(true)

--- a/src/cmd/compile/internal/walk/compare.go
+++ b/src/cmd/compile/internal/walk/compare.go
@@ -160,7 +160,7 @@ func walkCompare(n *ir.BinaryExpr, init *ir.Nodes) ir.Node {
 		// We can compare several elements at once with 2/4/8 byte integer compares
 		inline = t.NumElem() <= 1 || (types.IsSimple[t.Elem().Kind()] && (t.NumElem() <= 4 || t.Elem().Size()*t.NumElem() <= maxcmpsize))
 	case types.TSTRUCT:
-		inline = compare.EqStructCost(t, unalignedLoad) <= 4
+		inline = compare.EqStructCost(t) <= 4
 	}
 
 	cmpl := n.X

--- a/src/cmd/compile/internal/walk/compare.go
+++ b/src/cmd/compile/internal/walk/compare.go
@@ -160,7 +160,7 @@ func walkCompare(n *ir.BinaryExpr, init *ir.Nodes) ir.Node {
 		// We can compare several elements at once with 2/4/8 byte integer compares
 		inline = t.NumElem() <= 1 || (types.IsSimple[t.Elem().Kind()] && (t.NumElem() <= 4 || t.Elem().Size()*t.NumElem() <= maxcmpsize))
 	case types.TSTRUCT:
-		inline = t.NumComponents(types.IgnoreBlankFields) <= 4
+		inline = compare.EqStructCost(t, unalignedLoad) <= 4
 	}
 
 	cmpl := n.X

--- a/test/codegen/comparisons.go
+++ b/test/codegen/comparisons.go
@@ -106,6 +106,26 @@ func CompareStruct2(s1, s2 T2) bool {
 	return s1 == s2
 }
 
+type T3 struct {
+	a [24]byte
+}
+
+func CompareStruct3(s1, s2 T3) bool {
+	// amd64:`CMPQ\tcommand-line-arguments[.+_a-z0-9]+\(SP\), [A-Z]`
+	// amd64:-`CALL`
+	return s1 == s2
+}
+
+type T4 struct {
+	a [32]byte
+}
+
+func CompareStruct4(s1, s2 T4) bool {
+	// amd64:`CMPQ\tcommand-line-arguments[.+_a-z0-9]+\(SP\), [A-Z]`
+	// amd64:-`CALL`
+	return s1 == s2
+}
+
 // -------------- //
 //    Ordering    //
 // -------------- //

--- a/test/codegen/comparisons.go
+++ b/test/codegen/comparisons.go
@@ -84,6 +84,28 @@ func CompareArray6(a, b unsafe.Pointer) bool {
 	return *((*[4]byte)(a)) != *((*[4]byte)(b))
 }
 
+// Check that some structs generate 2/4/8 byte compares.
+
+type T1 struct {
+	a [8]byte
+}
+
+func CompareStruct1(s1, s2 T1) bool {
+	// amd64:`CMPQ\tcommand-line-arguments[.+_a-z0-9]+\(SP\), [A-Z]`
+	// amd64:-`CALL`
+	return s1 == s2
+}
+
+type T2 struct {
+	a [16]byte
+}
+
+func CompareStruct2(s1, s2 T2) bool {
+	// amd64:`CMPQ\tcommand-line-arguments[.+_a-z0-9]+\(SP\), [A-Z]`
+	// amd64:-`CALL`
+	return s1 == s2
+}
+
 // -------------- //
 //    Ordering    //
 // -------------- //

--- a/test/codegen/comparisons.go
+++ b/test/codegen/comparisons.go
@@ -106,13 +106,16 @@ func CompareStruct2(s1, s2 T2) bool {
 	return s1 == s2
 }
 
+// Assert that a memequal call is still generated when
+// inlining would increase binary size too much.
+
 type T3 struct {
 	a [24]byte
 }
 
 func CompareStruct3(s1, s2 T3) bool {
-	// amd64:`CMPQ\tcommand-line-arguments[.+_a-z0-9]+\(SP\), [A-Z]`
-	// amd64:-`CALL`
+	// amd64:-`CMPQ\tcommand-line-arguments[.+_a-z0-9]+\(SP\), [A-Z]`
+	// amd64:`CALL`
 	return s1 == s2
 }
 
@@ -121,8 +124,8 @@ type T4 struct {
 }
 
 func CompareStruct4(s1, s2 T4) bool {
-	// amd64:`CMPQ\tcommand-line-arguments[.+_a-z0-9]+\(SP\), [A-Z]`
-	// amd64:-`CALL`
+	// amd64:-`CMPQ\tcommand-line-arguments[.+_a-z0-9]+\(SP\), [A-Z]`
+	// amd64:`CALL`
 	return s1 == s2
 }
 


### PR DESCRIPTION
This CL changes the heuristic used to determine whether we can inline a
struct equality check or if we must generate a function and call that
function for equality.

The old method was to count struct fields, but this can lead to poor
in lining decisions. We should really be determining the cost of the
equality check and use that to determine if we should inline or generate
a function.

The new benchmark provided in this CL returns the following when compared
against tip:

```
name         old time/op  new time/op  delta
EqStruct-32  2.46ns ± 4%  0.25ns ±10%  -89.72%  (p=0.000 n=39+39)
```

Fixes #38494