### PR TITLE
runtime, runtime/pprof: update doc on ThreadCreateProfile, "threadcreate"

### DIFF
--- a/src/net/http/pprof/pprof.go
+++ b/src/net/http/pprof/pprof.go
@@ -349,7 +349,7 @@ var profileDescriptions = map[string]string{
 	"heap":         "A sampling of memory allocations of live objects. You can specify the gc GET parameter to run GC before taking the heap sample.",
 	"mutex":        "Stack traces of holders of contended mutexes",
 	"profile":      "CPU profile. You can specify the duration in the seconds GET parameter. After you get the profile file, use the go tool pprof command to investigate the profile.",
-	"threadcreate": "Stack traces that led to the creation of new OS threads",
+	"threadcreate": "Number of OS threads",
 	"trace":        "A trace of execution of the current program. You can specify the duration in the seconds GET parameter. After you get the trace file, use the go tool trace command to investigate the trace.",
 }
 

--- a/src/runtime/mprof.go
+++ b/src/runtime/mprof.go
@@ -820,8 +820,7 @@ func MutexProfile(p []BlockProfileRecord) (n int, ok bool) {
 }
 
 // ThreadCreateProfile returns n, the number of records in the thread creation profile.
-// If len(p) >= n, ThreadCreateProfile copies the profile into p and returns n, true.
-// If len(p) < n, ThreadCreateProfile does not change p and returns n, false.
+// stack traces are not recorded and p is not modified.
 //
 // Most clients should use the runtime/pprof package instead
 // of calling ThreadCreateProfile directly.

--- a/src/runtime/pprof/pprof.go
+++ b/src/runtime/pprof/pprof.go
@@ -103,7 +103,7 @@ import (
 //	goroutine    - stack traces of all current goroutines
 //	heap         - a sampling of memory allocations of live objects
 //	allocs       - a sampling of all past memory allocations
-//	threadcreate - stack traces that led to the creation of new OS threads
+//	threadcreate - number of OS threads
 //	block        - stack traces that led to blocking on synchronization primitives
 //	mutex        - stack traces of holders of contended mutexes
 //


### PR DESCRIPTION
Retrieving the stack traces hasn't worked since 2013:
https://github.com/golang/go/issues/6104

However, this is not clear at all from the documentation, which is
confusing.

Once 6104 is fixed the documentation can be updated again, but there
doesn't seem much interest in doing so.