### PR TITLE
net/netip: Need to unmap the Addr in AddrFromSlice due to that there may be an IPv4-mapped IPv6 address

### DIFF
--- a/src/net/lookup.go
+++ b/src/net/lookup.go
@@ -255,9 +255,11 @@ func (r *Resolver) LookupNetIP(ctx context.Context, network, host string) ([]net
 	}
 	ret := make([]netip.Addr, 0, len(ips))
 	for _, ip := range ips {
-		if a, ok := netip.AddrFromSlice(ip); ok {
-			ret = append(ret, a)
+		a, err := netip.ParseAddr(ip.String())
+		if err != nil {
+			continue
 		}
+		ret = append(ret, a)
 	}
 	return ret, nil
 }

--- a/src/net/netip/netip.go
+++ b/src/net/netip/netip.go
@@ -354,7 +354,9 @@ func AddrFromSlice(slice []byte) (ip Addr, ok bool) {
 	case 4:
 		return AddrFrom4(*(*[4]byte)(slice)), true
 	case 16:
-		return ipv6Slice(slice), true
+		ipAddr := ipv6Slice(slice)
+		unwrapAddr := ipAddr.Unmap()
+		return unwrapAddr, true
 	}
 	return Addr{}, false
 }

--- a/src/net/netip/netip.go
+++ b/src/net/netip/netip.go
@@ -354,9 +354,7 @@ func AddrFromSlice(slice []byte) (ip Addr, ok bool) {
 	case 4:
 		return AddrFrom4(*(*[4]byte)(slice)), true
 	case 16:
-		ipAddr := ipv6Slice(slice)
-		unwrapAddr := ipAddr.Unmap()
-		return unwrapAddr, true
+		return ipv6Slice(slice), true
 	}
 	return Addr{}, false
 }


### PR DESCRIPTION
Generally, the code should not assert an IP address is IPv4 or IPv6 via the slice length due to there may be an IPv4-mapped IPv6 address, so need to unmap the Addr in `AddrFromSlice` in `net/netip` package.

This can be reproduced by calling `net.DefaultResolver.LookupNetIP` in `net` package to obtain all interfaces and then each interface address may be in an IPv4-mapped IPv6 address, and this will cause the problem when checking an address's IP family.
