### PR TITLE
x/website: wrong link to go1.19 sync/atomic

### DIFF
--- a/doc/go1.19.html
+++ b/doc/go1.19.html
@@ -35,7 +35,7 @@ Do not send CLs removing the interior tags from such phrases.
   the memory model used by C, C++, Java, JavaScript, Rust, and Swift.
   Go only provides sequentially consistent atomics, not any of the more relaxed forms found in other languages.
   Along with the memory model update,
-  Go 1.19 introduces <a href="#sync/atomic">new types in the <code>sync/atomic</code> package</a>
+  Go 1.19 introduces <a href="https://pkg.go.dev/sync/atomic@master">new types in the <code>sync/atomic</code> package</a>
   that make it easier to use atomic values, such as
   <a href="/pkg/sync/atomic/#Int64">atomic.Int64</a>
   and


### PR DESCRIPTION
This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
