### PR TITLE
runtime: fix misleading comments in amd64 assembly

### DIFF
--- a/src/runtime/sys_darwin_amd64.s
+++ b/src/runtime/sys_darwin_amd64.s
@@ -582,7 +582,7 @@ TEXT runtime·pthread_cond_signal_trampoline(SB),NOSPLIT,$0
 TEXT runtime·pthread_self_trampoline(SB),NOSPLIT,$0
 	PUSHQ	BP
 	MOVQ	SP, BP
-	MOVQ	DI, BX		// BX is caller-save
+	MOVQ	DI, BX		// BX is callee-saved
 	CALL	libc_pthread_self(SB)
 	MOVQ	AX, 0(BX)	// return value
 	POPQ	BP

--- a/src/runtime/sys_openbsd_amd64.s
+++ b/src/runtime/sys_openbsd_amd64.s
@@ -178,7 +178,7 @@ TEXT runtime·exit_trampoline(SB),NOSPLIT,$0
 TEXT runtime·getthrid_trampoline(SB),NOSPLIT,$0
 	PUSHQ	BP
 	MOVQ	SP, BP
-	MOVQ	DI, BX			// BX is caller-save
+	MOVQ	DI, BX			// BX is callee-saved
 	CALL	libc_getthrid(SB)
 	MOVL	AX, 0(BX)		// return value
 	POPQ	BP


### PR DESCRIPTION
The RBX register is actually callee-saved, as specified in the System V ABI used
by OpenBSD and Darwin. The comments are also now more consistent with the fact that
the code re-uses RBX after calling a function.