### PR TITLE
net/textproto: dont't ignore error in skipSpace function

### DIFF
--- a/src/net/textproto/reader.go
+++ b/src/net/textproto/reader.go
@@ -160,10 +160,6 @@ func (r *Reader) readContinuedLineSlice(validateFirstLine func([]byte) error) ([
 	for {
 		n, err := r.skipSpace()
 		if n == 0 || err != nil {
-			// If function reads something, it ignores io.EOF.
-			if err == io.EOF && len(r.buf) > 0 {
-				err = nil
-			}
 			return r.buf, err
 		}
 		line, err := r.readLineSlice()

--- a/src/net/textproto/reader_test.go
+++ b/src/net/textproto/reader_test.go
@@ -244,6 +244,7 @@ func (r *autoRewind) Read(p []byte) (int, error) {
 	return n, err
 }
 
+// Special io reader that does not hold errors. Issue 53858
 func TestReadMimeHeaderRewind(t *testing.T) {
 	// Improper message, expect EOF as error
 	r := &autoRewind{


### PR DESCRIPTION
skipSpace ignores the error it encounters while using a reader 
which seems like a bug. Refactor the function and have it 
returns the errors. 

Modified readContinuedLineSlice and have it ignore io.EOF 
while something is ever read in the function to keep its 
behaviour unchanged.

Update  #53858