### PR TITLE
net: add FlagRunning to exactly reflect the states of an interface.

### DIFF
--- a/api/next/53482.txt
+++ b/api/next/53482.txt
@@ -1,0 +1,2 @@
+pkg net, const FlagRunning = 32 #53482
+pkg net, const FlagRunning Flags #53482

--- a/src/net/interface.go
+++ b/src/net/interface.go
@@ -39,11 +39,12 @@ type Interface struct {
 type Flags uint
 
 const (
-	FlagUp           Flags = 1 << iota // interface is up
+	FlagUp           Flags = 1 << iota // interface is administratively up
 	FlagBroadcast                      // interface supports broadcast access capability
 	FlagLoopback                       // interface is a loopback interface
 	FlagPointToPoint                   // interface belongs to a point-to-point link
 	FlagMulticast                      // interface supports multicast access capability
+	FlagRunning                        // interface is in running state
 )
 
 var flagNames = []string{
@@ -52,6 +53,7 @@ var flagNames = []string{
 	"loopback",
 	"pointtopoint",
 	"multicast",
+	"running",
 }
 
 func (f Flags) String() string {

--- a/src/net/interface_aix.go
+++ b/src/net/interface_aix.go
@@ -101,6 +101,9 @@ func linkFlags(rawFlags int32) Flags {
 	if rawFlags&syscall.IFF_UP != 0 {
 		f |= FlagUp
 	}
+	if rawFlags&syscall.IFF_RUNNING != 0 {
+		f |= FlagRunning
+	}
 	if rawFlags&syscall.IFF_BROADCAST != 0 {
 		f |= FlagBroadcast
 	}

--- a/src/net/interface_bsd.go
+++ b/src/net/interface_bsd.go
@@ -59,6 +59,9 @@ func linkFlags(rawFlags int) Flags {
 	if rawFlags&syscall.IFF_UP != 0 {
 		f |= FlagUp
 	}
+	if rawFlags&syscall.IFF_RUNNING != 0 {
+		f |= FlagRunning
+	}
 	if rawFlags&syscall.IFF_BROADCAST != 0 {
 		f |= FlagBroadcast
 	}

--- a/src/net/interface_linux.go
+++ b/src/net/interface_linux.go
@@ -99,6 +99,9 @@ func linkFlags(rawFlags uint32) Flags {
 	if rawFlags&syscall.IFF_UP != 0 {
 		f |= FlagUp
 	}
+	if rawFlags&syscall.IFF_RUNNING != 0 {
+		f |= FlagRunning
+	}
 	if rawFlags&syscall.IFF_BROADCAST != 0 {
 		f |= FlagBroadcast
 	}

--- a/src/net/interface_plan9.go
+++ b/src/net/interface_plan9.go
@@ -95,9 +95,9 @@ func readInterface(i int) (*Interface, error) {
 			}
 		}
 
-		ifc.Flags = FlagUp | FlagBroadcast | FlagMulticast
+		ifc.Flags = FlagUp | FlagRunning | FlagBroadcast | FlagMulticast
 	} else {
-		ifc.Flags = FlagUp | FlagMulticast | FlagLoopback
+		ifc.Flags = FlagUp | FlagRunning | FlagMulticast | FlagLoopback
 	}
 
 	return ifc, nil

--- a/src/net/interface_solaris.go
+++ b/src/net/interface_solaris.go
@@ -37,6 +37,9 @@ func linkFlags(rawFlags int) Flags {
 	if rawFlags&syscall.IFF_UP != 0 {
 		f |= FlagUp
 	}
+	if rawFlags&syscall.IFF_RUNNING != 0 {
+		f |= FlagRunning
+	}
 	if rawFlags&syscall.IFF_BROADCAST != 0 {
 		f |= FlagBroadcast
 	}

--- a/src/net/interface_windows.go
+++ b/src/net/interface_windows.go
@@ -62,6 +62,7 @@ func interfaceTable(ifindex int) ([]Interface, error) {
 			}
 			if aa.OperStatus == windows.IfOperStatusUp {
 				ifi.Flags |= FlagUp
+				ifi.Flags |= FlagRunning
 			}
 			// For now we need to infer link-layer service
 			// capabilities from media types.


### PR DESCRIPTION
Correctly set this flag while parsing the syscall result.

The FlagUp flag can not distinguish the following situations:
1. interface is plugged, automatically up, and in running(UP) state
2. interface is not plugged, administratively or manually set to up,
but in DOWN state

So, We can't distinguish the state of a NIC by the FlagUp flag alone.

Fixes #53482