### PR TITLE
cmd/go/internal/modload: improve error message for failing to read module listed in go.work

### DIFF
--- a/src/cmd/go/internal/modload/init.go
+++ b/src/cmd/go/internal/modload/init.go
@@ -719,7 +719,7 @@ func LoadModFile(ctx context.Context) *Requirements {
 		data, f, err := ReadModFile(gomod, fixVersion(ctx, &fixed))
 		if err != nil {
 			if inWorkspaceMode() {
-				base.Fatalf("go: cannot load module %s named in go.work file: %v", filepath.Base(modroot), err)
+				base.Fatalf("go: cannot load module added to go.work file: %v", err)
 			} else {
 				base.Fatalf("go: %v", err)
 			}

--- a/src/cmd/go/internal/modload/init.go
+++ b/src/cmd/go/internal/modload/init.go
@@ -718,7 +718,11 @@ func LoadModFile(ctx context.Context) *Requirements {
 		var fixed bool
 		data, f, err := ReadModFile(gomod, fixVersion(ctx, &fixed))
 		if err != nil {
-			base.Fatalf("go: %v", err)
+			if inWorkspaceMode() {
+				base.Fatalf("go: cannot load module %s named in go.work file: %v", filepath.Base(modroot), err)
+			} else {
+				base.Fatalf("go: %v", err)
+			}
 		}
 
 		modFiles = append(modFiles, f)

--- a/src/cmd/go/internal/modload/init.go
+++ b/src/cmd/go/internal/modload/init.go
@@ -719,7 +719,7 @@ func LoadModFile(ctx context.Context) *Requirements {
 		data, f, err := ReadModFile(gomod, fixVersion(ctx, &fixed))
 		if err != nil {
 			if inWorkspaceMode() {
-				base.Fatalf("go: cannot load module added to go.work file: %v", err)
+				base.Fatalf("go: cannot load module listed in go.work file: %v", err)
 			} else {
 				base.Fatalf("go: %v", err)
 			}

--- a/src/cmd/go/testdata/script/work_use_issue55952.txt
+++ b/src/cmd/go/testdata/script/work_use_issue55952.txt
@@ -1,5 +1,5 @@
 ! go list .
-stderr '^go: cannot load module y named in go\.work file: open .+go\.mod: no such file or directory$'
+stderr '^go: cannot load module added to go\.work file: open .+go\.mod: no such file or directory$'
 
 -- go.work --
 use ./y

--- a/src/cmd/go/testdata/script/work_use_issue55952.txt
+++ b/src/cmd/go/testdata/script/work_use_issue55952.txt
@@ -1,5 +1,5 @@
 ! go list .
-stderr '^go: cannot load module added to go\.work file: open .+go\.mod: no such file or directory$'
+stderr '^go: cannot load module listed in go\.work file: open .+go\.mod: no such file or directory$'
 
 -- go.work --
 use ./y

--- a/src/cmd/go/testdata/script/work_use_issue55952.txt
+++ b/src/cmd/go/testdata/script/work_use_issue55952.txt
@@ -1,5 +1,5 @@
 ! go list .
-stderr '^go: cannot load module listed in go\.work file: open .+go\.mod: no such file or directory$'
+stderr '^go: cannot load module listed in go\.work file: open .+go\.mod:'
 
 -- go.work --
 use ./y

--- a/src/cmd/go/testdata/script/work_use_issue55952.txt
+++ b/src/cmd/go/testdata/script/work_use_issue55952.txt
@@ -1,0 +1,11 @@
+! go list .
+stderr '^go: cannot load module y named in go\.work file: open .+go\.mod: no such file or directory$'
+
+-- go.work --
+use ./y
+-- x/go.mod --
+module x
+
+go 1.19
+-- x/m.go --
+package m


### PR DESCRIPTION
Run "go build ./x" in this workspace:

  -- go.work --
  use ./y
  -- x/go.mod --
  module x

  go 1.19
  -- x/m.go --
  package m

It fails with: "go: open /tmp/foo/y/go.mod: no such file or directory".
It's unclear where the name "y" comes from.
This change will emit error like: "go: cannot load module listed in
go.work file: open /tmp/foo/y/go.mod: no such file or directory"

Fixes #55952.