### PR TITLE
feat(net/http): provide an option to access /index.html without 301 redirect

### DIFF
--- a/src/net/http/filetransport.go
+++ b/src/net/http/filetransport.go
@@ -28,7 +28,7 @@ type fileTransport struct {
 //   res, err := c.Get("file:///etc/passwd")
 //   ...
 func NewFileTransport(fs FileSystem) RoundTripper {
-	return fileTransport{fileHandler{fs}}
+	return fileTransport{fileHandler{fs, true}}
 }
 
 func (t fileTransport) RoundTrip(req *Request) (resp *Response, err error) {

--- a/src/net/http/httptest/fs_server_test.go
+++ b/src/net/http/httptest/fs_server_test.go
@@ -1,0 +1,58 @@
+package httptest_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestHttpFileServerSkipPermanentRedirect(t *testing.T) {
+	URL, _ := url.Parse("/index.html")
+	fs := http.Dir("./")
+	respRecorder := httptest.NewRecorder()
+	req := &http.Request{
+		Method:     "GET",
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		URL:        URL,
+	}
+
+	fileServer := http.FileServer(fs)
+
+	// skip 301 redirect
+	fileServer.(*http.FileHandler).SkipPermanentRedirect()
+
+	fileServer.ServeHTTP(respRecorder, req)
+	if respRecorder.Code != 200 {
+		t.Fatal("Expect code 200, result code: ", respRecorder.Code, "body response:", respRecorder.Body.String())
+	}
+
+	bodyString := respRecorder.Body.String()
+	if !strings.Contains(bodyString, "<body>") {
+		t.Fatalf("Unexpected body response: %s", respRecorder.Body.String())
+	}
+
+}
+
+func TestHttpFileServerPermanentRedirect(t *testing.T) {
+	URL, _ := url.Parse("/index.html")
+	fs := http.Dir("./")
+	respRecorder := httptest.NewRecorder()
+	req := &http.Request{
+		Method:     "GET",
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		URL:        URL,
+	}
+
+	fileServer := http.FileServer(fs)
+
+	fileServer.ServeHTTP(respRecorder, req)
+	if respRecorder.Code != 301 {
+		t.Fatal("Expect code 301, result code: ", respRecorder.Code, "body:", respRecorder.Body.String())
+	}
+}

--- a/src/net/http/httptest/index.html
+++ b/src/net/http/httptest/index.html
@@ -1,0 +1,1 @@
+<body>index.html page</body>


### PR DESCRIPTION

For: https://github.com/golang/go/issues/53870
BREAKING CHANGES: http.ServeFile won't redirect /index.html


