### PR TITLE
runtime: fix typos

### DIFF
--- a/src/runtime/mprof.go
+++ b/src/runtime/mprof.go
@@ -947,7 +947,7 @@ func goroutineProfileWithLabelsConcurrent(p []StackRecord, labels []unsafe.Point
 	goroutineProfile.active = true
 	goroutineProfile.records = p
 	goroutineProfile.labels = labels
-	// The finializer goroutine needs special handling because it can vary over
+	// The finalizer goroutine needs special handling because it can vary over
 	// time between being a user goroutine (eligible for this profile) and a
 	// system goroutine (to be excluded). Pick one before restarting the world.
 	if fing != nil {


### PR DESCRIPTION
"finializer" =>  "finalizer"