### PR TITLE
strconv: add a test case when base is illegal

### DIFF
--- a/src/strconv/itoa_test.go
+++ b/src/strconv/itoa_test.go
@@ -93,6 +93,14 @@ func TestItoa(t *testing.T) {
 			}
 		}
 	}
+
+	// Override when base is illegal
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic due to illegal base")
+		}
+	}()
+	FormatUint(12345678, 1)
 }
 
 type uitob64Test struct {


### PR DESCRIPTION
Increase unit test coverage of strconv/itoa.go from 83.8% to 85%