### PR TITLE
crypto/x509: remove unused member Raw from certificate

### DIFF
--- a/src/crypto/x509/x509.go
+++ b/src/crypto/x509/x509.go
@@ -141,7 +141,6 @@ func MarshalPKIXPublicKey(pub any) ([]byte, error) {
 // These structures reflect the ASN.1 structure of X.509 certificates.:
 
 type certificate struct {
-	Raw                asn1.RawContent
 	TBSCertificate     tbsCertificate
 	SignatureAlgorithm pkix.AlgorithmIdentifier
 	SignatureValue     asn1.BitString
@@ -1586,7 +1585,6 @@ func CreateCertificate(rand io.Reader, template, parent *Certificate, pub, priv 
 	}
 
 	signedCert, err := asn1.Marshal(certificate{
-		nil,
 		c,
 		signatureAlgorithm,
 		asn1.BitString{Bytes: signature, BitLength: len(signature) * 8},


### PR DESCRIPTION
As noticed in the review of the CRL RawIssuer updates (https://go-review.googlesource.com/c/go/+/418834), the Raw field on the internal type certificate of crypto/x509 is unused and could be removed.

From looking at encoding/asn1's implementation, it appears this field would be set on unmarshal but not during marshaling. However, we unmarshal into the x509.Certificate class directly, avoiding this internal class entirely.