### PR TITLE
spec: fix typo for octal_lit

### DIFF
--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -296,7 +296,7 @@ the literal's value.
 int_lit        = decimal_lit | binary_lit | octal_lit | hex_lit .
 decimal_lit    = "0" | ( "1" … "9" ) [ [ "_" ] decimal_digits ] .
 binary_lit     = "0" ( "b" | "B" ) [ "_" ] binary_digits .
-octal_lit      = "0" [ "o" | "O" ] [ "_" ] octal_digits .
+octal_lit      = "0" ( "o" | "O" ) [ "_" ] octal_digits .
 hex_lit        = "0" ( "x" | "X" ) [ "_" ] hex_digits .
 
 decimal_digits = decimal_digit { [ "_" ] decimal_digit } .


### PR DESCRIPTION
Fixes typo for `octal_lit` where the `"o" | "O"` alternation should be inside a grouping and not an option.