### PR TITLE
net/http: fix when writeLoop exited still has request in writech

### DIFF
--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -719,6 +719,13 @@ func (pc *persistConn) shouldRetryRequest(req *Request, err error) bool {
 		// can "rewind" the body with GetBody.
 		return req.outgoingLength() == 0 || req.GetBody != nil
 	}
+	if len(pc.writech) != 0 {
+		// Request was sent successfully into writech, but isn't read from it
+		// because writeLoop exited.
+		// In this case, you can retry without considering idempotence.
+		// see https://github.com/golang/go/issues/49621
+		return true
+	}
 	if !req.isReplayable() {
 		// Don't retry non-idempotent requests.
 		return false

--- a/src/net/http/transport_test.go
+++ b/src/net/http/transport_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"go/token"
-	"golang.org/x/net/http/httpguts"
 	"internal/nettrace"
 	"io"
 	"log"
@@ -45,6 +44,8 @@ import (
 	"testing"
 	"testing/iotest"
 	"time"
+
+	"golang.org/x/net/http/httpguts"
 )
 
 // TODO: test 5 pipelined requests with responses: 1) OK, 2) OK, Connection: Close

--- a/src/net/http/transport_test.go
+++ b/src/net/http/transport_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"go/token"
+	"golang.org/x/net/http/httpguts"
 	"internal/nettrace"
 	"io"
 	"log"
@@ -44,8 +45,6 @@ import (
 	"testing"
 	"testing/iotest"
 	"time"
-
-	"golang.org/x/net/http/httpguts"
 )
 
 // TODO: test 5 pipelined requests with responses: 1) OK, 2) OK, Connection: Close
@@ -6752,7 +6751,7 @@ func TestIssue49621(t *testing.T) {
 	go func() { s.Serve(ln) }()
 
 	for i := 0; i < 10; i++ {
-		testIssue49621Request(t, addr)
+		testIssue49621Request(t, "http://"+addr)
 	}
 	s.Close()
 }
@@ -6779,8 +6778,9 @@ func testIssue49621Request(t *testing.T, addr string) {
 				_ = resp.Body.Close()
 				return
 			}
-
-			t.Errorf("resp = %v, err = %v\n", resp, err)
+			if err == ExportErrServerClosedIdle {
+				t.Errorf("resp = %v, err = %v\n", resp, err)
+			}
 		}()
 	}
 	wg.Wait()


### PR DESCRIPTION
When there is still a request in writech after
writeLoop exits, the request body will not be
closed and will not be retried.
The request is not sent to the server, so it can
be safely retried without regard to idempotence.

Fixes #49621