### PR TITLE
all: use grep -E/-F instead of fgrep/egrep

### DIFF
--- a/src/buildall.bash
+++ b/src/buildall.bash
@@ -41,7 +41,7 @@ gettargets() {
 }
 
 selectedtargets() {
-	gettargets | egrep "$pattern"
+	gettargets | grep -E "$pattern"
 }
 
 # put linux first in the target list to get all the architectures up front.

--- a/src/syscall/mkerrors.sh
+++ b/src/syscall/mkerrors.sh
@@ -342,7 +342,7 @@ errors=$(
 signals=$(
 	echo '#include <signal.h>' | $CC -x c - -E -dM $ccflags |
 	awk '$1=="#define" && $2 ~ /^SIG[A-Z0-9]+$/ { print $2 }' |
-	grep -Ev 'SIGSTKSIZE|SIGSTKSZ|SIGRT' |
+	grep -v 'SIGSTKSIZE\|SIGSTKSZ\|SIGRT' |
 	sort
 )
 
@@ -352,7 +352,7 @@ echo '#include <errno.h>' | $CC -x c - -E -dM $ccflags |
 	sort >_error.grep
 echo '#include <signal.h>' | $CC -x c - -E -dM $ccflags |
 	awk '$1=="#define" && $2 ~ /^SIG[A-Z0-9]+$/ { print "^\t" $2 "[ \t]*=" }' |
-	grep -Ev 'SIGSTKSIZE|SIGSTKSZ|SIGRT' |
+	grep -v 'SIGSTKSIZE\|SIGSTKSZ\|SIGRT' |
 	sort >_signal.grep
 
 echo '// mkerrors.sh' "$@"

--- a/src/syscall/mkerrors.sh
+++ b/src/syscall/mkerrors.sh
@@ -342,7 +342,7 @@ errors=$(
 signals=$(
 	echo '#include <signal.h>' | $CC -x c - -E -dM $ccflags |
 	awk '$1=="#define" && $2 ~ /^SIG[A-Z0-9]+$/ { print $2 }' |
-	grep -E -v '(SIGSTKSIZE|SIGSTKSZ|SIGRT)' |
+	grep -Ev 'SIGSTKSIZE|SIGSTKSZ|SIGRT' |
 	sort
 )
 
@@ -352,7 +352,7 @@ echo '#include <errno.h>' | $CC -x c - -E -dM $ccflags |
 	sort >_error.grep
 echo '#include <signal.h>' | $CC -x c - -E -dM $ccflags |
 	awk '$1=="#define" && $2 ~ /^SIG[A-Z0-9]+$/ { print "^\t" $2 "[ \t]*=" }' |
-	grep -E -v '(SIGSTKSIZE|SIGSTKSZ|SIGRT)' |
+	grep -Ev 'SIGSTKSIZE|SIGSTKSZ|SIGRT' |
 	sort >_signal.grep
 
 echo '// mkerrors.sh' "$@"

--- a/src/syscall/mkerrors.sh
+++ b/src/syscall/mkerrors.sh
@@ -342,7 +342,7 @@ errors=$(
 signals=$(
 	echo '#include <signal.h>' | $CC -x c - -E -dM $ccflags |
 	awk '$1=="#define" && $2 ~ /^SIG[A-Z0-9]+$/ { print $2 }' |
-	egrep -v '(SIGSTKSIZE|SIGSTKSZ|SIGRT)' |
+	grep -E -v '(SIGSTKSIZE|SIGSTKSZ|SIGRT)' |
 	sort
 )
 
@@ -352,7 +352,7 @@ echo '#include <errno.h>' | $CC -x c - -E -dM $ccflags |
 	sort >_error.grep
 echo '#include <signal.h>' | $CC -x c - -E -dM $ccflags |
 	awk '$1=="#define" && $2 ~ /^SIG[A-Z0-9]+$/ { print "^\t" $2 "[ \t]*=" }' |
-	egrep -v '(SIGSTKSIZE|SIGSTKSZ|SIGRT)' |
+	grep -E -v '(SIGSTKSIZE|SIGSTKSZ|SIGRT)' |
 	sort >_signal.grep
 
 echo '// mkerrors.sh' "$@"


### PR DESCRIPTION
egrep and fgrep are obsolescent now. 

This PR updates all egrep and fgrep commands to grep -E and grep -F.
Running egrep/fgrep command with grep v3.8 will output the following warning to stderr:
egrep: warning: egrep is obsolescent; using grep -E

see also:
https://www.phoronix.com/news/GNU-Grep-3.8-Stop-egrep-fgrep
https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00001.html