### PR TITLE
go: Filter build paths on staticly linked arches

### DIFF
--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2258,6 +2258,17 @@ func (p *Package) collectDeps() {
 // to their VCS information (vcsStatusError).
 var vcsStatusCache par.Cache
 
+func filterCompilerFlags(flags string) string {
+	var newflags []string
+	for _, flag := range strings.Fields(flags) {
+		if strings.HasPrefix(flag, "--sysroot") || strings.HasPrefix(flag, "-fmacro-prefix-map") || strings.HasPrefix(flag, "-fdebug-prefix-map") {
+			continue
+		}
+		newflags = append(newflags, flag)
+	}
+	return strings.Join(newflags, " ")
+}
+
 // setBuildInfo gathers build information, formats it as a string to be
 // embedded in the binary, then sets p.Internal.BuildInfo to that string.
 // setBuildInfo should only be called on a main package with no errors.
@@ -2364,7 +2375,7 @@ func (p *Package) setBuildInfo(autoVCS bool) {
 	if gcflags := BuildGcflags.String(); gcflags != "" && cfg.BuildContext.Compiler == "gc" {
 		appendSetting("-gcflags", gcflags)
 	}
-	if ldflags := BuildLdflags.String(); ldflags != "" {
+	if ldflags := filterCompilerFlags(BuildLdflags.String()); ldflags != "" {
 		// https://go.dev/issue/52372: only include ldflags if -trimpath is not set,
 		// since it can include system paths through various linker flags (notably
 		// -extar, -extld, and -extldflags).
@@ -2403,7 +2414,7 @@ func (p *Package) setBuildInfo(autoVCS bool) {
 	// subset of flags that are known not to be paths?
 	if cfg.BuildContext.CgoEnabled && !cfg.BuildTrimpath {
 		for _, name := range []string{"CGO_CFLAGS", "CGO_CPPFLAGS", "CGO_CXXFLAGS", "CGO_LDFLAGS"} {
-			appendSetting(name, cfg.Getenv(name))
+			appendSetting(name, filterCompilerFlags(cfg.Getenv(name)))
 		}
 	}
 	appendSetting("GOARCH", cfg.BuildContext.GOARCH)


### PR DESCRIPTION
Filter out build time paths from ldflags and other flags variables when they're embedded in the go binary so that builds are reproducible regardless of build location. This codepath is hit for statically linked go binaries such as those on mips/ppc.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
