### PR TITLE
flag: highlight support for double dashes in docs

### DIFF
--- a/src/flag/flag.go
+++ b/src/flag/flag.go
@@ -49,10 +49,11 @@ The arguments are indexed from 0 through flag.NArg()-1.
 The following forms are permitted:
 
 	-flag
+	--flag   // double dashes are also permitted
 	-flag=x
 	-flag x  // non-boolean flags only
 
-One or two minus signs may be used; they are equivalent.
+One or two dashes may be used; they are equivalent.
 The last form is not permitted for boolean flags because the
 meaning of the command
 


### PR DESCRIPTION
Updating examples, to show that double dashes are also permitted. This has been easy to miss previously.