### PR TITLE
doc/go_mem.html: delete a sentence that is ambiguous

### DIFF
--- a/doc/go_mem.html
+++ b/doc/go_mem.html
@@ -183,13 +183,7 @@ which are unordered by happens before.
 </p>
 
 <p>
-Note that if there are no read-write or write-write data races on memory location <i>x</i>,
-then any read <i>r</i> on <i>x</i> has only one possible <i>W</i>(<i>r</i>):
-the single <i>w</i> that immediately precedes it in the happens before order.
-</p>
-
-<p>
-More generally, it can be shown that any Go program that is data-race-free,
+It can be shown that any Go program that is data-race-free,
 meaning it has no program executions with read-write or write-write data races,
 can only have outcomes explained by some sequentially consistent interleaving
 of the goroutine executions.


### PR DESCRIPTION
It is unclear what the statement
"then any read r on x has only one possible W(r)" means:

A. If the context here is about: In a given program execution
(aka given a specific mapping W),
then this statement is trivial to mention,
as W(r) is by definition a write operation w,
therefore the only one.

B. If the context here is about: Among all possible
program execution (aka all possible mappings {W})
that satisfies requirement 1,2,3,
then this statement is not true.
Because W(r) can be different write operations
in different program execution
(data-race-free doesn't imply deterministic execution).

Alternatively, a less ambiguous statement could be like:

"if there are no read-write or write-write data races on memory location x,
then any read r on x has only one possible W(r), among all program
executions {W} that share the same synchronized before relation."