### PR TITLE
text/template: add ExecuteFuncMap and ExecuteTemplateFuncMap

### DIFF
--- a/api/next/54432.txt
+++ b/api/next/54432.txt
@@ -1,0 +1,4 @@
+pkg html/template, method (*Template) ExecuteFuncMap(io.Writer, interface{}, template.FuncMap) error #54432
+pkg html/template, method (*Template) ExecuteTemplateFuncMap(io.Writer, string, interface{}, template.FuncMap) error #54432
+pkg text/template, method (*Template) ExecuteFuncMap(io.Writer, interface{}, FuncMap) error #54432
+pkg text/template, method (*Template) ExecuteTemplateFuncMap(io.Writer, string, interface{}, FuncMap) error #54432

--- a/src/html/template/template.go
+++ b/src/html/template/template.go
@@ -124,6 +124,20 @@ func (t *Template) Execute(wr io.Writer, data any) error {
 	return t.text.Execute(wr, data)
 }
 
+// ExecuteFuncMap applies a parsed template to the specified data object,
+// FuncMap overlay and writes the output to wr.
+// If an error occurs executing the template or writing its output,
+// execution stops, but partial results may already have been written to
+// the output writer.
+// A template may be executed safely in parallel, although if parallel
+// executions share a Writer the output may be interleaved.
+func (t *Template) ExecuteFuncMap(wr io.Writer, data any, funcs FuncMap) error {
+	if err := t.escape(); err != nil {
+		return err
+	}
+	return t.text.ExecuteFuncMap(wr, data, funcs)
+}
+
 // ExecuteTemplate applies the template associated with t that has the given
 // name to the specified data object and writes the output to wr.
 // If an error occurs executing the template or writing its output,
@@ -137,6 +151,21 @@ func (t *Template) ExecuteTemplate(wr io.Writer, name string, data any) error {
 		return err
 	}
 	return tmpl.text.Execute(wr, data)
+}
+
+// ExecuteTemplateFuncMap applies the template associated with t that has the given
+// name to the specified data object and FuncMap overlay writing the output to wr.
+// If an error occurs executing the template or writing its output,
+// execution stops, but partial results may already have been written to
+// the output writer.
+// A template may be executed safely in parallel, although if parallel
+// executions share a Writer the output may be interleaved.
+func (t *Template) ExecuteTemplateFuncMap(wr io.Writer, name string, data any, funcs FuncMap) error {
+	tmpl, err := t.lookupAndEscapeTemplate(name)
+	if err != nil {
+		return err
+	}
+	return tmpl.text.ExecuteFuncMap(wr, data, funcs)
 }
 
 // lookupAndEscapeTemplate guarantees that the template with the given name


### PR DESCRIPTION
There have been several requests for the ability to add or overlay
functions at time of template execution. One suggestion was to optimize
the template Clone feature to avoid creating a new function or API
however, this would be very complicated to do. (#38114)

This PR suggests a simpler solution.

Add the following new functions to text/template and html/template:

```go
func ExecuteFuncMap(wr io.Writer, data any, funcs FuncMap) error { ... }

func ExecuteTemplateFuncMap(wr io.Writer, name string, data any, funcs FuncMap) error { ... }
```

These functions then simply allow one to overlay a new FuncMap over the
already parsed functions. This requires a function map to be added to
the execution state which is then further passed to sub-template
executions.

As you can see the required change is quite simple and avoids the need
for complex locking changes or parent-child relationships in Template.

Updates #38114
