### PR TITLE
debug/elf: return error on reading from SHT_NOBITS sections

### DIFF
--- a/src/debug/elf/elf_test.go
+++ b/src/debug/elf/elf_test.go
@@ -47,25 +47,3 @@ func TestNames(t *testing.T) {
 		}
 	}
 }
-
-func TestNobitsSection(t *testing.T) {
-	const testdata = "testdata/gcc-amd64-linux-exec"
-	f, err := Open(testdata)
-	if err != nil {
-		t.Fatalf("could not read %s: %v", testdata, err)
-	}
-	defer f.Close()
-	bss := f.Section(".bss")
-	bssData, err := bss.Data()
-	if err != nil {
-		t.Fatalf("error reading .bss section: %v", err)
-	}
-	if g, w := uint64(len(bssData)), bss.Size; g != w {
-		t.Errorf(".bss section length mismatch: got %d, want %d", g, w)
-	}
-	for i := range bssData {
-		if bssData[i] != 0 {
-			t.Fatalf("unexpected non-zero byte at offset %d: %#x", i, bssData[i])
-		}
-	}
-}

--- a/src/debug/elf/file.go
+++ b/src/debug/elf/file.go
@@ -103,6 +103,9 @@ type Section struct {
 // Even if the section is stored compressed in the ELF file,
 // Data returns uncompressed data.
 func (s *Section) Data() ([]byte, error) {
+	if s.Type == SHT_NOBITS {
+		return make([]byte, s.Size), nil
+	}
 	return saferio.ReadData(s.Open(), s.Size)
 }
 

--- a/src/debug/elf/file.go
+++ b/src/debug/elf/file.go
@@ -102,10 +102,9 @@ type Section struct {
 // Data reads and returns the contents of the ELF section.
 // Even if the section is stored compressed in the ELF file,
 // Data returns uncompressed data.
+//
+// For an SHT_NOBITS section, Data always returns a non-nil error.
 func (s *Section) Data() ([]byte, error) {
-	if s.Type == SHT_NOBITS {
-		return make([]byte, s.Size), nil
-	}
 	return saferio.ReadData(s.Open(), s.Size)
 }
 
@@ -121,9 +120,12 @@ func (f *File) stringTable(link uint32) ([]byte, error) {
 // Open returns a new ReadSeeker reading the ELF section.
 // Even if the section is stored compressed in the ELF file,
 // the ReadSeeker reads uncompressed data.
+//
+// For an SHT_NOBITS section, all calls to the opened reader
+// will return a non-nil error.
 func (s *Section) Open() io.ReadSeeker {
 	if s.Type == SHT_NOBITS {
-		return io.NewSectionReader(&zeroReader{}, 0, int64(s.Size))
+		return io.NewSectionReader(&nobitsSectionReader{}, 0, int64(s.Size))
 	}
 	if s.Flags&SHF_COMPRESSED == 0 {
 		return io.NewSectionReader(s.sr, 0, 1<<63-1)
@@ -1605,11 +1607,8 @@ func (f *File) DynString(tag DynTag) ([]string, error) {
 	return all, nil
 }
 
-type zeroReader struct{}
+type nobitsSectionReader struct{}
 
-func (*zeroReader) ReadAt(p []byte, off int64) (n int, err error) {
-	for i := range p {
-		p[i] = 0
-	}
-	return len(p), nil
+func (*nobitsSectionReader) ReadAt(p []byte, off int64) (n int, err error) {
+	return 0, errors.New("unexpected read from SHT_NOBITS section")
 }

--- a/src/debug/elf/file_test.go
+++ b/src/debug/elf/file_test.go
@@ -944,6 +944,30 @@ func TestNoSectionOverlaps(t *testing.T) {
 	}
 }
 
+func TestNobitsSection(t *testing.T) {
+	const testdata = "testdata/gcc-amd64-linux-exec"
+	f, err := Open(testdata)
+	if err != nil {
+		t.Fatalf("could not read %s: %v", testdata, err)
+	}
+	defer f.Close()
+
+	wantError := "unexpected read from SHT_NOBITS section"
+	bss := f.Section(".bss")
+
+	_, err = bss.Data()
+	if err == nil || err.Error() != wantError {
+		t.Fatalf("bss.Data() got error %q, want error %q", err, wantError)
+	}
+
+	r := bss.Open()
+	p := make([]byte, 1)
+	_, err = r.Read(p)
+	if err == nil || err.Error() != wantError {
+		t.Fatalf("r.Read(p) got error %q, want error %q", err, wantError)
+	}
+}
+
 // TestLargeNumberOfSections tests the case that a file has greater than or
 // equal to 65280 (0xff00) sections.
 func TestLargeNumberOfSections(t *testing.T) {

--- a/src/debug/elf/file_test.go
+++ b/src/debug/elf/file_test.go
@@ -9,6 +9,7 @@ import (
 	"compress/gzip"
 	"debug/dwarf"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"math/rand"
 	"net"

--- a/src/debug/elf/file_test.go
+++ b/src/debug/elf/file_test.go
@@ -9,7 +9,6 @@ import (
 	"compress/gzip"
 	"debug/dwarf"
 	"encoding/binary"
-	"fmt"
 	"io"
 	"math/rand"
 	"net"
@@ -18,7 +17,6 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
-	"time"
 )
 
 type fileTest struct {
@@ -1199,55 +1197,5 @@ func TestIssue10996(t *testing.T) {
 	_, err := NewFile(bytes.NewReader(data))
 	if err == nil {
 		t.Fatalf("opening invalid ELF file unexpectedly succeeded")
-	}
-}
-
-// TestInvalidBssSection is a regression test for golang.org/issue/54967.
-//
-// (*Section).Data should not use safeio to read data from the SHT_NOBITS
-// section. Otherwise, when the section size is an incorrect huge value,
-// it will result in OOM.
-func TestInvalidBssSection(t *testing.T) {
-	c := make(chan error)
-	go func() {
-		defer func() {
-			switch err := recover().(type) {
-			case nil:
-				c <- nil
-			case error:
-				c <- err
-			default:
-				c <- fmt.Errorf("unexpected panic value: %T(%v)", err, err)
-			}
-		}()
-
-		size := uint64(3349099659509720927)
-		s := new(Section)
-		s.SectionHeader = SectionHeader{
-			Name:      ".bss",
-			Type:      SHT_NOBITS,
-			Flags:     SHF_WRITE + SHF_ALLOC,
-			Addr:      0x80496d4,
-			Offset:    0x6d4,
-			Size:      size,
-			Link:      0x0,
-			Info:      0x0,
-			Addralign: 0x4,
-			Entsize:   0x0,
-			FileSize:  size,
-		}
-		_, _ = s.Data()
-	}()
-
-	select {
-	case err := <-c:
-		wantErr := "runtime error: makeslice: len out of range"
-		if err == nil {
-			t.Errorf("got error nil; want error %q", wantErr)
-		} else if errMsg := err.Error(); errMsg != wantErr {
-			t.Errorf("got error %q; want error %q", errMsg, wantErr)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("test timed out (saferio.ReadData is called?)")
 	}
 }


### PR DESCRIPTION
An SHT_NOBITS section contains no bytes and occupies no space in the
file. This change makes it return an error on reading from this section
so that it will force the caller to check for an SHT_NNOBITS section.

We have considered another option to return "nil, nil" for the Data
method. It's abandoned because it might lead a program to simply do
the wrong thing, thinking that the section is empty.

Please note that it breaks programs which expect a byte slice with the
length described by the sh_size field. There are two reasons to
introduce this breaking change: 1. SHT_NOBITS means no data and it's
unnecessary to allocate memory for it; 2. it could result in an OOM if
the file is corrupted and has a huge sh_size.

Fixes #54967.