### PR TITLE
net/url: normalize hex values before comparision

### DIFF
--- a/src/net/url/url.go
+++ b/src/net/url/url.go
@@ -673,7 +673,30 @@ func (u *URL) setPath(p string) error {
 		return err
 	}
 	u.Path = path
-	if escp := escape(path, encodePath); p == escp {
+	escp := escape(path, encodePath)
+	// p may contain lowercase hexadecimal letters.
+	// So, before comparing p with escp, we need to convert all lowercase
+	// hexadecimal digits to uppercase  (since escp has uppercase hex)
+	var p_upper strings.Builder
+	p_upper.Grow(len(p))
+	for i := 0; i < len(p); i++ {
+		p_upper.WriteByte(p[i])
+		if p[i] != '%' {
+			continue
+		}
+		if p[i+1] > 'a' {
+			p_upper.WriteByte(p[i+1] + 'A' - 'a')
+		} else {
+			p_upper.WriteByte(p[i+1])
+		}
+		if p[i+2] > 'a' {
+			p_upper.WriteByte(p[i+2] + 'A' - 'a')
+		} else {
+			p_upper.WriteByte(p[i+2])
+		}
+		i += 2
+	}
+	if p_upper.String() == escp {
 		// Default encoding is fine.
 		u.RawPath = ""
 	} else {

--- a/src/net/url/url_test.go
+++ b/src/net/url/url_test.go
@@ -54,6 +54,17 @@ var urltests = []URLTest{
 		},
 		"",
 	},
+	// path with lowercase hex escaping (golang.org/issue/33596)
+	{
+		"http://www.google.com/file%3Fone%3ftwo",
+		&URL{
+			Scheme:  "http",
+			Host:    "www.google.com",
+			Path:    "/file?one?two",
+			RawPath: "",
+		},
+		"",
+	},
 	// fragment with hex escaping
 	{
 		"http://www.google.com/#file%20one%26two",


### PR DESCRIPTION
"%3f" and "%3F" are identical strings. But currently, setPath() treats them
as different strings because of the lowercase f character in "%3f", causing
RawPath to be set.

This patch fixes this bug by normalizing the hexadecimal values of the two
strings being compared. Since `escp` is generated by escape(), all of its
hex values are uppercase. So, this patch only acts upon the `p` string,
which might contain lowercase hex values (since `p` is supplied by the user)
and converts all of the lowercase hex values to uppercase.

Fixes #33596