### PR TITLE
bytes/buffer: add Buffer.Init([]byte)

### DIFF
--- a/src/bytes/buffer.go
+++ b/src/bytes/buffer.go
@@ -452,6 +452,15 @@ func (b *Buffer) ReadString(delim byte) (line string, err error) {
 	return string(slice), err
 }
 
+// Init initializes the buffer using buf as its initial contents.
+// the buffer takes ownership of buf, and the caller should not use
+// buf after this call.
+func (b *Buffer) Init(buf []byte) {
+	b.buf = buf
+	b.off = 0
+	b.lastRead = opInvalid
+}
+
 // NewBuffer creates and initializes a new Buffer using buf as its
 // initial contents. The new Buffer takes ownership of buf, and the
 // caller should not use buf after this call. NewBuffer is intended to


### PR DESCRIPTION
currently bytes.NewBuffer can be used to initialize Buffer with a custom buf, but in performance-sensitive scenarios, I hope to reuse Buffer to avoid heap allocation and memcpy, so I added the Init method so that I can replace a Buffer's buf.