### PR TITLE
go/types,cmd/compile/internal/types2: add support for unsafe.{String,StringData,SliceData}

### DIFF
--- a/src/cmd/compile/internal/types2/builtins_test.go
+++ b/src/cmd/compile/internal/types2/builtins_test.go
@@ -129,6 +129,14 @@ var builtinCalls = []struct {
 	{"Slice", `var p *int; _ = unsafe.Slice(p, 1)`, `func(*int, int) []int`},
 	{"Slice", `var p *byte; var n uintptr; _ = unsafe.Slice(p, n)`, `func(*byte, uintptr) []byte`},
 
+	{"SliceData", "var a = []int{1,2,3}; _ = unsafe.SliceData(a)", `func([]int) *int`},
+
+	{"String", `var p *byte; _ = unsafe.String(p, 1)`, `func(*byte, int) string`},
+	{"String", `var p *byte; var n uintptr; _ = unsafe.String(p, n)`, `func(*byte, uintptr) string`},
+
+	{"StringData", `var s ="1223"; _ = unsafe.StringData(s)`, `func(string) *byte`},
+	{"StringData", `_ = unsafe.StringData("123")`, `func(string) *byte`},
+
 	{"assert", `assert(true)`, `invalid type`},                                    // constant
 	{"assert", `type B bool; const pred B = 1 < 2; assert(pred)`, `invalid type`}, // constant
 

--- a/src/cmd/compile/internal/types2/universe.go
+++ b/src/cmd/compile/internal/types2/universe.go
@@ -165,6 +165,9 @@ const (
 	_Offsetof
 	_Sizeof
 	_Slice
+	_SliceData
+	_String
+	_StringData
 
 	// testing support
 	_Assert
@@ -193,11 +196,14 @@ var predeclaredFuncs = [...]struct {
 	_Real:    {"real", 1, false, expression},
 	_Recover: {"recover", 0, false, statement},
 
-	_Add:      {"Add", 2, false, expression},
-	_Alignof:  {"Alignof", 1, false, expression},
-	_Offsetof: {"Offsetof", 1, false, expression},
-	_Sizeof:   {"Sizeof", 1, false, expression},
-	_Slice:    {"Slice", 2, false, expression},
+	_Add:       {"Add", 2, false, expression},
+	_Alignof:   {"Alignof", 1, false, expression},
+	_Offsetof:  {"Offsetof", 1, false, expression},
+	_Sizeof:    {"Sizeof", 1, false, expression},
+	_Slice:     {"Slice", 2, false, expression},
+	_SliceData: {"SliceData", 1, false, expression},
+	_String:   {"String", 2, false, expression},
+	_StringData: {"StringData", 1, false, expression},
 
 	_Assert: {"assert", 1, false, statement},
 	_Trace:  {"trace", 0, true, statement},

--- a/src/go/types/builtins.go
+++ b/src/go/types/builtins.go
@@ -751,6 +751,65 @@ func (check *Checker) builtin(x *operand, call *ast.CallExpr, id builtinId) (_ b
 		if check.Types != nil {
 			check.recordBuiltinType(call.Fun, makeSig(x.typ, typ, y.typ))
 		}
+	case _StringData:
+		// unsafe.StringData(str string) *byte
+		if !check.allowVersion(check.pkg, 1, 17) {
+			check.errorf(call.Fun, _InvalidUnsafeStringData, "unsafe.Slice requires go1.17 or later")
+			return
+		}
+		typ, ok := under(x.typ).(*Basic)
+		if !ok || (typ.Kind() != String && typ.Kind() != UntypedString) {
+			check.invalidArg(x, _InvalidUnsafeStringData, "%s is not a string", x)
+			return
+		}
+		x.mode = value
+		x.typ = NewPointer(aliases[0])
+		if check.Types != nil {
+			check.recordBuiltinType(call.Fun, makeSig(x.typ, typ))
+		}
+
+	case _String:
+		// unsafe.String(ptr *byte, len IntegerType) string
+		if !check.allowVersion(check.pkg, 1, 17) {
+			check.errorf(call.Fun, _InvalidUnsafeString, "unsafe.Slice requires go1.17 or later")
+			return
+		}
+
+		typ, _ := under(x.typ).(*Pointer)
+		if typ == nil && typ.Elem() != Typ[Uint8] {
+			check.invalidArg(x, _InvalidUnsafeString, "%s is not a pointer", x)
+			return
+		}
+
+		var y operand
+		arg(&y, 1)
+		if !check.isValidIndex(&y, _InvalidUnsafeString, "length", false) {
+			return
+		}
+
+		x.mode = value
+		x.typ = Typ[String]
+		if check.Types != nil {
+			check.recordBuiltinType(call.Fun, makeSig(x.typ, typ, y.typ))
+		}
+
+	case _SliceData:
+		// unsafe.SliceData(str string) *byte
+		if !check.allowVersion(check.pkg, 1, 17) {
+			check.errorf(call.Fun, _InvalidUnsafeSliceData, "unsafe.SliceData requires go1.17 or later")
+			return
+		}
+
+		typ, ok := under(x.typ).(*Slice)
+		if !ok {
+			check.invalidArg(x, _InvalidUnsafeSliceData, "%s is not a slice", x)
+			return
+		}
+		x.mode = value
+		x.typ = NewPointer(typ.Elem())
+		if check.Types != nil {
+			check.recordBuiltinType(call.Fun, makeSig(x.typ, typ))
+		}
 
 	case _Assert:
 		// assert(pred) causes a typechecker error if pred is false.

--- a/src/go/types/builtins_test.go
+++ b/src/go/types/builtins_test.go
@@ -130,6 +130,14 @@ var builtinCalls = []struct {
 	{"Slice", `var p *int; _ = unsafe.Slice(p, 1)`, `func(*int, int) []int`},
 	{"Slice", `var p *byte; var n uintptr; _ = unsafe.Slice(p, n)`, `func(*byte, uintptr) []byte`},
 
+	{"SliceData", "var a = []int{1,2,3}; _ = unsafe.SliceData(a)", `func([]int) *int`},
+
+	{"String", `var p *byte; _ = unsafe.String(p, 1)`, `func(*byte, int) string`},
+	{"String", `var p *byte; var n uintptr; _ = unsafe.String(p, n)`, `func(*byte, uintptr) string`},
+
+	{"StringData", `var s ="1223"; _ = unsafe.StringData(s)`, `func(string) *byte`},
+	{"StringData", `_ = unsafe.StringData("123")`, `func(string) *byte`},
+
 	{"assert", `assert(true)`, `invalid type`},                                    // constant
 	{"assert", `type B bool; const pred B = 1 < 2; assert(pred)`, `invalid type`}, // constant
 

--- a/src/go/types/errorcodes.go
+++ b/src/go/types/errorcodes.go
@@ -1298,6 +1298,30 @@ const (
 	//  var _ = unsafe.Slice(&x, uint64(1) << 63)
 	_InvalidUnsafeSlice
 
+	// _InvalidUnsafeSliceData occurs when unsafe.SliceData called with type
+	// is not slice
+	// Example:
+	// import "unsafe"
+	// var x int
+	// var _ = unsafe.SliceData(x)
+	_InvalidUnsafeSliceData
+
+	// _InvalidUnsafeString occurs when unsafe.String is called with a
+	// pointer argument that is not of pointer type or a length argument
+	// that is not of integer type, negative, or out of bounds.
+	// Example:
+	// import "unsafe"
+	// var b [10]byte
+	// var _ = unsafe.String(&b[0], -1)
+	_InvalidUnsafeString
+
+	// _InvalidUnsafeStringData
+	// Example:
+	// import "unsafe"
+	// var x int
+	// var _ = unsafe.StringData(x)
+	_InvalidUnsafeStringData
+
 	// All codes below were added in Go 1.18.
 
 	// _UnsupportedFeature occurs when a language feature is used that is not

--- a/src/go/types/universe.go
+++ b/src/go/types/universe.go
@@ -166,6 +166,9 @@ const (
 	_Offsetof
 	_Sizeof
 	_Slice
+	_SliceData
+	_String
+	_StringData
 
 	// testing support
 	_Assert
@@ -194,11 +197,14 @@ var predeclaredFuncs = [...]struct {
 	_Real:    {"real", 1, false, expression},
 	_Recover: {"recover", 0, false, statement},
 
-	_Add:      {"Add", 2, false, expression},
-	_Alignof:  {"Alignof", 1, false, expression},
-	_Offsetof: {"Offsetof", 1, false, expression},
-	_Sizeof:   {"Sizeof", 1, false, expression},
-	_Slice:    {"Slice", 2, false, expression},
+	_Add:       {"Add", 2, false, expression},
+	_Alignof:   {"Alignof", 1, false, expression},
+	_Offsetof:  {"Offsetof", 1, false, expression},
+	_Sizeof:    {"Sizeof", 1, false, expression},
+	_Slice:     {"Slice", 2, false, expression},
+	_SliceData: {"SliceData", 1, false, expression},
+	_String:   {"String", 2, false, expression},
+	_StringData: {"StringData", 1, false, expression},
 
 	_Assert: {"assert", 1, false, statement},
 	_Trace:  {"trace", 0, true, statement},

--- a/src/unsafe/unsafe.go
+++ b/src/unsafe/unsafe.go
@@ -239,3 +239,23 @@ func Add(ptr Pointer, len IntegerType) Pointer
 // At run time, if len is negative, or if ptr is nil and len is not zero,
 // a run-time panic occurs.
 func Slice(ptr *ArbitraryType, len IntegerType) []ArbitraryType
+
+// SliceData return the data ptr of slice
+// SliceData(s) is equivalent to( when s is type []byte)
+// (*byte)(*(*unsafe.Pointer)(unsafe.Pointer(&s))
+func SliceData(slice []ArbitraryType) *ArbitraryType
+
+// String returns a String whose underlying array starts at ptr to byte
+// and whose length  are len.
+// except that, as a special case, if ptr is nil and len is zero,
+// String returns "".
+//
+// The len argument must be of integer type or an untyped constant.
+// A constant len argument must be non-negative and representable by a value of type int;
+// if it is an untyped constant it is given type int.
+// At run time, if len is negative, or if ptr is nil and len is not zero,
+// a run-time panic occurs.
+func String(ptr *byte, len IntegerType) string
+
+//StringData get the data ptr of string
+func StringData(str string) *byte


### PR DESCRIPTION
#53003
