### PR TITLE
net: call getSystemDNSConfig inside lookupWithFake to avoid nil dereference panic when running tests alone

### DIFF
--- a/src/net/dnsclient_unix_test.go
+++ b/src/net/dnsclient_unix_test.go
@@ -1440,7 +1440,7 @@ func TestDNSGoroutineRace(t *testing.T) {
 func lookupWithFake(fake fakeDNSServer, name string, typ dnsmessage.Type) error {
 	r := Resolver{PreferGo: true, Dial: fake.DialContext}
 
-	conf := resolvConf.dnsConfig.Load()
+	conf := getSystemDNSConfig()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
It happens with tests that only call lookupWithFake, and before them no-one calls resolverConf.tryUpdate. running alone one of these: TestIssue8434, TestIssueNoSuchHostExists cause a nil dereference panic.