### PR TITLE
runtime: remove 104 byte stack guard

### DIFF
--- a/src/runtime/asm_amd64.s
+++ b/src/runtime/asm_amd64.s
@@ -168,7 +168,7 @@ TEXT runtime·rt0_go(SB),NOSPLIT|TOPFRAME,$0
 	// create istack out of the given (operating system) stack.
 	// _cgo_init may update stackguard.
 	MOVQ	$runtime·g0(SB), DI
-	LEAQ	(-64*1024+104)(SP), BX
+	LEAQ	(-64*1024)(SP), BX
 	MOVQ	BX, g_stackguard0(DI)
 	MOVQ	BX, g_stackguard1(DI)
 	MOVQ	BX, (g_stack+stack_lo)(DI)


### PR DESCRIPTION
The number 104 appears to date back to the
first implementation of split stacks in
https://go.googlesource.com/go/+/b987f7a757f53f460973622a36eebb696f9b5060.
That change introduces a 104 byte stack guard.  
it doesn't makes any sense today. 