### PR TITLE
crypto/x509: update parseCertificate() to guarantee version cannot be negative

### DIFF
--- a/src/crypto/x509/parser.go
+++ b/src/crypto/x509/parser.go
@@ -815,7 +815,7 @@ func parseCertificate(der []byte) (*Certificate, error) {
 	if !tbs.ReadOptionalASN1Integer(&cert.Version, cryptobyte_asn1.Tag(0).Constructed().ContextSpecific(), 0) {
 		return nil, errors.New("x509: malformed version")
 	}
-	if cert.Version < 0 {
+	if cert.Version < 0 || cert.Version > 3 {
 		return nil, errors.New("x509: malformed version")
 	}
 	// for backwards compat reasons Version is one-indexed,


### PR DESCRIPTION
After the call to ReadOptionalASN1Integer() Version can be really large (e.g., 2,147,483,647) when performing the Version++ on line 823. In that case it would then wrap, leading to a negative Version, which will pass the version check on line 824. 

This change adds a check to make sure Version is reasonable prior to the increment, thereby guaranteeing it will not wrap.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
