### PR TITLE
bytes: document that Reader.Reset affects the result of Size

### DIFF
--- a/src/bytes/reader.go
+++ b/src/bytes/reader.go
@@ -30,10 +30,10 @@ func (r *Reader) Len() int {
 	return int(int64(len(r.s)) - r.i)
 }
 
-// Size returns the original length of the underlying byte slice.
-// Size is the number of bytes available for reading via ReadAt.
-// The returned value is always the same and is not affected by calls
-// to any other method.
+// Size returns the original length of the underlying byte slice. 
+// Size is the number of bytes available for reading via ReadAt. 
+// The returned value will not change between calls 
+// unless the byte slice is changed by Reset.
 func (r *Reader) Size() int64 { return int64(len(r.s)) }
 
 // Read implements the io.Reader interface.

--- a/src/bytes/reader.go
+++ b/src/bytes/reader.go
@@ -30,8 +30,8 @@ func (r *Reader) Len() int {
 	return int(int64(len(r.s)) - r.i)
 }
 
-// Size returns the original length of the underlying byte slice. 
-// Size is the number of bytes available for reading via ReadAt. 
+// Size returns the original length of the underlying byte slice.
+// Size is the number of bytes available for reading via ReadAt.
 // The result is unaffected by any method calls except Reset.
 func (r *Reader) Size() int64 { return int64(len(r.s)) }
 

--- a/src/bytes/reader.go
+++ b/src/bytes/reader.go
@@ -32,8 +32,7 @@ func (r *Reader) Len() int {
 
 // Size returns the original length of the underlying byte slice. 
 // Size is the number of bytes available for reading via ReadAt. 
-// The returned value will not change between calls 
-// unless the byte slice is changed by Reset.
+// The result is unaffected by any method calls except Reset.
 func (r *Reader) Size() int64 { return int64(len(r.s)) }
 
 // Read implements the io.Reader interface.


### PR DESCRIPTION
The Reader.Reset changes the underlying byte slice, so it actually 
changes the return value of the Size method.

Fixes #54018