### PR TITLE
make.bat: handle spaces in path when determining bootstrap version

### DIFF
--- a/src/make.bat
+++ b/src/make.bat
@@ -93,7 +93,7 @@ setlocal
 set GOOS=
 set GOARCH=
 set GOEXPERIMENT=
-for /f "tokens=*" %%g IN ('%GOROOT_BOOTSTRAP%\bin\go version') do (set GOROOT_BOOTSTRAP_VERSION=%%g)
+for /f "tokens=*" %%g IN ('"%GOROOT_BOOTSTRAP%\bin\go" version') do (set GOROOT_BOOTSTRAP_VERSION=%%g)
 set GOROOT_BOOTSTRAP_VERSION=%GOROOT_BOOTSTRAP_VERSION:go version =%
 echo Building Go cmd/dist using %GOROOT_BOOTSTRAP%. (%GOROOT_BOOTSTRAP_VERSION%)
 if x%vflag==x-v echo cmd/dist


### PR DESCRIPTION
Single quotes don't account for whitespace in this context, which causes
output to look like this:

$ ./make.bat
'C:\Program' is not recognized as an internal or external command,
operable program or batch file.
Building Go cmd/dist using C:\Program Files\Go. (go version =)

When it should look like this:

Building Go cmd/dist using C:\Program Files\Go. (go1.19 windows/amd64)

For #44505.