### PR TITLE
net: The Go DNS resolver on Windows should filter disabled interfaces

### DIFF
--- a/src/net/dnsconfig_windows.go
+++ b/src/net/dnsconfig_windows.go
@@ -30,6 +30,10 @@ func dnsReadConfig(ignoredFilename string) (conf *dnsConfig) {
 	// In practice, however, it mostly works.
 	for _, aa := range aas {
 		for dns := aa.FirstDnsServerAddress; dns != nil; dns = dns.Next {
+			// Only take interfaces whose OperStatus is IfOperStatusUp(0x01) into DNS configs.
+			if aa.OperStatus == 0x01 {
+				continue
+			}
 			sa, err := dns.Address.Sockaddr.Sockaddr()
 			if err != nil {
 				continue

--- a/src/net/dnsconfig_windows.go
+++ b/src/net/dnsconfig_windows.go
@@ -6,6 +6,7 @@ package net
 
 import (
 	"syscall"
+	"syscall/windows"
 	"time"
 )
 
@@ -31,7 +32,7 @@ func dnsReadConfig(ignoredFilename string) (conf *dnsConfig) {
 	for _, aa := range aas {
 		for dns := aa.FirstDnsServerAddress; dns != nil; dns = dns.Next {
 			// Only take interfaces whose OperStatus is IfOperStatusUp(0x01) into DNS configs.
-			if aa.OperStatus != 0x01 {
+			if aa.OperStatus != windows.IfOperStatusUp {
 				continue
 			}
 			sa, err := dns.Address.Sockaddr.Sockaddr()

--- a/src/net/dnsconfig_windows.go
+++ b/src/net/dnsconfig_windows.go
@@ -31,7 +31,7 @@ func dnsReadConfig(ignoredFilename string) (conf *dnsConfig) {
 	for _, aa := range aas {
 		for dns := aa.FirstDnsServerAddress; dns != nil; dns = dns.Next {
 			// Only take interfaces whose OperStatus is IfOperStatusUp(0x01) into DNS configs.
-			if aa.OperStatus == 0x01 {
+			if aa.OperStatus != 0x01 {
 				continue
 			}
 			sa, err := dns.Address.Sockaddr.Sockaddr()


### PR DESCRIPTION
The Go DNS resolver on Windows should filter disabled interfaces. Otherwise disabled TUN devices, VPNs will be also considered as valid nameservers and finally timedout.

Fixes #56160
