### PR TITLE
make.bat: fix GOROOT_BOOTSTRAP default location

### DIFF
--- a/src/make.bat
+++ b/src/make.bat
@@ -80,9 +80,7 @@ for /f "tokens=*" %%g in ('where go 2^>nul') do (
 		)
 	)
 )
-if "x%GOROOT_BOOTSTRAP%"=="x" if exist "%HOMEDRIVE%%HOMEPATH%\go1.17" set GOROOT_BOOTSTRAP=%HOMEDRIVE%%HOMEPATH%\go1.17
-if "x%GOROOT_BOOTSTRAP%"=="x" if exist "%HOMEDRIVE%%HOMEPATH%\sdk\go1.17" set GOROOT_BOOTSTRAP=%HOMEDRIVE%%HOMEPATH%\sdk\go1.17
-if "x%GOROOT_BOOTSTRAP%"=="x" set GOROOT_BOOTSTRAP=%HOMEDRIVE%%HOMEPATH%\Go1.4
+if "x%GOROOT_BOOTSTRAP%"=="x" set GOROOT_BOOTSTRAP=%ProgramFiles%\go
 
 :bootstrapset
 if not exist "%GOROOT_BOOTSTRAP%\bin\go.exe" goto bootstrapfail


### PR DESCRIPTION
Go windows installer default directory is now "%ProgramFiles%\go", So make this default location for make.bat too and don't try look at other location.