### PR TITLE
net: retry with bigger buffer in resSearch

### DIFF
--- a/src/net/cgo_unix.go
+++ b/src/net/cgo_unix.go
@@ -367,7 +367,6 @@ func resSearch(ctx context.Context, hostname string, rtype, class int) ([]dnsmes
 		_C_free(unsafe.Pointer(buf))
 		bufSize = size
 		buf = (*_C_uchar)(_C_malloc(uintptr(bufSize)))
-		continue
 	}
 
 	var p dnsmessage.Parser

--- a/src/net/cgo_unix.go
+++ b/src/net/cgo_unix.go
@@ -14,7 +14,6 @@ package net
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math"
 	"syscall"
 	"unsafe"
@@ -356,11 +355,8 @@ func resSearch(ctx context.Context, hostname string, rtype, class int) ([]dnsmes
 	defer _C_FreeCString(s)
 
 	for {
-		size, err := _C_res_nsearch(state, s, class, rtype, buf, bufSize)
+		size, _ := _C_res_nsearch(state, s, class, rtype, buf, bufSize)
 		if size <= 0 {
-			if err != nil {
-				return nil, fmt.Errorf("res_nsearch failure: %v", err)
-			}
 			return nil, errors.New("res_nsearch failure")
 		}
 		if size <= bufSize {

--- a/src/net/cgo_unix.go
+++ b/src/net/cgo_unix.go
@@ -14,7 +14,6 @@ package net
 import (
 	"context"
 	"errors"
-	"math"
 	"syscall"
 	"unsafe"
 
@@ -356,7 +355,7 @@ func resSearch(ctx context.Context, hostname string, rtype, class int) ([]dnsmes
 
 	for {
 		size, _ := _C_res_nsearch(state, s, class, rtype, buf, bufSize)
-		if size <= 0 || size > math.MaxUint16 {
+		if size <= 0 || size > 0xffff {
 			return nil, errors.New("res_nsearch failure")
 		}
 		if size <= bufSize {


### PR DESCRIPTION
Glibc returns size > bufSize, when the entire dns reply does not fit inside the provided buffer.