### PR TITLE
cmd/trace: display goroutines (PC=0) with clearer description

### DIFF
--- a/src/cmd/trace/goroutines.go
+++ b/src/cmd/trace/goroutines.go
@@ -64,6 +64,11 @@ func httpGoroutines(w http.ResponseWriter, r *http.Request) {
 	var glist []gtype
 	for k, v := range gss {
 		v.ID = k
+		// If goroutine didn't run during the trace (no sampled PC),
+		// the v.ID and v.Name will be zero value.
+		if v.ID == 0 && v.Name == "" {
+			v.Name = "(Inactive, no stack trace sampled)"
+		}
 		glist = append(glist, v)
 	}
 	sort.Slice(glist, func(i, j int) bool { return glist[i].ExecTime > glist[j].ExecTime })


### PR DESCRIPTION
This PR fixes: #54425 #49994