### PR TITLE
crypto: use BigEndian in consume functions

### DIFF
--- a/src/crypto/md5/md5.go
+++ b/src/crypto/md5/md5.go
@@ -100,11 +100,11 @@ func appendUint32(b []byte, x uint32) []byte {
 }
 
 func consumeUint64(b []byte) ([]byte, uint64) {
-	return b[8:], binary.BigEndian.Uint64(b[0:8])
+	return b[8:], binary.BigEndian.Uint64(b)
 }
 
 func consumeUint32(b []byte) ([]byte, uint32) {
-	return b[4:], binary.BigEndian.Uint32(b[0:4])
+	return b[4:], binary.BigEndian.Uint32(b)
 }
 
 // New returns a new hash.Hash computing the MD5 checksum. The Hash also

--- a/src/crypto/sha1/sha1.go
+++ b/src/crypto/sha1/sha1.go
@@ -93,16 +93,11 @@ func appendUint32(b []byte, x uint32) []byte {
 }
 
 func consumeUint64(b []byte) ([]byte, uint64) {
-	_ = b[7]
-	x := uint64(b[7]) | uint64(b[6])<<8 | uint64(b[5])<<16 | uint64(b[4])<<24 |
-		uint64(b[3])<<32 | uint64(b[2])<<40 | uint64(b[1])<<48 | uint64(b[0])<<56
-	return b[8:], x
+	return b[8:], binary.BigEndian.Uint64(b)
 }
 
 func consumeUint32(b []byte) ([]byte, uint32) {
-	_ = b[3]
-	x := uint32(b[3]) | uint32(b[2])<<8 | uint32(b[1])<<16 | uint32(b[0])<<24
-	return b[4:], x
+	return b[4:], binary.BigEndian.Uint32(b)
 }
 
 func (d *digest) Reset() {

--- a/src/crypto/sha256/sha256.go
+++ b/src/crypto/sha256/sha256.go
@@ -119,16 +119,11 @@ func appendUint32(b []byte, x uint32) []byte {
 }
 
 func consumeUint64(b []byte) ([]byte, uint64) {
-	_ = b[7]
-	x := uint64(b[7]) | uint64(b[6])<<8 | uint64(b[5])<<16 | uint64(b[4])<<24 |
-		uint64(b[3])<<32 | uint64(b[2])<<40 | uint64(b[1])<<48 | uint64(b[0])<<56
-	return b[8:], x
+	return b[8:], binary.BigEndian.Uint64(b)
 }
 
 func consumeUint32(b []byte) ([]byte, uint32) {
-	_ = b[3]
-	x := uint32(b[3]) | uint32(b[2])<<8 | uint32(b[1])<<16 | uint32(b[0])<<24
-	return b[4:], x
+	return b[4:], binary.BigEndian.Uint32(b)
 }
 
 func (d *digest) Reset() {

--- a/src/crypto/sha512/sha512.go
+++ b/src/crypto/sha512/sha512.go
@@ -204,10 +204,7 @@ func appendUint64(b []byte, x uint64) []byte {
 }
 
 func consumeUint64(b []byte) ([]byte, uint64) {
-	_ = b[7]
-	x := uint64(b[7]) | uint64(b[6])<<8 | uint64(b[5])<<16 | uint64(b[4])<<24 |
-		uint64(b[3])<<32 | uint64(b[2])<<40 | uint64(b[1])<<48 | uint64(b[0])<<56
-	return b[8:], x
+	return b[8:], binary.BigEndian.Uint64(b)
 }
 
 // New returns a new hash.Hash computing the SHA-512 checksum.


### PR DESCRIPTION
In MarshalBinary function in the sha packages, the functions appendUint32 and appendUint64 use BigEndian.PutUint32/64 for the conversion.
However, in Unmarshal, the implementation is hardcoded, but the BigEndian.Uint32/64 functions could also be used, like in crypto/md5 package.
In md5 package there is an unnecessary subslice, because binary.BigEndian.Uint32/64 automatically use the first bytes of the slice.