### PR TITLE
encoding/json: do not use Buffer when no indent

### DIFF
--- a/src/encoding/json/encode_test.go
+++ b/src/encoding/json/encode_test.go
@@ -714,14 +714,15 @@ func TestStringBytes(t *testing.T) {
 	s := string(r) + "\xff\xff\xffhello" // some invalid UTF-8 too
 
 	for _, escapeHTML := range []bool{true, false} {
-		es := &encodeState{}
+		var esBuf, esBytesBuf bytes.Buffer
+		es := &encodeState{w: &esBuf}
 		es.string(s, escapeHTML)
 
-		esBytes := &encodeState{}
+		esBytes := &encodeState{w: &esBytesBuf}
 		esBytes.stringBytes([]byte(s), escapeHTML)
 
-		enc := es.Buffer.String()
-		encBytes := esBytes.Buffer.String()
+		enc := esBuf.String()
+		encBytes := esBytesBuf.String()
 		if enc != encBytes {
 			i := 0
 			for i < len(enc) && i < len(encBytes) && enc[i] == encBytes[i] {

--- a/src/encoding/json/stream_test.go
+++ b/src/encoding/json/stream_test.go
@@ -84,6 +84,7 @@ func TestEncoderErrorAndReuseEncodeState(t *testing.T) {
 		I int
 	}
 	data := Data{A: "a", I: 1}
+	buf.Reset()
 	if err := enc.Encode(data); err != nil {
 		t.Errorf("Marshal(%v) = %v", data, err)
 	}


### PR DESCRIPTION
Using bytes.Buffer is not necessary since we can write the encoded output directly to provided writer.