### PR TITLE
sync/atomic: disallow type conversions of atomic.Pointer[T]

### DIFF
--- a/src/sync/atomic/type.go
+++ b/src/sync/atomic/type.go
@@ -35,12 +35,18 @@ func b32(b bool) uint32 {
 	return 0
 }
 
+type noTypeConversion[T any] struct{}
+
 // For testing *Pointer[T]'s methods can be inlined.
 // Keep in sync with cmd/compile/internal/test/inl_test.go:TestIntendedInlining.
 var _ = &Pointer[int]{}
 
 // A Pointer is an atomic pointer of type *T. The zero value is a nil *T.
 type Pointer[T any] struct {
+	// We need this field to disallow type conversion.
+	// See issue golang/go#56603 for more details.
+	_ noTypeConversion[T]
+
 	_ noCopy
 	v unsafe.Pointer
 }

--- a/src/sync/atomic/type.go
+++ b/src/sync/atomic/type.go
@@ -44,7 +44,7 @@ var _ = &Pointer[int]{}
 // A Pointer is an atomic pointer of type *T. The zero value is a nil *T.
 type Pointer[T any] struct {
 	// We need this field to disallow type conversion.
-	// See issue golang/go#56603 for more details.
+	// See issue go.dev/issue/56603 for more details.
 	_ noTypeConversion[T]
 
 	_ noCopy

--- a/src/sync/atomic/type.go
+++ b/src/sync/atomic/type.go
@@ -42,6 +42,7 @@ var _ = &Pointer[int]{}
 // A Pointer is an atomic pointer of type *T. The zero value is a nil *T.
 type Pointer[T any] struct {
 	// Mention T in a field to disallow conversion between Pointer types.
+	// See go.dev/issue/56603 for more details.
 	_ [0]T
 
 	_ noCopy

--- a/src/sync/atomic/type.go
+++ b/src/sync/atomic/type.go
@@ -43,8 +43,7 @@ var _ = &Pointer[int]{}
 
 // A Pointer is an atomic pointer of type *T. The zero value is a nil *T.
 type Pointer[T any] struct {
-	// We need this field to disallow type conversion.
-	// See issue go.dev/issue/56603 for more details.
+	// Mention T in a field to disallow conversion between Pointer types.
 	_ noTypeConversion[T]
 
 	_ noCopy

--- a/src/sync/atomic/type.go
+++ b/src/sync/atomic/type.go
@@ -35,8 +35,6 @@ func b32(b bool) uint32 {
 	return 0
 }
 
-type noTypeConversion[T any] struct{}
-
 // For testing *Pointer[T]'s methods can be inlined.
 // Keep in sync with cmd/compile/internal/test/inl_test.go:TestIntendedInlining.
 var _ = &Pointer[int]{}
@@ -44,7 +42,7 @@ var _ = &Pointer[int]{}
 // A Pointer is an atomic pointer of type *T. The zero value is a nil *T.
 type Pointer[T any] struct {
 	// Mention T in a field to disallow conversion between Pointer types.
-	_ noTypeConversion[T]
+	_ [0]T
 
 	_ noCopy
 	v unsafe.Pointer


### PR DESCRIPTION
Fixes #56603