### PR TITLE
`go:linkname must refer to declared function or variable` is not an error in 1.17

### DIFF
--- a/src/cmd/compile/internal/noder/noder.go
+++ b/src/cmd/compile/internal/noder/noder.go
@@ -296,8 +296,8 @@ func (p *noder) processPragmas() {
 		}
 		n := ir.AsNode(typecheck.Lookup(l.local).Def)
 		if n == nil || n.Op() != ir.ONAME {
-			// TODO(mdempsky): Change to p.errorAt before Go 1.17 release.
-			// base.WarnfAt(p.makeXPos(l.pos), "//go:linkname must refer to declared function or variable (will be an error in Go 1.17)")
+			// TODO(mdempsky): Change to p.errorAt before Go 1.18 release.
+			// base.WarnfAt(p.makeXPos(l.pos), "//go:linkname must refer to declared function or variable (will be an error in Go 1.18)")
 			continue
 		}
 		if n.Sym().Linkname != "" {


### PR DESCRIPTION
In version 1.17, `go:linkname must refer to declared function or variable` is not an error
may be should change the comment to 1.18
