### PR TITLE
cmd/go/internal/modcmd: expand help text for go mod tidy

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -1319,6 +1319,9 @@
 //
 // The -x flag causes tidy to print the commands download executes.
 //
+// Tidy treats all build constraints except 'ignore' as satisfied, including
+// implicit constraints from filenames.
+//
 // See https://golang.org/ref/mod#go-mod-tidy for more about 'go mod tidy'.
 //
 // # Make vendored copy of dependencies

--- a/src/cmd/go/internal/modcmd/tidy.go
+++ b/src/cmd/go/internal/modcmd/tidy.go
@@ -50,6 +50,9 @@ file.
 
 The -x flag causes tidy to print the commands download executes.
 
+Tidy treats all build constraints except 'ignore' as satisfied, including
+implicit constraints from filenames.
+
 See https://golang.org/ref/mod#go-mod-tidy for more about 'go mod tidy'.
 	`,
 	Run: runTidy,


### PR DESCRIPTION
"go mod tidy" will ignore files with the build constraint "ignore". This is documented in https://go.dev/ref/mod#go-mod-tidy. While this URL in mentioned in the existing help text, the fact about the special handling of the `ignore` tag is significant enough to be mentioned explicitly in the help text. From the existing link it's not immediately obvious that this special behavior exists.

Take most of the relevant text from the online description and add it to the help text of "go mod tidy".

Fixes #54993