### PR TITLE
crypto: use encoding append functions

### DIFF
--- a/src/crypto/internal/boring/sha.go
+++ b/src/crypto/internal/boring/sha.go
@@ -57,6 +57,7 @@ _goboringcrypto_gosha512(void *p, size_t n, void *out)
 */
 import "C"
 import (
+	"encoding/binary"
 	"errors"
 	"hash"
 	"unsafe"
@@ -162,14 +163,14 @@ func (h *sha1Hash) MarshalBinary() ([]byte, error) {
 	d := (*sha1Ctx)(unsafe.Pointer(&h.ctx))
 	b := make([]byte, 0, sha1MarshaledSize)
 	b = append(b, sha1Magic...)
-	b = appendUint32(b, d.h[0])
-	b = appendUint32(b, d.h[1])
-	b = appendUint32(b, d.h[2])
-	b = appendUint32(b, d.h[3])
-	b = appendUint32(b, d.h[4])
+	b = binary.BigEndian.AppendUint32(b, d.h[0])
+	b = binary.BigEndian.AppendUint32(b, d.h[1])
+	b = binary.BigEndian.AppendUint32(b, d.h[2])
+	b = binary.BigEndian.AppendUint32(b, d.h[3])
+	b = binary.BigEndian.AppendUint32(b, d.h[4])
 	b = append(b, d.x[:d.nx]...)
 	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = appendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
+	b = binary.BigEndian.AppendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
 	return b, nil
 }
 
@@ -288,17 +289,17 @@ func (h *sha224Hash) MarshalBinary() ([]byte, error) {
 	d := (*sha256Ctx)(unsafe.Pointer(&h.ctx))
 	b := make([]byte, 0, marshaledSize256)
 	b = append(b, magic224...)
-	b = appendUint32(b, d.h[0])
-	b = appendUint32(b, d.h[1])
-	b = appendUint32(b, d.h[2])
-	b = appendUint32(b, d.h[3])
-	b = appendUint32(b, d.h[4])
-	b = appendUint32(b, d.h[5])
-	b = appendUint32(b, d.h[6])
-	b = appendUint32(b, d.h[7])
+	b = binary.BigEndian.AppendUint32(b, d.h[0])
+	b = binary.BigEndian.AppendUint32(b, d.h[1])
+	b = binary.BigEndian.AppendUint32(b, d.h[2])
+	b = binary.BigEndian.AppendUint32(b, d.h[3])
+	b = binary.BigEndian.AppendUint32(b, d.h[4])
+	b = binary.BigEndian.AppendUint32(b, d.h[5])
+	b = binary.BigEndian.AppendUint32(b, d.h[6])
+	b = binary.BigEndian.AppendUint32(b, d.h[7])
 	b = append(b, d.x[:d.nx]...)
 	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = appendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
+	b = binary.BigEndian.AppendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
 	return b, nil
 }
 
@@ -306,17 +307,17 @@ func (h *sha256Hash) MarshalBinary() ([]byte, error) {
 	d := (*sha256Ctx)(unsafe.Pointer(&h.ctx))
 	b := make([]byte, 0, marshaledSize256)
 	b = append(b, magic256...)
-	b = appendUint32(b, d.h[0])
-	b = appendUint32(b, d.h[1])
-	b = appendUint32(b, d.h[2])
-	b = appendUint32(b, d.h[3])
-	b = appendUint32(b, d.h[4])
-	b = appendUint32(b, d.h[5])
-	b = appendUint32(b, d.h[6])
-	b = appendUint32(b, d.h[7])
+	b = binary.BigEndian.AppendUint32(b, d.h[0])
+	b = binary.BigEndian.AppendUint32(b, d.h[1])
+	b = binary.BigEndian.AppendUint32(b, d.h[2])
+	b = binary.BigEndian.AppendUint32(b, d.h[3])
+	b = binary.BigEndian.AppendUint32(b, d.h[4])
+	b = binary.BigEndian.AppendUint32(b, d.h[5])
+	b = binary.BigEndian.AppendUint32(b, d.h[6])
+	b = binary.BigEndian.AppendUint32(b, d.h[7])
 	b = append(b, d.x[:d.nx]...)
 	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = appendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
+	b = binary.BigEndian.AppendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
 	return b, nil
 }
 
@@ -465,17 +466,17 @@ func (h *sha384Hash) MarshalBinary() ([]byte, error) {
 	d := (*sha512Ctx)(unsafe.Pointer(&h.ctx))
 	b := make([]byte, 0, marshaledSize512)
 	b = append(b, magic384...)
-	b = appendUint64(b, d.h[0])
-	b = appendUint64(b, d.h[1])
-	b = appendUint64(b, d.h[2])
-	b = appendUint64(b, d.h[3])
-	b = appendUint64(b, d.h[4])
-	b = appendUint64(b, d.h[5])
-	b = appendUint64(b, d.h[6])
-	b = appendUint64(b, d.h[7])
+	b = binary.BigEndian.AppendUint64(b, d.h[0])
+	b = binary.BigEndian.AppendUint64(b, d.h[1])
+	b = binary.BigEndian.AppendUint64(b, d.h[2])
+	b = binary.BigEndian.AppendUint64(b, d.h[3])
+	b = binary.BigEndian.AppendUint64(b, d.h[4])
+	b = binary.BigEndian.AppendUint64(b, d.h[5])
+	b = binary.BigEndian.AppendUint64(b, d.h[6])
+	b = binary.BigEndian.AppendUint64(b, d.h[7])
 	b = append(b, d.x[:d.nx]...)
 	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = appendUint64(b, d.nl>>3|d.nh<<61)
+	b = binary.BigEndian.AppendUint64(b, d.nl>>3|d.nh<<61)
 	return b, nil
 }
 
@@ -483,17 +484,17 @@ func (h *sha512Hash) MarshalBinary() ([]byte, error) {
 	d := (*sha512Ctx)(unsafe.Pointer(&h.ctx))
 	b := make([]byte, 0, marshaledSize512)
 	b = append(b, magic512...)
-	b = appendUint64(b, d.h[0])
-	b = appendUint64(b, d.h[1])
-	b = appendUint64(b, d.h[2])
-	b = appendUint64(b, d.h[3])
-	b = appendUint64(b, d.h[4])
-	b = appendUint64(b, d.h[5])
-	b = appendUint64(b, d.h[6])
-	b = appendUint64(b, d.h[7])
+	b = binary.BigEndian.AppendUint64(b, d.h[0])
+	b = binary.BigEndian.AppendUint64(b, d.h[1])
+	b = binary.BigEndian.AppendUint64(b, d.h[2])
+	b = binary.BigEndian.AppendUint64(b, d.h[3])
+	b = binary.BigEndian.AppendUint64(b, d.h[4])
+	b = binary.BigEndian.AppendUint64(b, d.h[5])
+	b = binary.BigEndian.AppendUint64(b, d.h[6])
+	b = binary.BigEndian.AppendUint64(b, d.h[7])
 	b = append(b, d.x[:d.nx]...)
 	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = appendUint64(b, d.nl>>3|d.nh<<61)
+	b = binary.BigEndian.AppendUint64(b, d.nl>>3|d.nh<<61)
 	return b, nil
 }
 
@@ -553,47 +554,10 @@ func (h *sha512Hash) UnmarshalBinary(b []byte) error {
 	return nil
 }
 
-func appendUint64(b []byte, x uint64) []byte {
-	var a [8]byte
-	putUint64(a[:], x)
-	return append(b, a[:]...)
-}
-
-func appendUint32(b []byte, x uint32) []byte {
-	var a [4]byte
-	putUint32(a[:], x)
-	return append(b, a[:]...)
-}
-
 func consumeUint64(b []byte) ([]byte, uint64) {
-	_ = b[7]
-	x := uint64(b[7]) | uint64(b[6])<<8 | uint64(b[5])<<16 | uint64(b[4])<<24 |
-		uint64(b[3])<<32 | uint64(b[2])<<40 | uint64(b[1])<<48 | uint64(b[0])<<56
-	return b[8:], x
+	return b[8:], binary.BigEndian.Uint64(b)
 }
 
 func consumeUint32(b []byte) ([]byte, uint32) {
-	_ = b[3]
-	x := uint32(b[3]) | uint32(b[2])<<8 | uint32(b[1])<<16 | uint32(b[0])<<24
-	return b[4:], x
-}
-
-func putUint64(x []byte, s uint64) {
-	_ = x[7]
-	x[0] = byte(s >> 56)
-	x[1] = byte(s >> 48)
-	x[2] = byte(s >> 40)
-	x[3] = byte(s >> 32)
-	x[4] = byte(s >> 24)
-	x[5] = byte(s >> 16)
-	x[6] = byte(s >> 8)
-	x[7] = byte(s)
-}
-
-func putUint32(x []byte, s uint32) {
-	_ = x[3]
-	x[0] = byte(s >> 24)
-	x[1] = byte(s >> 16)
-	x[2] = byte(s >> 8)
-	x[3] = byte(s)
+	return b[4:], binary.BigEndian.Uint32(b)
 }

--- a/src/crypto/internal/boring/sha.go
+++ b/src/crypto/internal/boring/sha.go
@@ -57,7 +57,6 @@ _goboringcrypto_gosha512(void *p, size_t n, void *out)
 */
 import "C"
 import (
-	"encoding/binary"
 	"errors"
 	"hash"
 	"unsafe"
@@ -163,14 +162,14 @@ func (h *sha1Hash) MarshalBinary() ([]byte, error) {
 	d := (*sha1Ctx)(unsafe.Pointer(&h.ctx))
 	b := make([]byte, 0, sha1MarshaledSize)
 	b = append(b, sha1Magic...)
-	b = binary.BigEndian.AppendUint32(b, d.h[0])
-	b = binary.BigEndian.AppendUint32(b, d.h[1])
-	b = binary.BigEndian.AppendUint32(b, d.h[2])
-	b = binary.BigEndian.AppendUint32(b, d.h[3])
-	b = binary.BigEndian.AppendUint32(b, d.h[4])
+	b = appendUint32(b, d.h[0])
+	b = appendUint32(b, d.h[1])
+	b = appendUint32(b, d.h[2])
+	b = appendUint32(b, d.h[3])
+	b = appendUint32(b, d.h[4])
 	b = append(b, d.x[:d.nx]...)
 	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = binary.BigEndian.AppendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
+	b = appendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
 	return b, nil
 }
 
@@ -289,17 +288,17 @@ func (h *sha224Hash) MarshalBinary() ([]byte, error) {
 	d := (*sha256Ctx)(unsafe.Pointer(&h.ctx))
 	b := make([]byte, 0, marshaledSize256)
 	b = append(b, magic224...)
-	b = binary.BigEndian.AppendUint32(b, d.h[0])
-	b = binary.BigEndian.AppendUint32(b, d.h[1])
-	b = binary.BigEndian.AppendUint32(b, d.h[2])
-	b = binary.BigEndian.AppendUint32(b, d.h[3])
-	b = binary.BigEndian.AppendUint32(b, d.h[4])
-	b = binary.BigEndian.AppendUint32(b, d.h[5])
-	b = binary.BigEndian.AppendUint32(b, d.h[6])
-	b = binary.BigEndian.AppendUint32(b, d.h[7])
+	b = appendUint32(b, d.h[0])
+	b = appendUint32(b, d.h[1])
+	b = appendUint32(b, d.h[2])
+	b = appendUint32(b, d.h[3])
+	b = appendUint32(b, d.h[4])
+	b = appendUint32(b, d.h[5])
+	b = appendUint32(b, d.h[6])
+	b = appendUint32(b, d.h[7])
 	b = append(b, d.x[:d.nx]...)
 	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = binary.BigEndian.AppendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
+	b = appendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
 	return b, nil
 }
 
@@ -307,17 +306,17 @@ func (h *sha256Hash) MarshalBinary() ([]byte, error) {
 	d := (*sha256Ctx)(unsafe.Pointer(&h.ctx))
 	b := make([]byte, 0, marshaledSize256)
 	b = append(b, magic256...)
-	b = binary.BigEndian.AppendUint32(b, d.h[0])
-	b = binary.BigEndian.AppendUint32(b, d.h[1])
-	b = binary.BigEndian.AppendUint32(b, d.h[2])
-	b = binary.BigEndian.AppendUint32(b, d.h[3])
-	b = binary.BigEndian.AppendUint32(b, d.h[4])
-	b = binary.BigEndian.AppendUint32(b, d.h[5])
-	b = binary.BigEndian.AppendUint32(b, d.h[6])
-	b = binary.BigEndian.AppendUint32(b, d.h[7])
+	b = appendUint32(b, d.h[0])
+	b = appendUint32(b, d.h[1])
+	b = appendUint32(b, d.h[2])
+	b = appendUint32(b, d.h[3])
+	b = appendUint32(b, d.h[4])
+	b = appendUint32(b, d.h[5])
+	b = appendUint32(b, d.h[6])
+	b = appendUint32(b, d.h[7])
 	b = append(b, d.x[:d.nx]...)
 	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = binary.BigEndian.AppendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
+	b = appendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
 	return b, nil
 }
 
@@ -466,17 +465,17 @@ func (h *sha384Hash) MarshalBinary() ([]byte, error) {
 	d := (*sha512Ctx)(unsafe.Pointer(&h.ctx))
 	b := make([]byte, 0, marshaledSize512)
 	b = append(b, magic384...)
-	b = binary.BigEndian.AppendUint64(b, d.h[0])
-	b = binary.BigEndian.AppendUint64(b, d.h[1])
-	b = binary.BigEndian.AppendUint64(b, d.h[2])
-	b = binary.BigEndian.AppendUint64(b, d.h[3])
-	b = binary.BigEndian.AppendUint64(b, d.h[4])
-	b = binary.BigEndian.AppendUint64(b, d.h[5])
-	b = binary.BigEndian.AppendUint64(b, d.h[6])
-	b = binary.BigEndian.AppendUint64(b, d.h[7])
+	b = appendUint64(b, d.h[0])
+	b = appendUint64(b, d.h[1])
+	b = appendUint64(b, d.h[2])
+	b = appendUint64(b, d.h[3])
+	b = appendUint64(b, d.h[4])
+	b = appendUint64(b, d.h[5])
+	b = appendUint64(b, d.h[6])
+	b = appendUint64(b, d.h[7])
 	b = append(b, d.x[:d.nx]...)
 	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = binary.BigEndian.AppendUint64(b, d.nl>>3|d.nh<<61)
+	b = appendUint64(b, d.nl>>3|d.nh<<61)
 	return b, nil
 }
 
@@ -484,17 +483,17 @@ func (h *sha512Hash) MarshalBinary() ([]byte, error) {
 	d := (*sha512Ctx)(unsafe.Pointer(&h.ctx))
 	b := make([]byte, 0, marshaledSize512)
 	b = append(b, magic512...)
-	b = binary.BigEndian.AppendUint64(b, d.h[0])
-	b = binary.BigEndian.AppendUint64(b, d.h[1])
-	b = binary.BigEndian.AppendUint64(b, d.h[2])
-	b = binary.BigEndian.AppendUint64(b, d.h[3])
-	b = binary.BigEndian.AppendUint64(b, d.h[4])
-	b = binary.BigEndian.AppendUint64(b, d.h[5])
-	b = binary.BigEndian.AppendUint64(b, d.h[6])
-	b = binary.BigEndian.AppendUint64(b, d.h[7])
+	b = appendUint64(b, d.h[0])
+	b = appendUint64(b, d.h[1])
+	b = appendUint64(b, d.h[2])
+	b = appendUint64(b, d.h[3])
+	b = appendUint64(b, d.h[4])
+	b = appendUint64(b, d.h[5])
+	b = appendUint64(b, d.h[6])
+	b = appendUint64(b, d.h[7])
 	b = append(b, d.x[:d.nx]...)
 	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = binary.BigEndian.AppendUint64(b, d.nl>>3|d.nh<<61)
+	b = appendUint64(b, d.nl>>3|d.nh<<61)
 	return b, nil
 }
 
@@ -554,10 +553,47 @@ func (h *sha512Hash) UnmarshalBinary(b []byte) error {
 	return nil
 }
 
+func appendUint64(b []byte, x uint64) []byte {
+	var a [8]byte
+	putUint64(a[:], x)
+	return append(b, a[:]...)
+}
+
+func appendUint32(b []byte, x uint32) []byte {
+	var a [4]byte
+	putUint32(a[:], x)
+	return append(b, a[:]...)
+}
+
 func consumeUint64(b []byte) ([]byte, uint64) {
-	return b[8:], binary.BigEndian.Uint64(b)
+	_ = b[7]
+	x := uint64(b[7]) | uint64(b[6])<<8 | uint64(b[5])<<16 | uint64(b[4])<<24 |
+		uint64(b[3])<<32 | uint64(b[2])<<40 | uint64(b[1])<<48 | uint64(b[0])<<56
+	return b[8:], x
 }
 
 func consumeUint32(b []byte) ([]byte, uint32) {
-	return b[4:], binary.BigEndian.Uint32(b)
+	_ = b[3]
+	x := uint32(b[3]) | uint32(b[2])<<8 | uint32(b[1])<<16 | uint32(b[0])<<24
+	return b[4:], x
+}
+
+func putUint64(x []byte, s uint64) {
+	_ = x[7]
+	x[0] = byte(s >> 56)
+	x[1] = byte(s >> 48)
+	x[2] = byte(s >> 40)
+	x[3] = byte(s >> 32)
+	x[4] = byte(s >> 24)
+	x[5] = byte(s >> 16)
+	x[6] = byte(s >> 8)
+	x[7] = byte(s)
+}
+
+func putUint32(x []byte, s uint32) {
+	_ = x[3]
+	x[0] = byte(s >> 24)
+	x[1] = byte(s >> 16)
+	x[2] = byte(s >> 8)
+	x[3] = byte(s)
 }

--- a/src/crypto/md5/md5.go
+++ b/src/crypto/md5/md5.go
@@ -59,13 +59,13 @@ const (
 func (d *digest) MarshalBinary() ([]byte, error) {
 	b := make([]byte, 0, marshaledSize)
 	b = append(b, magic...)
-	b = appendUint32(b, d.s[0])
-	b = appendUint32(b, d.s[1])
-	b = appendUint32(b, d.s[2])
-	b = appendUint32(b, d.s[3])
+	b = binary.BigEndian.AppendUint32(b, d.s[0])
+	b = binary.BigEndian.AppendUint32(b, d.s[1])
+	b = binary.BigEndian.AppendUint32(b, d.s[2])
+	b = binary.BigEndian.AppendUint32(b, d.s[3])
 	b = append(b, d.x[:d.nx]...)
 	b = b[:len(b)+len(d.x)-d.nx] // already zero
-	b = appendUint64(b, d.len)
+	b = binary.BigEndian.AppendUint64(b, d.len)
 	return b, nil
 }
 
@@ -85,18 +85,6 @@ func (d *digest) UnmarshalBinary(b []byte) error {
 	b, d.len = consumeUint64(b)
 	d.nx = int(d.len % BlockSize)
 	return nil
-}
-
-func appendUint64(b []byte, x uint64) []byte {
-	var a [8]byte
-	binary.BigEndian.PutUint64(a[:], x)
-	return append(b, a[:]...)
-}
-
-func appendUint32(b []byte, x uint32) []byte {
-	var a [4]byte
-	binary.BigEndian.PutUint32(a[:], x)
-	return append(b, a[:]...)
 }
 
 func consumeUint64(b []byte) ([]byte, uint64) {

--- a/src/crypto/sha1/sha1.go
+++ b/src/crypto/sha1/sha1.go
@@ -50,14 +50,14 @@ const (
 func (d *digest) MarshalBinary() ([]byte, error) {
 	b := make([]byte, 0, marshaledSize)
 	b = append(b, magic...)
-	b = appendUint32(b, d.h[0])
-	b = appendUint32(b, d.h[1])
-	b = appendUint32(b, d.h[2])
-	b = appendUint32(b, d.h[3])
-	b = appendUint32(b, d.h[4])
+	b = binary.BigEndian.AppendUint32(b, d.h[0])
+	b = binary.BigEndian.AppendUint32(b, d.h[1])
+	b = binary.BigEndian.AppendUint32(b, d.h[2])
+	b = binary.BigEndian.AppendUint32(b, d.h[3])
+	b = binary.BigEndian.AppendUint32(b, d.h[4])
 	b = append(b, d.x[:d.nx]...)
 	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = appendUint64(b, d.len)
+	b = binary.BigEndian.AppendUint64(b, d.len)
 	return b, nil
 }
 
@@ -78,18 +78,6 @@ func (d *digest) UnmarshalBinary(b []byte) error {
 	b, d.len = consumeUint64(b)
 	d.nx = int(d.len % chunk)
 	return nil
-}
-
-func appendUint64(b []byte, x uint64) []byte {
-	var a [8]byte
-	binary.BigEndian.PutUint64(a[:], x)
-	return append(b, a[:]...)
-}
-
-func appendUint32(b []byte, x uint32) []byte {
-	var a [4]byte
-	binary.BigEndian.PutUint32(a[:], x)
-	return append(b, a[:]...)
 }
 
 func consumeUint64(b []byte) ([]byte, uint64) {

--- a/src/crypto/sha256/sha256.go
+++ b/src/crypto/sha256/sha256.go
@@ -70,17 +70,17 @@ func (d *digest) MarshalBinary() ([]byte, error) {
 	} else {
 		b = append(b, magic256...)
 	}
-	b = appendUint32(b, d.h[0])
-	b = appendUint32(b, d.h[1])
-	b = appendUint32(b, d.h[2])
-	b = appendUint32(b, d.h[3])
-	b = appendUint32(b, d.h[4])
-	b = appendUint32(b, d.h[5])
-	b = appendUint32(b, d.h[6])
-	b = appendUint32(b, d.h[7])
+	b = binary.BigEndian.AppendUint32(b, d.h[0])
+	b = binary.BigEndian.AppendUint32(b, d.h[1])
+	b = binary.BigEndian.AppendUint32(b, d.h[2])
+	b = binary.BigEndian.AppendUint32(b, d.h[3])
+	b = binary.BigEndian.AppendUint32(b, d.h[4])
+	b = binary.BigEndian.AppendUint32(b, d.h[5])
+	b = binary.BigEndian.AppendUint32(b, d.h[6])
+	b = binary.BigEndian.AppendUint32(b, d.h[7])
 	b = append(b, d.x[:d.nx]...)
 	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = appendUint64(b, d.len)
+	b = binary.BigEndian.AppendUint64(b, d.len)
 	return b, nil
 }
 
@@ -104,18 +104,6 @@ func (d *digest) UnmarshalBinary(b []byte) error {
 	b, d.len = consumeUint64(b)
 	d.nx = int(d.len % chunk)
 	return nil
-}
-
-func appendUint64(b []byte, x uint64) []byte {
-	var a [8]byte
-	binary.BigEndian.PutUint64(a[:], x)
-	return append(b, a[:]...)
-}
-
-func appendUint32(b []byte, x uint32) []byte {
-	var a [4]byte
-	binary.BigEndian.PutUint32(a[:], x)
-	return append(b, a[:]...)
 }
 
 func consumeUint64(b []byte) ([]byte, uint64) {

--- a/src/crypto/sha512/sha512.go
+++ b/src/crypto/sha512/sha512.go
@@ -153,17 +153,17 @@ func (d *digest) MarshalBinary() ([]byte, error) {
 	default:
 		return nil, errors.New("crypto/sha512: invalid hash function")
 	}
-	b = appendUint64(b, d.h[0])
-	b = appendUint64(b, d.h[1])
-	b = appendUint64(b, d.h[2])
-	b = appendUint64(b, d.h[3])
-	b = appendUint64(b, d.h[4])
-	b = appendUint64(b, d.h[5])
-	b = appendUint64(b, d.h[6])
-	b = appendUint64(b, d.h[7])
+	b = binary.BigEndian.AppendUint64(b, d.h[0])
+	b = binary.BigEndian.AppendUint64(b, d.h[1])
+	b = binary.BigEndian.AppendUint64(b, d.h[2])
+	b = binary.BigEndian.AppendUint64(b, d.h[3])
+	b = binary.BigEndian.AppendUint64(b, d.h[4])
+	b = binary.BigEndian.AppendUint64(b, d.h[5])
+	b = binary.BigEndian.AppendUint64(b, d.h[6])
+	b = binary.BigEndian.AppendUint64(b, d.h[7])
 	b = append(b, d.x[:d.nx]...)
 	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = appendUint64(b, d.len)
+	b = binary.BigEndian.AppendUint64(b, d.len)
 	return b, nil
 }
 
@@ -195,12 +195,6 @@ func (d *digest) UnmarshalBinary(b []byte) error {
 	b, d.len = consumeUint64(b)
 	d.nx = int(d.len % chunk)
 	return nil
-}
-
-func appendUint64(b []byte, x uint64) []byte {
-	var a [8]byte
-	binary.BigEndian.PutUint64(a[:], x)
-	return append(b, a[:]...)
 }
 
 func consumeUint64(b []byte) ([]byte, uint64) {


### PR DESCRIPTION
Replace custom append functions in the hash functions with the implementation of the encoding/binary package that do the same thing.
The binary bigendian functions are already used in other parts of the code in the crypto package.