### PR TITLE
runtime: immediately handoff P before returning to C host program

### DIFF
--- a/src/runtime/cgocall.go
+++ b/src/runtime/cgocall.go
@@ -246,7 +246,7 @@ func cgocallbackg(fn, frame unsafe.Pointer, ctxt uintptr) {
 	osPreemptExtEnter(gp.m)
 
 	// going back to cgo call
-	reentersyscall(savedpc, uintptr(savedsp))
+	reentersyscall(savedpc, uintptr(savedsp), true)
 
 	gp.m.syscall = syscall
 }

--- a/src/runtime/cgocall.go
+++ b/src/runtime/cgocall.go
@@ -246,7 +246,7 @@ func cgocallbackg(fn, frame unsafe.Pointer, ctxt uintptr) {
 	osPreemptExtEnter(gp.m)
 
 	// going back to cgo call
-	reentersyscall(savedpc, uintptr(savedsp), true)
+	reentersyscall(savedpc, uintptr(savedsp))
 
 	gp.m.syscall = syscall
 }


### PR DESCRIPTION
Fixes #57103

when cgo returns to C, runtime should immediately handoff P since we have no indication that C will call in to Go again, and more importantly we are dropping the M, so keeping oldp is on that M doesn't make much sense. Even if C calls us again on the same thread we may not even get the same M.