### PR TITLE
token: change the bit operation to division to make the code more rea…

### DIFF
--- a/src/go/token/position.go
+++ b/src/go/token/position.go
@@ -544,7 +544,7 @@ func searchInts(a []int, x int) int {
 	// TODO(gri): Remove this when compilers have caught up.
 	i, j := 0, len(a)
 	for i < j {
-		h := int(uint(i+j) >> 1) // avoid overflow when computing h
+		h := int(uint(i+j) / 2) // avoid overflow when computing h
 		// i ≤ h < j
 		if a[h] <= x {
 			i = h + 1


### PR DESCRIPTION
The Go compiler can already support the conversion of division to shift operation, so, change the bit operation to division to make the code more readable