### PR TITLE
crypto/tls: exposed underlying net.Conn

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -219,6 +219,9 @@ type ConnectionState struct {
 	// HandshakeComplete is true if the handshake has concluded.
 	HandshakeComplete bool
 
+	// UnderlyingConn is the underlying net.Conn connection.
+	UnderlyingConn net.Conn
+
 	// DidResume is true if this connection was successfully resumed from a
 	// previous session with a session ticket or similar mechanism.
 	DidResume bool

--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -1486,6 +1486,7 @@ func (c *Conn) ConnectionState() ConnectionState {
 func (c *Conn) connectionStateLocked() ConnectionState {
 	var state ConnectionState
 	state.HandshakeComplete = c.isHandshakeComplete.Load()
+	state.UnderlyingConn = c.conn
 	state.Version = c.vers
 	state.NegotiatedProtocol = c.clientProtocol
 	state.DidResume = c.didResume


### PR DESCRIPTION
Exposed the underlying net.Conn connection. This can be useful for setting e.g. TCP params.