### PR TITLE
src/crypto/crypto: provide more meaningful panic message

### DIFF
--- a/src/crypto/crypto.go
+++ b/src/crypto/crypto.go
@@ -130,8 +130,10 @@ func (h Hash) New() hash.Hash {
 		if f != nil {
 			return f()
 		}
+	} else {
+		panic("crypto: requested hash function #" + strconv.Itoa(int(h)) + " is invalid")
 	}
-	panic("crypto: requested hash function #" + strconv.Itoa(int(h)) + " is unavailable")
+	panic("crypto: requested hash function " + h.String() + " has not been imported")
 }
 
 // Available reports whether the given hash function is linked into the binary.


### PR DESCRIPTION
Provides better information when a hash algorithm is not imported or invalid