### PR TITLE
math/big: replace dead link in a comment with link to an archive.org copy

### DIFF
--- a/src/math/big/prime.go
+++ b/src/math/big/prime.go
@@ -141,7 +141,7 @@ NextRandom:
 //
 // Jacobsen, "Pseudoprime Statistics, Tables, and Data", http://ntheory.org/pseudoprimes.html.
 //
-// Nicely, "The Baillie-PSW Primality Test", http://www.trnicely.net/misc/bpsw.html.
+// Nicely, "The Baillie-PSW Primality Test", https://web.archive.org/web/20191121062007/http://www.trnicely.net/misc/bpsw.html.
 // (Note that Nicely's definition of the "extra strong" test gives the wrong Jacobi condition,
 // as pointed out by Jacobsen.)
 //


### PR DESCRIPTION
Happy to use another service if web.archive.org isn't suitable.

Note: the original page redirects and then links to some nsfw content.
