### PR TITLE
text/template: remove concurrency from scanner

### DIFF
--- a/src/text/template/parse/lex_test.go
+++ b/src/text/template/parse/lex_test.go
@@ -546,22 +546,6 @@ func TestPos(t *testing.T) {
 	}
 }
 
-// Test that an error shuts down the lexing goroutine.
-func TestShutdown(t *testing.T) {
-	// We need to duplicate template.Parse here to hold on to the lexer.
-	const text = "erroneous{{define}}{{else}}1234"
-	lexer := lex("foo", text, "{{", "}}", false, true, true)
-	_, err := New("root").parseLexer(lexer)
-	if err == nil {
-		t.Fatalf("expected error")
-	}
-	// The error should have drained the input. Therefore, the lexer should be shut down.
-	token, ok := <-lexer.items
-	if ok {
-		t.Fatalf("input was not drained; got %v", token)
-	}
-}
-
 // parseLexer is a local version of parse that lets us pass in the lexer instead of building it.
 // We expect an error, so the tree set and funcs list are explicitly nil.
 func (t *Tree) parseLexer(lex *lexer) (tree *Tree, err error) {

--- a/src/text/template/parse/parse.go
+++ b/src/text/template/parse/parse.go
@@ -210,7 +210,6 @@ func (t *Tree) recover(errp *error) {
 			panic(e)
 		}
 		if t != nil {
-			t.lex.drain()
 			t.stopParse()
 		}
 		*errp = e.(error)


### PR DESCRIPTION
Makes the scanner in text/template fully synchronous. Replaces the unbuffered item channel with a slice implementing a simple queue.
