### PR TITLE
cmd: fix wrong function names in comments, fix typos

### DIFF
--- a/src/cmd/compile/internal/abt/avlint32.go
+++ b/src/cmd/compile/internal/abt/avlint32.go
@@ -37,12 +37,12 @@ func makeNode(key int32) *node32 {
 	return &node32{key: key, height_: LEAF_HEIGHT}
 }
 
-// IsSingle returns true iff t is empty.
+// IsEmpty returns true if t is empty.
 func (t *T) IsEmpty() bool {
 	return t.root == nil
 }
 
-// IsSingle returns true iff t is a singleton (leaf).
+// IsSingle returns true if t is a singleton (leaf).
 func (t *T) IsSingle() bool {
 	return t.root != nil && t.root.isLeaf()
 }

--- a/src/cmd/compile/internal/pkginit/initAsanGlobals.go
+++ b/src/cmd/compile/internal/pkginit/initAsanGlobals.go
@@ -189,7 +189,7 @@ func createtypes() (*types.Type, *types.Type, *types.Type) {
 	return asanGlobal, asanLocation, defString
 }
 
-// Calculate redzone for globals.
+// GetRedzoneSizeForGlobal calculates redzone for globals.
 func GetRedzoneSizeForGlobal(size int64) int64 {
 	maxRZ := int64(1 << 18)
 	minRZ := int64(32)

--- a/src/cmd/go/internal/script/cmds.go
+++ b/src/cmd/go/internal/script/cmds.go
@@ -981,7 +981,7 @@ func Stop() Cmd {
 		})
 }
 
-// stoperr is the sentinel error type returned by the Stop command.
+// stopError is the sentinel error type returned by the Stop command.
 type stopError struct {
 	msg string
 }


### PR DESCRIPTION
Fixed typos and incorrect function names in comments.