### PR TITLE
mime/multipart: change %v to %w for EOF error

### DIFF
--- a/src/mime/multipart/multipart.go
+++ b/src/mime/multipart/multipart.go
@@ -360,7 +360,7 @@ func (r *Reader) nextPart(rawPart bool) (*Part, error) {
 			return nil, io.EOF
 		}
 		if err != nil {
-			return nil, fmt.Errorf("multipart: NextPart: %v", err)
+			return nil, fmt.Errorf("multipart: NextPart: %w", err)
 		}
 
 		if r.isBoundaryDelimiterLine(line) {


### PR DESCRIPTION
Fixes fmt.Errorf error returned that uses %v instead of %w. It is currently not possible to use errors.Is with the error returned by the NextPart function.