### PR TITLE
cmd/cgo: enable reproducible builds when LTO is enabled

### DIFF
--- a/src/cmd/go/testdata/script/build_issue413974.txt
+++ b/src/cmd/go/testdata/script/build_issue413974.txt
@@ -1,0 +1,33 @@
+# Regression test for https://go.dev/issue/53528:
+# cgo build should reproduce binaries with LTO enable
+
+[!cgo] skip
+[short] skip 'links cgo binaries'
+
+env GOFLAGS=-ldflags=-linkmode=external
+env CGO_CFLAGS=-flto
+
+go build -o main.exe
+mv main.exe main1.exe
+
+env GOCACHE=$WORK${/}gocache
+mkdir $GOCACHE
+go build -o main.exe
+mv main.exe main2.exe
+
+cmp -q main2.exe main1.exe
+
+-- go.mod --
+module main
+
+go 1.18
+-- main.go --
+package main
+
+import "C"
+
+var _ C.int
+
+func main() {
+       println("Hello World")
+}


### PR DESCRIPTION
The work directory of the compiler is embedded into
compressed sections of the LTO objects. Making them unreproducible between
builds.

The culprit is that the line macros uses bare symbol names, and GCC
prepends each symbol with current directory when compiling.

See See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108534

For each cgo2.c file we parse out the bare symbols in the line macros
and ensure they are rewritten with -fdebug-prefix-map to point at the
absolute directory /tmp.

Reproduction of the issue:

    $ CGO_CFLAGS='-flto' go build -work -trimpath -ldflags '-linkmode=external' main.go
    WORK=/tmp/go-build2408155205
    $ cd /tmp/go-build2408155205/b001
    $ objdump -h ./_x002.o | grep GoStringLen
      7 .gnu.lto__GoStringLen.0.6b7d5558e3553715 0000013b  0000000000000000  0000000000000000  0000009c  2**0
    $ objcopy ./_x002.o /dev/null --dump-section .gnu.lto__GoStringLen.0.6b7d5558e3553715=GoStringLen.zst
    $ unzstd ./GoStringLen.zst
    $ strings GoStringLen
    /tmp/go-build2408155205/b001