### PR TITLE
cmd/test2json: use original environment to mirror go test

### DIFF
--- a/src/cmd/go/internal/tool/tool.go
+++ b/src/cmd/go/internal/tool/tool.go
@@ -86,6 +86,9 @@ func runTool(ctx context.Context, cmd *base.Command, args []string) {
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
 	}
+	if toolName == "test2json" {
+		toolCmd.Env = append([]string{}, cfg.OrigEnv...)
+	}
 	err := toolCmd.Start()
 	if err == nil {
 		c := make(chan os.Signal, 100)


### PR DESCRIPTION
The go test is using original environment variables, but test2json is using compiled ones. This change will shift test2json to behave the same way as a regular go test command.

Fixes #54545