### PR TITLE
os: remove read-only directories in Remove on Windows

### DIFF
--- a/src/os/file_windows.go
+++ b/src/os/file_windows.go
@@ -245,9 +245,20 @@ func Remove(name string) error {
 	if e == nil {
 		return nil
 	}
+
 	e1 := syscall.RemoveDirectory(p)
 	if e1 == nil {
 		return nil
+	} else {
+		//Empty directories with "read-only" attribute on Windows can cause issues so we have to try with chmod to remove it
+		a, e2 := syscall.GetFileAttributes(p)
+		if e2 == nil && a&syscall.FILE_ATTRIBUTE_DIRECTORY != 0 && IsPermission(e1) {
+			if fs, err := Stat(fixLongPath(name)); err == nil {
+				if err = Chmod(fixLongPath(name), FileMode(0200|int(fs.Mode()))); err == nil {
+					e1 = syscall.RemoveDirectory(p)
+				}
+			}
+		}
 	}
 
 	// Both failed: figure out which error to return.


### PR DESCRIPTION
Allows Remove to remove directory with read-only attribute in Windows

Fixes #26295

(Read-only attribute in Windows doesn't prevent users to delete a directory, it is just used to know if the folder has custom icon or other custom properties)

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
