### PR TITLE
cmd/compile: avoid excessive libfuzzer instrumentation of int compares

### DIFF
--- a/src/cmd/compile/internal/walk/compare.go
+++ b/src/cmd/compile/internal/walk/compare.go
@@ -109,7 +109,7 @@ func walkCompare(n *ir.BinaryExpr, init *ir.Nodes) ir.Node {
 
 	switch t.Kind() {
 	default:
-		if base.Debug.Libfuzzer != 0 && t.IsInteger() {
+		if base.Debug.Libfuzzer != 0 && t.IsInteger() && (n.X.Name() == nil || !n.X.Name().Libfuzzer8BitCounter()) {
 			n.X = cheapExpr(n.X, init)
 			n.Y = cheapExpr(n.Y, init)
 


### PR DESCRIPTION
Do not intercept integer compares that are used to increment libFuzzer's
8-bit counters. This is unnecessary and has a negative impact on the
fuzzing performance. This fixes #53760.