### PR TITLE
net/textproto: add extra field to indicate whether EOF is reached

### DIFF
--- a/src/net/textproto/reader_test.go
+++ b/src/net/textproto/reader_test.go
@@ -246,7 +246,7 @@ func (r *autoRewind) Read(p []byte) (int, error) {
 	return n, err
 }
 
-// Test method can be applied on rewind readers. Issue #
+// Test method can be applied on rewind readers. Issue #53858
 func TestReadRewindReader(t *testing.T) {
 	msg1 := "From: Gopher <from@example.com>\r\n" +
 		"To: Another Gopher <to@example.com>\r\n" +

--- a/src/net/textproto/reader_test.go
+++ b/src/net/textproto/reader_test.go
@@ -248,9 +248,10 @@ func (r *autoRewind) Read(p []byte) (int, error) {
 
 // Test method can be applied on rewind readers. Issue #53858
 func TestReadRewindReader(t *testing.T) {
+	// Sample MIMEHeader string ending with new line
 	msg1 := "From: Gopher <from@example.com>\r\n" +
 		"To: Another Gopher <to@example.com>\r\n" +
-		"Subject: Gophers at Gophercon\r\n"
+		"Subject: Gophers at Gophercon\r\n\r\n"
 
 	r := &autoRewind{
 		buf: msg1,
@@ -259,7 +260,7 @@ func TestReadRewindReader(t *testing.T) {
 	tp := NewReader(bufio.NewReader(r))
 	_, err := tp.ReadMIMEHeader()
 
-	if err != io.EOF {
+	if err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
The existing implementation of ReadMIMEHeader() relies on the assumption that bufio will keep the EOF error. In the case where a rewind reader is use, bufio will always return a string and ignore the EOF. So a variable is used to indicate that EOF is reached.

Corresponding test is provided.

Fix #53858