### PR TITLE
archive/zip: fix a bug with zip64 check

### DIFF
--- a/src/archive/zip/reader.go
+++ b/src/archive/zip/reader.go
@@ -554,7 +554,7 @@ func readDirectoryEnd(r io.ReaderAt, size int64) (dir *directoryEnd, baseOffset 
 	d.comment = string(b[:l])
 
 	// These values mean that the file can be a zip64 file
-	if d.directoryRecords == 0xffff || d.directorySize == 0xffff || d.directoryOffset == 0xffffffff {
+	if d.directoryRecords == 0xffff || d.directorySize == 0xffffffff || d.directoryOffset == 0xffffffff {
 		p, err := findDirectory64End(r, directoryEndOffset)
 		if err == nil && p >= 0 {
 			directoryEndOffset = p


### PR DESCRIPTION
Seems to be a bug here. Size of central directory is a 32-bit value so it should be compared to 0xffffffff