### PR TITLE
internal/fuzz: make T.Skip ignore inputs when fuzzing

### DIFF
--- a/src/internal/fuzz/worker.go
+++ b/src/internal/fuzz/worker.go
@@ -472,21 +472,21 @@ func (w *worker) stop() error {
 //
 // RunFuzzWorker returns an error if it could not communicate with the
 // coordinator process.
-func RunFuzzWorker(ctx context.Context, fn func(CorpusEntry) error) error {
+func RunFuzzWorker(ctx context.Context, fn func(CorpusEntry) (bool, error)) error {
 	comm, err := getWorkerComm()
 	if err != nil {
 		return err
 	}
 	srv := &workerServer{
 		workerComm: comm,
-		fuzzFn: func(e CorpusEntry) (time.Duration, error) {
+		fuzzFn: func(e CorpusEntry) (time.Duration, bool, error) {
 			timer := time.AfterFunc(10*time.Second, func() {
 				panic("deadlocked!") // this error message won't be printed
 			})
 			defer timer.Stop()
 			start := time.Now()
-			err := fn(e)
-			return time.Since(start), err
+			skipped, err := fn(e)
+			return time.Since(start), skipped, err
 		},
 		m: newMutator(),
 	}
@@ -628,7 +628,7 @@ type workerServer struct {
 	// time it took to run the input. It sets a deadline of 10 seconds, at which
 	// point it will panic with the assumption that the process is hanging or
 	// deadlocked.
-	fuzzFn func(CorpusEntry) (time.Duration, error)
+	fuzzFn func(CorpusEntry) (time.Duration, bool, error)
 }
 
 // serve reads serialized RPC messages on fuzzIn. When serve receives a message,
@@ -734,8 +734,12 @@ func (ws *workerServer) fuzz(ctx context.Context, args fuzzArgs) (resp fuzzRespo
 	}
 	fuzzOnce := func(entry CorpusEntry) (dur time.Duration, cov []byte, errMsg string) {
 		mem.header().count++
+		var skipped bool
 		var err error
-		dur, err = ws.fuzzFn(entry)
+		dur, skipped, err = ws.fuzzFn(entry)
+		if skipped {
+			return dur, nil, ""
+		}
 		if err != nil {
 			errMsg = err.Error()
 			if errMsg == "" {
@@ -851,12 +855,15 @@ func (ws *workerServer) minimizeInput(ctx context.Context, vals []any, mem *shar
 		return false, nil
 	}
 
-	// Check that the original value preserves coverage or causes an error.
-	// If not, then whatever caused us to think the value was interesting may
-	// have been a flake, and we can't minimize it.
+	// Check that the original value is not skipped, preserves coverage or
+	// causes an error. If not, then whatever caused us to think the value
+	// was interesting may have been a flake, and we can't minimize it.
 	*count++
-	_, retErr = ws.fuzzFn(CorpusEntry{Values: vals})
-	if keepCoverage != nil {
+	var skipped bool
+	_, skipped, retErr = ws.fuzzFn(CorpusEntry{Values: vals})
+	if skipped {
+		return false, nil
+	} else if keepCoverage != nil {
 		if !hasCoverageBit(keepCoverage, coverageSnapshot) || retErr != nil {
 			return false, nil
 		}
@@ -883,20 +890,22 @@ func (ws *workerServer) minimizeInput(ctx context.Context, vals []any, mem *shar
 		*bPtr = (*bPtr)[:len(candidate)]
 		mem.setValueLen(len(candidate))
 		*count++
-		_, err := ws.fuzzFn(CorpusEntry{Values: vals})
-		if err != nil {
-			retErr = err
-			if keepCoverage != nil {
-				// Now that we've found a crash, that's more important than any
-				// minimization of interesting inputs that was being done. Clear out
-				// keepCoverage to only minimize the crash going forward.
-				keepCoverage = nil
+		_, skipped, err := ws.fuzzFn(CorpusEntry{Values: vals})
+		if !skipped {
+			if err != nil {
+				retErr = err
+				if keepCoverage != nil {
+					// Now that we've found a crash, that's more important than any
+					// minimization of interesting inputs that was being done. Clear out
+					// keepCoverage to only minimize the crash going forward.
+					keepCoverage = nil
+				}
+				return true
 			}
-			return true
-		}
-		// Minimization should preserve coverage bits.
-		if keepCoverage != nil && isCoverageSubset(keepCoverage, coverageSnapshot) {
-			return true
+			// Minimization should preserve coverage bits.
+			if keepCoverage != nil && isCoverageSubset(keepCoverage, coverageSnapshot) {
+				return true
+			}
 		}
 		vals[args.Index] = prev
 		return false

--- a/src/testing/fuzz.go
+++ b/src/testing/fuzz.go
@@ -272,14 +272,14 @@ func (f *F) Fuzz(ff any) {
 	// run calls fn on a given input, as a subtest with its own T.
 	// run is analogous to T.Run. The test filtering and cleanup works similarly.
 	// fn is called in its own goroutine.
-	run := func(captureOut io.Writer, e corpusEntry) (ok bool) {
+	run := func(captureOut io.Writer, e corpusEntry) (ok, skipped bool) {
 		if e.Values == nil {
 			// The corpusEntry must have non-nil Values in order to run the
 			// test. If Values is nil, it is a bug in our code.
 			panic(fmt.Sprintf("corpus file %q was not unmarshaled", e.Path))
 		}
 		if shouldFailFast() {
-			return true
+			return true, false
 		}
 		testName := f.name
 		if e.Path != "" {
@@ -337,7 +337,7 @@ func (f *F) Fuzz(ff any) {
 		})
 		<-t.signal
 		f.common.inFuzzFn, f.inFuzzFn = false, false
-		return !t.Failed()
+		return !t.Failed(), t.Skipped()
 	}
 
 	switch f.fuzzContext.mode {
@@ -374,16 +374,18 @@ func (f *F) Fuzz(ff any) {
 	case fuzzWorker:
 		// Fuzzing is enabled, and this is a worker process. Follow instructions
 		// from the coordinator.
-		if err := f.fuzzContext.deps.RunFuzzWorker(func(e corpusEntry) error {
+		if err := f.fuzzContext.deps.RunFuzzWorker(func(e corpusEntry) (bool, error) {
 			// Don't write to f.w (which points to Stdout) if running from a
 			// fuzz worker. This would become very verbose, particularly during
 			// minimization. Return the error instead, and let the caller deal
 			// with the output.
 			var buf strings.Builder
-			if ok := run(&buf, e); !ok {
-				return errors.New(buf.String())
+			ok, skipped := run(&buf, e)
+			// Only report the error if the input was not skipped.
+			if !ok && !skipped {
+				return false, errors.New(buf.String())
 			}
-			return nil
+			return skipped, nil
 		}); err != nil {
 			// Internal errors are marked with f.Fail; user code may call this too, before F.Fuzz.
 			// The worker will exit with fuzzWorkerExitCode, indicating this is a failure

--- a/src/testing/internal/testdeps/deps.go
+++ b/src/testing/internal/testdeps/deps.go
@@ -166,7 +166,7 @@ func (TestDeps) CoordinateFuzzing(
 	return err
 }
 
-func (TestDeps) RunFuzzWorker(fn func(fuzz.CorpusEntry) error) error {
+func (TestDeps) RunFuzzWorker(fn func(fuzz.CorpusEntry) (bool, error)) error {
 	// Worker processes may or may not receive a signal when the user presses ^C
 	// On POSIX operating systems, a signal sent to a process group is delivered
 	// to all processes in that group. This is not the case on Windows.

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -1619,7 +1619,7 @@ func (f matchStringOnly) SetPanicOnExit0(bool)                        {}
 func (f matchStringOnly) CoordinateFuzzing(time.Duration, int64, time.Duration, int64, int, []corpusEntry, []reflect.Type, string, string) error {
 	return errMain
 }
-func (f matchStringOnly) RunFuzzWorker(func(corpusEntry) error) error { return errMain }
+func (f matchStringOnly) RunFuzzWorker(func(corpusEntry) (bool, error)) error { return errMain }
 func (f matchStringOnly) ReadCorpus(string, []reflect.Type) ([]corpusEntry, error) {
 	return nil, errMain
 }
@@ -1669,7 +1669,7 @@ type testDeps interface {
 	StopTestLog() error
 	WriteProfileTo(string, io.Writer, int) error
 	CoordinateFuzzing(time.Duration, int64, time.Duration, int64, int, []corpusEntry, []reflect.Type, string, string) error
-	RunFuzzWorker(func(corpusEntry) error) error
+	RunFuzzWorker(func(corpusEntry) (bool, error)) error
 	ReadCorpus(string, []reflect.Type) ([]corpusEntry, error)
 	CheckCorpus([]any, []reflect.Type) error
 	ResetCoverage()


### PR DESCRIPTION
Calling T.Skip previously had the same effect as returning early from a fuzz test. Now it will signal to the fuzzer that the input should never be considered "interesting" even if it produces new coverage. This is equivalent to "return 1" in go-fuzz.

Fixes #48779