### PR TITLE
spec: improve clarity of function result

### DIFF
--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -1165,10 +1165,13 @@ is <code>nil</code>.
 <pre class="ebnf">
 FunctionType   = "func" Signature .
 Signature      = Parameters [ Result ] .
-Result         = Parameters | Type .
+Result         = Results | Type .
 Parameters     = "(" [ ParameterList [ "," ] ] ")" .
 ParameterList  = ParameterDecl { "," ParameterDecl } .
 ParameterDecl  = [ IdentifierList ] [ "..." ] Type .
+Results        = "(" [ ResultList [ "," ] ] ")" .
+ResultList     = ResultDecl { "," ResultDecl } .
+ResultDecl     = [ IdentifierList ] Type .
 </pre>
 
 <p>


### PR DESCRIPTION
The spec for the `Result` of a `FunctionType` implies that its `ParameterList` can end with a `ParameterDecl` of the form `Identifier ...Type`. Personally, I have never seen this form, and my language server complains when I have a function signature like this. While it's more verbose and less concise, I believe the change from this commit is technically correct.