### PR TITLE
os: fix a typo in path_windows.go

### DIFF
--- a/src/os/path_windows.go
+++ b/src/os/path_windows.go
@@ -11,7 +11,7 @@ const (
 
 // IsPathSeparator reports whether c is a directory separator character.
 func IsPathSeparator(c uint8) bool {
-	// NOTE: Windows accept / as path separator.
+	// NOTE: Windows accepts / as path separator.
 	return c == '\\' || c == '/'
 }
 


### PR DESCRIPTION
I believe the path_windows.go file has a typo, which is fixed in this PR