### PR TITLE
More specific error message when searching for module

### DIFF
--- a/src/cmd/go/internal/modload/import_test.go
+++ b/src/cmd/go/internal/modload/import_test.go
@@ -27,7 +27,8 @@ var importTests = []struct {
 	},
 	{
 		path: "golang.org/x/net",
-		err:  `module golang.org/x/net@.* found \(v[01]\.\d+\.\d+\), but does not contain package golang.org/x/net`,
+		err:  "module golang.org/x/net@.* found \(v[01]\.\d+\.\d+\), but does not contain package golang.org/x/net... " +
+		"no go files found, are you sure you have the correct import path?",
 	},
 	{
 		path: "golang.org/x/text",

--- a/src/cmd/go/internal/modload/query.go
+++ b/src/cmd/go/internal/modload/query.go
@@ -996,9 +996,17 @@ func (e *PackageNotInModuleError) Error() string {
 	}
 
 	if strings.Contains(e.Pattern, "...") {
-		return fmt.Sprintf("module %s@%s found%s, but does not contain packages matching %s", e.Mod.Path, e.Query, found, e.Pattern)
+		return fmt.Sprintf(
+			"module %s@%s found%s, but does not contain packages matching %s... "+
+				"no go files found, are you sure you have the correct import path?",
+			e.Mod.Path, e.Query, found, e.Pattern,
+		)
 	}
-	return fmt.Sprintf("module %s@%s found%s, but does not contain package %s", e.Mod.Path, e.Query, found, e.Pattern)
+	return fmt.Sprintf(
+		"module %s@%s found%s, but does not contain package %s... "+
+			"no go files found, are you sure you have the correct import path?",
+		e.Mod.Path, e.Query, found, e.Pattern,
+	)
 }
 
 func (e *PackageNotInModuleError) ImportPath() string {


### PR DESCRIPTION
Add a more specific error message when searching for a module that has no source .go files

Fixes https://github.com/golang/go/issues/39593

By implementing the extra error message suggested by @kstenerud 