### PR TITLE
net/http: convert URL credentials to Authorization header for js fetch

### DIFF
--- a/src/net/http/roundtrip_js.go
+++ b/src/net/http/roundtrip_js.go
@@ -90,6 +90,17 @@ func (t *Transport) RoundTrip(req *Request) (*Response, error) {
 			headers.Call("append", key, value)
 		}
 	}
+	// If the URL has credentials, convert to an Authorization header
+	url := *req.URL
+	if url.User != nil {
+		url.User = nil
+		if req.Header.Get("Authorization") == "" {
+			username := url.User.Username()
+			password, _ := url.User.Password()
+			authorization := "Basic " + basicAuth(username, password)
+			headers.Call("append", "Authorization", authorization)
+		}
+	}
 	opt.Set("headers", headers)
 
 	if req.Body != nil {
@@ -112,7 +123,7 @@ func (t *Transport) RoundTrip(req *Request) (*Response, error) {
 		}
 	}
 
-	fetchPromise := js.Global().Call("fetch", req.URL.String(), opt)
+	fetchPromise := js.Global().Call("fetch", url.String(), opt)
 	var (
 		respCh           = make(chan *Response, 1)
 		errCh            = make(chan error, 1)


### PR DESCRIPTION
The fetch JS API will refuse to accept URLs that contain credentials:

    > fetch("https://user:pass@example.com")
    TypeError: Failed to execute 'fetch' on 'Window': Request cannot be constructed from a URL that includes credentials

However the non-JS http.RoundTripper does accept URLs with credentials.
By converting the credentials to an Authorization header, we can have parity.
This header is added only if Authorization header is not already set.