### PR TITLE
image/png: optimise RGBA encoding

### DIFF
--- a/src/image/png/writer.go
+++ b/src/image/png/writer.go
@@ -451,28 +451,34 @@ func (e *encoder) writeImage(w io.Writer, m image.Image, cb int, level int) erro
 				offset := (y - b.Min.Y) * nrgba.Stride
 				copy(cr[0][1:], nrgba.Pix[offset:offset+b.Dx()*4])
 			} else if rgba != nil {
-				for x := b.Min.X; x < b.Max.X; x++ {
-					offset := rgba.PixOffset(x, y)
-					a := rgba.Pix[offset+3]
-					if a == 0 {
-						// Do nothing, keep next 4 bites as 0, it's a transparent pixel
-					} else if a == 0xff {
-						// opaque pixel, no need to un-premultiply
-						copy(cr[0][i:i+4], rgba.Pix[rgba.PixOffset(x, y):rgba.PixOffset(x, y)+4])
+				dst := cr[0][1:]
+				src := rgba.Pix[rgba.PixOffset(b.Min.X, y):rgba.PixOffset(b.Max.X, y)]
+				for ; len(src) >= 4; dst, src = dst[4:], src[4:] {
+					d := (*[4]byte)(dst)
+					s := (*[4]byte)(src)
+					if s[3] == 0x00 {
+						d[0] = 0
+						d[1] = 0
+						d[2] = 0
+						d[3] = 0
+					} else if s[3] == 0xff {
+						copy(d[:], s[:])
 					} else {
-						// This code does the same as color.NRGBAModel.Convert(m.At(x, y)).(color.NRGBA),
-						// with no extra memory allocations.
-						a32 := uint32(a) | uint32(a)<<8
-						// Iterate over r, g, b channels
-						for j := 0; j < 3; j++ {
-							ch := uint32(rgba.Pix[offset+j])
-							ch |= ch << 8
-							ch = (ch * 0xffff) / a32
-							cr[0][i+j] = uint8(ch >> 8)
-						}
-						cr[0][i+3] = a
+						// This code does the same as color.NRGBAModel.Convert(
+						// rgba.At(x, y)).(color.NRGBA) but with no extra memory
+						// allocations or interface/function call overhead.
+						//
+						// The multiplier m combines 0x101 (which converts
+						// 8-bit color to 16-bit color) and 0xffff (which, when
+						// combined with the division-by-a, converts from
+						// alpha-premultiplied to non-alpha-premultiplied).
+						const m = 0x101 * 0xffff
+						a := uint32(s[3]) * 0x101
+						d[0] = uint8((uint32(s[0]) * m / a) >> 8)
+						d[1] = uint8((uint32(s[1]) * m / a) >> 8)
+						d[2] = uint8((uint32(s[2]) * m / a) >> 8)
+						d[3] = s[3]
 					}
-					i += 4
 				}
 			} else {
 				// Convert from image.Image (which is alpha-premultiplied) to PNG's non-alpha-premultiplied.

--- a/src/image/png/writer_test.go
+++ b/src/image/png/writer_test.go
@@ -30,7 +30,6 @@ func diff(m0, m1 image.Image) error {
 			r0, g0, b0, a0 := c0.RGBA()
 			r1, g1, b1, a1 := c1.RGBA()
 			if r0 != r1 || g0 != g1 || b0 != b1 || a0 != a1 {
-				//return fmt.Errorf("colors differ at (%d, %d): %v vs %v", x, y, c0, c1)
 				return fmt.Errorf("colors differ at (%v, %v): %T%v vs %T%v", x, y, c0, c0, c1, c1)
 			}
 		}
@@ -373,9 +372,9 @@ func TestWriteRGBA(t *testing.T) {
 	for y := 0; y < height; y++ {
 		for x := 0; x < width; x++ {
 			opaqueColor := color.RGBA{uint8(x), uint8(y), uint8(y + x), 255}
-			transparentColor := color.RGBA{uint8(x) % 127, uint8(y) % 127, uint8(y+x) % 127, 128}
+			translucentColor := color.RGBA{uint8(x) % 128, uint8(y) % 128, uint8(y+x) % 128, 128}
 			opaqueImg.Set(x, y, opaqueColor)
-			translucentImg.Set(x, y, transparentColor)
+			translucentImg.Set(x, y, translucentColor)
 			if y%2 == 0 {
 				mixedImg.Set(x, y, opaqueColor)
 			}

--- a/src/image/png/writer_test.go
+++ b/src/image/png/writer_test.go
@@ -30,7 +30,7 @@ func diff(m0, m1 image.Image) error {
 			r0, g0, b0, a0 := c0.RGBA()
 			r1, g1, b1, a1 := c1.RGBA()
 			if r0 != r1 || g0 != g1 || b0 != b1 || a0 != a1 {
-				return fmt.Errorf("colors differ at (%v, %v): %T%v vs %T%v", x, y, c0, c0, c1, c1)
+				return fmt.Errorf("colors differ at (%d, %d): %T%v vs %T%v", x, y, c0, c0, c1, c1)
 			}
 		}
 	}

--- a/src/image/png/writer_test.go
+++ b/src/image/png/writer_test.go
@@ -15,7 +15,38 @@ import (
 	"testing"
 )
 
-func diff(m0, m1 image.Image) error {
+// totalLoss returns the total difference between two colors, in the range [0, 257*4]
+// 0 means the colors are identical
+// Difference between opaque black and white is 257*3
+// Difference between NRGBA{10, 20, 30, 255}, NRGBA{11, 22, 33, 255} ≈ 6
+func totalLoss(c0, c1 color.Color) float64 {
+	var loss uint32
+	r0, g0, b0, a0 := c0.RGBA()
+	r1, g1, b1, a1 := c1.RGBA()
+	s0 := []uint32{r0, g0, b0, a0}
+	s1 := []uint32{r1, g1, b1, a1}
+	for i := 0; i < 4; i++ {
+		if s0[i] > s1[i] {
+			loss += s0[i] - s1[i]
+		} else {
+			loss += s1[i] - s0[i]
+		}
+	}
+	return float64(loss) / 255.0
+}
+
+func assertAlmostEqual(c0, c1 color.Color, expectedLoss float64) error {
+	r0, g0, b0, a0 := c0.RGBA()
+	r1, g1, b1, a1 := c1.RGBA()
+	loss := totalLoss(c0, c1)
+	if loss > expectedLoss {
+		return fmt.Errorf("%T%v vs %T%v ({%d %d %d %d} vs {%d %d %d %d}), expected loss: %.2f, actual: %.2f",
+			c0, c0, c1, c1, r0, g0, b0, a0, r1, g1, b1, a1, expectedLoss, loss)
+	}
+	return nil
+}
+
+func diff(m0, m1 image.Image, expectedLoss float64) error {
 	b0, b1 := m0.Bounds(), m1.Bounds()
 	if !b0.Size().Eq(b1.Size()) {
 		return fmt.Errorf("dimensions differ: %v vs %v", b0, b1)
@@ -26,10 +57,9 @@ func diff(m0, m1 image.Image) error {
 		for x := b0.Min.X; x < b0.Max.X; x++ {
 			c0 := m0.At(x, y)
 			c1 := m1.At(x+dx, y+dy)
-			r0, g0, b0, a0 := c0.RGBA()
-			r1, g1, b1, a1 := c1.RGBA()
-			if r0 != r1 || g0 != g1 || b0 != b1 || a0 != a1 {
-				return fmt.Errorf("colors differ at (%d, %d): %v vs %v", x, y, c0, c1)
+			if err := assertAlmostEqual(c0, c1, expectedLoss); err != nil {
+				//fmt.Printf("colors differ at (%d, %d): %v\n", x, y, err)
+				return fmt.Errorf("colors differ at (%d, %d): %w", x, y, err)
 			}
 		}
 	}
@@ -43,6 +73,30 @@ func encodeDecode(m image.Image) (image.Image, error) {
 		return nil, err
 	}
 	return Decode(&b)
+}
+
+// Test for test
+func TestLossCalculation(t *testing.T) {
+	const uncertainty = 0.05
+	testCases := []struct {
+		c0, c1       color.Color
+		expectedLoss float64
+	}{
+		{color.Black, color.White, 257 * 3},
+		{color.Transparent, color.White, 257 * 4},
+		{color.NRGBA{11, 222, 33, 255}, color.RGBA{11, 222, 33, 255}, 0},
+		{color.NRGBA{2, 4, 8, 127}, color.RGBA{1, 2, 4, 127}, uncertainty},
+		{color.NRGBA{10, 20, 30, 255}, color.NRGBA{11, 22, 33, 255}, 6},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%T%v vs %T%v", tc.c0, tc.c0, tc.c1, tc.c1), func(t *testing.T) {
+			loss := totalLoss(tc.c0, tc.c1)
+			if loss < tc.expectedLoss-uncertainty || loss > tc.expectedLoss+uncertainty {
+				t.Errorf("expected loss to be %.2f±%.2f, got %.2f",
+					tc.expectedLoss, uncertainty, loss)
+			}
+		})
+	}
 }
 
 func TestWriter(t *testing.T) {
@@ -71,7 +125,7 @@ func TestWriter(t *testing.T) {
 			continue
 		}
 		// Compare the two.
-		err = diff(m0, m2)
+		err = diff(m0, m2, 0)
 		if err != nil {
 			t.Error(fn, err)
 			continue
@@ -220,7 +274,7 @@ func TestSubImage(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	err = diff(m0, m1)
+	err = diff(m0, m1, 0)
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
Optimised RGBA image encoding to PNG. Improved test coverage. Reworked benchmark.

Performance improvement with both old and new versions of the benchmark:

name                           old speed      new speed      delta
EncodeRGBA_OriginalVersion-10   115MB/s ± 1%   308MB/s ± 1%  +166.70%  (p=0.000 n=19+17)
EncodeRGBA_NewVersion-10       40.3MB/s ± 1%  51.1MB/s ± 2%   +26.93%  (p=0.000 n=18+20)

name                           old allocs/op  new allocs/op  delta
EncodeRGBA_OriginalVersion-10      614k ± 0%        0k ± 0%   -99.99%  (p=0.000 n=20+20)
EncodeRGBA_NewVersion-10           614k ± 0%        0k ± 0%   -99.99%  (p=0.000 n=20+20)
