### PR TITLE
debug/elf: guard access to File.gnuVersym

### DIFF
--- a/src/debug/elf/file.go
+++ b/src/debug/elf/file.go
@@ -1570,12 +1570,16 @@ func (f *File) gnuVersionInit(str []byte) bool {
 // gnuVersion adds Library and Version information to sym,
 // which came from offset i of the symbol table.
 func (f *File) gnuVersion(i int) (library string, version string) {
-	// Each entry is two bytes.
+	// Each entry is two bytes; skip undef entry at beginning.
 	i = (i + 1) * 2
 	if i >= len(f.gnuVersym) {
 		return
 	}
-	j := int(f.ByteOrder.Uint16(f.gnuVersym[i:]))
+	s := f.gnuVersym[i:]
+	if len(s) < 2 {
+		return
+	}
+	j := int(f.ByteOrder.Uint16(s))
 	if j < 2 || j >= len(f.gnuNeed) {
 		return
 	}


### PR DESCRIPTION
The size of gnuVersym should be multiples of 2. If not, the input is
invalid. No Library and Version information is added to sym in this
case. The current implementation of gnuVersion does not report errors
for invalid input.

While at here, bring back the comment that states that the undef entry
at the beginning is skipped. This is not an off-by-one error.

No test case because the problem can only happen for invalid data. Let
the fuzzer find cases like this.

Fixes #56429.