### PR TITLE
crypto/tls: return a copy of the OSCP response

### DIFF
--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -1518,7 +1518,9 @@ func (c *Conn) OCSPResponse() []byte {
 	c.handshakeMutex.Lock()
 	defer c.handshakeMutex.Unlock()
 
-	return c.ocspResponse
+	response := make([]byte, len(c.ocspResponse))
+	copy(response, c.ocspResponse)
+	return response
 }
 
 // VerifyHostname checks that the peer certificate chain is valid for


### PR DESCRIPTION
I noticed `OCSPResponse()` returns `ocspResponse` (a non-exported slice field) without duplicating it first. Because this field is a slice, there are two problems:

1. If the return value is modified, the change will also be reflected in the `Conn` object.
2. If the `ocspResponse` field changes, the return value will also change. The return is surrounded by a `Lock`/`Unlock` which indicates it could change. Maybe that's a different problem.

Here's a simple program to demonstrate the first problem:
```go
package main

import "fmt"

type Foo struct {
	bar []byte
}

func (f *Foo) Bar() []byte {
	return f.bar
}

func main() {
	foo := Foo{[]byte("hello")}
	fmt.Println("before:", string(foo.Bar()))
	bar := foo.Bar()
	bar[0] = byte('j')
	fmt.Println("after:", string(foo.Bar()))
}
```
When executed, it will output:
```
before: hello
after: jello
```
