### PR TITLE
crypto/tls: exposed access to underlying connection

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -219,6 +219,9 @@ type ConnectionState struct {
 	// HandshakeComplete is true if the handshake has concluded.
 	HandshakeComplete bool
 
+	// UnderlyingConn is the underlying net.Conn to access TCP/UDP connection params.
+	UnderlyingConn net.Conn
+
 	// DidResume is true if this connection was successfully resumed from a
 	// previous session with a session ticket or similar mechanism.
 	DidResume bool

--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -1486,6 +1486,7 @@ func (c *Conn) ConnectionState() ConnectionState {
 func (c *Conn) connectionStateLocked() ConnectionState {
 	var state ConnectionState
 	state.HandshakeComplete = c.isHandshakeComplete.Load()
+	state.UnderlyingConn = c.conn
 	state.Version = c.vers
 	state.NegotiatedProtocol = c.clientProtocol
 	state.DidResume = c.didResume


### PR DESCRIPTION
The underlying (tcp) connection is exposed inside tls connection. This is useful for e.g. changing TCP params of the existing connection.