### PR TITLE
go/types, types2: use "cannot convert... to type..." instead of "cannot convert... to..."

### DIFF
--- a/src/cmd/compile/internal/types2/conversions.go
+++ b/src/cmd/compile/internal/types2/conversions.go
@@ -72,20 +72,11 @@ func (check *Checker) conversion(x *operand, T Type) {
 
 	if !ok {
 		var err error_
-		if check.conf.CompilerErrorMessages {
-			if cause != "" {
-				// Add colon at end of line if we have a following cause.
-				err.errorf(x, "cannot convert %s to type %s:", x, T)
-				err.errorf(nopos, cause)
-			} else {
-				err.errorf(x, "cannot convert %s to type %s", x, T)
-			}
-		} else {
-			err.errorf(x, "cannot convert %s to %s", x, T)
-			if cause != "" {
-				err.errorf(nopos, cause)
-			}
+		err.errorf(x, "cannot convert %s to type %s", x, T)
+		if cause != "" {
+			err.errorf(nopos, cause)
 		}
+
 		check.report(&err)
 		x.mode = invalid
 		return

--- a/src/go/types/conversions.go
+++ b/src/go/types/conversions.go
@@ -74,19 +74,9 @@ func (check *Checker) conversion(x *operand, T Type) {
 	if !ok {
 		var err error_
 		err.code = _InvalidConversion
-		if compilerErrorMessages {
-			if cause != "" {
-				// Add colon at end of line if we have a following cause.
-				err.errorf(x.Pos(), "cannot convert %s to type %s:", x, T)
-				err.errorf(token.NoPos, cause)
-			} else {
-				err.errorf(x.Pos(), "cannot convert %s to type %s", x, T)
-			}
-		} else {
-			err.errorf(x.Pos(), "cannot convert %s to %s", x, T)
-			if cause != "" {
-				err.errorf(token.NoPos, cause)
-			}
+		err.errorf(x.Pos(), "cannot convert %s to type %s", x, T)
+		if cause != "" {
+			err.errorf(token.NoPos, cause)
 		}
 		check.report(&err)
 		x.mode = invalid


### PR DESCRIPTION
For #55326