### PR TITLE
html/template: fix typo in content_test.go

### DIFF
--- a/src/html/template/content_test.go
+++ b/src/html/template/content_test.go
@@ -280,7 +280,7 @@ func TestTypedContent(t *testing.T) {
 			[]string{
 				`#ZgotmplZ`,
 				`#ZgotmplZ`,
-				// Commas are not esacped
+				// Commas are not escaped.
 				`Hello,#ZgotmplZ`,
 				// Leading spaces are not percent escapes.
 				` dir=%22ltr%22`,


### PR DESCRIPTION
esacped -> escaped