### PR TITLE
net: fix LookupNetIP to return IPv4 addresses instead of IPv4 in IPv6

### DIFF
--- a/src/net/lookup.go
+++ b/src/net/lookup.go
@@ -250,6 +250,9 @@ func (r *Resolver) LookupNetIP(ctx context.Context, network, host string) ([]net
 	}
 	ret := make([]netip.Addr, 0, len(ips))
 	for _, ip := range ips {
+		if ip4 := ip.To4(); ip4 != nil {
+			ip = ip4
+		}
 		if a, ok := netip.AddrFromSlice(ip); ok {
 			ret = append(ret, a)
 		}


### PR DESCRIPTION
The method is currently just a wrapper around the old way. But the old way
represents IPv4 in 16 bytes slice, so when this wrapper parses the slice it
will always create an IPv6 address. For IPv4 addresses, it's IPv4 in IPv6.
The fix converts the old IPv4 address representation to 4 bytes slice
before parsing, so it's parsed as IPv4 and not IPv4 in IPv6.

Fixes #53554