### PR TITLE
net: support context cancellation in resSearch

### DIFF
--- a/src/net/cgo_unix.go
+++ b/src/net/cgo_unix.go
@@ -331,6 +331,33 @@ func cgoLookupCNAME(ctx context.Context, name string) (cname string, err error, 
 // resSearch will make a call to the 'res_nsearch' routine in the C library
 // and parse the output as a slice of DNS resources.
 func resSearch(ctx context.Context, hostname string, rtype, class int) ([]dnsmessage.Resource, error) {
+	if ctx.Done() == nil {
+		return cgoResSearch(hostname, rtype, class)
+	}
+
+	type result struct {
+		err error
+		res []dnsmessage.Resource
+	}
+
+	res := make(chan result, 1)
+	go func() {
+		r, err := cgoResSearch(hostname, rtype, class)
+		res <- result{
+			err: err,
+			res: r,
+		}
+	}()
+
+	select {
+	case res := <-res:
+		return res.res, res.err
+	case <-ctx.Done():
+		return nil, mapErr(ctx.Err())
+	}
+}
+
+func cgoResSearch(hostname string, rtype, class int) ([]dnsmessage.Resource, error) {
 	acquireThread()
 	defer releaseThread()
 

--- a/src/net/cgo_unix.go
+++ b/src/net/cgo_unix.go
@@ -336,16 +336,16 @@ func resSearch(ctx context.Context, hostname string, rtype, class int) ([]dnsmes
 	}
 
 	type result struct {
-		err error
 		res []dnsmessage.Resource
+		err error
 	}
 
 	res := make(chan result, 1)
 	go func() {
 		r, err := cgoResSearch(hostname, rtype, class)
 		res <- result{
-			err: err,
 			res: r,
+			err: err,
 		}
 	}()
 


### PR DESCRIPTION
As with all the stuff that call cgo from net package.