### PR TITLE
regexp: add explicit test for bytes version of match function

### DIFF
--- a/src/regexp/all_test.go
+++ b/src/regexp/all_test.go
@@ -107,6 +107,11 @@ func matchFunctionTest(t *testing.T, test *FindTest) {
 	if m != (len(test.matches) > 0) {
 		t.Errorf("Match failure on %s: %t should be %t", test, m, len(test.matches) > 0)
 	}
+	// now try bytes
+	m, err = Match(test.pat, []byte(test.text))
+	if m != (len(test.matches) > 0) {
+		t.Errorf("Match failure on %s: %t should be %t", test, m, len(test.matches) > 0)
+	}
 }
 
 func TestMatchFunction(t *testing.T) {


### PR DESCRIPTION
TestMatchFunction seems to be an analogue to TestMatch using the 
uncompiled functions instead of methods on compiled expressions.
It is missing the bytes version, though, and while that is covered
indirectly by other tests, it should be good to explicitly cover it here
and make the two tests behave symmetrically.