### PR TITLE
cmd/go/internal: wrap error with %w instead of %v

### DIFF
--- a/src/cmd/go/internal/vcs/vcs.go
+++ b/src/cmd/go/internal/vcs/vcs.go
@@ -208,7 +208,7 @@ func parseRevTime(out []byte) (string, time.Time, error) {
 
 	secs, err := strconv.ParseInt(string(buf[i+1:]), 10, 64)
 	if err != nil {
-		return "", time.Time{}, fmt.Errorf("unrecognized VCS tool output: %v", err)
+		return "", time.Time{}, fmt.Errorf("unrecognized VCS tool output: %w", err)
 	}
 
 	return rev, time.Unix(secs, 0), nil
@@ -563,7 +563,7 @@ func fossilStatus(vcsFossil *Cmd, rootDir string) (Status, error) {
 
 	commitTime, err := time.ParseInLocation("2006-01-02 15:04:05", checkout[i+1:], time.UTC)
 	if err != nil {
-		return Status{}, fmt.Errorf("%v: %v", errFossilInfo, err)
+		return Status{}, fmt.Errorf("%v: %w", errFossilInfo, err)
 	}
 
 	// Also look for untracked changes.
@@ -1061,7 +1061,7 @@ func RepoRootForImportPath(importPath string, mod ModuleMode, security web.Secur
 	if err == errUnknownSite {
 		rr, err = repoRootForImportDynamic(importPath, mod, security)
 		if err != nil {
-			err = importErrorf(importPath, "unrecognized import path %q: %v", importPath, err)
+			err = importErrorf(importPath, "unrecognized import path %q: %w", importPath, err)
 		}
 	}
 	if err != nil {
@@ -1207,7 +1207,7 @@ func repoRootForImportDynamic(importPath string, mod ModuleMode, security web.Se
 	}
 	resp, err := web.Get(security, url)
 	if err != nil {
-		msg := "https fetch: %v"
+		msg := "https fetch: %w"
 		if security == web.Insecure {
 			msg = "http/" + msg
 		}
@@ -1224,13 +1224,13 @@ func repoRootForImportDynamic(importPath string, mod ModuleMode, security web.Se
 		}
 	}
 	if err != nil {
-		return nil, fmt.Errorf("parsing %s: %v", importPath, err)
+		return nil, fmt.Errorf("parsing %s: %w", importPath, err)
 	}
 	// Find the matched meta import.
 	mmi, err := matchGoImport(imports, importPath)
 	if err != nil {
 		if _, ok := err.(ImportMismatchError); !ok {
-			return nil, fmt.Errorf("parse %s: %v", url, err)
+			return nil, fmt.Errorf("parse %s: %w", url, err)
 		}
 		return nil, fmt.Errorf("parse %s: no go-import meta tags (%s)", resp.URL, err)
 	}
@@ -1259,7 +1259,7 @@ func repoRootForImportDynamic(importPath string, mod ModuleMode, security web.Se
 	}
 
 	if err := validateRepoRoot(mmi.RepoRoot); err != nil {
-		return nil, fmt.Errorf("%s: invalid repo root %q: %v", resp.URL, mmi.RepoRoot, err)
+		return nil, fmt.Errorf("%s: invalid repo root %q: %w", resp.URL, mmi.RepoRoot, err)
 	}
 	var vcs *Cmd
 	if mmi.VCS == "mod" {
@@ -1336,7 +1336,7 @@ func metaImportsForPrefix(importPrefix string, mod ModuleMode, security web.Secu
 		}
 		resp, err := web.Get(security, url)
 		if err != nil {
-			return setCache(fetchResult{url: url, err: fmt.Errorf("fetching %s: %v", importPrefix, err)})
+			return setCache(fetchResult{url: url, err: fmt.Errorf("fetching %s: %w", importPrefix, err)})
 		}
 		body := resp.Body
 		defer body.Close()
@@ -1349,7 +1349,7 @@ func metaImportsForPrefix(importPrefix string, mod ModuleMode, security web.Secu
 			}
 		}
 		if err != nil {
-			return setCache(fetchResult{url: url, err: fmt.Errorf("parsing %s: %v", resp.URL, err)})
+			return setCache(fetchResult{url: url, err: fmt.Errorf("parsing %s: %w", resp.URL, err)})
 		}
 		if len(imports) == 0 {
 			err = fmt.Errorf("fetching %s: no go-import meta tag found in %s", importPrefix, resp.URL)


### PR DESCRIPTION
This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
