### PR TITLE
crypto/x509: fix certificate request creation with RSA-PSS

### DIFF
--- a/src/crypto/x509/x509.go
+++ b/src/crypto/x509/x509.go
@@ -2110,8 +2110,16 @@ func CreateCertificateRequest(rand io.Reader, template *CertificateRequest, priv
 		signed = h.Sum(nil)
 	}
 
+	var signerOpts crypto.SignerOpts = hashFunc
+	if template.SignatureAlgorithm != 0 && template.SignatureAlgorithm.isRSAPSS() {
+		signerOpts = &rsa.PSSOptions{
+			SaltLength: rsa.PSSSaltLengthEqualsHash,
+			Hash:       hashFunc,
+		}
+	}
+
 	var signature []byte
-	signature, err = key.Sign(rand, signed, hashFunc)
+	signature, err = key.Sign(rand, signed, signerOpts)
 	if err != nil {
 		return
 	}

--- a/src/crypto/x509/x509_test.go
+++ b/src/crypto/x509/x509_test.go
@@ -1417,6 +1417,7 @@ func TestCreateCertificateRequest(t *testing.T) {
 		sigAlgo SignatureAlgorithm
 	}{
 		{"RSA", testPrivateKey, SHA256WithRSA},
+		{"RSA-PSS-SHA256", testPrivateKey, SHA256WithRSAPSS},
 		{"ECDSA-256", ecdsa256Priv, ECDSAWithSHA256},
 		{"ECDSA-384", ecdsa384Priv, ECDSAWithSHA256},
 		{"ECDSA-521", ecdsa521Priv, ECDSAWithSHA256},


### PR DESCRIPTION
In case of a RSA-PSS algorithm, the hashFunc of CreateCertificateRequest
is embedded in a rsa.PSSOptions struct. Given to key.Sign(), this will
generate a proper RSA-PSS signature.

Pasted from the RSA-PSS handling code in CreateCertificate().

Fixes #45990 
Fixes #65074