### PR TITLE
use proper prototypes for C code within documentation

### DIFF
--- a/src/cmd/cgo/doc.go
+++ b/src/cmd/cgo/doc.go
@@ -220,7 +220,7 @@ received from Go. For example:
 	//		return f();
 	// }
 	//
-	// int fortytwo()
+	// int fortytwo(void)
 	// {
 	//	    return 42;
 	// }
@@ -728,7 +728,7 @@ Instead, the build process generates an object file using dynamic
 linkage to the desired libraries. The main function is provided by
 _cgo_main.c:
 
-	int main() { return 0; }
+	int main(void) { return 0; }
 	void crosscall2(void(*fn)(void*), void *a, int c, uintptr_t ctxt) { }
 	uintptr_t _cgo_wait_runtime_init_done(void) { return 0; }
 	void _cgo_release_context(uintptr_t ctxt) { }


### PR DESCRIPTION
In C the sematic of an empty argument list (without `void`) is quite dangerous which is why usually you shouldn't use it and enable `-Wstrict-prototypes` for your code.

While golang does this wrong all over the code base and it'd be a lot of work to change that, fixing code that's part of the documentation is a quick fix to stop setting a bad example.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
