### PR TITLE
cmd/go: record the -buildmode flag in debug.BuildInfo

### DIFF
--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2346,6 +2346,15 @@ func (p *Package) setBuildInfo(includeVCS bool) {
 	if BuildAsmflags.present {
 		appendSetting("-asmflags", BuildAsmflags.String())
 	}
+	buildmode := cfg.BuildBuildmode
+	if buildmode == "default" {
+		if p.Name == "main" {
+			buildmode = "exe"
+		} else {
+			buildmode = "archive"
+		}
+	}
+	appendSetting("-buildmode", buildmode)
 	appendSetting("-compiler", cfg.BuildContext.Compiler)
 	if gccgoflags := BuildGccgoflags.String(); gccgoflags != "" && cfg.BuildContext.Compiler == "gccgo" {
 		appendSetting("-gccgoflags", gccgoflags)

--- a/src/cmd/go/testdata/script/mod_list_command_line_arguments.txt
+++ b/src/cmd/go/testdata/script/mod_list_command_line_arguments.txt
@@ -14,7 +14,7 @@ go build -o a.exe a.go
 go version -m a.exe
 stdout '^\tpath\tcommand-line-arguments$'
 stdout '^\tdep\ta\t\(devel\)\t$'
-! stdout mod
+! stdout mod[^e]
 
 -- a/go.mod --
 module a

--- a/src/cmd/go/testdata/script/version.txt
+++ b/src/cmd/go/testdata/script/version.txt
@@ -32,15 +32,17 @@ go build -o fortune.exe rsc.io/fortune
 go version fortune.exe
 stdout '^fortune.exe: .+'
 go version -m fortune.exe
+stdout -buildmode=exe
 stdout '^\tpath\trsc.io/fortune'
 stdout '^\tmod\trsc.io/fortune\tv1.0.0'
 
 # Check the build info of a binary built from $GOROOT/src/cmd
 go build -o test2json.exe cmd/test2json
 go version -m test2json.exe
+stdout -buildmode=exe
 stdout '^test2json.exe: .+'
 stdout '^\tpath\tcmd/test2json$'
-! stdout 'mod'
+! stdout 'mod[^e]'
 
 # Repeat the test with -buildmode=pie.
 [!buildmode:pie] stop
@@ -48,6 +50,7 @@ go build -buildmode=pie -o external.exe rsc.io/fortune
 go version external.exe
 stdout '^external.exe: .+'
 go version -m external.exe
+stdout -buildmode=pie
 stdout '^\tpath\trsc.io/fortune'
 stdout '^\tmod\trsc.io/fortune\tv1.0.0'
 
@@ -59,6 +62,7 @@ go build -buildmode=pie -ldflags=-linkmode=internal -o internal.exe rsc.io/fortu
 go version internal.exe
 stdout '^internal.exe: .+'
 go version -m internal.exe
+stdout -buildmode=pie
 stdout '^\tpath\trsc.io/fortune'
 stdout '^\tmod\trsc.io/fortune\tv1.0.0'
 


### PR DESCRIPTION
Fixes #53856
