### PR TITLE
Increasing the code readability

### DIFF
--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -27,6 +27,7 @@ by automatic tools such as integrated development environments.
 </p>
 
 <h2 id="Notation">Notation</h2>
+
 <p>
 The syntax is specified using a
 <a href="https://en.wikipedia.org/wiki/Wirth_syntax_notation">variant</a>
@@ -48,6 +49,7 @@ Repetition  = "{" Expression "}" .
 Productions are expressions constructed from terms and the following
 operators, in increasing precedence:
 </p>
+
 <pre class="grammar">
 |   alternation
 ()  grouping
@@ -81,14 +83,17 @@ those are treated as two code points.  For simplicity, this document
 will use the unqualified term <i>character</i> to refer to a Unicode code point
 in the source text.
 </p>
+
 <p>
 Each code point is distinct; for instance, uppercase and lowercase letters
 are different characters.
 </p>
+
 <p>
 Implementation restriction: For compatibility with other tools, a
 compiler may disallow the NUL character (U+0000) in the source text.
 </p>
+
 <p>
 Implementation restriction: For compatibility with other tools, a
 compiler may ignore a UTF-8-encoded byte order mark
@@ -101,6 +106,7 @@ A byte order mark may be disallowed anywhere else in the source.
 <p>
 The following terms are used to denote specific Unicode character categories:
 </p>
+
 <pre class="ebnf">
 newline        = /* the Unicode code point U+000A */ .
 unicode_char   = /* an arbitrary Unicode code point except newline */ .
@@ -120,6 +126,7 @@ as Unicode letters, and those in the Number category Nd as Unicode digits.
 <p>
 The underscore character <code>_</code> (U+005F) is considered a lowercase letter.
 </p>
+
 <pre class="ebnf">
 letter        = unicode_letter | "_" .
 decimal_digit = "0" … "9" .
@@ -179,6 +186,7 @@ using the following two rules:
 </p>
 
 <ol>
+	
 <li>
 When the input is broken into tokens, a semicolon is automatically inserted
 into the token stream immediately after a line's final token if that token is
@@ -216,6 +224,7 @@ into the token stream immediately after a line's final token if that token is
 To allow complex statements to occupy a single line, a semicolon
 may be omitted before a closing <code>")"</code> or <code>"}"</code>.
 </li>
+	
 </ol>
 
 <p>
@@ -231,9 +240,11 @@ Identifiers name program entities such as variables and types.
 An identifier is a sequence of one or more letters and digits.
 The first character in an identifier must be a letter.
 </p>
+
 <pre class="ebnf">
 identifier = letter { letter | unicode_digit } .
 </pre>
+
 <pre>
 a
 _x9
@@ -251,6 +262,7 @@ Some identifiers are <a href="#Predeclared_identifiers">predeclared</a>.
 <p>
 The following keywords are reserved and may not be used as identifiers.
 </p>
+
 <pre class="grammar">
 break        default      func         interface    select
 case         defer        go           map          struct
@@ -265,6 +277,7 @@ continue     for          import       return       var
 The following character sequences represent <a href="#Operators">operators</a>
 (including <a href="#Assignment_statements">assignment operators</a>) and punctuation:
 </p>
+
 <pre class="grammar">
 +    &amp;     +=    &amp;=     &amp;&amp;    ==    !=    (    )
 -    |     -=    |=     ||    &lt;     &lt;=    [    ]
@@ -292,6 +305,7 @@ For readability, an underscore character <code>_</code> may appear after
 a base prefix or between successive digits; such underscores do not change
 the literal's value.
 </p>
+
 <pre class="ebnf">
 int_lit        = decimal_lit | binary_lit | octal_lit | hex_lit .
 decimal_lit    = "0" | ( "1" … "9" ) [ [ "_" ] decimal_digits ] .


### PR DESCRIPTION
While reading the source code I've seen their are multiple places where, their is no spacing between two different element, I've added some spaces between different element's so that developers can read the source code easily while they are trying to find or fix a bug in the program.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
