### PR TITLE
net/http: remove redundant code

### DIFF
--- a/src/net/http/client.go
+++ b/src/net/http/client.go
@@ -362,7 +362,7 @@ func setRequestCancel(req *Request, rt RoundTripper, deadline time.Time) (stopTi
 	initialReqCancel := req.Cancel // the user's original Request.Cancel, if any
 
 	var cancelCtx func()
-	if oldCtx := req.Context(); timeBeforeContextDeadline(deadline, oldCtx) {
+	if timeBeforeContextDeadline(deadline, oldCtx) {
 		req.ctx, cancelCtx = context.WithDeadline(oldCtx, deadline)
 	}
 


### PR DESCRIPTION
Remove redundant code at line 365, `oldCtx := req.Context()`,  because it's the same as line 349.
