### PR TITLE
encoding/json: reduce the number of allocations when decoding in streaming mode (Token API)

### DIFF
--- a/src/encoding/json/stream.go
+++ b/src/encoding/json/stream.go
@@ -369,6 +369,11 @@ func (d Delim) String() string {
 // to mark the start and end of arrays and objects.
 // Commas and colons are elided.
 func (dec *Decoder) Token() (Token, error) {
+	dec.scan.inStream = true
+	defer func() {
+		dec.scan.inStream = false
+	}()
+
 	for {
 		c, err := dec.peek()
 		if err != nil {


### PR DESCRIPTION

When the scanner is used by the Token API it always resets the state before so that the scanner behaves as if it was parsing a top-level value, which causes it to allocate and set the 'err' field because the following character is not a space. This error value is completely unnecessary because it's dropped by the next invocation of readValue().

Fixes #56299
