### PR TITLE
math/big: add Log10 (decimal logarithm) function for type *Int, *Float and *Rat

### DIFF
--- a/src/math/big/float.go
+++ b/src/math/big/float.go
@@ -331,6 +331,40 @@ func (z *Float) SetMantExp(mant *Float, exp int) *Float {
 	return z
 }
 
+// Log10 sets z to log(x) (the decimal logarithm of x) and returns z.
+func (z *Float) Log10(x *Float) *Float {
+	if !isOverflow(x) {
+		v, _ := x.Float64()
+		z = NewFloat(math.Log10(v))
+		return z
+	}
+
+	x.Sqrt(x)
+	numMul := 2
+
+	for isOverflow(x) {
+		x.Sqrt(x)
+		numMul = numMul << 1
+	}
+
+	v, _ := x.Float64()
+	bigNumLog := math.Log10(v) * float64(numMul)
+
+	z = NewFloat(bigNumLog)
+
+	return z
+}
+
+// isOverflow checks if bigNum is too big to be handled by a type float64.
+func isOverflow(bigNum *Float) bool {
+	_, acc := bigNum.Float64()
+	if acc == Exact {
+		return false
+	} else {
+		return true
+	}
+}
+
 // Signbit reports whether x is negative or negative zero.
 func (x *Float) Signbit() bool {
 	return x.neg

--- a/src/math/big/int.go
+++ b/src/math/big/int.go
@@ -9,7 +9,9 @@ package big
 import (
 	"fmt"
 	"io"
+	"math"
 	"math/rand"
+	"strconv"
 	"strings"
 )
 
@@ -525,6 +527,31 @@ func (z *Int) Exp(x, y, m *Int) *Int {
 	}
 
 	return z
+}
+
+// Log10 returns log(x) (the decimal logarithm of x).
+// The returned value is of type float64 to have an accurate result.
+func Log10(x *Int) float64 {
+	if !isOverflow(x) {
+		return math.Log10(float64(x.Int64()))
+	}
+
+	x.Sqrt(x)
+	numMul := 2
+
+	for isOverflow(x) {
+		x.Sqrt(x)
+		numMul = numMul << 1
+	}
+
+	bigNumLog := math.Log10(float64(x.Int64())) * float64(numMul)
+
+	return bigNumLog
+}
+
+// isOverflow checks if bigNum is too big to be handled by a type int64.
+func isOverflow(bigNum *Int) bool {
+	return bigNum.String() != strconv.Itoa(int(bigNum.Int64()))
 }
 
 // GCD sets z to the greatest common divisor of a and b and returns z.


### PR DESCRIPTION
This function will compute the decimal logarithm for type *Int, *Float and *Rat.

To quickly explain how this works:
We use convert the big number to float64 and use math.Log10 function.

The problem is that an overflow can happen when converting if the number is too big.
So we check if this is the case. If yes, we compute the square root of the big number.

If converted to float64, the square root doesn't overflow, then we can compute the Log10 of the original big number thanks to this equation: log(A) = log(sqrt(A)) * 2

If the square root cause an overflow, we compute the square root of that square root, and so forth...

For more explaination: please see https://github.com/Xeway/bigmath/blob/main/DETAILS.md