### PR TITLE
net/url: fixed panic while nil error print

### DIFF
--- a/src/net/url/url.go
+++ b/src/net/url/url.go
@@ -27,7 +27,12 @@ type Error struct {
 }
 
 func (e *Error) Unwrap() error { return e.Err }
-func (e *Error) Error() string { return fmt.Sprintf("%s %q: %s", e.Op, e.URL, e.Err) }
+func (e *Error) Error() string {
+	if e.Err == nil {
+		return fmt.Sprintf("%s %q: nil", e.Op, e.URL)
+	}
+	return fmt.Sprintf("%s %q: %s", e.Op, e.URL, e.Err)
+}
 
 func (e *Error) Timeout() bool {
 	t, ok := e.Err.(interface {


### PR DESCRIPTION
The error print for `net/url` package error will panic in case the error is nil, because through the `fmt.Sprintf` it tries to convert it to string, which will call the `err.Error` on a nil value. This pull request adds a safe check to handle this issue.
