### PR TITLE
sync: simplify code of Once

### DIFF
--- a/src/sync/once.go
+++ b/src/sync/once.go
@@ -60,7 +60,7 @@ func (o *Once) Do(f func()) {
 	// This is why the slow path falls back to a mutex, and why
 	// the atomic.StoreUint32 must be delayed until after f returns.
 
-	if atomic.LoadUint32(&o.done) == 0 {
+	if o.done == 0 {
 		// Outlined slow-path to allow inlining of the fast-path.
 		o.doSlow(f)
 	}


### PR DESCRIPTION
Hi. I read the sync.Once's implementation and also read the detail in https://go.dev/ref/mem. And I found the `atomic.LoadUint32()` may not needed. I get the conclusion like this:

- In fact the first comparison is used to skip lock when a function is runned for more efficiency. The method will work even the most out comparison is removed.
- There are direct comparison in mutex lock guard scope, that means the variable change could be observed by another goroutine if it's changed by `atomic.StoreUint32()` in a winner goroutine. Because it's possible the winner goroutine call `atomic.StoreUint32()` when another goroutine reaches after `atomic.LoadUint32()` and is blocked on getting lock.

`atomic.LoadUint32()` seems not more effective than direct read. it also doesn't lead to less lock competition. Please figure out if I have any wrong point. Thanks.