### PR TITLE
go/time : Added json tags in struct field

### DIFF
--- a/src/time/time.go
+++ b/src/time/time.go
@@ -138,15 +138,15 @@ type Time struct {
 	// If the hasMonotonic bit is 1, then the 33-bit field holds a 33-bit
 	// unsigned wall seconds since Jan 1 year 1885, and ext holds a
 	// signed 64-bit monotonic clock reading, nanoseconds since process start.
-	wall uint64
-	ext  int64
+	wall uint64 `json:"wall"`
+	ext  int64. `json:"ext"`
 
 	// loc specifies the Location that should be used to
 	// determine the minute, hour, month, day, and year
 	// that correspond to this Time.
 	// The nil location means UTC.
 	// All UTC times are represented with loc==nil, never loc==&utcLoc.
-	loc *Location
+	loc *Location `json:"loc"`
 }
 
 const (


### PR DESCRIPTION
This change modifies Go's time package to be used as a type in CRD generations.

Since the json tag were missing for struct Time {} in go/src/time/time.go . It was not allowing time.Time to be used as a variable in CRD genetration in k8s.
