### PR TITLE
encoding/json: fix using omitempty in combination with MarshalJSON

### DIFF
--- a/src/encoding/json/encode.go
+++ b/src/encoding/json/encode.go
@@ -760,31 +760,25 @@ FieldLoop:
 		}
 		opts.quoted = f.quoted
 
-		if !f.omitEmpty {
-			f.encoder(e, fv, opts)
-			next = ','
-		} else {
-			startLen := e.Len()
+		startLen := e.Len()
+		f.encoder(e, fv, opts)
+		newLen := e.Len()
 
-			f.encoder(e, fv, opts)
-
-			newLen := e.Len()
-			if writtenLen := newLen - startLen; writtenLen <= 5 {
-				// using `Next` and `bytes.NewBuffer` we can modify the end of the
-				// underlying slice efficiently (without doing any copying)
-				fullBuf := e.Next(newLen) // extract underlying slice from buffer
-				switch string(fullBuf[startLen:newLen]) {
-				case "false", "0", "\"\"", "null", "[]":
-					// reconstruct buffer without zero value
-					e.Buffer = *bytes.NewBuffer(fullBuf[:omitEmptyResetLocation])
-					continue
-				default:
-					// reconstruct original buffer
-					e.Buffer = *bytes.NewBuffer(fullBuf)
-				}
+		if f.omitEmpty && (newLen-startLen) <= 5 {
+			// using `Next` and `bytes.NewBuffer` we can modify the end of the
+			// underlying slice efficiently (without doing any copying)
+			fullBuf := e.Next(newLen) // extract underlying slice from buffer
+			switch string(fullBuf[startLen:newLen]) {
+			case "false", "0", "\"\"", "null", "[]":
+				// reconstruct buffer without zero value
+				e.Buffer = *bytes.NewBuffer(fullBuf[:omitEmptyResetLocation])
+				continue
+			default:
+				// reconstruct original buffer
+				e.Buffer = *bytes.NewBuffer(fullBuf)
 			}
-			next = ','
 		}
+		next = ','
 	}
 	if next == '{' {
 		e.WriteString("{}")

--- a/src/encoding/json/encode_test.go
+++ b/src/encoding/json/encode_test.go
@@ -17,6 +17,12 @@ import (
 	"unicode"
 )
 
+type NullMarshal int
+
+func (NullMarshal) MarshalJSON() ([]byte, error) {
+	return []byte(`null`), nil
+}
+
 type Optionals struct {
 	Sr string `json:"sr"`
 	So string `json:"so,omitempty"`
@@ -42,6 +48,9 @@ type Optionals struct {
 
 	Str struct{} `json:"str"`
 	Sto struct{} `json:"sto,omitempty"`
+
+	Nur NullMarshal `json:"nur"`
+	Nuo NullMarshal `json:"nuo,omitempty"`
 }
 
 var optionalsExpected = `{
@@ -53,7 +62,8 @@ var optionalsExpected = `{
  "br": false,
  "ur": 0,
  "str": {},
- "sto": {}
+ "sto": {},
+ "nur": null
 }`
 
 func TestOmitEmpty(t *testing.T) {
@@ -1082,9 +1092,9 @@ func TestMarshalRawMessageValue(t *testing.T) {
 		{map[string]any{"M": &rawNil}, `{"M":null}`, true},
 		{&map[string]any{"M": &rawNil}, `{"M":null}`, true},
 		{T1{rawNil}, "{}", true},
-		{T2{&rawNil}, `{"M":null}`, true},
+		{T2{&rawNil}, "{}", true},
 		{&T1{rawNil}, "{}", true},
-		{&T2{&rawNil}, `{"M":null}`, true},
+		{&T2{&rawNil}, "{}", true},
 
 		// Test with empty, but non-nil, RawMessage.
 		{rawEmpty, "", false},


### PR DESCRIPTION
The `omitempty` option does not support objects with a `MarshalJSON` function.
This means that a field annotated with the `omitempty` tag can still contain a `null`, `0`, `false`, `""` or `[]` value and will never be omitted.
This PR fixes this issue: if the `MarshalJSON` function returns an empty value, that value is omitted.

See https://github.com/golang/go/issues/45669#issuecomment-1155646246 for more background information.