### PR TITLE
internal/fuzz: fix typo in function comments

### DIFF
--- a/src/internal/fuzz/mem.go
+++ b/src/internal/fuzz/mem.go
@@ -50,7 +50,7 @@ type sharedMemHeader struct {
 	// rawInMem is true if the region holds raw bytes, which occurs during
 	// minimization. If true after the worker fails during minimization, this
 	// indicates that an unrecoverable error occurred, and the region can be
-	// used to retrive the raw bytes that caused the error.
+	// used to retrieve the raw bytes that caused the error.
 	rawInMem bool
 }
 


### PR DESCRIPTION
The correct word to use here is 'retrieve' not 'retrive'