### PR TITLE
cmd/go/internal/modfetch: report error on failing to derive pseudo version from recent tag

### DIFF
--- a/src/cmd/go/internal/modfetch/coderepo.go
+++ b/src/cmd/go/internal/modfetch/coderepo.go
@@ -607,7 +607,10 @@ func (r *codeRepo) convert(info *codehost.RevInfo, statVers string) (*RevInfo, e
 		return !isRetracted(v)
 	}
 	if pseudoBase == "" {
-		tag, _ := r.code.RecentTag(info.Name, tagPrefix, tagAllowed)
+		tag, err := r.code.RecentTag(info.Name, tagPrefix, tagAllowed)
+		if err != nil {
+			return nil, err
+		}
 		if tag != "" {
 			pseudoBase, _ = tagToVersion(tag)
 		}


### PR DESCRIPTION
The current implementation ignores the error when it tries to get
the recent tag on revisions, which results in incorrect pseudo
version (v0.0.0-) is derived.

Fixes #53935