### PR TITLE
crypto/x509: switch test to ParseRevocationList

### DIFF
--- a/src/crypto/x509/x509_test.go
+++ b/src/crypto/x509/x509_test.go
@@ -3504,13 +3504,12 @@ func TestDisableSHA1ForCertOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to generate test CRL: %s", err)
 	}
-	// TODO(rolandshoemaker): this should be ParseRevocationList once it lands
-	crl, err := ParseCRL(crlDER)
+	crl, err := ParseRevocationList(crlDER)
 	if err != nil {
 		t.Fatalf("failed to parse test CRL: %s", err)
 	}
 
-	if err = cert.CheckCRLSignature(crl); err != nil {
+	if err = crl.CheckSignatureFrom(cert); err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}
 


### PR DESCRIPTION
In following with Roland's TODO, switch TestDisableSHA1ForCertOnly to ParseRevocationList(...) over ParseCRL(...).
