### PR TITLE
net/http: use Copy in ServeContent if CopyN not needed

### DIFF
--- a/src/net/http/fs.go
+++ b/src/net/http/fs.go
@@ -334,7 +334,12 @@ func serveContent(w ResponseWriter, r *Request, name string, modtime time.Time, 
 	w.WriteHeader(code)
 
 	if r.Method != "HEAD" {
-		io.CopyN(w, sendContent, sendSize)
+		if sendSize == size {
+			// use Copy in the non-range case to make use of WriterTo if available
+			io.Copy(w, sendContent)
+		} else {
+			io.CopyN(w, sendContent, sendSize)
+		}
 	}
 }
 

--- a/src/net/http/fs.go
+++ b/src/net/http/fs.go
@@ -333,7 +333,7 @@ func serveContent(w ResponseWriter, r *Request, name string, modtime time.Time, 
 
 	w.WriteHeader(code)
 
-	if r.Method != "HEAD" {
+	if r.Method != MethodHead {
 		if sendSize == size {
 			// use Copy in the non-range case to make use of WriterTo if available
 			io.Copy(w, sendContent)

--- a/src/net/http/fs_test.go
+++ b/src/net/http/fs_test.go
@@ -897,6 +897,7 @@ func testServeContent(t *testing.T, mode testMode) {
 		wantContentType  string
 		wantContentRange string
 		wantStatus       int
+		wantContent      []byte
 	}
 	htmlModTime := mustStat(t, "testdata/index.html").ModTime()
 	tests := map[string]testCase{
@@ -1117,6 +1118,7 @@ func testServeContent(t *testing.T, mode testMode) {
 			serveContentType: "text/plain; charset=utf-8",
 			wantContentType:  "text/plain; charset=utf-8",
 			wantStatus:       StatusOK,
+			wantContent:      []byte("foobar"),
 		},
 		"do_not_use_writeTo_for_range_requests": {
 			content:          &panicOnWriterTo{ReadSeeker: strings.NewReader("foobar")},
@@ -1127,6 +1129,7 @@ func testServeContent(t *testing.T, mode testMode) {
 			wantContentType:  "text/plain; charset=utf-8",
 			wantContentRange: "bytes 0-4/6",
 			wantStatus:       StatusPartialContent,
+			wantContent:      []byte("fooba"),
 		},
 	}
 	for testName, tt := range tests {
@@ -1141,7 +1144,8 @@ func testServeContent(t *testing.T, mode testMode) {
 		} else {
 			content = tt.content
 		}
-		for _, method := range []string{"GET", "HEAD"} {
+		contentOut := &strings.Builder{}
+		for _, method := range []string{MethodGet, MethodHead} {
 			//restore content in case it is consumed by previous method
 			if content, ok := content.(*strings.Reader); ok {
 				content.Seek(0, io.SeekStart)
@@ -1167,7 +1171,8 @@ func testServeContent(t *testing.T, mode testMode) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			io.Copy(io.Discard, res.Body)
+			contentOut.Reset()
+			io.Copy(contentOut, res.Body)
 			res.Body.Close()
 			if res.StatusCode != tt.wantStatus {
 				t.Errorf("test %q using %q: got status = %d; want %d", testName, method, res.StatusCode, tt.wantStatus)
@@ -1180,6 +1185,9 @@ func testServeContent(t *testing.T, mode testMode) {
 			}
 			if g, e := res.Header.Get("Last-Modified"), tt.wantLastMod; g != e {
 				t.Errorf("test %q using %q: got last-modified = %q, want %q", testName, method, g, e)
+			}
+			if g, e := contentOut.String(), tt.wantContent; e != nil && method == MethodGet && g != string(e) {
+				t.Errorf("test %q using %q: got unexpected content %q, want %q", testName, method, g, e)
 			}
 		}
 	}

--- a/src/net/http/fs_test.go
+++ b/src/net/http/fs_test.go
@@ -1112,6 +1112,22 @@ func testServeContent(t *testing.T, mode testMode) {
 			wantStatus:  412,
 			wantLastMod: htmlModTime.UTC().Format(TimeFormat),
 		},
+		"uses_writeTo_if_available_and_non-range": {
+			content:          &panicOnNonWriterTo{seekWriterTo: strings.NewReader("foobar")},
+			serveContentType: "text/plain; charset=utf-8",
+			wantContentType:  "text/plain; charset=utf-8",
+			wantStatus:       StatusOK,
+		},
+		"do_not_use_writeTo_for_range_requests": {
+			content:          &panicOnWriterTo{ReadSeeker: strings.NewReader("foobar")},
+			serveContentType: "text/plain; charset=utf-8",
+			reqHeader: map[string]string{
+				"Range": "bytes=0-4",
+			},
+			wantContentType:  "text/plain; charset=utf-8",
+			wantContentRange: "bytes 0-4/6",
+			wantStatus:       StatusPartialContent,
+		},
 	}
 	for testName, tt := range tests {
 		var content io.ReadSeeker
@@ -1167,6 +1183,21 @@ func testServeContent(t *testing.T, mode testMode) {
 			}
 		}
 	}
+}
+
+type seekWriterTo interface {
+	io.Seeker
+	io.WriterTo
+}
+
+type panicOnNonWriterTo struct {
+	io.Reader
+	seekWriterTo
+}
+
+type panicOnWriterTo struct {
+	io.ReadSeeker
+	io.WriterTo
 }
 
 // Issue 12991


### PR DESCRIPTION
This small PR allows optimizations made in io.Copy (like the use of 
io.WriterTo) to be used in one possible path of http.ServeContent
(in case of a non-Range request).
This, in turn, allows us to skip the buffer allocation in io.Copy.