### PR TITLE
math: implement Abs function using generics

### DIFF
--- a/src/math/abs.go
+++ b/src/math/abs.go
@@ -10,6 +10,10 @@ package math
 //
 //	Abs(±Inf) = +Inf
 //	Abs(NaN) = NaN
-func Abs(x float64) float64 {
-	return Float64frombits(Float64bits(x) &^ (1 << 63))
+type number interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~float32 | ~float64
+}
+
+func Abs[T number](x T) T {
+	return T(Float64frombits(Float64bits(float64(x)) &^ (1 << 63)))
 }

--- a/src/math/example_test.go
+++ b/src/math/example_test.go
@@ -174,14 +174,32 @@ func ExampleMod() {
 }
 
 func ExampleAbs() {
-	x := math.Abs(-2)
-	fmt.Printf("%.1f\n", x)
+	xFloat64 := math.Abs(float64(-2))
+	fmt.Printf("%.1f, %T\n", xFloat64, xFloat64)
 
-	y := math.Abs(2)
-	fmt.Printf("%.1f\n", y)
+	yFloat64 := math.Abs(float64(2))
+	fmt.Printf("%.1f, %T\n", yFloat64, yFloat64)
+
+	xInt := math.Abs(int(-2))
+	fmt.Printf("%d, %T\n", xInt, xInt)
+
+	yInt := math.Abs(int(2))
+	fmt.Printf("%d, %T\n", yInt, yInt)
+
+	type int64Type int64
+	xTypeInt64 := math.Abs(int64Type(-2))
+	fmt.Printf("%d, %T\n", xTypeInt64, xTypeInt64)
+
+	yTypeInt64 := math.Abs(int64Type(2))
+	fmt.Printf("%d, %T\n", yTypeInt64, yTypeInt64)
+
 	// Output:
-	// 2.0
-	// 2.0
+	// 2.0, float64
+	// 2.0, float64
+	// 2, int
+	// 2, int
+	// 2, math_test.int64Type
+	// 2, math_test.int64Type
 }
 func ExampleDim() {
 	fmt.Printf("%.2f\n", math.Dim(4, -2))


### PR DESCRIPTION
Enabling the following list of numeric types:
- ~int,
- ~int8,
- ~int16,
- ~int32,
- ~int64,
- ~float32,
- ~float64

The existing implementation for Abs is optimized for float64 arguments. 
This commit adds generic parameter to the Abs function after verifying 
that it does not degrade performance

The investigation for this change is described at 
https://github.com/golang/go/issues/55929

Fixes #55929