### PR TITLE
spec: fix typo in invalid examples of a recursive arrays

### DIFF
--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -951,7 +951,7 @@ if those containing types are only array or struct types.
 </p>
 
 <pre>
-// valid array types
+// invalid array types
 type (
 	T1 [10]T1                 // element type of T1 is T1
 	T2 [10]struct{ f T2 }     // T2 contains T2 as component of a struct


### PR DESCRIPTION
fix for #57323 