### PR TITLE
net/http: make DefaultTransport docs about HTTP proxy consistent

### DIFF
--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -38,8 +38,8 @@ import (
 // DefaultTransport is the default implementation of Transport and is
 // used by DefaultClient. It establishes network connections as needed
 // and caches them for reuse by subsequent calls. It uses HTTP proxies
-// as directed by the $HTTP_PROXY and $NO_PROXY (or $http_proxy and
-// $no_proxy) environment variables.
+// as directed by the environment variables HTTP_PROXY, HTTPS_PROXY
+// and NO_PROXY (or the lowercase versions thereof).
 var DefaultTransport RoundTripper = &Transport{
 	Proxy: ProxyFromEnvironment,
 	DialContext: defaultTransportDialContext(&net.Dialer{


### PR DESCRIPTION
The changes improve the documentation for DefaultTransport, making
the style with how the HTTP proxy environment variables are being
referred to, consistent with the rest of the project's
documentation.

Also mention HTTPS_PROXY environment variables, as suggested in #32649.