### PR TITLE
testing: skip parallel tests when -failfast is enabled

### DIFF
--- a/src/cmd/go/testdata/script/test_fail_fast.txt
+++ b/src/cmd/go/testdata/script/test_fail_fast.txt
@@ -16,17 +16,26 @@ stdout -count=2 'FAIL - '
 
 # mix with parallel tests
 ! go test ./failfast_test.go -run='TestFailingB|TestParallelFailingA' -failfast=true
-stdout -count=2 'FAIL - '
+stdout -count=1 'FAIL - '
 ! go test ./failfast_test.go -run='TestFailingB|TestParallelFailingA' -failfast=false
 stdout -count=2 'FAIL - '
 ! go test ./failfast_test.go -run='TestFailingB|TestParallelFailing[AB]' -failfast=true
-stdout -count=3 'FAIL - '
+stdout -count=1 'FAIL - '
 ! go test ./failfast_test.go -run='TestFailingB|TestParallelFailing[AB]' -failfast=false
 stdout -count=3 'FAIL - '
 
+# parallel subtests with timeout
+# the timeouts are necessary to avoid race conditions in the test case
+! go test -parallel=2 ./failfast_test.go -run='TestWithFailingParallelSubtestsA' -failfast=false
+stdout -count=3 'FAIL - '
+! go test -parallel=2 ./failfast_test.go -run='TestWithFailingParallelSubtestsA' -failfast=true
+stdout -count=2 'FAIL - '
+! go test -parallel=1 ./failfast_test.go -run='TestWithFailingParallelSubtestsA' -failfast=true
+stdout -count=1 'FAIL - '
+
 # mix with parallel sub-tests
 ! go test ./failfast_test.go -run='TestFailingB|TestParallelFailing[AB]|TestParallelFailingSubtestsA' -failfast=true
-stdout -count=3 'FAIL - '
+stdout -count=1 'FAIL - '
 ! go test ./failfast_test.go -run='TestFailingB|TestParallelFailing[AB]|TestParallelFailingSubtestsA' -failfast=false
 stdout -count=5 'FAIL - '
 ! go test ./failfast_test.go -run='TestParallelFailingSubtestsA' -failfast=true
@@ -55,7 +64,10 @@ stdout -count=2 'FAIL - '
 
 package failfast
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestA(t *testing.T) {
 	// Edge-case testing, mixing unparallel tests too
@@ -79,6 +91,26 @@ func TestParallelFailingA(t *testing.T) {
 func TestParallelFailingB(t *testing.T) {
 	t.Parallel()
 	t.Errorf("FAIL - %s", t.Name())
+}
+
+func TestWithFailingParallelSubtestsA(t *testing.T) {
+	t.Run("SubtestsA1", func(t *testing.T) {
+		t.Parallel()
+		time.Sleep(100 * time.Millisecond)
+
+		t.Errorf("FAIL - %s", t.Name())
+	})
+	t.Run("SubtestsA2", func(t *testing.T) {
+		t.Parallel()
+		time.Sleep(100 * time.Millisecond)
+
+		t.Errorf("FAIL - %s", t.Name())
+	})
+	t.Run("SubtestsA3", func(t *testing.T) {
+		t.Parallel()
+
+		t.Errorf("FAIL - %s", t.Name())
+	})
 }
 
 func TestParallelFailingSubtestsA(t *testing.T) {

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -1271,6 +1271,10 @@ func (t *T) Parallel() {
 	<-t.parent.barrier // Wait for the parent test to complete.
 	t.context.waitParallel()
 
+	if shouldFailFast() {
+		t.SkipNow()
+	}
+
 	if t.chatty != nil {
 		t.chatty.Updatef(t.name, "=== CONT  %s\n", t.name)
 	}


### PR DESCRIPTION
The t.Parallel method does not interact well with the -failfast flag.
See golang/go#30522.

With `-failfast` enabled tests blocking on `t.Parallel()` can be skipped
after the first test failure.  
This won't immediately kill any parallel tests which are already running
but it will prevent more tests from starting.

I've chosen to use `t.SkipNow()` when we detect that we want to failfast
after a parallel test wakes up.  
This to me seemed like the cleanest solution and doesn't hide 
what is happening.  
Though arguably we could print a more detailed message?

Fixes #30522