### PR TITLE
go/doc: fix example generation for package prefixed with go-

### DIFF
--- a/src/go/doc/example.go
+++ b/src/go/doc/example.go
@@ -238,6 +238,9 @@ func playExample(file *ast.File, f *ast.FuncDecl) *ast.File {
 				// We can't resolve dot imports (yet).
 				return nil
 			}
+		} else {
+			// Trim 'go-' prefix from package name (like done at runtime) to ensure match
+			n = strings.TrimPrefix(n, "go-")
 		}
 		if unresolved[n] {
 			// Copy the spec and its path to avoid modifying the original.

--- a/src/go/doc/testdata/examples/issue56740.go
+++ b/src/go/doc/testdata/examples/issue56740.go
@@ -1,0 +1,17 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package foo_test
+
+import (
+	"fmt"
+
+	"github.com/xxx/go-foo"
+)
+
+func ExampleMyMethod() {
+	fmt.Println(foo.MyMethod())
+	// Output:
+	// expected output
+}

--- a/src/go/doc/testdata/examples/issue56740.golden
+++ b/src/go/doc/testdata/examples/issue56740.golden
@@ -1,0 +1,14 @@
+-- MyMethod.Play --
+package main
+
+import (
+	"fmt"
+
+	"github.com/xxx/go-foo"
+)
+
+func main() {
+	fmt.Println(foo.MyMethod())
+}
+-- MyMethod.Output --
+expected output


### PR DESCRIPTION
Trim go- prefix from package name (like it's done on runtime) before looking for related unresolved package.

Fixes #56740
