### PR TITLE
syscall: fix sycall.ptrace cause nosplit stack over 792 byte limit

### DIFF
--- a/src/syscall/ptrace_darwin.go
+++ b/src/syscall/ptrace_darwin.go
@@ -6,9 +6,4 @@
 
 package syscall
 
-// Nosplit because it is called from forkAndExecInChild.
-//
-//go:nosplit
-func ptrace(request int, pid int, addr uintptr, data uintptr) error {
-	return ptrace1(request, pid, addr, data)
-}
+var ptrace = ptrace1

--- a/test/fixedbugs/issue54291.go
+++ b/test/fixedbugs/issue54291.go
@@ -1,0 +1,11 @@
+// run -race -gcflags=all="-N -l"
+package main
+
+import (
+	"os/exec"
+)
+
+func main() {
+	cmd := exec.Command("echo", "test")
+	_ = cmd.Start()
+}


### PR DESCRIPTION
Fixes #54291
