### PR TITLE
os: update name <dirinfo> field in struct file to <dirInfo>

### DIFF
--- a/src/os/dir_darwin.go
+++ b/src/os/dir_darwin.go
@@ -25,16 +25,16 @@ func (d *dirInfo) close() {
 }
 
 func (f *File) readdir(n int, mode readdirMode) (names []string, dirents []DirEntry, infos []FileInfo, err error) {
-	if f.dirinfo == nil {
+	if f.dirInfo == nil {
 		dir, call, errno := f.pfd.OpenDir()
 		if errno != nil {
 			return nil, nil, nil, &PathError{Op: call, Path: f.name, Err: errno}
 		}
-		f.dirinfo = &dirInfo{
+		f.dirInfo = &dirInfo{
 			dir: dir,
 		}
 	}
-	d := f.dirinfo
+	d := f.dirInfo
 
 	size := n
 	if size <= 0 {

--- a/src/os/dir_plan9.go
+++ b/src/os/dir_plan9.go
@@ -10,11 +10,11 @@ import (
 )
 
 func (file *File) readdir(n int, mode readdirMode) (names []string, dirents []DirEntry, infos []FileInfo, err error) {
-	// If this file has no dirinfo, create one.
-	if file.dirinfo == nil {
-		file.dirinfo = new(dirInfo)
+	// If this file has no dirInfo, create one.
+	if file.dirInfo == nil {
+		file.dirInfo = new(dirInfo)
 	}
-	d := file.dirinfo
+	d := file.dirInfo
 	size := n
 	if size <= 0 {
 		size = 100

--- a/src/os/dir_unix.go
+++ b/src/os/dir_unix.go
@@ -42,12 +42,12 @@ func (d *dirInfo) close() {
 }
 
 func (f *File) readdir(n int, mode readdirMode) (names []string, dirents []DirEntry, infos []FileInfo, err error) {
-	// If this file has no dirinfo, create one.
-	if f.dirinfo == nil {
-		f.dirinfo = new(dirInfo)
-		f.dirinfo.buf = dirBufPool.Get().(*[]byte)
+	// If this file has no dirInfo, create one.
+	if f.dirInfo == nil {
+		f.dirInfo = new(dirInfo)
+		f.dirInfo.buf = dirBufPool.Get().(*[]byte)
 	}
-	d := f.dirinfo
+	d := f.dirInfo
 
 	// Change the meaning of n for the implementation below.
 	//

--- a/src/os/dir_windows.go
+++ b/src/os/dir_windows.go
@@ -11,11 +11,11 @@ import (
 )
 
 func (file *File) readdir(n int, mode readdirMode) (names []string, dirents []DirEntry, infos []FileInfo, err error) {
-	// If this file has no dirinfo, create one.
+	// If this file has no dirInfo, create one.
 	needdata := true
-	if file.dirinfo == nil {
+	if file.dirInfo == nil {
 		needdata = false
-		file.dirinfo, err = openDir(file.name)
+		file.dirInfo, err = openDir(file.name)
 		if err != nil {
 			err = &PathError{Op: "readdir", Path: file.name, Err: err}
 			return
@@ -25,10 +25,10 @@ func (file *File) readdir(n int, mode readdirMode) (names []string, dirents []Di
 	if wantAll {
 		n = -1
 	}
-	d := &file.dirinfo.data
-	for n != 0 && !file.dirinfo.isempty {
+	d := &file.dirInfo.data
+	for n != 0 && !file.dirInfo.isempty {
 		if needdata {
-			e := syscall.FindNextFile(file.dirinfo.h, d)
+			e := syscall.FindNextFile(file.dirInfo.h, d)
 			runtime.KeepAlive(file)
 			if e != nil {
 				if e == syscall.ERROR_NO_MORE_FILES {
@@ -49,7 +49,7 @@ func (file *File) readdir(n int, mode readdirMode) (names []string, dirents []Di
 		} else {
 			f := newFileStatFromWin32finddata(d)
 			f.name = name
-			f.path = file.dirinfo.path
+			f.path = file.dirInfo.path
 			f.appendNameToPath = true
 			if mode == readdirDirEntry {
 				dirents = append(dirents, dirEntry{f})

--- a/src/os/file.go
+++ b/src/os/file.go
@@ -230,7 +230,7 @@ func (f *File) Seek(offset int64, whence int) (ret int64, err error) {
 		return 0, err
 	}
 	r, e := f.seek(offset, whence)
-	if e == nil && f.dirinfo != nil && r != 0 {
+	if e == nil && f.dirInfo != nil && r != 0 {
 		e = syscall.EISDIR
 	}
 	if e != nil {

--- a/src/os/file_plan9.go
+++ b/src/os/file_plan9.go
@@ -344,10 +344,10 @@ func (f *File) seek(offset int64, whence int) (ret int64, err error) {
 		return 0, err
 	}
 	defer f.decref()
-	if f.dirinfo != nil {
-		// Free cached dirinfo, so we allocate a new one if we
+	if f.dirInfo != nil {
+		// Free cached dirInfo, so we allocate a new one if we
 		// access this file as a directory again. See #35767 and #37161.
-		f.dirinfo = nil
+		f.dirInfo = nil
 	}
 	return syscall.Seek(f.fd, offset, whence)
 }

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -54,7 +54,7 @@ func rename(oldname, newname string) error {
 type file struct {
 	pfd         poll.FD
 	name        string
-	dirinfo     *dirInfo // nil unless directory being read
+	dirInfo     *dirInfo // nil unless directory being read
 	nonblock    bool     // whether we set nonblocking mode
 	stdoutOrErr bool     // whether this is stdout or stderr
 	appendMode  bool     // whether file is opened for appending
@@ -254,9 +254,9 @@ func (file *file) close() error {
 	if file == nil {
 		return syscall.EINVAL
 	}
-	if file.dirinfo != nil {
-		file.dirinfo.close()
-		file.dirinfo = nil
+	if file.dirInfo != nil {
+		file.dirInfo.close()
+		file.dirInfo = nil
 	}
 	var err error
 	if e := file.pfd.Close(); e != nil {
@@ -276,11 +276,11 @@ func (file *file) close() error {
 // relative to the current offset, and 2 means relative to the end.
 // It returns the new offset and an error, if any.
 func (f *File) seek(offset int64, whence int) (ret int64, err error) {
-	if f.dirinfo != nil {
-		// Free cached dirinfo, so we allocate a new one if we
+	if f.dirInfo != nil {
+		// Free cached dirInfo, so we allocate a new one if we
 		// access this file as a directory again. See #35767 and #37161.
-		f.dirinfo.close()
-		f.dirinfo = nil
+		f.dirInfo.close()
+		f.dirInfo = nil
 	}
 	ret, err = f.pfd.Seek(offset, whence)
 	runtime.KeepAlive(f)

--- a/src/os/file_windows.go
+++ b/src/os/file_windows.go
@@ -214,11 +214,11 @@ func (file *file) close() error {
 // relative to the current offset, and 2 means relative to the end.
 // It returns the new offset and an error, if any.
 func (f *File) seek(offset int64, whence int) (ret int64, err error) {
-	if f.dirinfo != nil {
-		// Free cached dirinfo, so we allocate a new one if we
+	if f.dirInfo != nil {
+		// Free cached dirInfo, so we allocate a new one if we
 		// access this file as a directory again. See #35767 and #37161.
-		f.dirinfo.close()
-		f.dirinfo = nil
+		f.dirInfo.close()
+		f.dirInfo = nil
 	}
 	ret, err = f.pfd.Seek(offset, whence)
 	runtime.KeepAlive(f)


### PR DESCRIPTION
In Go, the naming convention is camelCase, which is used for variables, consts, struct fields, etc..., <dirinfo> is a private field in the file struct, so it should be changed to <dirInfo> to be consistent with the effective Go naming convention.
