### PR TITLE
database/sql: add configuration option to ignore null values in Scan

### DIFF
--- a/src/database/sql/convert.go
+++ b/src/database/sql/convert.go
@@ -212,9 +212,8 @@ func convertAssign(dest, src any) error {
 	return convertAssignRows(dest, src, nil)
 }
 
-// coalesceNullValuesToZero determines whether to interpret null values from SQL as the
-// equivalent zero value in go
-var coalesceNullValuesToZero = false
+// ignoreNullValues determines whether to ignore null values in SQL
+var ignoreNullValues = false
 
 // convertAssignRows copies to dest the value in src, converting it if possible.
 // An error is returned if the copy would result in loss of information.
@@ -319,15 +318,8 @@ func convertAssignRows(dest, src any, rows *Rows) error {
 			*d = nil
 			return nil
 		default:
-			if coalesceNullValuesToZero {
-				dpv := reflect.ValueOf(d)
-				if dpv.Kind() == reflect.Pointer {
-					dv := reflect.Indirect(dpv)
-					dv.Set(reflect.Zero(dv.Type()))
-					return nil
-				} else {
-					return errors.New("destination not a pointer")
-				}
+			if ignoreNullValues {
+				return nil
 			}
 		}
 	// The driver is returning a cursor the client may iterate over.

--- a/src/database/sql/sql_test.go
+++ b/src/database/sql/sql_test.go
@@ -1496,6 +1496,8 @@ func TestCursorFake(t *testing.T) {
 }
 
 func TestInvalidNilValues(t *testing.T) {
+	coalesceNullValuesToZero = false
+
 	var date1 time.Time
 	var date2 int
 
@@ -1536,6 +1538,90 @@ func TestInvalidNilValues(t *testing.T) {
 			}
 			if err.Error() != tt.expectedError {
 				t.Fatalf("Expected error: %s\nReceived: %s", tt.expectedError, err.Error())
+			}
+
+			err = conn.PingContext(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestValidNilValues(t *testing.T) {
+	coalesceNullValuesToZero = true
+
+	var date1 time.Time
+	var int1 int
+	var float1 float64
+	var uint1 uint
+	var string1 string
+	var bool1 bool
+	type testStruct struct {
+		name string
+	}
+	var struct1 testStruct
+	var int2 int
+	int2 = 17
+
+	tests := []struct {
+		name  string
+		input any
+	}{
+		{
+			name:  "date",
+			input: &date1,
+		},
+		{
+			name:  "int",
+			input: &int1,
+		},
+		{
+			name:  "initialized int",
+			input: &int2,
+		},
+		{
+			name:  "float",
+			input: &float1,
+		},
+		{
+			name:  "uint",
+			input: &uint1,
+		},
+		{
+			name:  "string",
+			input: &string1,
+		},
+		{
+			name:  "bool",
+			input: &bool1,
+		},
+		{
+			name:  "struct",
+			input: &struct1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := newTestDB(t, "people")
+			defer closeDB(t, db)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			conn, err := db.Conn(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			conn.dc.ci.(*fakeConn).skipDirtySession = true
+			defer conn.Close()
+
+			zeroVal := reflect.Zero(reflect.Indirect(reflect.ValueOf(tt.input)).Type())
+			err = conn.QueryRowContext(ctx, "SELECT|people|bdate|age=?", 1).Scan(tt.input)
+			if err != nil {
+				t.Fatalf("expected no error when querying nil column, but get %s", err.Error())
+			} else if !reflect.Indirect(reflect.ValueOf(tt.input)).Equal(zeroVal) {
+				t.Fatalf("expected scan to coalesce to zero value %v, but got %v", zeroVal, reflect.Indirect(reflect.ValueOf(tt.input)))
 			}
 
 			err = conn.PingContext(ctx)


### PR DESCRIPTION
Fixes https://github.com/golang/go/issues/28414

Currently, when scanning a NULL database value into a go type that is not nil-able, this package throws an error like "sql: Scan error on column index 0, name "foo": converting NULL to int is unsupported". This makes logical sense; nil and 0 are different values, and only the latter can be assigned to an int. The Null* types (NullString, NullInt, etc) account for this difference, giving programmers the ability to safely bridge the gap between nullable SQL values and primitive go types.

I propose we give programmers the option to change that behavior and instead ignore NULL values. There are a few reasons I think this option makes sense:
Alignment with programmer intent

In go, if I want a struct field with a string field, I would write type foo struct{ bar string }
In mysql, if I want a table with a string column, I would write CREATE TABLE foo (bar varchar(255));

But this produces incompatible types -- in mysql, any value can be NULL unless you explicitly say otherwise. If we wanted to enforce that our foo.bar column could never be NULL, we would have to write CREATE TABLE foo (bar varchar(255) NOT NULL); This nuance is seldom clear to programmers, and is a lesson that generally only gets learned the hard way. For instance, if you google "go sql null", you will get back numerous pages of blog posts, stack overflow posts, etc -- whether or not it is "right", the undeniable fact is that this behavior subverts programmer expectations on a regular basis.

Furthermore, when a programmer writes some go code to fetch sql data and work with it in a go program, choosing to type their variable as a non-nilable type is a signal that they do not need to write special handling for the null case. It isn't up to us to determine whether or not they should; by writing their code this way, the programmer has indicated that they have no use for this distinction. When we force them to care (at runtime, often long after the code has been written, when we unexpectedly encounter a NULL value in the database), this produces broken software that isn't always straightforward to triage/remediate.

Fundamentally, the responsibility of this package is to bridge the gap between sql and go. Accounting for the disparate treatment of NULL in these two languages is currently the responsibility of the programmer, but by reconciling this difference in the translation layer, we can prevent bugs and make it easier to write great go code.
Consistency with json unmarshaling behaviors

As shown in [this playground](https://go.dev/play/p/iTpNi9LewMR), unmarshaling json with NULL values into non-nilable types already works according to the programmer expectations described above -- we leave these values untouched. Whether or not the json unmarshaler is "right" is up for debate (see https://github.com/golang/go/issues/33835), but the fact of the matter is that this will likely have to remain the default behavior forever. The fact that these two standard libraries have opposite opinions is unfortunate, and can probably never be changed. However, we compound this issue by giving programmers no mechanism to make them behave the same way. So, every go programmer has to be aware of this distinction and correctly design their types for the environment(s) that they expect to instantiate them from. This is clunky at best, and in practice it creates vast swaths of bug habitat.

It would be great to introduce an analogous configuration option in the standard json unmarshaler (or perhaps even reuse the same configuration flag), but that is out of scope for this issue.

For the above reasons, it's important to give programmers the ability to opt out of this behavior. Using Null* types or pointers to primitives remain viable for situations where we need to distinguish between NULL and other values, but in situations where the programmer does not care about this distinction, we should allow them this freedom.

A NOTE ON ignoreNullValues
As currently written, ignoreNullValues cannot be configured by the programmer, so this PR as written doesn't actually change any behavior. The intent is to expose this as a configuration option (note that we must leave it off by default so as not to break existing code). But, I wasn't entirely sure of the most standard way to do so -- guidance here would be much appreciated.