### PR TITLE
syscall: Makes copies from JS to Go more efficient

### DIFF
--- a/src/syscall/fs_js.go
+++ b/src/syscall/fs_js.go
@@ -389,9 +389,9 @@ func Read(fd int, b []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	js.CopyBytesToGo(b, buf)
 
 	n2 := n.Int()
+	js.CopyBytesToGo(b[:n2], buf)
 	f.pos += int64(n2)
 	return n2, err
 }
@@ -433,8 +433,10 @@ func Pread(fd int, b []byte, offset int64) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	js.CopyBytesToGo(b, buf)
-	return n.Int(), nil
+
+	n2 := n.Int()
+	js.CopyBytesToGo(b[:n2], buf)
+	return n2, nil
 }
 
 func Pwrite(fd int, b []byte, offset int64) (int, error) {

--- a/src/syscall/js/js.go
+++ b/src/syscall/js/js.go
@@ -558,6 +558,12 @@ func (e *ValueError) Error() string {
 // It panics if src is not an Uint8Array or Uint8ClampedArray.
 // It returns the number of bytes copied, which will be the minimum of the lengths of src and dst.
 func CopyBytesToGo(dst []byte, src Value) int {
+	// Avoid host function call overhead when len == zero.
+	// This is needed because js returns zero instead of io.EOF.
+	if len(dst) == 0 {
+		return 0
+	}
+
 	n, ok := copyBytesToGo(dst, src.ref)
 	runtime.KeepAlive(src)
 	if !ok {


### PR DESCRIPTION
This reduces impact of EOF or other short reads when `GOOS=js`.

Fixes golang/go#53566