### PR TITLE
flag: support func flags without arguments

### DIFF
--- a/api/next/53747.txt
+++ b/api/next/53747.txt
@@ -1,0 +1,2 @@
+pkg flag, func BoolFunc(string, string, func(string) error) #53747
+pkg flag, method (*FlagSet) BoolFunc(string, string, func(string) error) #53747

--- a/src/flag/example_func_test.go
+++ b/src/flag/example_func_test.go
@@ -39,3 +39,19 @@ func ExampleFunc() {
 	//     	IP address to parse
 	// {ip: <nil>, loopback: false}
 }
+
+func ExampleFuncNoArg() {
+	fs := flag.NewFlagSet("ExampleFuncNoArg", flag.ContinueOnError)
+	fs.SetOutput(os.Stdout)
+
+	fs.FuncNoArg("log", "logs a dummy message", func(s string) error {
+		fmt.Println("dummy message")
+		return nil
+	})
+	fs.Parse([]string{"-log"})
+	fs.Parse([]string{"-log", "1"})
+
+	// Output:
+	// dummy message
+	// dummy message
+}

--- a/src/flag/example_func_test.go
+++ b/src/flag/example_func_test.go
@@ -40,11 +40,11 @@ func ExampleFunc() {
 	// {ip: <nil>, loopback: false}
 }
 
-func ExampleFuncNoArg() {
-	fs := flag.NewFlagSet("ExampleFuncNoArg", flag.ContinueOnError)
+func ExampleBoolFunc() {
+	fs := flag.NewFlagSet("ExampleBoolFunc", flag.ContinueOnError)
 	fs.SetOutput(os.Stdout)
 
-	fs.FuncNoArg("log", "logs a dummy message", func(s string) error {
+	fs.BoolFunc("log", "logs a dummy message", func(s string) error {
 		fmt.Println("dummy message")
 		return nil
 	})

--- a/src/flag/flag.go
+++ b/src/flag/flag.go
@@ -331,11 +331,16 @@ func (v textValue) String() string {
 }
 
 // -- func Value
-type funcValue func(string) error
+type funcValue struct {
+	Function      func(string) error
+	NeedsArgument bool
+}
 
-func (f funcValue) Set(s string) error { return f(s) }
+func (f funcValue) Set(s string) error { return f.Function(s) }
 
 func (f funcValue) String() string { return "" }
+
+func (f funcValue) IsBoolFlag() bool { return !f.NeedsArgument }
 
 // Value is the interface to the dynamic value stored in a flag.
 // (The default value is represented as a string.)
@@ -943,7 +948,14 @@ func TextVar(p encoding.TextUnmarshaler, name string, value encoding.TextMarshal
 // Each time the flag is seen, fn is called with the value of the flag.
 // If fn returns a non-nil error, it will be treated as a flag value parsing error.
 func (f *FlagSet) Func(name, usage string, fn func(string) error) {
-	f.Var(funcValue(fn), name, usage)
+	f.Var(funcValue{fn, true}, name, usage)
+}
+
+// FuncNoArg defines a flag with the specified name and usage string without requiring values.
+// Each time the flag is seen, fn is called with the value of the flag.
+// If fn returns a non-nil error, it will be treated as a flag value parsing error.
+func (f *FlagSet) FuncNoArg(name, usage string, fn func(string) error) {
+	f.Var(funcValue{fn, false}, name, usage)
 }
 
 // Func defines a flag with the specified name and usage string.
@@ -951,6 +963,13 @@ func (f *FlagSet) Func(name, usage string, fn func(string) error) {
 // If fn returns a non-nil error, it will be treated as a flag value parsing error.
 func Func(name, usage string, fn func(string) error) {
 	CommandLine.Func(name, usage, fn)
+}
+
+// Func defines a flag with the specified name and usage string without requiring values.
+// Each time the flag is seen, fn is called with the value of the flag.
+// If fn returns a non-nil error, it will be treated as a flag value parsing error.
+func FuncNoArg(name, usage string, fn func(string) error) {
+	CommandLine.FuncNoArg(name, usage, fn)
 }
 
 // Var defines a flag with the specified name and usage string. The type and

--- a/src/flag/flag.go
+++ b/src/flag/flag.go
@@ -555,9 +555,11 @@ func UnquoteUsage(flag *Flag) (name string, usage string) {
 	}
 	// No explicit name, so use type if we can find one.
 	name = "value"
-	switch flag.Value.(type) {
+	switch t := flag.Value.(type) {
 	case boolFlag:
-		name = ""
+		if t.IsBoolFlag() {
+			name = ""
+		}
 	case *durationValue:
 		name = "duration"
 	case *float64Value:
@@ -951,10 +953,10 @@ func (f *FlagSet) Func(name, usage string, fn func(string) error) {
 	f.Var(funcValue{fn, true}, name, usage)
 }
 
-// FuncNoArg defines a flag with the specified name and usage string without requiring values.
+// BoolFunc defines a flag with the specified name and usage string without requiring values.
 // Each time the flag is seen, fn is called with the value of the flag.
 // If fn returns a non-nil error, it will be treated as a flag value parsing error.
-func (f *FlagSet) FuncNoArg(name, usage string, fn func(string) error) {
+func (f *FlagSet) BoolFunc(name, usage string, fn func(string) error) {
 	f.Var(funcValue{fn, false}, name, usage)
 }
 
@@ -968,8 +970,8 @@ func Func(name, usage string, fn func(string) error) {
 // Func defines a flag with the specified name and usage string without requiring values.
 // Each time the flag is seen, fn is called with the value of the flag.
 // If fn returns a non-nil error, it will be treated as a flag value parsing error.
-func FuncNoArg(name, usage string, fn func(string) error) {
-	CommandLine.FuncNoArg(name, usage, fn)
+func BoolFunc(name, usage string, fn func(string) error) {
+	CommandLine.BoolFunc(name, usage, fn)
 }
 
 // Var defines a flag with the specified name and usage string. The type and

--- a/src/flag/flag_test.go
+++ b/src/flag/flag_test.go
@@ -38,7 +38,7 @@ func TestEverything(t *testing.T) {
 	Float64("test_float64", 0, "float64 value")
 	Duration("test_duration", 0, "time.Duration value")
 	Func("test_func", "func value", func(string) error { return nil })
-	FuncNoArg("test_func_noarg", "func", func(string) error { return nil })
+	BoolFunc("test_boolfunc", "func", func(string) error { return nil })
 
 	m := make(map[string]*Flag)
 	desired := "0"
@@ -55,7 +55,7 @@ func TestEverything(t *testing.T) {
 				ok = true
 			case f.Name == "test_func" && f.Value.String() == "":
 				ok = true
-			case f.Name == "test_func_noarg" && f.Value.String() == "":
+			case f.Name == "test_boolfunc" && f.Value.String() == "":
 				ok = true
 			}
 			if !ok {
@@ -88,7 +88,7 @@ func TestEverything(t *testing.T) {
 	Set("test_float64", "1")
 	Set("test_duration", "1s")
 	Set("test_func", "1")
-	Set("test_func_noarg", "")
+	Set("test_boolfunc", "")
 	desired = "1"
 	Visit(visitor)
 	if len(m) != 10 {
@@ -308,11 +308,11 @@ func TestUserDefinedFunc(t *testing.T) {
 	}
 }
 
-func TestUserDefinedFuncNoArg(t *testing.T) {
+func TestUserDefinedBoolFunc(t *testing.T) {
 	flags := NewFlagSet("test", ContinueOnError)
 	flags.SetOutput(io.Discard)
 	var ss []string
-	flags.FuncNoArg("v", "usage", func(s string) error {
+	flags.BoolFunc("v", "usage", func(s string) error {
 		ss = append(ss, s)
 		return nil
 	})
@@ -333,10 +333,10 @@ func TestUserDefinedFuncNoArg(t *testing.T) {
 	if usage := buf.String(); !strings.Contains(usage, "usage") {
 		t.Errorf("usage string not included: %q", usage)
 	}
-	// test FuncNoArg error
+	// test BoolFunc error
 	flags = NewFlagSet("test", ContinueOnError)
 	flags.SetOutput(io.Discard)
-	flags.FuncNoArg("v", "usage", func(s string) error {
+	flags.BoolFunc("v", "usage", func(s string) error {
 		return fmt.Errorf("test error")
 	})
 	// flag not set, so no error


### PR DESCRIPTION
Current implementation forces a func flag to have a value
When displaying the usage is possible to see a "value" required for the flag and when you execute it without flag you receive the error flag needs an argument

Converted funcValue to a struct and create 2 additional functions to avoid breaking changes

#53747 