### PR TITLE
image/jpeg: return io.ErrUnexpectedEOF on truncated data

### DIFF
--- a/src/image/jpeg/huffman.go
+++ b/src/image/jpeg/huffman.go
@@ -49,7 +49,7 @@ func (d *decoder) ensureNBits(n int32) error {
 	for {
 		c, err := d.readByteStuffedByte()
 		if err != nil {
-			if err == io.EOF {
+			if err == io.ErrUnexpectedEOF {
 				return errShortHuffmanData
 			}
 			return err

--- a/src/image/jpeg/reader.go
+++ b/src/image/jpeg/reader.go
@@ -164,7 +164,10 @@ func (d *decoder) fill() error {
 	n, err := d.r.Read(d.bytes.buf[d.bytes.j:])
 	d.bytes.j += n
 	if n > 0 {
-		err = nil
+		return nil
+	}
+	if err == io.EOF {
+		err = io.ErrUnexpectedEOF
 	}
 	return err
 }
@@ -261,9 +264,6 @@ func (d *decoder) readFull(p []byte) error {
 			break
 		}
 		if err := d.fill(); err != nil {
-			if err == io.EOF {
-				err = io.ErrUnexpectedEOF
-			}
 			return err
 		}
 	}
@@ -291,9 +291,6 @@ func (d *decoder) ignore(n int) error {
 			break
 		}
 		if err := d.fill(); err != nil {
-			if err == io.EOF {
-				err = io.ErrUnexpectedEOF
-			}
 			return err
 		}
 	}

--- a/src/image/jpeg/reader_test.go
+++ b/src/image/jpeg/reader_test.go
@@ -490,6 +490,20 @@ func TestExtraneousData(t *testing.T) {
 	}
 }
 
+func TestIssue56724(t *testing.T) {
+	b, err := os.ReadFile("../testdata/video-001.jpeg")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b = b[:24] // truncate image data
+
+	_, err = Decode(bytes.NewReader(b))
+	if err != io.ErrUnexpectedEOF {
+		t.Errorf("got: %v, want: %v", err, io.ErrUnexpectedEOF)
+	}
+}
+
 func benchmarkDecode(b *testing.B, filename string) {
 	data, err := os.ReadFile(filename)
 	if err != nil {


### PR DESCRIPTION
Decoder calls fill from readFull, ignore and readByte and
readByte did not check returned io.EOF.

This change moves io.EOF translation inside fill.

name                 old speed      new speed      delta
DecodeBaseline-8     67.4MB/s ± 0%  67.3MB/s ± 0%  -0.20%  (p=0.000 n=16+19)
DecodeProgressive-8  43.7MB/s ± 0%  43.6MB/s ± 0%  -0.06%  (p=0.013 n=17+19)

Fixes #56724