### PR TITLE
strings: add a test case of growLen is negative

### DIFF
--- a/src/strings/builder_test.go
+++ b/src/strings/builder_test.go
@@ -109,6 +109,15 @@ func TestBuilderGrow(t *testing.T) {
 			t.Errorf("growLen=%d: got %d allocs during Write; want %v", growLen, g, w)
 		}
 	}
+	// when growLen < 0, should panic
+	var a Builder
+	n := -1
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("a.Grow(%d) should panic()", n)
+		}
+	}()
+	a.Grow(n)
 }
 
 func TestBuilderWrite2(t *testing.T) {


### PR DESCRIPTION
Before committing,  the test coverage of strings/builder.go is 97.4%
After committing,  the test coverage of strings/builder.go is 100%


