### PR TITLE
internal/edwards25519: skip zero coef in VarTimeDoubleScalarBaseMult

### DIFF
--- a/src/crypto/internal/edwards25519/scalarmult.go
+++ b/src/crypto/internal/edwards25519/scalarmult.go
@@ -167,8 +167,8 @@ func (v *Point) VarTimeDoubleScalarBaseMult(a *Scalar, A *Point, b *Scalar) *Poi
 
 	// Find the first nonzero coefficient.
 	i := 255
-	for j := i; j >= 0; j-- {
-		if aNaf[j] != 0 || bNaf[j] != 0 {
+	for ; i >= 0; i-- {
+		if aNaf[i] != 0 || bNaf[i] != 0 {
 			break
 		}
 	}


### PR DESCRIPTION
The comment says "Find the first nonzero coefficient.", but actually this code does nothing.

I fixed it to work correctly.

```
name                            old time/op  new time/op  delta
VarTimeDoubleScalarBaseMult-10  37.5µs ± 0%  36.9µs ± 0%  -1.48%  (p=0.000 n=19+16)
```
