### PR TITLE
flag: clarify that the main func at pkg.go.dev is part of a testing suite

### DIFF
--- a/src/flag/example_test.go
+++ b/src/flag/example_test.go
@@ -78,6 +78,7 @@ func Example() {
 	// to enable the flag package to see the flags defined there, one must
 	// execute, typically at the start of main (not init!):
 	//	flag.Parse()
-	// We don't run it here because this is not a main function and
+	// We don't run it here because this is not a main function (it's renamed to
+	// "main" in playground, but bear in mind that this is a test example) and
 	// the testing suite has already parsed the flags.
 }

--- a/src/flag/example_test.go
+++ b/src/flag/example_test.go
@@ -78,7 +78,8 @@ func Example() {
 	// to enable the flag package to see the flags defined there, one must
 	// execute, typically at the start of main (not init!):
 	//	flag.Parse()
-	// We don't run it here because this is not a main function (it's renamed to
-	// "main" in playground, but bear in mind that this is a test example) and
-	// the testing suite has already parsed the flags.
+	// We don't call it here because this code is a function called "Example"
+	// that is part of the testing suite for the package, which has already
+	// parsed the flags. When viewed at pkg.go.dev, however, the function is
+	// renamed to "main" and it could be run as a standalone example.
 }


### PR DESCRIPTION
flag.Example() has this comment:

    ... one must execute, typically at the start of main (not init!):
      flag.Parse()
    We don't run it here because this is not a main function

This example function will be renamed to "main" at pkg.go.dev, which
makes the comment confusing.
See https://pkg.go.dev/flag#example-package.

This change modify the comment to clarify this situation.