### PR TITLE
net/http: build error chains in transport that can be unwrapped

### DIFF
--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -2043,7 +2043,7 @@ func (pc *persistConn) mapRoundTripError(req *transportRequest, startBytesWritte
 		if pc.nwrite == startBytesWritten {
 			return nothingWrittenError{err}
 		}
-		return fmt.Errorf("net/http: HTTP/1.x transport connection broken: %v", err)
+		return fmt.Errorf("net/http: HTTP/1.x transport connection broken: %w", err)
 	}
 	return err
 }
@@ -2250,7 +2250,7 @@ func (pc *persistConn) readLoopPeekFailLocked(peekErr error) {
 		// common case.
 		pc.closeLocked(errServerClosedIdle)
 	} else {
-		pc.closeLocked(fmt.Errorf("readLoopPeekFailLocked: %v", peekErr))
+		pc.closeLocked(fmt.Errorf("readLoopPeekFailLocked: %w", peekErr))
 	}
 }
 
@@ -2382,6 +2382,10 @@ func (b *readWriteCloserBody) Read(p []byte) (n int, err error) {
 // nothingWrittenError wraps a write errors which ended up writing zero bytes.
 type nothingWrittenError struct {
 	error
+}
+
+func (nwe nothingWrittenError) Unwrap() error {
+	return nwe.error
 }
 
 func (pc *persistConn) writeLoop() {
@@ -2621,7 +2625,7 @@ func (pc *persistConn) roundTrip(req *transportRequest) (resp *Response, err err
 				req.logf("writeErrCh resv: %T/%#v", err, err)
 			}
 			if err != nil {
-				pc.close(fmt.Errorf("write error: %v", err))
+				pc.close(fmt.Errorf("write error: %w", err))
 				return nil, pc.mapRoundTripError(req, startBytesWritten, err)
 			}
 			if d := pc.t.ResponseHeaderTimeout; d > 0 {


### PR DESCRIPTION
In some places of the HTTP transport errors were constructed that
wrapped other errors without providing the ability to call
`errors.Unwrap` on them to get the underlying error.
These places have been fixed to use `%w` when using `fmt.Errorf`
or to implement `Unwrap() error`.

Fixes #56435