### PR TITLE
net: rework the CNAME handling on unix

### DIFF
--- a/src/internal/syscall/unix/net_darwin.go
+++ b/src/internal/syscall/unix/net_darwin.go
@@ -119,8 +119,11 @@ func syscall_syscall6X(fn, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err 
 //go:linkname syscall_syscall9 syscall.syscall9
 func syscall_syscall9(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2 uintptr, err syscall.Errno)
 
+// Based on https://opensource.apple.com/source/libresolv/libresolv-65/resolv.h.auto.html
 type ResState struct {
-	unexported [69]uintptr
+	_           [496]byte
+	Res_h_errno int32
+	_           [52]byte
 }
 
 //go:cgo_import_dynamic libresolv_res_9_ninit res_9_ninit "/usr/lib/libresolv.9.dylib"

--- a/src/net/cgo_stub.go
+++ b/src/net/cgo_stub.go
@@ -31,10 +31,22 @@ func cgoLookupIP(ctx context.Context, network, name string) (addrs []IPAddr, err
 	panic("cgo stub: cgo not available")
 }
 
-func cgoLookupCNAME(ctx context.Context, name string) (cname string, err error, completed bool) {
+func cgoLookupCNAME(ctx context.Context, name string) (cname string, err error) {
 	panic("cgo stub: cgo not available")
 }
 
 func cgoLookupPTR(ctx context.Context, addr string) (ptrs []string, err error) {
 	panic("cgo stub: cgo not available")
 }
+
+func cgoLookupCanonicalName(ctx context.Context, network string, name string) (cname string, err error) {
+	panic("cgo stub: cgo not available")
+}
+
+type stubError struct{}
+
+func (stubError) Error() string {
+	panic("cgo stub: cgo not available")
+}
+
+var errCgoDNSLookupFailed = stubError{}

--- a/src/net/cgo_unix_cgo.go
+++ b/src/net/cgo_unix_cgo.go
@@ -17,6 +17,7 @@ package net
 #include <unistd.h>
 #include <string.h>
 #include <stdlib.h>
+#include <netdb.h>
 
 #ifndef EAI_NODATA
 #define EAI_NODATA -5
@@ -29,6 +30,12 @@ package net
 */
 import "C"
 import "unsafe"
+
+const (
+	_C_HOST_NOT_FOUND = C.HOST_NOT_FOUND
+	_C_TRY_AGAIN      = C.TRY_AGAIN
+	_C_NO_DATA        = C.NO_DATA
+)
 
 const (
 	_C_AF_INET      = C.AF_INET
@@ -56,10 +63,12 @@ type (
 	_C_struct_sockaddr = C.struct_sockaddr
 )
 
+func _C_GoString(p *_C_char) string      { return C.GoString(p) }
 func _C_malloc(n uintptr) unsafe.Pointer { return C.malloc(C.size_t(n)) }
 func _C_free(p unsafe.Pointer)           { C.free(p) }
 
 func _C_ai_addr(ai *_C_struct_addrinfo) **_C_struct_sockaddr { return &ai.ai_addr }
+func _C_ai_canonname(ai *_C_struct_addrinfo) **_C_char       { return &ai.ai_canonname }
 func _C_ai_family(ai *_C_struct_addrinfo) *_C_int            { return &ai.ai_family }
 func _C_ai_flags(ai *_C_struct_addrinfo) *_C_int             { return &ai.ai_flags }
 func _C_ai_next(ai *_C_struct_addrinfo) **_C_struct_addrinfo { return &ai.ai_next }

--- a/src/net/cgo_unix_cgo_darwin.go
+++ b/src/net/cgo_unix_cgo_darwin.go
@@ -19,3 +19,13 @@ import (
 // This will cause a compile error when the size of
 // unix.ResState is too small.
 type _ [unsafe.Sizeof(unix.ResState{}) - unsafe.Sizeof(C.struct___res_state{})]byte
+
+// This will cause a compile error when:
+// unsafe.Sizeof(new(unix.ResState).Res_h_errno) != unsafe.Sizeof(new(C.struct___res_state).res_h_errno)
+type _ [unsafe.Sizeof(new(unix.ResState).Res_h_errno) - unsafe.Sizeof(new(C.struct___res_state).res_h_errno)]byte
+type _ [unsafe.Sizeof(new(C.struct___res_state).res_h_errno) - unsafe.Sizeof(new(unix.ResState).Res_h_errno)]byte
+
+// This will cause a compile error when:
+// unsafe.Offsetof(new(unix.ResState).Res_h_errno) != unsafe.Offsetof(new(C.struct___res_state).res_h_errno)
+type _ [unsafe.Offsetof(new(unix.ResState).Res_h_errno) - unsafe.Offsetof(new(C.struct___res_state).res_h_errno)]byte
+type _ [unsafe.Offsetof(new(C.struct___res_state).res_h_errno) - unsafe.Offsetof(new(unix.ResState).Res_h_errno)]byte

--- a/src/net/cgo_unix_cgo_res.go
+++ b/src/net/cgo_unix_cgo_res.go
@@ -17,10 +17,29 @@ package net
 #include <string.h>
 #include <arpa/nameser.h>
 #include <resolv.h>
+#include <netdb.h>
+
+#ifdef __GLIBC__
+#define is_glibc 1
+#else
+#define is_glibc 0
+#endif
+
+int c_res_search(const char *dname, int class, int type, unsigned char *answer, int anslen, int *herrno) {
+	int ret = res_search(dname, class, type, answer, anslen);
+
+	if (ret < 0) {
+		*herrno = h_errno;
+	}
+
+	return ret;
+}
 
 #cgo !android,!openbsd LDFLAGS: -lresolv
 */
 import "C"
+
+import "runtime"
 
 type _C_struct___res_state = struct{}
 
@@ -32,7 +51,29 @@ func _C_res_nclose(state *_C_struct___res_state) {
 	return
 }
 
-func _C_res_nsearch(state *_C_struct___res_state, dname *_C_char, class, typ int, ans *_C_uchar, anslen int) (int, error) {
-	x, err := C.res_search(dname, C.int(class), C.int(typ), ans, C.int(anslen))
-	return int(x), err
+const isGlibc = C.is_glibc == 1
+
+func _C_res_nsearch(state *_C_struct___res_state, dname *_C_char, class, typ int, ans *_C_uchar, anslen int) (ret int, herrno int, err error) {
+	var h C.int
+	x, err := C.c_res_search(dname, C.int(class), C.int(typ), ans, C.int(anslen), &h)
+
+	if x <= 0 {
+		if runtime.GOOS == "linux" {
+			// On glibc and musl h_errno is a thread-safe macro:
+			// https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=ed4d0184a16db455d626e64722daf9ca4b71742a;hp=c0b338331e8eb0979b909479d6aa9fd1cddd63ec
+			// http://git.etalabs.net/cgit/musl/commit/?id=9d0b8b92a508c328e7eac774847f001f80dfb5ff
+			if isGlibc {
+				return -1, int(h), err
+			}
+			// musl does not set errno with the cause of the failure.
+			return -1, int(h), nil
+		}
+
+		// On Openbsd h_errno is not thread-safe.
+		// Android h_errno is also thread-safe: https://android.googlesource.com/platform/bionic/+/589afca/libc/dns/resolv/res_state.c
+		// but the h_errno doesn't seem to be set on noSuchHost.
+		return -2, 0, nil
+	}
+
+	return int(x), 0, nil
 }

--- a/src/net/cgo_unix_cgo_resn.go
+++ b/src/net/cgo_unix_cgo_resn.go
@@ -33,7 +33,10 @@ func _C_res_nclose(state *_C_struct___res_state) {
 	C.res_nclose(state)
 }
 
-func _C_res_nsearch(state *_C_struct___res_state, dname *_C_char, class, typ int, ans *_C_uchar, anslen int) (int, error) {
-	x, err := C.res_nsearch(state, dname, C.int(class), C.int(typ), ans, C.int(anslen))
-	return int(x), err
+func _C_res_nsearch(state *_C_struct___res_state, dname *_C_char, class, typ int, ans *_C_uchar, anslen int) (ret int, herrno int, err error) {
+	x, _ := C.res_nsearch(state, dname, C.int(class), C.int(typ), ans, C.int(anslen))
+	if x <= 0 {
+		return -1, int(state.res_h_errno), nil
+	}
+	return int(x), 0, nil
 }

--- a/src/net/dnsclient.go
+++ b/src/net/dnsclient.go
@@ -49,20 +49,12 @@ func reverseaddr(addr string) (arpa string, err error) {
 	return string(buf), nil
 }
 
-func equalASCIIName(x, y dnsmessage.Name) bool {
+func equalASCIIName(x, y *dnsmessage.Name) bool {
 	if x.Length != y.Length {
 		return false
 	}
 	for i := 0; i < int(x.Length); i++ {
-		a := x.Data[i]
-		b := y.Data[i]
-		if 'A' <= a && a <= 'Z' {
-			a += 0x20
-		}
-		if 'A' <= b && b <= 'Z' {
-			b += 0x20
-		}
-		if a != b {
+		if lowerASCII(x.Data[i]) != lowerASCII(y.Data[i]) {
 			return false
 		}
 	}

--- a/src/net/dnsclient_unix.go
+++ b/src/net/dnsclient_unix.go
@@ -91,7 +91,7 @@ func checkResponse(reqID uint16, reqQues dnsmessage.Question, respHdr dnsmessage
 	if reqID != respHdr.ID {
 		return false
 	}
-	if reqQues.Type != respQues.Type || reqQues.Class != respQues.Class || !equalASCIIName(reqQues.Name, respQues.Name) {
+	if reqQues.Type != respQues.Type || reqQues.Class != respQues.Class || !equalASCIIName(&reqQues.Name, &respQues.Name) {
 		return false
 	}
 	return true
@@ -323,7 +323,6 @@ func (r *Resolver) tryOneName(ctx context.Context, cfg *dnsConfig, name string, 
 				if err == errNoSuchHost {
 					// The name does not exist, so trying
 					// another server won't help.
-
 					dnsErr.IsNotFound = true
 					return p, server, dnsErr
 				}
@@ -345,6 +344,7 @@ func (r *Resolver) tryOneName(ctx context.Context, cfg *dnsConfig, name string, 
 				// server won't help.
 
 				lastErr.(*DNSError).IsNotFound = true
+				lastErr.(*DNSError).isNoData = true
 				return p, server, lastErr
 			}
 		}
@@ -439,26 +439,22 @@ func (conf *resolverConfig) releaseSema() {
 	<-conf.ch
 }
 
-func (r *Resolver) lookup(ctx context.Context, name string, qtype dnsmessage.Type, conf *dnsConfig) (dnsmessage.Parser, string, error) {
+func (r *Resolver) lookup(ctx context.Context, name string, qtype dnsmessage.Type, conf *dnsConfig) (p dnsmessage.Parser, server string, queriedName string, err error) {
 	if !isDomainName(name) {
 		// We used to use "invalid domain name" as the error,
 		// but that is a detail of the specific lookup mechanism.
 		// Other lookups might allow broader name syntax
 		// (for example Multicast DNS allows UTF-8; see RFC 6762).
 		// For consistency with libc resolvers, report no such host.
-		return dnsmessage.Parser{}, "", &DNSError{Err: errNoSuchHost.Error(), Name: name, IsNotFound: true}
+		return dnsmessage.Parser{}, "", "", &DNSError{Err: errNoSuchHost.Error(), Name: name, IsNotFound: true}
 	}
 
 	if conf == nil {
 		conf = getSystemDNSConfig()
 	}
 
-	var (
-		p      dnsmessage.Parser
-		server string
-		err    error
-	)
 	for _, fqdn := range conf.nameList(name) {
+		queriedName = fqdn
 		p, server, err = r.tryOneName(ctx, conf, fqdn, qtype)
 		if err == nil {
 			break
@@ -470,7 +466,7 @@ func (r *Resolver) lookup(ctx context.Context, name string, qtype dnsmessage.Typ
 		}
 	}
 	if err == nil {
-		return p, server, nil
+		return p, server, queriedName, nil
 	}
 	if err, ok := err.(*DNSError); ok {
 		// Show original name passed to lookup, not suffixed one.
@@ -478,7 +474,7 @@ func (r *Resolver) lookup(ctx context.Context, name string, qtype dnsmessage.Typ
 		// just one is misleading. See also golang.org/issue/6324.
 		err.Name = name
 	}
-	return dnsmessage.Parser{}, "", err
+	return dnsmessage.Parser{}, "", queriedName, err
 }
 
 // avoidDNS reports whether this is a hostname for which we should not
@@ -644,9 +640,6 @@ func (r *Resolver) goLookupIPCNAMEOrder(ctx context.Context, network, name strin
 
 	lane := make(chan result, 1)
 	qtypes := []dnsmessage.Type{dnsmessage.TypeA, dnsmessage.TypeAAAA}
-	if network == "CNAME" {
-		qtypes = append(qtypes, dnsmessage.TypeCNAME)
-	}
 	switch ipVersion(network) {
 	case '4':
 		qtypes = []dnsmessage.Type{dnsmessage.TypeA}
@@ -736,10 +729,7 @@ func (r *Resolver) goLookupIPCNAMEOrder(ctx context.Context, network, name strin
 						break loop
 					}
 					addrs = append(addrs, IPAddr{IP: IP(a.A[:])})
-					if cname.Length == 0 && h.Name.Length != 0 {
-						cname = h.Name
-					}
-
+					cname = h.Name
 				case dnsmessage.TypeAAAA:
 					aaaa, err := result.p.AAAAResource()
 					if err != nil {
@@ -751,24 +741,7 @@ func (r *Resolver) goLookupIPCNAMEOrder(ctx context.Context, network, name strin
 						break loop
 					}
 					addrs = append(addrs, IPAddr{IP: IP(aaaa.AAAA[:])})
-					if cname.Length == 0 && h.Name.Length != 0 {
-						cname = h.Name
-					}
-
-				case dnsmessage.TypeCNAME:
-					c, err := result.p.CNAMEResource()
-					if err != nil {
-						lastErr = &DNSError{
-							Err:    errCannotUnmarshalDNSMessage.Error(),
-							Name:   name,
-							Server: result.server,
-						}
-						break loop
-					}
-					if cname.Length == 0 && c.CNAME.Length > 0 {
-						cname = c.CNAME
-					}
-
+					cname = h.Name
 				default:
 					if err := result.p.SkipAnswer(); err != nil {
 						lastErr = &DNSError{
@@ -778,7 +751,6 @@ func (r *Resolver) goLookupIPCNAMEOrder(ctx context.Context, network, name strin
 						}
 						break loop
 					}
-					continue
 				}
 			}
 		}
@@ -789,7 +761,7 @@ func (r *Resolver) goLookupIPCNAMEOrder(ctx context.Context, network, name strin
 			addrs = nil
 			break
 		}
-		if len(addrs) > 0 || network == "CNAME" && cname.Length > 0 {
+		if len(addrs) > 0 {
 			break
 		}
 	}
@@ -800,7 +772,7 @@ func (r *Resolver) goLookupIPCNAMEOrder(ctx context.Context, network, name strin
 		lastErr.Name = name
 	}
 	sortByRFC6724(addrs)
-	if len(addrs) == 0 && !(network == "CNAME" && cname.Length > 0) {
+	if len(addrs) == 0 {
 		if order == hostLookupDNSFiles {
 			var canonical string
 			addrs, canonical = goLookupIPFiles(name)
@@ -820,10 +792,36 @@ func (r *Resolver) goLookupIPCNAMEOrder(ctx context.Context, network, name strin
 	return addrs, cname, nil
 }
 
-// goLookupCNAME is the native Go (non-cgo) implementation of LookupCNAME.
-func (r *Resolver) goLookupCNAME(ctx context.Context, host string, order hostLookupOrder, conf *dnsConfig) (string, error) {
-	_, cname, err := r.goLookupIPCNAMEOrder(ctx, "CNAME", host, order, conf)
-	return cname.String(), err
+// goLookupCanonicalName returns the canonical name of the host
+func (r *Resolver) goLookupCanonicalName(ctx context.Context, host string, order hostLookupOrder, conf *dnsConfig) (string, error) {
+	_, cname, err := r.goLookupIPCNAMEOrder(ctx, "ip", host, order, conf)
+	if err != nil {
+		return "", err
+	}
+	return cname.String(), nil
+}
+
+// goLookupCNAME queries the CNAME record and returns the last CNAME in the CNAME chain or when
+// the DNS query returns no answer records it returns the queried name.
+func (r *Resolver) goLookupCNAME(ctx context.Context, host string, conf *dnsConfig) (string, error) {
+	p, server, queriedName, err := r.lookup(ctx, host, dnsmessage.TypeCNAME, conf)
+	if err != nil {
+		var dnsErr *DNSError
+		if errors.As(err, &dnsErr) && dnsErr.isNoData {
+			return absDomainName(queriedName), nil
+		}
+		return "", err
+	}
+
+	cname, err := lastCNAMEinChain(dnsmessage.MustNewName(queriedName), p)
+	if err != nil {
+		return "", &DNSError{
+			Err:    err.Error(),
+			Server: server,
+		}
+	}
+
+	return cname, nil
 }
 
 // goLookupPTR is the native Go implementation of LookupAddr.
@@ -843,7 +841,7 @@ func (r *Resolver) goLookupPTR(ctx context.Context, addr string, order hostLooku
 	if err != nil {
 		return nil, err
 	}
-	p, server, err := r.lookup(ctx, arpa, dnsmessage.TypePTR, conf)
+	p, server, _, err := r.lookup(ctx, arpa, dnsmessage.TypePTR, conf)
 	if err != nil {
 		var dnsErr *DNSError
 		if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
@@ -893,4 +891,57 @@ func (r *Resolver) goLookupPTR(ctx context.Context, addr string, order hostLooku
 	}
 
 	return ptrs, nil
+}
+
+func lowerDNSName(a *dnsmessage.Name) {
+	lowerASCIIBytes(a.Data[:a.Length])
+}
+
+// lastCNAMEinChain returns the last CNAME in CNAME chain.
+func lastCNAMEinChain(queryName dnsmessage.Name, p dnsmessage.Parser) (string, error) {
+	curName := queryName
+
+	// All (or most) responses contain the CNAMEs in order
+	// so this in practice should never be used.
+	// The key must be in lower case for case insensitive match.
+	var cnames map[dnsmessage.Name]dnsmessage.Name
+
+	for {
+		hdr, err := p.AnswerHeader()
+		if err == dnsmessage.ErrSectionDone {
+			break
+		}
+		if err != nil || hdr.Class != dnsmessage.ClassINET || hdr.Type != dnsmessage.TypeCNAME {
+			return "", errCannotUnmarshalDNSMessage
+		}
+		cname, err := p.CNAMEResource()
+		if err != nil {
+			return "", errCannotUnmarshalDNSMessage
+		}
+
+		if !equalASCIIName(&curName, &hdr.Name) {
+			// Out of order CNAME record; add it to the map for later processing.
+			if cnames == nil {
+				cnames = make(map[dnsmessage.Name]dnsmessage.Name)
+			}
+			lowerDNSName(&hdr.Name)
+			// Not lowering the cname ASCII case here to preserve the DNS case.
+			cnames[hdr.Name] = cname.CNAME
+			continue
+		}
+
+		curName = cname.CNAME
+	}
+
+	for len(cnames) != 0 {
+		lowerDNSName(&curName)
+		cname, ok := cnames[curName]
+		if !ok {
+			return "", errCannotUnmarshalDNSMessage
+		}
+		delete(cnames, curName)
+		curName = cname
+	}
+
+	return curName.String(), nil
 }

--- a/src/net/dnsclient_unix_test.go
+++ b/src/net/dnsclient_unix_test.go
@@ -1405,7 +1405,7 @@ func TestStrictErrorsLookupTXT(t *testing.T) {
 
 	for _, strict := range []bool{true, false} {
 		r := Resolver{StrictErrors: strict, Dial: fake.DialContext}
-		p, _, err := r.lookup(context.Background(), name, dnsmessage.TypeTXT, nil)
+		p, _, _, err := r.lookup(context.Background(), name, dnsmessage.TypeTXT, nil)
 		var wantErr error
 		var wantRRs int
 		if strict {

--- a/src/net/lookup_plan9.go
+++ b/src/net/lookup_plan9.go
@@ -245,14 +245,14 @@ func (*Resolver) lookupPortWithNetwork(ctx context.Context, network, errNetwork,
 }
 
 func (r *Resolver) lookupCNAME(ctx context.Context, name string) (cname string, err error) {
-	if order, conf := systemConf().hostLookupOrder(r, name); order != hostLookupCgo {
-		return r.goLookupCNAME(ctx, name, order, conf)
+	if systemConf().mustUseGoResolver(r) {
+		return r.goLookupCNAME(ctx, name, getSystemDNSConfig())
 	}
 
 	lines, err := queryDNS(ctx, name, "cname")
 	if err != nil {
 		if stringsHasSuffix(err.Error(), "dns failure") || stringsHasSuffix(err.Error(), "resource does not exist; negrcode 0") {
-			cname = name + "."
+			cname = absDomainName(name)
 			err = nil
 		}
 		return

--- a/src/net/lookup_windows.go
+++ b/src/net/lookup_windows.go
@@ -256,8 +256,8 @@ func (r *Resolver) lookupPort(ctx context.Context, network, service string) (int
 }
 
 func (r *Resolver) lookupCNAME(ctx context.Context, name string) (string, error) {
-	if order, conf := systemConf().hostLookupOrder(r, name); order != hostLookupCgo {
-		return r.goLookupCNAME(ctx, name, order, conf)
+	if systemConf().mustUseGoResolver(r) {
+		return r.goLookupCNAME(ctx, name, getSystemDNSConfig())
 	}
 
 	// TODO(bradfitz): finish ctx plumbing. Nothing currently depends on this.

--- a/src/net/net.go
+++ b/src/net/net.go
@@ -617,6 +617,16 @@ var (
 	errNoSuchHost = errors.New("no such host")
 )
 
+func isErrorNoSuchHost(err error) bool {
+	var e *DNSError
+	if errors.As(err, &e) {
+		if e.IsNotFound {
+			return true
+		}
+	}
+	return false
+}
+
 // DNSError represents a DNS lookup error.
 type DNSError struct {
 	Err         string // description of the error
@@ -625,6 +635,10 @@ type DNSError struct {
 	IsTimeout   bool   // if true, timed out; not all timeouts set this
 	IsTemporary bool   // if true, error is temporary; not all errors set this
 	IsNotFound  bool   // if true, host could not be found
+
+	// used internally: if true, dns query returned with
+	// success, but with no answer records
+	isNoData bool
 }
 
 func (e *DNSError) Error() string {


### PR DESCRIPTION
This change reworks the LookupCNAME handling:
1) It removes the fallback to the go resolver 
when cgoLookupCNAME faills (even noSuchHosts), this
also implies using the canonical name from getaddrinfo.
2) Improves the error handling of the res_search cgo routines, so
returning proper &DNSError to match the go resolver behaviour and
detecting the noSuchHost condition.
3) Makes the LookupCNAME return the last CNAME in the chain,
not the first one.

More details about current issues are described in #59943.
 
Fixes #59943
Updates #50101