### PR TITLE
net: ensure ipv6 endpoints are tried first

### DIFF
--- a/src/net/dial.go
+++ b/src/net/dial.go
@@ -421,6 +421,13 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (Conn
 	var primaries, fallbacks addrList
 	if d.dualStack() && network == "tcp" {
 		primaries, fallbacks = addrs.partition(isIPv4)
+
+		// when fallbacks is not empty, ensure primaries
+		// are ipv6 addresses as per happy eyeballs spec
+		if len(fallbacks) > 0 && !isIPv4(fallbacks[0]) {
+			primaries, fallbacks = fallbacks, primaries
+		}
+
 	} else {
 		primaries = addrs
 	}


### PR DESCRIPTION
When connecting to an endpoint that resolves to ipv4 and ipv6 addresses, ensure that ipv6 addresses are tried first, as per happy eyeballs RFC.

Currently whether ipv4 or ipv6 addresses are tried first depends on the DNS resolution speed. If the A resolution returned first, it would be first in the address list, and partition() uses the label of the first result to build the primaries category.

Fixes #54928