### PR TITLE
internal/saferio: handle potential total size overflow in SliceCap

### DIFF
--- a/src/internal/saferio/io.go
+++ b/src/internal/saferio/io.go
@@ -122,7 +122,11 @@ func SliceCap(v any, c uint64) int {
 		panic("SliceCap called with non-pointer type")
 	}
 	size := typ.Elem().Size()
-	if uintptr(c)*size > chunk {
+	total := uintptr(c) * size
+	if size > 0 && total/size != uintptr(c) {
+		return -1
+	}
+	if total > chunk {
 		c = uint64(chunk / size)
 		if c == 0 {
 			c = 1

--- a/src/internal/saferio/io.go
+++ b/src/internal/saferio/io.go
@@ -121,12 +121,11 @@ func SliceCap(v any, c uint64) int {
 	if typ.Kind() != reflect.Ptr {
 		panic("SliceCap called with non-pointer type")
 	}
-	size := typ.Elem().Size()
-	total := uintptr(c) * size
-	if size > 0 && total/size != uintptr(c) {
+	size := uint64(typ.Elem().Size())
+	if size > 0 && c > (1<<64-1)/size {
 		return -1
 	}
-	if total > chunk {
+	if c*size > chunk {
 		c = uint64(chunk / size)
 		if c == 0 {
 			c = 1

--- a/src/internal/saferio/io_test.go
+++ b/src/internal/saferio/io_test.go
@@ -126,4 +126,11 @@ func TestSliceCap(t *testing.T) {
 			t.Errorf("SliceCap returned %d, expected failure", c)
 		}
 	})
+
+	t.Run("overflow", func(t *testing.T) {
+		c := SliceCap((*int64)(nil), 1<<62)
+		if c >= 0 {
+			t.Errorf("SliceCap returned %d, expected failure", c)
+		}
+	})
 }


### PR DESCRIPTION
Before the change, "SliceCap((*int64)(nil), 1<<62)" returns 1<<62.
That's because "uintptr(c)*size" overflows and gives 0 which is less
than the "chunk". SliceCap should return -1 in this case.