### PR TITLE
context: make use of a rw-mutex to protect cancelCtx fields

### DIFF
--- a/src/context/context.go
+++ b/src/context/context.go
@@ -342,7 +342,7 @@ func init() {
 type cancelCtx struct {
 	Context
 
-	mu       sync.Mutex            // protects following fields
+	mu       sync.RWMutex          // protects following fields
 	done     atomic.Value          // of chan struct{}, created lazily, closed by first cancel call
 	children map[canceler]struct{} // set to nil by the first cancel call
 	err      error                 // set to non-nil by the first cancel call
@@ -371,9 +371,9 @@ func (c *cancelCtx) Done() <-chan struct{} {
 }
 
 func (c *cancelCtx) Err() error {
-	c.mu.Lock()
+	c.mu.RLock()
 	err := c.err
-	c.mu.Unlock()
+	c.mu.RUnlock()
 	return err
 }
 


### PR DESCRIPTION
Reduce mutex contention on `cancelCtx` when cancellation error is queried from multiple goroutines.

Signed-off-by: Miguel Ángel Ortuño <ortuman@gmail.com>
