### PR TITLE
runtime: fix comments for physPageSize

### DIFF
--- a/src/runtime/malloc.go
+++ b/src/runtime/malloc.go
@@ -329,7 +329,7 @@ const (
 // Mapping and unmapping operations must be done at multiples of
 // physPageSize.
 //
-// This must be set by the OS init code (typically in osinit) before
+// This must be set by the OS init code (typically in args) before
 // mallocinit.
 var physPageSize uintptr
 

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -664,6 +664,7 @@ func cpuinit() {
 
 // The bootstrap sequence is:
 //
+//	call args
 //	call osinit
 //	call schedinit
 //	make & queue new G


### PR DESCRIPTION
physPageSize is initialized in runtime.args()