### PR TITLE
build: default GOROOT_BOOTSTRAP in make.{bash,bat} error msg from 1.4 to 1.17

### DIFF
--- a/src/make.bash
+++ b/src/make.bash
@@ -67,9 +67,10 @@
 # timing information to this file. Useful for profiling where the
 # time goes when these scripts run.
 #
-# GOROOT_BOOTSTRAP: A working Go tree >= Go 1.4 for bootstrap.
+# GOROOT_BOOTSTRAP: A working Go tree >= Go 1.17 for bootstrap.
 # If $GOROOT_BOOTSTRAP/bin/go is missing, $(go env GOROOT) is
-# tried for all "go" in $PATH. $HOME/go1.4 by default.
+# tried for all "go" in $PATH. $HOME/go1.4, $HOME/sdk/go1.17
+# or $HOME/go1.17 by default.
 
 set -e
 
@@ -172,7 +173,7 @@ IFS=$'\n'; for go_exe in $(type -ap go); do
 done; unset IFS
 if [ ! -x "$GOROOT_BOOTSTRAP/bin/go" ]; then
 	echo "ERROR: Cannot find $GOROOT_BOOTSTRAP/bin/go." >&2
-	echo "Set \$GOROOT_BOOTSTRAP to a working Go tree >= Go 1.4." >&2
+	echo "Set \$GOROOT_BOOTSTRAP to a working Go tree >= Go 1.17." >&2
 	exit 1
 fi
 # Get the exact bootstrap toolchain version to help with debugging.
@@ -185,7 +186,7 @@ if $verbose; then
 fi
 if [ "$GOROOT_BOOTSTRAP" = "$GOROOT" ]; then
 	echo "ERROR: \$GOROOT_BOOTSTRAP must not be set to \$GOROOT" >&2
-	echo "Set \$GOROOT_BOOTSTRAP to a working Go tree >= Go 1.4." >&2
+	echo "Set \$GOROOT_BOOTSTRAP to a working Go tree >= Go 1.17." >&2
 	exit 1
 fi
 rm -f cmd/dist/dist
@@ -213,7 +214,7 @@ fi
 
 # Run dist bootstrap to complete make.bash.
 # Bootstrap installs a proper cmd/dist, built with the new toolchain.
-# Throw ours, built with Go 1.4, away after bootstrap.
+# Throw ours, built with Go 1.17, away after bootstrap.
 ./cmd/dist/dist bootstrap -a $vflag $GO_DISTFLAGS "$@"
 rm -f ./cmd/dist/dist
 

--- a/src/make.bat
+++ b/src/make.bat
@@ -128,7 +128,7 @@ if x%4==x--no-banner set bootstrapflags=%bootstrapflags% --no-banner
 
 :: Run dist bootstrap to complete make.bash.
 :: Bootstrap installs a proper cmd/dist, built with the new toolchain.
-:: Throw ours, built with Go 1.4, away after bootstrap.
+:: Throw ours, built with Go 1.17, away after bootstrap.
 .\cmd\dist\dist.exe bootstrap -a %vflag% %bootstrapflags%
 if errorlevel 1 goto fail
 del .\cmd\dist\dist.exe
@@ -147,7 +147,7 @@ goto end
 
 :bootstrapfail
 echo ERROR: Cannot find %GOROOT_BOOTSTRAP%\bin\go.exe
-echo Set GOROOT_BOOTSTRAP to a working Go tree ^>= Go 1.4.
+echo Set GOROOT_BOOTSTRAP to a working Go tree ^>= Go 1.17.
 
 :fail
 set GOBUILDFAIL=1

--- a/src/make.rc
+++ b/src/make.rc
@@ -72,12 +72,12 @@ for(p in $path){
 }
 if(! test -x $GOROOT_BOOTSTRAP/bin/go){
 	echo 'ERROR: Cannot find '$GOROOT_BOOTSTRAP'/bin/go.' >[1=2]
-	echo 'Set $GOROOT_BOOTSTRAP to a working Go tree >= Go 1.4.' >[1=2]
+	echo 'Set $GOROOT_BOOTSTRAP to a working Go tree >= Go 1.17.' >[1=2]
 	exit bootstrap
 }
 if(~ $GOROOT_BOOTSTRAP $GOROOT){
 	echo 'ERROR: $GOROOT_BOOTSTRAP must not be set to $GOROOT' >[1=2]
-	echo 'Set $GOROOT_BOOTSTRAP to a working Go tree >= Go 1.4.' >[1=2]
+	echo 'Set $GOROOT_BOOTSTRAP to a working Go tree >= Go 1.17.' >[1=2]
 	exit bootstrap
 }
 
@@ -105,7 +105,7 @@ if(~ $1 --dist-tool){
 
 # Run dist bootstrap to complete make.bash.
 # Bootstrap installs a proper cmd/dist, built with the new toolchain.
-# Throw ours, built with Go 1.4, away after bootstrap.
+# Throw ours, built with Go 1.17, away after bootstrap.
 ./cmd/dist/dist bootstrap -a $vflag $*
 rm -f ./cmd/dist/dist
 


### PR DESCRIPTION
Fixes #54301
