### PR TITLE
log/syslog: return nil directly

### DIFF
--- a/src/log/syslog/syslog.go
+++ b/src/log/syslog/syslog.go
@@ -255,7 +255,7 @@ func (w *Writer) writeAndRetry(p Priority, s string) (int, error) {
 
 	if w.conn != nil {
 		if n, err := w.write(pr, s); err == nil {
-			return n, err
+			return n, nil
 		}
 	}
 	if err := w.connect(); err != nil {


### PR DESCRIPTION
Reduce return complexity.
