### PR TITLE
net: return errNoSuchHost when no entry found in /etc/hosts and order is hostLookupFiles

### DIFF
--- a/src/net/conf_test.go
+++ b/src/net/conf_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+//go:build !js
 
 package net
 

--- a/src/net/conf_test.go
+++ b/src/net/conf_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !js
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || aix
 
 package net
 

--- a/src/net/conf_test.go
+++ b/src/net/conf_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || aix
+//go:build unix
 
 package net
 

--- a/src/net/dnsclient_unix.go
+++ b/src/net/dnsclient_unix.go
@@ -556,8 +556,12 @@ func (r *Resolver) goLookupHostOrder(ctx context.Context, name string, order hos
 	if order == hostLookupFilesDNS || order == hostLookupFiles {
 		// Use entries from /etc/hosts if they match.
 		addrs, _ = lookupStaticHost(name)
-		if len(addrs) > 0 || order == hostLookupFiles {
+		if len(addrs) > 0 {
 			return
+		}
+
+		if order == hostLookupFiles {
+			return nil, &DNSError{Err: errNoSuchHost.Error(), Name: name, IsNotFound: true}
 		}
 	}
 	ips, _, err := r.goLookupIPCNAMEOrder(ctx, "ip", name, order, conf)

--- a/src/net/dnsclient_unix_test.go
+++ b/src/net/dnsclient_unix_test.go
@@ -2529,7 +2529,7 @@ func TestLookupOrderFilesNoSuchHost(t *testing.T) {
 
 	resolvConf := dnsConfig{servers: defaultNS}
 	if runtime.GOOS == "openbsd" {
-		// Set error to ErrNotExist, so the hostLookupOrder
+		// Set error to ErrNotExist, so that the hostLookupOrder
 		// returns hostLookupFiles for openbsd.
 		resolvConf.err = fs.ErrNotExist
 	}

--- a/src/net/dnsclient_unix_test.go
+++ b/src/net/dnsclient_unix_test.go
@@ -2551,6 +2551,7 @@ func TestLookupOrderFilesNoSuchHost(t *testing.T) {
 
 	order, _ := systemConf().hostLookupOrder(DefaultResolver, testName)
 	if order != hostLookupFiles {
+		// skip test for systems which do not return hostLookupFiles
 		t.Skipf("hostLookupOrder did not return hostLookupFiles")
 	}
 

--- a/src/net/dnsclient_unix_test.go
+++ b/src/net/dnsclient_unix_test.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -2531,7 +2530,7 @@ func TestLookupOrderFilesNoSuchHost(t *testing.T) {
 	if runtime.GOOS == "openbsd" {
 		// Set error to ErrNotExist, so that the hostLookupOrder
 		// returns hostLookupFiles for openbsd.
-		resolvConf.err = fs.ErrNotExist
+		resolvConf.err = os.ErrNotExist
 	}
 
 	if !conf.forceUpdateConf(&resolvConf, time.Now().Add(time.Hour)) {
@@ -2539,12 +2538,9 @@ func TestLookupOrderFilesNoSuchHost(t *testing.T) {
 	}
 
 	tmpFile := filepath.Join(t.TempDir(), "hosts")
-	f, err := os.OpenFile(tmpFile, os.O_CREATE|os.O_WRONLY, 0660)
-	if err != nil {
+	if err := os.WriteFile(tmpFile, []byte{}, 0660); err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
-
 	testHookHostsPath = tmpFile
 
 	const testName = "test.invalid"

--- a/src/net/dnsclient_unix_test.go
+++ b/src/net/dnsclient_unix_test.go
@@ -2547,6 +2547,13 @@ func TestLookupOrderFilesNoSuchHost(t *testing.T) {
 
 	testHookHostsPath = tmpFile
 
+	const testName = "test.invalid"
+
+	order, _ := systemConf().hostLookupOrder(DefaultResolver, testName)
+	if order != hostLookupFiles {
+		t.Skipf("hostLookupOrder did not return hostLookupFiles")
+	}
+
 	var lookupTests = []struct {
 		name   string
 		lookup func(name string) error
@@ -2582,14 +2589,14 @@ func TestLookupOrderFilesNoSuchHost(t *testing.T) {
 	}
 
 	for _, v := range lookupTests {
-		err := v.lookup("test.invalid")
+		err := v.lookup(testName)
 
 		if err == nil {
 			t.Errorf("Lookup%v: unexpected success", v.name)
 			continue
 		}
 
-		expectedErr := DNSError{Err: errNoSuchHost.Error(), Name: "test.invalid", IsNotFound: true}
+		expectedErr := DNSError{Err: errNoSuchHost.Error(), Name: testName, IsNotFound: true}
 		var dnsErr *DNSError
 		errors.As(err, &dnsErr)
 		if dnsErr == nil || *dnsErr != expectedErr {

--- a/src/net/dnsclient_unix_test.go
+++ b/src/net/dnsclient_unix_test.go
@@ -2518,7 +2518,7 @@ func TestLookupOrderFilesNoSuchHost(t *testing.T) {
 	defer func(orig string) { testHookHostsPath = orig }(testHookHostsPath)
 	if runtime.GOOS != "openbsd" {
 		defer setSystemNSS(getSystemNSS(), 0)
-		setSystemNSS(nssStr("hosts: files"), time.Hour)
+		setSystemNSS(nssStr(t, "hosts: files"), time.Hour)
 	}
 
 	conf, err := newResolvConfTest()

--- a/src/net/hosts.go
+++ b/src/net/hosts.go
@@ -101,7 +101,7 @@ func readHosts() {
 
 			is[addr] = append(is[addr], name)
 
-			if v,ok := hs[key]; ok {
+			if v, ok := hs[key]; ok {
 				hs[key] = byName{
 					addrs:         append(v.addrs, addr),
 					canonicalName: v.canonicalName,

--- a/src/net/hosts.go
+++ b/src/net/hosts.go
@@ -101,7 +101,7 @@ func readHosts() {
 
 			is[addr] = append(is[addr], name)
 
-			if v, ok := hs[key]; ok {
+			if v,ok := hs[key]; ok {
 				hs[key] = byName{
 					addrs:         append(v.addrs, addr),
 					canonicalName: v.canonicalName,


### PR DESCRIPTION
When /etc/nsswitch.conf lists: "hosts: files" then LookupHost returns two nils when no entry inside /etc/hosts is found.