### PR TITLE
net: report completed when context is done in cgoLookupIP and cgoLookupPTR

### DIFF
--- a/src/net/cgo_unix.go
+++ b/src/net/cgo_unix.go
@@ -262,7 +262,7 @@ func cgoLookupPTR(ctx context.Context, addr string) (names []string, err error, 
 	case r := <-result:
 		return r.names, r.err, true
 	case <-ctx.Done():
-		return nil, mapErr(ctx.Err()), false
+		return nil, mapErr(ctx.Err()), true
 	}
 }
 

--- a/src/net/cgo_unix.go
+++ b/src/net/cgo_unix.go
@@ -222,7 +222,7 @@ func cgoLookupIP(ctx context.Context, network, name string) (addrs []IPAddr, err
 	case r := <-result:
 		return r.addrs, r.err, true
 	case <-ctx.Done():
-		return nil, mapErr(ctx.Err()), false
+		return nil, mapErr(ctx.Err()), true
 	}
 }
 


### PR DESCRIPTION
All the Lookup* methods that resolve hostnames eventually call lookupIP 
or lookupHost method. When the order is selected to be hostLookupCGO
then lookupHost calls cgoLookupHost which internally calls cgoLookupIP 
(the lookupIP directly calls cgoLookupIP).  
When we provide a context that is cancelled after cgo call, then the 
cgoLookupIP returns completed  == false, which caues the
lookupIP/lookupHost to fallback to the go resolver. 
This fallback is unnecessary because our context is already cancelled.

The same thing can happen to LookupAddr.