### PR TITLE
mime/multipart: use %w when wrapping error in NextPart

### DIFF
--- a/src/mime/multipart/multipart.go
+++ b/src/mime/multipart/multipart.go
@@ -360,7 +360,7 @@ func (r *Reader) nextPart(rawPart bool) (*Part, error) {
 			return nil, io.EOF
 		}
 		if err != nil {
-			return nil, fmt.Errorf("multipart: NextPart: %v", err)
+			return nil, fmt.Errorf("multipart: NextPart: %w", err)
 		}
 
 		if r.isBoundaryDelimiterLine(line) {


### PR DESCRIPTION
Use "%w" instead of "%v" as format verb for error value in the NextPart
method. This way it will be possible to use common go error utilities
from std library when parsing from custom io.Readers.

This issue was discovered during attempts to use
http.Request.ParseMultipartForm together with http.MaxBytesHandler.