### PR TITLE
hash: use encoding append functions

### DIFF
--- a/src/hash/adler32/adler32.go
+++ b/src/hash/adler32/adler32.go
@@ -14,6 +14,7 @@
 package adler32
 
 import (
+	"encoding/binary"
 	"errors"
 	"hash"
 )
@@ -59,7 +60,7 @@ const (
 func (d *digest) MarshalBinary() ([]byte, error) {
 	b := make([]byte, 0, marshaledSize)
 	b = append(b, magic...)
-	b = appendUint32(b, uint32(*d))
+	b = binary.BigEndian.AppendUint32(b, uint32(*d))
 	return b, nil
 }
 
@@ -72,16 +73,6 @@ func (d *digest) UnmarshalBinary(b []byte) error {
 	}
 	*d = digest(readUint32(b[len(magic):]))
 	return nil
-}
-
-func appendUint32(b []byte, x uint32) []byte {
-	a := [4]byte{
-		byte(x >> 24),
-		byte(x >> 16),
-		byte(x >> 8),
-		byte(x),
-	}
-	return append(b, a[:]...)
 }
 
 func readUint32(b []byte) uint32 {

--- a/src/hash/crc32/crc32.go
+++ b/src/hash/crc32/crc32.go
@@ -13,6 +13,7 @@
 package crc32
 
 import (
+	"encoding/binary"
 	"errors"
 	"hash"
 	"sync"
@@ -172,8 +173,8 @@ const (
 func (d *digest) MarshalBinary() ([]byte, error) {
 	b := make([]byte, 0, marshaledSize)
 	b = append(b, magic...)
-	b = appendUint32(b, tableSum(d.tab))
-	b = appendUint32(b, d.crc)
+	b = binary.BigEndian.AppendUint32(b, tableSum(d.tab))
+	b = binary.BigEndian.AppendUint32(b, d.crc)
 	return b, nil
 }
 
@@ -189,16 +190,6 @@ func (d *digest) UnmarshalBinary(b []byte) error {
 	}
 	d.crc = readUint32(b[8:])
 	return nil
-}
-
-func appendUint32(b []byte, x uint32) []byte {
-	a := [4]byte{
-		byte(x >> 24),
-		byte(x >> 16),
-		byte(x >> 8),
-		byte(x),
-	}
-	return append(b, a[:]...)
 }
 
 func readUint32(b []byte) uint32 {
@@ -258,7 +249,7 @@ func tableSum(t *Table) uint32 {
 	b := a[:0]
 	if t != nil {
 		for _, x := range t {
-			b = appendUint32(b, x)
+			b = binary.BigEndian.AppendUint32(b, x)
 		}
 	}
 	return ChecksumIEEE(b)

--- a/src/hash/crc64/crc64.go
+++ b/src/hash/crc64/crc64.go
@@ -8,6 +8,7 @@
 package crc64
 
 import (
+	"encoding/binary"
 	"errors"
 	"hash"
 	"sync"
@@ -113,8 +114,8 @@ const (
 func (d *digest) MarshalBinary() ([]byte, error) {
 	b := make([]byte, 0, marshaledSize)
 	b = append(b, magic...)
-	b = appendUint64(b, tableSum(d.tab))
-	b = appendUint64(b, d.crc)
+	b = binary.BigEndian.AppendUint64(b, tableSum(d.tab))
+	b = binary.BigEndian.AppendUint64(b, d.crc)
 	return b, nil
 }
 
@@ -130,20 +131,6 @@ func (d *digest) UnmarshalBinary(b []byte) error {
 	}
 	d.crc = readUint64(b[12:])
 	return nil
-}
-
-func appendUint64(b []byte, x uint64) []byte {
-	a := [8]byte{
-		byte(x >> 56),
-		byte(x >> 48),
-		byte(x >> 40),
-		byte(x >> 32),
-		byte(x >> 24),
-		byte(x >> 16),
-		byte(x >> 8),
-		byte(x),
-	}
-	return append(b, a[:]...)
 }
 
 func readUint64(b []byte) uint64 {
@@ -217,7 +204,7 @@ func tableSum(t *Table) uint64 {
 	b := a[:0]
 	if t != nil {
 		for _, x := range t {
-			b = appendUint64(b, x)
+			b = binary.BigEndian.AppendUint64(b, x)
 		}
 	}
 	return Checksum(b, MakeTable(ISO))

--- a/src/hash/fnv/fnv.go
+++ b/src/hash/fnv/fnv.go
@@ -13,6 +13,7 @@
 package fnv
 
 import (
+	"encoding/binary"
 	"errors"
 	"hash"
 	"math/bits"
@@ -225,21 +226,21 @@ const (
 func (s *sum32) MarshalBinary() ([]byte, error) {
 	b := make([]byte, 0, marshaledSize32)
 	b = append(b, magic32...)
-	b = appendUint32(b, uint32(*s))
+	b = binary.BigEndian.AppendUint32(b, uint32(*s))
 	return b, nil
 }
 
 func (s *sum32a) MarshalBinary() ([]byte, error) {
 	b := make([]byte, 0, marshaledSize32)
 	b = append(b, magic32a...)
-	b = appendUint32(b, uint32(*s))
+	b = binary.BigEndian.AppendUint32(b, uint32(*s))
 	return b, nil
 }
 
 func (s *sum64) MarshalBinary() ([]byte, error) {
 	b := make([]byte, 0, marshaledSize64)
 	b = append(b, magic64...)
-	b = appendUint64(b, uint64(*s))
+	b = binary.BigEndian.AppendUint64(b, uint64(*s))
 	return b, nil
 
 }
@@ -247,23 +248,23 @@ func (s *sum64) MarshalBinary() ([]byte, error) {
 func (s *sum64a) MarshalBinary() ([]byte, error) {
 	b := make([]byte, 0, marshaledSize64)
 	b = append(b, magic64a...)
-	b = appendUint64(b, uint64(*s))
+	b = binary.BigEndian.AppendUint64(b, uint64(*s))
 	return b, nil
 }
 
 func (s *sum128) MarshalBinary() ([]byte, error) {
 	b := make([]byte, 0, marshaledSize128)
 	b = append(b, magic128...)
-	b = appendUint64(b, s[0])
-	b = appendUint64(b, s[1])
+	b = binary.BigEndian.AppendUint64(b, s[0])
+	b = binary.BigEndian.AppendUint64(b, s[1])
 	return b, nil
 }
 
 func (s *sum128a) MarshalBinary() ([]byte, error) {
 	b := make([]byte, 0, marshaledSize128)
 	b = append(b, magic128a...)
-	b = appendUint64(b, s[0])
-	b = appendUint64(b, s[1])
+	b = binary.BigEndian.AppendUint64(b, s[0])
+	b = binary.BigEndian.AppendUint64(b, s[1])
 	return b, nil
 }
 
@@ -338,30 +339,6 @@ func (s *sum128a) UnmarshalBinary(b []byte) error {
 func readUint32(b []byte) uint32 {
 	_ = b[3]
 	return uint32(b[3]) | uint32(b[2])<<8 | uint32(b[1])<<16 | uint32(b[0])<<24
-}
-
-func appendUint32(b []byte, x uint32) []byte {
-	a := [4]byte{
-		byte(x >> 24),
-		byte(x >> 16),
-		byte(x >> 8),
-		byte(x),
-	}
-	return append(b, a[:]...)
-}
-
-func appendUint64(b []byte, x uint64) []byte {
-	a := [8]byte{
-		byte(x >> 56),
-		byte(x >> 48),
-		byte(x >> 40),
-		byte(x >> 32),
-		byte(x >> 24),
-		byte(x >> 16),
-		byte(x >> 8),
-		byte(x),
-	}
-	return append(b, a[:]...)
 }
 
 func readUint64(b []byte) uint64 {


### PR DESCRIPTION
Use the new method in the encoding/binary package to replace the custom method