### PR TITLE
crypto/sha: remove redundant type conversion

### DIFF
--- a/src/crypto/sha1/sha1.go
+++ b/src/crypto/sha1/sha1.go
@@ -56,7 +56,7 @@ func (d *digest) MarshalBinary() ([]byte, error) {
 	b = appendUint32(b, d.h[3])
 	b = appendUint32(b, d.h[4])
 	b = append(b, d.x[:d.nx]...)
-	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
+	b = b[:len(b)+len(d.x)-d.nx] // already zero
 	b = appendUint64(b, d.len)
 	return b, nil
 }

--- a/src/crypto/sha256/sha256.go
+++ b/src/crypto/sha256/sha256.go
@@ -79,7 +79,7 @@ func (d *digest) MarshalBinary() ([]byte, error) {
 	b = appendUint32(b, d.h[6])
 	b = appendUint32(b, d.h[7])
 	b = append(b, d.x[:d.nx]...)
-	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
+	b = b[:len(b)+len(d.x)-d.nx] // already zero
 	b = appendUint64(b, d.len)
 	return b, nil
 }

--- a/src/crypto/sha512/sha512.go
+++ b/src/crypto/sha512/sha512.go
@@ -162,7 +162,7 @@ func (d *digest) MarshalBinary() ([]byte, error) {
 	b = appendUint64(b, d.h[6])
 	b = appendUint64(b, d.h[7])
 	b = append(b, d.x[:d.nx]...)
-	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
+	b = b[:len(b)+len(d.x)-d.nx] // already zero
 	b = appendUint64(b, d.len)
 	return b, nil
 }


### PR DESCRIPTION
Field nx of the struct digest is already of the int type, so a conversion to int does nothing.
In the crypto/md5 package, this conversion isn't present, so it can be safely removed.