### PR TITLE
os/exec: fix TestWaitInterrupt/WaitDelay error message

### DIFF
--- a/src/os/exec/exec_test.go
+++ b/src/os/exec/exec_test.go
@@ -1357,7 +1357,7 @@ func TestWaitInterrupt(t *testing.T) {
 		// context expired, a successful exit is valid (even if late) and does
 		// not merit a non-nil error.
 		if err != nil {
-			t.Errorf("Wait: %v; want %v", err, ctx.Err())
+			t.Errorf("Wait: %v; want nil", err)
 		}
 		if ps := cmd.ProcessState; !ps.Exited() {
 			t.Errorf("cmd did not exit: %v", ps)


### PR DESCRIPTION
As the comments say. Here we expect err to be nil instead of ctx.Err()