### PR TITLE
testing: tolerate \r\n as a newline separator in test output

### DIFF
--- a/src/cmd/internal/test2json/test2json.go
+++ b/src/cmd/internal/test2json/test2json.go
@@ -138,10 +138,12 @@ func (c *Converter) Exited(err error) {
 
 var (
 	// printed by test on successful run.
-	bigPass = []byte("PASS\n")
+	bigPass     = []byte("PASS\n")
+	bigPassCRLN = []byte("PASS\r\n")
 
 	// printed by test after a normal test failure.
-	bigFail = []byte("FAIL\n")
+	bigFail     = []byte("FAIL\n")
+	bigFailCRLN = []byte("FAIL\r\n")
 
 	// printed by 'go test' along with an error if the test binary terminates
 	// with an error.
@@ -171,10 +173,11 @@ var (
 // before or after emitting other events.
 func (c *Converter) handleInputLine(line []byte) {
 	// Final PASS or FAIL.
-	if bytes.Equal(line, bigPass) || bytes.Equal(line, bigFail) || bytes.HasPrefix(line, bigFailErrorPrefix) {
+	if bytes.Equal(line, bigPass) || bytes.Equal(line, bigPassCRLN) ||
+		bytes.Equal(line, bigFail) || bytes.Equal(line, bigFailCRLN) || bytes.HasPrefix(line, bigFailErrorPrefix) {
 		c.flushReport(0)
 		c.output.write(line)
-		if bytes.Equal(line, bigPass) {
+		if bytes.Equal(line, bigPass) || bytes.Equal(line, bigPassCRLN) {
 			c.result = "pass"
 		} else {
 			c.result = "fail"

--- a/src/cmd/internal/test2json/testdata/debugserver.json
+++ b/src/cmd/internal/test2json/testdata/debugserver.json
@@ -1,0 +1,6 @@
+{"Action":"run","Test":"Test1"}
+{"Action":"output","Test":"Test1","Output":"=== RUN   Test1\r\n"}
+{"Action":"output","Test":"Test1","Output":"--- PASS: Test1 (0.00s)\r\n"}
+{"Action":"pass","Test":"Test1"}
+{"Action":"output","Output":"PASS\r\n"}
+{"Action":"pass"}

--- a/src/cmd/internal/test2json/testdata/debugserver.test
+++ b/src/cmd/internal/test2json/testdata/debugserver.test
@@ -1,0 +1,3 @@
+=== RUN   Test1
+--- PASS: Test1 (0.00s)
+PASS


### PR DESCRIPTION
This allows to debug tests and parse their status with test2json on
mac.

On mac debugserver sets up a pseudo terminal for test executable under
debug. The terminal has the ONLCR option enabled which turns '\n' in
go test output into '\r\n'. Test2json doesn't expect '\r\n' as a new
line and reports no test status.

This commit changes test2json so that it handles 'PASS\r\n' and
'FAIL\r\n' in the same way as 'PASS\n' and 'FAIL\n'.

Fixes #34286

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
