### PR TITLE
build/constraint: update doc to mention a feature added in Go 1.17

### DIFF
--- a/src/go/build/constraint/expr.go
+++ b/src/go/build/constraint/expr.go
@@ -5,9 +5,7 @@
 // Package constraint implements parsing and evaluation of build constraint lines.
 // See https://golang.org/cmd/go/#hdr-Build_constraints for documentation about build constraints themselves.
 //
-// This package parses both the original “// +build” syntax and the “//go:build” syntax that will be added in Go 1.17.
-// The parser is being included in Go 1.16 to allow tools that need to process Go 1.17 source code
-// to still be built against the Go 1.16 release.
+// This package parses both the original “// +build” syntax and the “//go:build” syntax that was added in Go 1.17.
 // See https://golang.org/design/draft-gobuild for details about the “//go:build” syntax.
 package constraint
 


### PR DESCRIPTION
The pkg documentation mentions that the "//go:build" syntax "will be"
added in Go 1.17. In fact, it has been added in that Go release, so the
documentation can now be updated.