### PR TITLE
math/big: improve performance of Binomial

### DIFF
--- a/src/math/big/int.go
+++ b/src/math/big/int.go
@@ -206,47 +206,50 @@ func (z *Int) MulRange(a, b int64) *Int {
 }
 
 // Binomial sets z to the binomial coefficient of (n, k) and returns z.
-func (z *Int) Binomial(n, k int64) *Int {
-	if k > n {
+func (z *Int) Binomial(n_, k_ int64) *Int {
+	if k_ > n_ {
 		return z.SetInt64(0)
 	}
 	// reduce the number of multiplications by reducing k
-	if k > n-k {
-		k = n - k // Binomial(n, k) == Binomial(n, n-k)
+	if k_ > n_-k_ {
+		k_ = n_ - k_ // Binomial(n, k) == Binomial(n, n-k)
 	}
 	// C(n, k) == n * (n-1) * ... * (n-k+1) / k * (k-1) * ... * 1
 	//         == n * (n-1) * ... * (n-k+1) / 1 * (1+1) * ... * k
-	// using the multiplicative formula produces smaller values
-	// at each step, that require fewer allocations and computations:
+	//
+	// Using the multiplicative formula produces smaller values
+	// at each step, requiring fewer allocations and computations:
+	//
 	// z = 1
 	// for i := 0; i < k; i = i+1 {
-	//	 z *= n-i
-	//	 z /= i+1
+	//     z *= n-i
+	//     z /= i+1
 	// }
 	//
 	// finally to avoid computing i+1 twice per loop:
+	//
 	// z = 1
 	// i := 0
 	// for {
-	//   if i == k {
-	//	   break
-	//   }
-	//	 z *= n-i
-	//   i++
-	//	 z /= i
+	//     if i == k {
+	//         break
+	//     }
+	//     z *= n-i
+	//     i++
+	//     z /= i
 	// }
-	var bN, bK, bI, bNMinusI Int
-	bN.SetInt64(n)
-	bK.SetInt64(k)
+	var n, k, i, d Int
+	n.SetInt64(n_)
+	k.SetInt64(k_)
 	z.Set(intOne)
 	for {
-		if bI.Cmp(&bK) == 0 {
+		if i.Cmp(&k) == 0 {
 			break
 		}
-		bNMinusI.Sub(&bN, &bI)
-		z.Mul(z, &bNMinusI)
-		bI.Add(&bI, intOne)
-		z.Quo(z, &bI)
+		d.Sub(&n, &i)
+		z.Mul(z, &d)
+		i.Add(&i, intOne)
+		z.Quo(z, &i)
 	}
 	return z
 }

--- a/src/math/big/int.go
+++ b/src/math/big/int.go
@@ -205,14 +205,14 @@ func (z *Int) MulRange(a, b int64) *Int {
 	return z
 }
 
-// Binomial sets z to the binomial coefficient of (n, k) and returns z.
+// Binomial sets z to the binomial coefficient C(n, k) and returns z.
 func (z *Int) Binomial(n_, k_ int64) *Int {
 	if k_ > n_ {
 		return z.SetInt64(0)
 	}
 	// reduce the number of multiplications by reducing k
 	if k_ > n_-k_ {
-		k_ = n_ - k_ // Binomial(n, k) == Binomial(n, n-k)
+		k_ = n_ - k_ // C(n, k) == C(n, n-k)
 	}
 	// C(n, k) == n * (n-1) * ... * (n-k+1) / k * (k-1) * ... * 1
 	//         == n * (n-1) * ... * (n-k+1) / 1 * (1+1) * ... * k
@@ -230,10 +230,7 @@ func (z *Int) Binomial(n_, k_ int64) *Int {
 	//
 	// z = 1
 	// i := 0
-	// for {
-	//     if i == k {
-	//         break
-	//     }
+	// for i < k {
 	//     z *= n-i
 	//     i++
 	//     z /= i
@@ -242,10 +239,7 @@ func (z *Int) Binomial(n_, k_ int64) *Int {
 	n.SetInt64(n_)
 	k.SetInt64(k_)
 	z.Set(intOne)
-	for {
-		if i.Cmp(&k) == 0 {
-			break
-		}
+	for i.Cmp(&k) < 0 {
 		d.Sub(&n, &i)
 		z.Mul(z, &d)
 		i.Add(&i, intOne)

--- a/src/math/big/int.go
+++ b/src/math/big/int.go
@@ -235,13 +235,12 @@ func (z *Int) Binomial(n_, k_ int64) *Int {
 	//     i++
 	//     z /= i
 	// }
-	var n, k, i, d Int
+	var n, k, i, t Int
 	n.SetInt64(n_)
 	k.SetInt64(k_)
 	z.Set(intOne)
 	for i.Cmp(&k) < 0 {
-		d.Sub(&n, &i)
-		z.Mul(z, &d)
+		z.Mul(z, t.Sub(&n, &i))
 		i.Add(&i, intOne)
 		z.Quo(z, &i)
 	}


### PR DESCRIPTION
This change improves the performance of Binomial by implementing an
algorithm that produces smaller intermediate values at each step.

Working with smaller big.Int values has the advantage that  fewer allocations 
and computations are required for each mathematical operation.

The algorithm used is the Multiplicative Formula, which is a well known
way of calculating the Binomial coefficient and is described at:
https://en.wikipedia.org/wiki/Binomial_coefficient#Multiplicative_formula
https://en.wikipedia.org/wiki/Binomial_coefficient#In_programming_languages

In addition to that, an optimization has been made to remove a 
redundant computation of (i+1) on each loop which has a measurable
impact when using big.Int.

Performance improvement measured on an M1 MacBook Pro
running the existing benchmark for Binomial:

name        old time/op    new time/op    delta
Binomial-8     589ns ± 0%     435ns ± 0%  -26.05%  (p=0.000 n=10+10)

name        old alloc/op   new alloc/op   delta
Binomial-8    1.02kB ± 0%    0.08kB ± 0%  -92.19%  (p=0.000 n=10+10)

name        old allocs/op  new allocs/op  delta
Binomial-8      38.0 ± 0%       5.0 ± 0%  -86.84%  (p=0.000 n=10+10)
