### PR TITLE
crypto/x509: fix mac cert error handling

### DIFF
--- a/src/crypto/x509/internal/macos/security.go
+++ b/src/crypto/x509/internal/macos/security.go
@@ -201,7 +201,7 @@ func SecTrustEvaluateWithError(trustObj CFRef) error {
 	ret := syscall(abi.FuncPCABI0(x509_SecTrustEvaluateWithError_trampoline), uintptr(trustObj), uintptr(unsafe.Pointer(&errRef)), 0, 0, 0, 0)
 	if int32(ret) != 1 {
 		errStr := CFErrorCopyDescription(errRef)
-		err := fmt.Errorf("x509: %s", CFStringToString(errStr))
+		err := fmt.Errorf("%s", CFStringToString(errStr))
 		CFRelease(errRef)
 		CFRelease(errStr)
 		return err

--- a/src/crypto/x509/root_darwin.go
+++ b/src/crypto/x509/root_darwin.go
@@ -55,7 +55,7 @@ func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate
 	// using TLS or OCSP for that.
 
 	if err := macOS.SecTrustEvaluateWithError(trustObj); err != nil {
-		return nil, err
+		return nil, CertificateInvalidError{Reason: NotTrusted, Detail: err.Error()}
 	}
 
 	chain := [][]*Certificate{{}}

--- a/src/crypto/x509/verify.go
+++ b/src/crypto/x509/verify.go
@@ -56,6 +56,10 @@ const (
 	// CANotAuthorizedForExtKeyUsage results when an intermediate or root
 	// certificate does not permit a requested extended key usage.
 	CANotAuthorizedForExtKeyUsage
+	// NotTrusted results on Macs when a certificate is not trusted. This
+	// is needed to ensure we can properly catch this condition, otherwise
+	// it simply results in an `*error.ErrorString` type.
+	NotTrusted
 )
 
 // CertificateInvalidError results when an odd error occurs. Users of this
@@ -86,6 +90,8 @@ func (e CertificateInvalidError) Error() string {
 		return "x509: issuer has name constraints but leaf doesn't have a SAN extension"
 	case UnconstrainedName:
 		return "x509: issuer has name constraints but leaf contains unknown or unconstrained name: " + e.Detail
+	case NotTrusted:
+		return "x509: " + e.Detail
 	}
 	return "x509: unknown error"
 }


### PR DESCRIPTION
Fixes #52010 by wrapping Darwin cert errors in an appropriate x509 error object.