### PR TITLE
net: use correct dns msg size

### DIFF
--- a/src/net/cgo_unix.go
+++ b/src/net/cgo_unix.go
@@ -383,13 +383,13 @@ func cgoResSearch(hostname string, rtype, class int) ([]dnsmessage.Resource, err
 	s := _C_CString(hostname)
 	defer _C_FreeCString(s)
 
+	size := 0
 	for {
-		size, _ := _C_res_nsearch(state, s, class, rtype, buf, bufSize)
+		size, _ = _C_res_nsearch(state, s, class, rtype, buf, bufSize)
 		if size <= 0 || size > 0xffff {
 			return nil, errors.New("res_nsearch failure")
 		}
 		if size <= bufSize {
-			bufSize = size
 			break
 		}
 
@@ -400,7 +400,7 @@ func cgoResSearch(hostname string, rtype, class int) ([]dnsmessage.Resource, err
 	}
 
 	var p dnsmessage.Parser
-	if _, err := p.Start(unsafe.Slice((*byte)(unsafe.Pointer(buf)), bufSize)); err != nil {
+	if _, err := p.Start(unsafe.Slice((*byte)(unsafe.Pointer(buf)), size)); err != nil {
 		return nil, err
 	}
 	p.SkipAllQuestions()

--- a/src/net/cgo_unix.go
+++ b/src/net/cgo_unix.go
@@ -389,6 +389,7 @@ func cgoResSearch(hostname string, rtype, class int) ([]dnsmessage.Resource, err
 			return nil, errors.New("res_nsearch failure")
 		}
 		if size <= bufSize {
+			bufSize = size
 			break
 		}
 

--- a/src/net/cgo_unix.go
+++ b/src/net/cgo_unix.go
@@ -383,7 +383,7 @@ func cgoResSearch(hostname string, rtype, class int) ([]dnsmessage.Resource, err
 	s := _C_CString(hostname)
 	defer _C_FreeCString(s)
 
-	size := 0
+	var size int
 	for {
 		size, _ = _C_res_nsearch(state, s, class, rtype, buf, bufSize)
 		if size <= 0 || size > 0xffff {


### PR DESCRIPTION
Set bufSize to the actual dns message size, so that the p.Start (below) gets a fully valid dns message.