### PR TITLE
net/http: deflake TestCancelRequestWhenSharingConnection

### DIFF
--- a/src/net/http/transport_test.go
+++ b/src/net/http/transport_test.go
@@ -6530,6 +6530,9 @@ func testCancelRequestWhenSharingConnection(t *testing.T, mode testMode) {
 		if !errors.Is(err, context.Canceled) {
 			t.Errorf("request 2: got err %v, want Canceled", err)
 		}
+
+		// Unblock the first request.
+		close(idlec)
 	}()
 
 	// Wait for the second request to arrive at the server, and then cancel
@@ -6537,9 +6540,7 @@ func testCancelRequestWhenSharingConnection(t *testing.T, mode testMode) {
 	r2c := <-reqc
 	cancel()
 
-	// Give the cancellation a moment to take effect, and then unblock the first request.
-	time.Sleep(1 * time.Millisecond)
-	close(idlec)
+	<-idlec
 
 	close(r2c)
 	wg.Wait()


### PR DESCRIPTION
The test sleeps for 1 millisecond to give the cancellation a moment
to take effect. This is flaky because the request can finish before
the cancellation of the context is seen. It's easy to verify by adding

    time.Sleep(2*time.Millisecond)

after https://github.com/golang/go/blob/0a6c4c87404ecb018faf002919e5d5db04c69ee2/src/net/http/transport.go#L2619.
With this modification, the test fails about 5 times out of 10 runs.

The fix is easy. We just need to block the handler of the second
request until this request is cancelled. I have verify that the
updated test can uncover the issue fixed by CL 257818.

Fixes #55226.