### PR TITLE
net: turn off dns compression for go resolver queries

### DIFF
--- a/src/net/dnsclient_unix.go
+++ b/src/net/dnsclient_unix.go
@@ -54,7 +54,6 @@ var (
 func newRequest(q dnsmessage.Question) (id uint16, udpReq, tcpReq []byte, err error) {
 	id = uint16(randInt())
 	b := dnsmessage.NewBuilder(make([]byte, 2, 514), dnsmessage.Header{ID: id, RecursionDesired: true})
-	b.EnableCompression()
 	if err := b.StartQuestions(); err != nil {
 		return 0, nil, nil, err
 	}


### PR DESCRIPTION
We don't need compression enabled here, because we only set one question in the dns message. So there is nothing to compress. Also it reduces 8 allocs per LookupHost.