### PR TITLE
net/http/httputil: set HOST header always

### DIFF
--- a/src/net/http/httputil/dump.go
+++ b/src/net/http/httputil/dump.go
@@ -243,15 +243,9 @@ func DumpRequest(req *http.Request, body bool) ([]byte, error) {
 	fmt.Fprintf(&b, "%s %s HTTP/%d.%d\r\n", valueOrDefault(req.Method, "GET"),
 		reqURI, req.ProtoMajor, req.ProtoMinor)
 
-	absRequestURI := strings.HasPrefix(req.RequestURI, "http://") || strings.HasPrefix(req.RequestURI, "https://")
-	if !absRequestURI {
-		host := req.Host
-		if host == "" && req.URL != nil {
-			host = req.URL.Host
-		}
-		if host != "" {
-			fmt.Fprintf(&b, "Host: %s\r\n", host)
-		}
+	_, ok := req.Header["Host"]
+	if ok {
+		fmt.Fprintf(&b, "Host: %s\r\n", req.Header.Get("Host"))
 	}
 
 	chunked := len(req.TransferEncoding) > 0 && req.TransferEncoding[0] == "chunked"

--- a/src/net/http/httputil/example_test.go
+++ b/src/net/http/httputil/example_test.go
@@ -47,7 +47,7 @@ func ExampleDumpRequest() {
 	fmt.Printf("%s", b)
 
 	// Output:
-	// "POST / HTTP/1.1\r\nHost: www.example.org\r\nAccept-Encoding: gzip\r\nContent-Length: 75\r\nUser-Agent: Go-http-client/1.1\r\n\r\nGo is a general-purpose language designed with systems programming in mind."
+	// "POST / HTTP/1.1\r\nAccept-Encoding: gzip\r\nContent-Length: 75\r\nUser-Agent: Go-http-client/1.1\r\n\r\nGo is a general-purpose language designed with systems programming in mind."
 }
 
 func ExampleDumpRequestOut() {


### PR DESCRIPTION
According to RFC2616, all request messages must have HOST header.

> A client MUST include a Host header field in all HTTP/1.1 request messages .

https://www.rfc-editor.org/rfc/rfc2616#section-14.23

If `httputil.DumpRequest` follows the spec, we can send dumped request to another server directly.
I think it's better to follow the spec.