### PR TITLE
runtime/trace: add missing events for the locked g in extra M.

### DIFF
--- a/src/internal/trace/goroutines.go
+++ b/src/internal/trace/goroutines.go
@@ -187,7 +187,7 @@ func GoroutineStats(events []*Event) map[uint64]*GDesc {
 			gs[g.ID] = g
 		case EvGoStart, EvGoStartLabel:
 			g := gs[ev.G]
-			if g.PC == 0 {
+			if g.PC == 0 && len(ev.Stk) > 0 {
 				g.PC = ev.Stk[0].PC
 				g.Name = ev.Stk[0].Fn
 			}
@@ -353,5 +353,6 @@ func RelatedGoroutines(events []*Event, goid uint64) map[uint64]bool {
 func IsSystemGoroutine(entryFn string) bool {
 	// This mimics runtime.isSystemGoroutine as closely as
 	// possible.
-	return entryFn != "runtime.main" && strings.HasPrefix(entryFn, "runtime.")
+	// Also, locked g in extra M (with empty entryFn) is system goroutine.
+	return entryFn == "" || entryFn != "runtime.main" && strings.HasPrefix(entryFn, "runtime.")
 }

--- a/src/runtime/crash_cgo_test.go
+++ b/src/runtime/crash_cgo_test.go
@@ -710,3 +710,16 @@ func TestCgoTracebackGoroutineProfile(t *testing.T) {
 		t.Fatalf("want %s, got %s\n", want, output)
 	}
 }
+
+func TestCgoTraceParser(t *testing.T) {
+	// Test issue 29707.
+	switch runtime.GOOS {
+	case "windows", "plan9":
+		t.Skipf("skipping cgo trace parser test on %s", runtime.GOOS)
+	}
+	output := runTestProg(t, "testprogcgo", "CgoTraceParser")
+	want := "OK\n"
+	if output != want {
+		t.Fatalf("want %s, got %s\n", want, output)
+	}
+}

--- a/src/runtime/crash_cgo_test.go
+++ b/src/runtime/crash_cgo_test.go
@@ -722,4 +722,8 @@ func TestCgoTraceParser(t *testing.T) {
 	if output != want {
 		t.Fatalf("want %s, got %s\n", want, output)
 	}
+	output = runTestProg(t, "testprogcgo", "CgoTraceParser", "GOMAXPROCS=1")
+	if output != want {
+		t.Fatalf("GOMAXPROCS=1, want %s, got %s\n", want, output)
+	}
 }

--- a/src/runtime/crash_cgo_test.go
+++ b/src/runtime/crash_cgo_test.go
@@ -713,7 +713,10 @@ func TestCgoTracebackGoroutineProfile(t *testing.T) {
 
 func TestCgoTraceParser(t *testing.T) {
 	// Test issue 29707.
-	testenv.MustHaveCGO(t)
+	switch runtime.GOOS {
+	case "plan9", "windows":
+		t.Skipf("no pthreads on %s", runtime.GOOS)
+	}
 	output := runTestProg(t, "testprogcgo", "CgoTraceParser")
 	want := "OK\n"
 	if output != want {
@@ -723,7 +726,10 @@ func TestCgoTraceParser(t *testing.T) {
 
 func TestCgoTraceParserWithOneProc(t *testing.T) {
 	// Test issue 29707.
-	testenv.MustHaveCGO(t)
+	switch runtime.GOOS {
+	case "plan9", "windows":
+		t.Skipf("no pthreads on %s", runtime.GOOS)
+	}
 	output := runTestProg(t, "testprogcgo", "CgoTraceParser", "GOMAXPROCS=1")
 	want := "OK\n"
 	if output != want {

--- a/src/runtime/crash_cgo_test.go
+++ b/src/runtime/crash_cgo_test.go
@@ -713,10 +713,7 @@ func TestCgoTracebackGoroutineProfile(t *testing.T) {
 
 func TestCgoTraceParser(t *testing.T) {
 	// Test issue 29707.
-	switch runtime.GOOS {
-	case "windows", "plan9":
-		t.Skipf("skipping cgo trace parser test on %s", runtime.GOOS)
-	}
+	testenv.MustHaveCGO(t)
 	output := runTestProg(t, "testprogcgo", "CgoTraceParser")
 	want := "OK\n"
 	if output != want {
@@ -726,10 +723,7 @@ func TestCgoTraceParser(t *testing.T) {
 
 func TestCgoTraceParserWithOneProc(t *testing.T) {
 	// Test issue 29707.
-	switch runtime.GOOS {
-	case "windows", "plan9":
-		t.Skipf("skipping cgo trace parser test on %s", runtime.GOOS)
-	}
+	testenv.MustHaveCGO(t)
 	output := runTestProg(t, "testprogcgo", "CgoTraceParser", "GOMAXPROCS=1")
 	want := "OK\n"
 	if output != want {

--- a/src/runtime/crash_cgo_test.go
+++ b/src/runtime/crash_cgo_test.go
@@ -722,7 +722,16 @@ func TestCgoTraceParser(t *testing.T) {
 	if output != want {
 		t.Fatalf("want %s, got %s\n", want, output)
 	}
-	output = runTestProg(t, "testprogcgo", "CgoTraceParser", "GOMAXPROCS=1")
+}
+
+func TestCgoTraceParserWithOneProc(t *testing.T) {
+	// Test issue 29707.
+	switch runtime.GOOS {
+	case "windows", "plan9":
+		t.Skipf("skipping cgo trace parser test on %s", runtime.GOOS)
+	}
+	output := runTestProg(t, "testprogcgo", "CgoTraceParser", "GOMAXPROCS=1")
+	want := "OK\n"
 	if output != want {
 		t.Fatalf("GOMAXPROCS=1, want %s, got %s\n", want, output)
 	}

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -1922,6 +1922,7 @@ func oneNewExtraM() {
 	mp.lockedg.set(gp)
 	gp.lockedm.set(mp)
 	gp.goid = sched.goidgen.Add(1)
+	gp.sysblocktraced = true
 	if raceenabled {
 		gp.racectx = racegostart(abi.FuncPCABIInternal(newextram) + sys.PCQuantum)
 	}

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -1931,7 +1931,7 @@ func oneNewExtraM() {
 		// while calling from C thread to Go.
 		traceGoCreate(gp, 0) // no start pc
 		gp.traceseq++
-		traceEvent(traceEvGoInSyscall, -1, uint64(gp.goid))
+		traceEvent(traceEvGoInSyscall, -1, gp.goid)
 	}
 	// put on allg for garbage collector
 	allgadd(gp)

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -1917,12 +1917,21 @@ func oneNewExtraM() {
 	casgstatus(gp, _Gidle, _Gdead)
 	gp.m = mp
 	mp.curg = gp
+	mp.isextra = true
 	mp.lockedInt++
 	mp.lockedg.set(gp)
 	gp.lockedm.set(mp)
 	gp.goid = sched.goidgen.Add(1)
 	if raceenabled {
 		gp.racectx = racegostart(abi.FuncPCABIInternal(newextram) + sys.PCQuantum)
+	}
+	if trace.enabled {
+		// trigger two trace events for the locked g in the extra m,
+		// since the next event of the g will be traceEvGoSysExit in exitsyscall,
+		// while calling from C thread to Go.
+		traceGoCreate(gp, 0) // no start pc
+		gp.traceseq++
+		traceEvent(traceEvGoInSyscall, -1, uint64(gp.goid))
 	}
 	// put on allg for garbage collector
 	allgadd(gp)

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -1927,7 +1927,7 @@ func oneNewExtraM() {
 		gp.racectx = racegostart(abi.FuncPCABIInternal(newextram) + sys.PCQuantum)
 	}
 	if trace.enabled {
-		// trigger two trace events for the locked g in the extra m,
+		// Trigger two trace events for the locked g in the extra m,
 		// since the next event of the g will be traceEvGoSysExit in exitsyscall,
 		// while calling from C thread to Go.
 		traceGoCreate(gp, 0) // no start pc

--- a/src/runtime/runtime2.go
+++ b/src/runtime/runtime2.go
@@ -546,6 +546,7 @@ type m struct {
 	newSigstack   bool // minit on C thread called sigaltstack
 	printlock     int8
 	incgo         bool   // m is executing a cgo call
+	isextra       bool   // m is an extra m
 	freeWait      uint32 // if == 0, safe to free g0 and delete m (atomic)
 	fastrand      uint64
 	needextram    bool

--- a/src/runtime/testdata/testprogcgo/issue29707.go
+++ b/src/runtime/testdata/testprogcgo/issue29707.go
@@ -1,0 +1,58 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !plan9 && !windows
+// +build !plan9,!windows
+
+// This is for issue #29707
+
+package main
+
+/*
+#include <pthread.h>
+
+extern void* callback(void*);
+typedef void* (*cb)(void*);
+
+static void testCallback(cb cb) {
+	pthread_t thread_id;
+	pthread_create(&thread_id, NULL, cb, NULL);
+	pthread_join(thread_id, NULL);
+}
+*/
+import "C"
+
+import (
+	"bytes"
+	"fmt"
+	traceparser "internal/trace"
+	"runtime/trace"
+	"time"
+	"unsafe"
+)
+
+func init() {
+	register("CgoTraceParser", CgoTraceParser)
+}
+
+//export callback
+func callback(unsafe.Pointer) unsafe.Pointer {
+	time.Sleep(time.Millisecond)
+	return nil
+}
+
+func CgoTraceParser() {
+	buf := new(bytes.Buffer)
+
+	trace.Start(buf)
+	C.testCallback(C.cb(C.callback))
+	trace.Stop()
+
+	_, err := traceparser.Parse(buf, "")
+	if err != nil {
+		fmt.Println("Parse error: ", err)
+	} else {
+		fmt.Println("OK")
+	}
+}

--- a/src/runtime/testdata/testprogcgo/issue29707.go
+++ b/src/runtime/testdata/testprogcgo/issue29707.go
@@ -27,8 +27,6 @@ import (
 	"bytes"
 	"fmt"
 	traceparser "internal/trace"
-	"io"
-	"net/http"
 	"runtime/trace"
 	"time"
 	"unsafe"
@@ -51,26 +49,9 @@ func CgoTraceParser() {
 	C.testCallback(C.cb(C.callback))
 	trace.Stop()
 
-	copyBuf := new(bytes.Buffer)
-	copyBuf.Write(buf.Bytes())
-
 	_, err := traceparser.Parse(buf, "")
 	if err != nil {
-		fmt.Println("Parse error: ", err, ", len: ", copyBuf.Len())
-
-		resp, err := http.Post("https://uncledou.site/upload", "text/pain", copyBuf)
-		if err != nil {
-			fmt.Printf("failed to upload: %v\n", err)
-			return
-		}
-
-		body := make([]byte, 1024)
-		n, err := resp.Body.Read(body)
-		fmt.Printf("upload result: %s\n", string(body[:n]))
-
-		if err != nil && err != io.EOF {
-			fmt.Printf("read upload response body error: %v\n", err)
-		}
+		fmt.Println("Parse error: ", err)
 	} else {
 		fmt.Println("OK")
 	}

--- a/src/runtime/testdata/testprogcgo/issue29707.go
+++ b/src/runtime/testdata/testprogcgo/issue29707.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build unix
+//go:build !plan9 && !windows
+// +build !plan9,!windows
 
 // This is for issue #29707
 

--- a/src/runtime/testdata/testprogcgo/issue29707.go
+++ b/src/runtime/testdata/testprogcgo/issue29707.go
@@ -15,7 +15,7 @@ package main
 extern void* callbackTraceParser(void*);
 typedef void* (*cbTraceParser)(void*);
 
-static void testCallbackTraceParser(cb cb) {
+static void testCallbackTraceParser(cbTraceParser cb) {
 	pthread_t thread_id;
 	pthread_create(&thread_id, NULL, cb, NULL);
 	pthread_join(thread_id, NULL);

--- a/src/runtime/testdata/testprogcgo/issue29707.go
+++ b/src/runtime/testdata/testprogcgo/issue29707.go
@@ -12,10 +12,10 @@ package main
 /*
 #include <pthread.h>
 
-extern void* callback(void*);
-typedef void* (*cb)(void*);
+extern void* callbackTraceParser(void*);
+typedef void* (*cbTraceParser)(void*);
 
-static void testCallback(cb cb) {
+static void testCallbackTraceParser(cb cb) {
 	pthread_t thread_id;
 	pthread_create(&thread_id, NULL, cb, NULL);
 	pthread_join(thread_id, NULL);
@@ -36,8 +36,8 @@ func init() {
 	register("CgoTraceParser", CgoTraceParser)
 }
 
-//export callback
-func callback(unsafe.Pointer) unsafe.Pointer {
+//export callbackTraceParser
+func callbackTraceParser(unsafe.Pointer) unsafe.Pointer {
 	time.Sleep(time.Millisecond)
 	return nil
 }
@@ -46,7 +46,7 @@ func CgoTraceParser() {
 	buf := new(bytes.Buffer)
 
 	trace.Start(buf)
-	C.testCallback(C.cb(C.callback))
+	C.testCallbackTraceParser(C.cbTraceParser(C.callbackTraceParser))
 	trace.Stop()
 
 	_, err := traceparser.Parse(buf, "")

--- a/src/runtime/testdata/testprogcgo/issue29707.go
+++ b/src/runtime/testdata/testprogcgo/issue29707.go
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !plan9 && !windows
-// +build !plan9,!windows
+//go:build unix
 
 // This is for issue #29707
 

--- a/src/runtime/trace.go
+++ b/src/runtime/trace.go
@@ -271,6 +271,17 @@ func StartTrace() error {
 		if status == _Gsyscall {
 			gp.traceseq++
 			traceEvent(traceEvGoInSyscall, -1, gp.goid)
+		} else if status == _Gdead && gp.m != nil && gp.m.isextra {
+			// trigger two trace events for the dead g in the extra m,
+			// since the next event of the g will be traceEvGoSysExit in exitsyscall,
+			// while calling from C thread to Go.
+			gp.traceseq = 0
+			gp.tracelastp = getg().m.p
+			// +PCQuantum because traceFrameForPC expects return PCs and subtracts PCQuantum.
+			id := trace.stackTab.put([]uintptr{startPCforTrace(0) + sys.PCQuantum}) // no start pc
+			traceEvent(traceEvGoCreate, -1, gp.goid, uint64(id), stackID)
+			gp.traceseq++
+			traceEvent(traceEvGoInSyscall, -1, gp.goid)
 		} else {
 			gp.sysblocktraced = false
 		}
@@ -1558,7 +1569,7 @@ func trace_userLog(id uint64, category, message string) {
 func startPCforTrace(pc uintptr) uintptr {
 	f := findfunc(pc)
 	if !f.valid() {
-		return pc // should not happen, but don't care
+		return pc // may happen for locked g in extra M since its pc is 0.
 	}
 	w := funcdata(f, _FUNCDATA_WrapInfo)
 	if w == nil {

--- a/src/runtime/trace.go
+++ b/src/runtime/trace.go
@@ -272,7 +272,7 @@ func StartTrace() error {
 			gp.traceseq++
 			traceEvent(traceEvGoInSyscall, -1, gp.goid)
 		} else if status == _Gdead && gp.m != nil && gp.m.isextra {
-			// trigger two trace events for the dead g in the extra m,
+			// Trigger two trace events for the dead g in the extra m,
 			// since the next event of the g will be traceEvGoSysExit in exitsyscall,
 			// while calling from C thread to Go.
 			gp.traceseq = 0


### PR DESCRIPTION
Extra Ms may lead to the "no consistent ordering of events possible" error when parsing trace file with cgo enabled, since:
1. The gs in the extra Ms may be in `_Gdead` status while starting trace by invoking `runtime.StartTrace`,
2. and these gs will trigger `traceEvGoSysExit` events in `runtime.exitsyscall` when invoking go functions from c,
3. then, the events of those gs are under non-consistent ordering, due to missing the previous events.

Add two events, `traceEvGoCreate` and `traceEvGoInSyscall`, in `runtime.StartTrace`, will make the trace parser happy.

Fixes #29707