### PR TITLE
math: improve math.Log to handle subnormal floating number on amd64

### DIFF
--- a/src/math/all_test.go
+++ b/src/math/all_test.go
@@ -1511,6 +1511,27 @@ var logSC = []float64{
 	NaN(),
 }
 
+var vflogBC = []float64{
+	SmallestNonzeroFloat64,
+	LargestSubnormalFloat64,
+	SmallestNormalFloat64,
+	MaxFloat64,
+	-SmallestNonzeroFloat64,
+	-LargestSubnormalFloat64,
+	-SmallestNormalFloat64,
+	-MaxFloat64,
+}
+var logBC = []float64{
+	-744.4400719213812,
+	-708.3964185322641,
+	-708.3964185322641,
+	709.782712893384,
+	NaN(),
+	NaN(),
+	NaN(),
+	NaN(),
+}
+
 var vflogbSC = []float64{
 	Inf(-1),
 	0,
@@ -2715,6 +2736,12 @@ func TestLog(t *testing.T) {
 	for i := 0; i < len(vflogSC); i++ {
 		if f := Log(vflogSC[i]); !alike(logSC[i], f) {
 			t.Errorf("Log(%g) = %g, want %g", vflogSC[i], f, logSC[i])
+		}
+	}
+
+	for i := 0; i < len(vflogBC); i++ {
+		if f := Log(vflogBC[i]); !alike(logBC[i], f) {
+			t.Errorf("Log(%g) = %g, want %g", vflogBC[i], f, logBC[i])
 		}
 	}
 }


### PR DESCRIPTION
The existing implementation for math.Log on amd64/s390x, math/log_amd64.S,
doesn't normalize subnormal IEEE 64-bit floating point number correctly.
This only occurs on amd64/s390x. This commit add normalize logic to 
math/log_amd64.S.

Fixes #56600 