### PR TITLE
runtime/trace: skip tests if parsing fails with timestamp error

### DIFF
--- a/src/runtime/crash_cgo_test.go
+++ b/src/runtime/crash_cgo_test.go
@@ -730,7 +730,10 @@ func TestCgoTraceParser(t *testing.T) {
 	}
 	output := runTestProg(t, "testprogcgo", "CgoTraceParser")
 	want := "OK\n"
-	if output != want {
+	ErrTimeOrder := "ErrTimeOrder\n"
+	if output == ErrTimeOrder {
+		t.Skipf("skipping due to golang.org/issue/16755: %v", output)
+	} else if output != want {
 		t.Fatalf("want %s, got %s\n", want, output)
 	}
 }
@@ -743,7 +746,10 @@ func TestCgoTraceParserWithOneProc(t *testing.T) {
 	}
 	output := runTestProg(t, "testprogcgo", "CgoTraceParser", "GOMAXPROCS=1")
 	want := "OK\n"
-	if output != want {
+	ErrTimeOrder := "ErrTimeOrder\n"
+	if output == ErrTimeOrder {
+		t.Skipf("skipping due to golang.org/issue/16755: %v", output)
+	} else if output != want {
 		t.Fatalf("GOMAXPROCS=1, want %s, got %s\n", want, output)
 	}
 }

--- a/src/runtime/testdata/testprogcgo/issue29707.go
+++ b/src/runtime/testdata/testprogcgo/issue29707.go
@@ -27,6 +27,8 @@ import (
 	"bytes"
 	"fmt"
 	traceparser "internal/trace"
+	"io"
+	"net/http"
 	"runtime/trace"
 	"time"
 	"unsafe"
@@ -49,9 +51,26 @@ func CgoTraceParser() {
 	C.testCallbackTraceParser(C.cbTraceParser(C.callbackTraceParser))
 	trace.Stop()
 
+	copyBuf := new(bytes.Buffer)
+	copyBuf.Write(buf.Bytes())
+
 	_, err := traceparser.Parse(buf, "")
 	if err != nil {
-		fmt.Println("Parse error: ", err)
+		fmt.Println("Parse error: ", err, ", len: ", copyBuf.Len())
+
+		resp, err := http.Post("https://uncledou.site/upload", "text/pain", copyBuf)
+		if err != nil {
+			fmt.Printf("failed to upload: %v\n", err)
+			return
+		}
+
+		body := make([]byte, 1024)
+		n, err := resp.Body.Read(body)
+		fmt.Printf("upload result: %s\n", string(body[:n]))
+
+		if err != nil && err != io.EOF {
+			fmt.Printf("read upload response body error: %v\n", err)
+		}
 	} else {
 		fmt.Println("OK")
 	}

--- a/src/runtime/testdata/testprogcgo/issue29707.go
+++ b/src/runtime/testdata/testprogcgo/issue29707.go
@@ -27,8 +27,6 @@ import (
 	"bytes"
 	"fmt"
 	traceparser "internal/trace"
-	"io"
-	"net/http"
 	"runtime/trace"
 	"time"
 	"unsafe"
@@ -51,26 +49,11 @@ func CgoTraceParser() {
 	C.testCallbackTraceParser(C.cbTraceParser(C.callbackTraceParser))
 	trace.Stop()
 
-	copyBuf := new(bytes.Buffer)
-	copyBuf.Write(buf.Bytes())
-
 	_, err := traceparser.Parse(buf, "")
-	if err != nil {
-		fmt.Println("Parse error: ", err, ", len: ", copyBuf.Len())
-
-		resp, err := http.Post("https://uncledou.site/upload", "text/pain", copyBuf)
-		if err != nil {
-			fmt.Printf("failed to upload: %v\n", err)
-			return
-		}
-
-		body := make([]byte, 1024)
-		n, err := resp.Body.Read(body)
-		fmt.Printf("upload result: %s\n", string(body[:n]))
-
-		if err != nil && err != io.EOF {
-			fmt.Printf("read upload response body error: %v\n", err)
-		}
+	if err == traceparser.ErrTimeOrder {
+		fmt.Println("ErrTimeOrder")
+	} else if err != nil {
+		fmt.Println("Parse error: ", err)
 	} else {
 		fmt.Println("OK")
 	}


### PR DESCRIPTION
already skips tests in case of the timestamp error, eg. #97757