### PR TITLE
flag: remove "// BUG" comment

### DIFF
--- a/src/flag/flag.go
+++ b/src/flag/flag.go
@@ -1056,9 +1056,9 @@ func (f *FlagSet) parseOne() (bool, error) {
 			break
 		}
 	}
-	m := f.formal
-	flag, alreadythere := m[name] // BUG
-	if !alreadythere {
+
+	flag, ok := f.formal[name] 
+	if !ok {
 		if name == "help" || name == "h" { // special case for nice help message.
 			f.usage()
 			return false, ErrHelp

--- a/src/flag/flag.go
+++ b/src/flag/flag.go
@@ -1057,7 +1057,7 @@ func (f *FlagSet) parseOne() (bool, error) {
 		}
 	}
 
-	flag, ok := f.formal[name] 
+	flag, ok := f.formal[name]
 	if !ok {
 		if name == "help" || name == "h" { // special case for nice help message.
 			f.usage()


### PR DESCRIPTION
Remove a vestigial " // BUG" comment as there is no bug in the relevant code section and comment predated other changes.  Also removed a needless allocation and conformed to the "v, ok := a[x]" standard convention.  Tests are passing.  
