### PR TITLE
os/user: make Windows user lookup treat well-known groups as valid ac…

### DIFF
--- a/src/os/user/lookup_windows.go
+++ b/src/os/user/lookup_windows.go
@@ -84,13 +84,19 @@ func getProfilesDirectory() (string, error) {
 	}
 }
 
+// isValidUserAccountType returns true if acctType is a valid type for user accounts.
+func isValidUserAccountType(acctType uint32) bool {
+	// Some built-in system accounts are classified as well-known groups instead of users.
+	return acctType == syscall.SidTypeUser || acctType == syscall.SidTypeWellKnownGroup
+}
+
 // lookupUsernameAndDomain obtains the username and domain for usid.
 func lookupUsernameAndDomain(usid *syscall.SID) (username, domain string, e error) {
 	username, domain, t, e := usid.LookupAccount("")
 	if e != nil {
 		return "", "", e
 	}
-	if t != syscall.SidTypeUser {
+	if !isValidUserAccountType(t) {
 		return "", "", fmt.Errorf("user: should be user account type, not %d", t)
 	}
 	return username, domain, nil
@@ -324,7 +330,7 @@ func lookupUser(username string) (*User, error) {
 	if e != nil {
 		return nil, e
 	}
-	if t != syscall.SidTypeUser {
+	if !isValidUserAccountType(t) {
 		return nil, fmt.Errorf("user: should be user account type, not %d", t)
 	}
 	return newUserFromSid(sid)

--- a/src/os/user/lookup_windows_test.go
+++ b/src/os/user/lookup_windows_test.go
@@ -1,0 +1,17 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package user
+
+import (
+	"testing"
+)
+
+func TestLookupLocalSystem(t *testing.T) {
+	// The string representation of the SID for `NT AUTHORITY\SYSTEM`
+	const localSystemSID = "S-1-5-18"
+	if _, err := LookupId(localSystemSID); err != nil {
+		t.Fatalf("LookupId(%q): %v", localSystemSID, err)
+	}
+}


### PR DESCRIPTION
…counts

This change modifies account querying to consider both syscall.SidTypeUser and syscall.SidTypeWellKnownGroup types to be valid for user accounts.

Some built-in Windows accounts such as 'NT AUTHORITY\SYSTEM' are treated by the OS as users, but are internally classified by the OS as syscall.SidTypeWellKnownGroup instead of syscall.SidTypeUser.

Fixes #49509