### PR TITLE
hash: use encoding/binary for conversions

### DIFF
--- a/src/hash/adler32/adler32.go
+++ b/src/hash/adler32/adler32.go
@@ -14,6 +14,7 @@
 package adler32
 
 import (
+	"encoding/binary"
 	"errors"
 	"hash"
 )
@@ -75,18 +76,11 @@ func (d *digest) UnmarshalBinary(b []byte) error {
 }
 
 func appendUint32(b []byte, x uint32) []byte {
-	a := [4]byte{
-		byte(x >> 24),
-		byte(x >> 16),
-		byte(x >> 8),
-		byte(x),
-	}
-	return append(b, a[:]...)
+	return binary.BigEndian.AppendUint32(b, x)
 }
 
 func readUint32(b []byte) uint32 {
-	_ = b[3]
-	return uint32(b[3]) | uint32(b[2])<<8 | uint32(b[1])<<16 | uint32(b[0])<<24
+	return binary.BigEndian.Uint32(b)
 }
 
 // Add p to the running checksum d.

--- a/src/hash/crc32/crc32.go
+++ b/src/hash/crc32/crc32.go
@@ -13,6 +13,7 @@
 package crc32
 
 import (
+	"encoding/binary"
 	"errors"
 	"hash"
 	"sync"
@@ -191,18 +192,11 @@ func (d *digest) UnmarshalBinary(b []byte) error {
 }
 
 func appendUint32(b []byte, x uint32) []byte {
-	a := [4]byte{
-		byte(x >> 24),
-		byte(x >> 16),
-		byte(x >> 8),
-		byte(x),
-	}
-	return append(b, a[:]...)
+	return binary.BigEndian.AppendUint32(b, x)
 }
 
 func readUint32(b []byte) uint32 {
-	_ = b[3]
-	return uint32(b[3]) | uint32(b[2])<<8 | uint32(b[1])<<16 | uint32(b[0])<<24
+	return binary.BigEndian.Uint32(b)
 }
 
 // Update returns the result of adding the bytes in p to the crc.
@@ -238,7 +232,7 @@ func (d *digest) Sum32() uint32 { return d.crc }
 
 func (d *digest) Sum(in []byte) []byte {
 	s := d.Sum32()
-	return append(in, byte(s>>24), byte(s>>16), byte(s>>8), byte(s))
+	return binary.BigEndian.AppendUint32(in, s)
 }
 
 // Checksum returns the CRC-32 checksum of data

--- a/src/hash/crc64/crc64.go
+++ b/src/hash/crc64/crc64.go
@@ -8,6 +8,7 @@
 package crc64
 
 import (
+	"encoding/binary"
 	"errors"
 	"hash"
 	"sync"
@@ -133,23 +134,11 @@ func (d *digest) UnmarshalBinary(b []byte) error {
 }
 
 func appendUint64(b []byte, x uint64) []byte {
-	a := [8]byte{
-		byte(x >> 56),
-		byte(x >> 48),
-		byte(x >> 40),
-		byte(x >> 32),
-		byte(x >> 24),
-		byte(x >> 16),
-		byte(x >> 8),
-		byte(x),
-	}
-	return append(b, a[:]...)
+	return binary.BigEndian.AppendUint64(b, x)
 }
 
 func readUint64(b []byte) uint64 {
-	_ = b[7]
-	return uint64(b[7]) | uint64(b[6])<<8 | uint64(b[5])<<16 | uint64(b[4])<<24 |
-		uint64(b[3])<<32 | uint64(b[2])<<40 | uint64(b[1])<<48 | uint64(b[0])<<56
+	return binary.BigEndian.Uint64(b)
 }
 
 func update(crc uint64, tab *Table, p []byte) uint64 {
@@ -204,7 +193,7 @@ func (d *digest) Sum64() uint64 { return d.crc }
 
 func (d *digest) Sum(in []byte) []byte {
 	s := d.Sum64()
-	return append(in, byte(s>>56), byte(s>>48), byte(s>>40), byte(s>>32), byte(s>>24), byte(s>>16), byte(s>>8), byte(s))
+	return binary.BigEndian.AppendUint64(in, s)
 }
 
 // Checksum returns the CRC-64 checksum of data

--- a/src/hash/fnv/fnv.go
+++ b/src/hash/fnv/fnv.go
@@ -13,6 +13,7 @@
 package fnv
 
 import (
+	"encoding/binary"
 	"errors"
 	"hash"
 	"math/bits"
@@ -178,36 +179,32 @@ func (s *sum128a) BlockSize() int { return 1 }
 
 func (s *sum32) Sum(in []byte) []byte {
 	v := uint32(*s)
-	return append(in, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+	return binary.BigEndian.AppendUint32(in, v)
 }
 
 func (s *sum32a) Sum(in []byte) []byte {
 	v := uint32(*s)
-	return append(in, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+	return binary.BigEndian.AppendUint32(in, v)
 }
 
 func (s *sum64) Sum(in []byte) []byte {
 	v := uint64(*s)
-	return append(in, byte(v>>56), byte(v>>48), byte(v>>40), byte(v>>32), byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+	return binary.BigEndian.AppendUint64(in, v)
 }
 
 func (s *sum64a) Sum(in []byte) []byte {
 	v := uint64(*s)
-	return append(in, byte(v>>56), byte(v>>48), byte(v>>40), byte(v>>32), byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+	return binary.BigEndian.AppendUint64(in, v)
 }
 
 func (s *sum128) Sum(in []byte) []byte {
-	return append(in,
-		byte(s[0]>>56), byte(s[0]>>48), byte(s[0]>>40), byte(s[0]>>32), byte(s[0]>>24), byte(s[0]>>16), byte(s[0]>>8), byte(s[0]),
-		byte(s[1]>>56), byte(s[1]>>48), byte(s[1]>>40), byte(s[1]>>32), byte(s[1]>>24), byte(s[1]>>16), byte(s[1]>>8), byte(s[1]),
-	)
+	in = binary.BigEndian.AppendUint64(in, s[0])
+	return binary.BigEndian.AppendUint64(in, s[1])
 }
 
 func (s *sum128a) Sum(in []byte) []byte {
-	return append(in,
-		byte(s[0]>>56), byte(s[0]>>48), byte(s[0]>>40), byte(s[0]>>32), byte(s[0]>>24), byte(s[0]>>16), byte(s[0]>>8), byte(s[0]),
-		byte(s[1]>>56), byte(s[1]>>48), byte(s[1]>>40), byte(s[1]>>32), byte(s[1]>>24), byte(s[1]>>16), byte(s[1]>>8), byte(s[1]),
-	)
+	in = binary.BigEndian.AppendUint64(in, s[0])
+	return binary.BigEndian.AppendUint64(in, s[1])
 }
 
 const (
@@ -336,36 +333,17 @@ func (s *sum128a) UnmarshalBinary(b []byte) error {
 }
 
 func readUint32(b []byte) uint32 {
-	_ = b[3]
-	return uint32(b[3]) | uint32(b[2])<<8 | uint32(b[1])<<16 | uint32(b[0])<<24
+	return binary.BigEndian.Uint32(b)
 }
 
 func appendUint32(b []byte, x uint32) []byte {
-	a := [4]byte{
-		byte(x >> 24),
-		byte(x >> 16),
-		byte(x >> 8),
-		byte(x),
-	}
-	return append(b, a[:]...)
+	return binary.BigEndian.AppendUint32(b, x)
 }
 
 func appendUint64(b []byte, x uint64) []byte {
-	a := [8]byte{
-		byte(x >> 56),
-		byte(x >> 48),
-		byte(x >> 40),
-		byte(x >> 32),
-		byte(x >> 24),
-		byte(x >> 16),
-		byte(x >> 8),
-		byte(x),
-	}
-	return append(b, a[:]...)
+	return binary.BigEndian.AppendUint64(b, x)
 }
 
 func readUint64(b []byte) uint64 {
-	_ = b[7]
-	return uint64(b[7]) | uint64(b[6])<<8 | uint64(b[5])<<16 | uint64(b[4])<<24 |
-		uint64(b[3])<<32 | uint64(b[2])<<40 | uint64(b[1])<<48 | uint64(b[0])<<56
+	return binary.BigEndian.Uint64(b)
 }

--- a/src/hash/maphash/maphash.go
+++ b/src/hash/maphash/maphash.go
@@ -13,6 +13,7 @@
 package maphash
 
 import (
+	"encoding/binary"
 	"unsafe"
 )
 
@@ -290,15 +291,7 @@ func runtime_memhash(p unsafe.Pointer, seed, s uintptr) uintptr
 // For direct calls, it is more efficient to use Sum64.
 func (h *Hash) Sum(b []byte) []byte {
 	x := h.Sum64()
-	return append(b,
-		byte(x>>0),
-		byte(x>>8),
-		byte(x>>16),
-		byte(x>>24),
-		byte(x>>32),
-		byte(x>>40),
-		byte(x>>48),
-		byte(x>>56))
+	return binary.LittleEndian.AppendUint64(b, x)
 }
 
 // Size returns h's hash value size, 8 bytes.


### PR DESCRIPTION
Use the big endian and little endian conversion functions of the encoding/binary package, instead of a custom implementation in the current package, the behaviour is the same.