### PR TITLE
runtime/interal/atomic: don't allow splitting stack during system call

### DIFF
--- a/src/runtime/internal/atomic/types.go
+++ b/src/runtime/internal/atomic/types.go
@@ -136,6 +136,8 @@ type Bool struct {
 }
 
 // Load accesses and returns the value atomically.
+//
+//go:nosplit
 func (b *Bool) Load() bool {
 	return b.u.Load() != 0
 }


### PR DESCRIPTION
fixes #54412