### PR TITLE
cmd/link: support LLVM/Clang for MSVC

### DIFF
--- a/src/cmd/link/internal/ld/lib.go
+++ b/src/cmd/link/internal/ld/lib.go
@@ -1356,20 +1356,34 @@ func (ctxt *Link) hostlink() {
 	case objabi.Hwindows:
 		if windowsgui {
 			argv = append(argv, "-mwindows")
+			if usingClangForMSVC {
+				argv = append(argv, "-Wl,/SUBSYSTEM:WINDOWS")
+			}
 		} else {
 			argv = append(argv, "-mconsole")
+			if usingClangForMSVC {
+				argv = append(argv, "-Wl,/SUBSYSTEM:CONSOLE")
+			}
 		}
-		// Mark as having awareness of terminal services, to avoid
-		// ancient compatibility hacks.
-		argv = append(argv, "-Wl,--tsaware")
+		// The linker of MSVC have defferent flags from the linker of Mingw/GCC,
+		// and some flags for Mingw/GCC are not supported by MSVC.
+		if usingClangForMSVC {
+			argv = append(argv, "-Wl,/TSAWARE")
+			argv = append(argv, "-Wl,/NXCOMPAT")
+		} else {
+			// Mark as having awareness of terminal services, to avoid
+			// ancient compatibility hacks.
+			argv = append(argv, "-Wl,--tsaware")
 
-		// Enable DEP
-		argv = append(argv, "-Wl,--nxcompat")
+			// Enable DEP
+			argv = append(argv, "-Wl,--nxcompat")
 
-		argv = append(argv, fmt.Sprintf("-Wl,--major-os-version=%d", PeMinimumTargetMajorVersion))
-		argv = append(argv, fmt.Sprintf("-Wl,--minor-os-version=%d", PeMinimumTargetMinorVersion))
-		argv = append(argv, fmt.Sprintf("-Wl,--major-subsystem-version=%d", PeMinimumTargetMajorVersion))
-		argv = append(argv, fmt.Sprintf("-Wl,--minor-subsystem-version=%d", PeMinimumTargetMinorVersion))
+			argv = append(argv, fmt.Sprintf("-Wl,--major-os-version=%d", PeMinimumTargetMajorVersion))
+			argv = append(argv, fmt.Sprintf("-Wl,--minor-os-version=%d", PeMinimumTargetMinorVersion))
+			argv = append(argv, fmt.Sprintf("-Wl,--major-subsystem-version=%d", PeMinimumTargetMajorVersion))
+			argv = append(argv, fmt.Sprintf("-Wl,--minor-subsystem-version=%d", PeMinimumTargetMinorVersion))
+		}
+
 	case objabi.Haix:
 		argv = append(argv, "-pthread")
 		// prevent ld to reorder .text functions to keep the same

--- a/src/cmd/link/internal/ld/lib.go
+++ b/src/cmd/link/internal/ld/lib.go
@@ -1302,7 +1302,7 @@ func (ctxt *Link) hostlink() {
 	name := extld[0]
 	usingClangForMSVC := false
 	if out, err := exec.Command(name, "--version").CombinedOutput(); err == nil {
-		if bytes.Contains(out, []byte("msvc")) {
+		if bytes.Contains(out, []byte("clang ")) && bytes.Contains(out, []byte("msvc")) {
 			usingClangForMSVC = true
 		}
 	}
@@ -1622,7 +1622,7 @@ func (ctxt *Link) hostlink() {
 	}
 
 	const compressDWARF = "-Wl,--compress-debug-sections=zlib"
-	if ctxt.compressDWARF && linkerFlagSupported(ctxt.Arch, argv[0], altLinker, compressDWARF) {
+	if !usingClangForMSVC && ctxt.compressDWARF && linkerFlagSupported(ctxt.Arch, argv[0], altLinker, compressDWARF) {
 		argv = append(argv, compressDWARF)
 	}
 


### PR DESCRIPTION
I find that cgo can compatible with LLVM/Clang for MSVC well actually.
The only problem I have found is that some arguments for linker of Mingw/GCC can't be used in linker of MSVC, so I write a judgement.
If go detect that the toolchain is LLVM/Clang for MSVC, do not pass those arguments that are not supported by linker of MSVC.