### PR TITLE
net/http: prints offending linebreak in the chunked error

### DIFF
--- a/src/net/http/internal/chunked.go
+++ b/src/net/http/internal/chunked.go
@@ -77,8 +77,8 @@ func (cr *chunkedReader) Read(b []uint8) (n int, err error) {
 				break
 			}
 			if _, cr.err = io.ReadFull(cr.r, cr.buf[:2]); cr.err == nil {
-				if string(cr.buf[:]) != "\r\n" {
-					cr.err = errors.New("malformed chunked encoding")
+				if lb := string(cr.buf[:]); lb != "\r\n" {
+					cr.err = fmt.Errorf("malformed chunked encoding %q", lb)
 					break
 				}
 			} else {


### PR DESCRIPTION
Requests offending the chunking linebreak are hard to chase down as you don't have any clue on what was sent instead. This PR makes the error actionable by providing the offending bytes.
