### PR TITLE
runtime/cgo: let darwin pthread stacksize follow rlimit

### DIFF
--- a/src/runtime/cgo/gcc_darwin_amd64.c
+++ b/src/runtime/cgo/gcc_darwin_amd64.c
@@ -14,19 +14,12 @@ static void (*setg_gcc)(void*);
 void
 x_cgo_init(G *g, void (*setg)(void*), void **tlsg, void **tlsbase)
 {
-	pthread_attr_t attr;
-	size_t size, cur;
+	size_t size;
 
 	setg_gcc = setg;
 
-	pthread_attr_init(&attr);
-	pthread_attr_getstacksize(&attr, &size);
-	cur = pthread_get_stacksize_np(pthread_self());
-	if (cur > size) {
-		size = cur;
-	}
-	g->stacklo = (uintptr)&attr - size + 4096;
-	pthread_attr_destroy(&attr);
+	size = pthread_get_stacksize_np(pthread_self());
+	g->stacklo = (uintptr)&size - size + 4096;
 }
 
 
@@ -36,19 +29,15 @@ _cgo_sys_thread_start(ThreadStart *ts)
 	pthread_attr_t attr;
 	sigset_t ign, oset;
 	pthread_t p;
-	size_t size, cur;
+	size_t size;
 	int err;
 
 	sigfillset(&ign);
 	pthread_sigmask(SIG_SETMASK, &ign, &oset);
 
+	size = pthread_get_stacksize_np(pthread_self());
 	pthread_attr_init(&attr);
-	pthread_attr_getstacksize(&attr, &size);
-	cur = pthread_get_stacksize_np(pthread_self());
-	if (cur > size) {
-		size = cur;
-		pthread_attr_setstacksize(&attr, size);
-	}
+	pthread_attr_setstacksize(&attr, size);
 	// Leave stacklo=0 and set stackhi=size; mstart will do the rest.
 	ts->g->stackhi = size;
 	err = _cgo_try_pthread_create(&p, &attr, threadentry, ts);


### PR DESCRIPTION
On Mac OS X, the default stack size for non-main threads created by cgo is
fixed at 512KB and cannot be altered by setrlimit. This stack size is too
small for some recursive scenarios. We can solve this problem by explicitly
copying the stack size of the main thread when creating a new thread.