### PR TITLE
cmd/go/internal/imports: include ToolTags in the Tags map

### DIFF
--- a/src/cmd/go/internal/imports/tags.go
+++ b/src/cmd/go/internal/imports/tags.go
@@ -36,6 +36,9 @@ func loadTags() map[string]bool {
 	for _, tag := range cfg.BuildContext.BuildTags {
 		tags[tag] = true
 	}
+	for _, tag := range cfg.BuildContext.ToolTags {
+		tags[tag] = true
+	}
 	for _, tag := range cfg.BuildContext.ReleaseTags {
 		tags[tag] = true
 	}

--- a/src/cmd/go/testdata/script/test_race_tag.txt
+++ b/src/cmd/go/testdata/script/test_race_tag.txt
@@ -1,0 +1,29 @@
+# Tests Issue #54468
+
+[short] skip 'links a test binary'
+[!race] skip
+
+go mod tidy
+go test -c -o=$devnull -race .
+
+! stderr 'cannot find package'
+
+-- go.mod --
+module testrace
+
+go 1.18
+
+require rsc.io/sampler v1.0.0
+-- race_test.go --
+//go:build race
+
+package testrace
+
+import (
+        "testing"
+
+        _ "rsc.io/sampler"
+)
+
+func TestRaceTag(t *testing.T) {
+}


### PR DESCRIPTION
This fixes a regression introduced when the "race" mode tag was moved to
the ToolTags field in CL 358539.

Fixes #54468