### PR TITLE
net: treat EAI_NODATA as errNoSuchHost

### DIFF
--- a/src/internal/syscall/unix/net_darwin.go
+++ b/src/internal/syscall/unix/net_darwin.go
@@ -17,6 +17,7 @@ const (
 	AI_MASK      = 0x1407
 
 	EAI_AGAIN    = 2
+	EAI_NODATA   = 5
 	EAI_NONAME   = 8
 	EAI_SYSTEM   = 11
 	EAI_OVERFLOW = 14

--- a/src/internal/syscall/unix/net_darwin.go
+++ b/src/internal/syscall/unix/net_darwin.go
@@ -17,7 +17,7 @@ const (
 	AI_MASK      = 0x1407
 
 	EAI_AGAIN    = 2
-	EAI_NODATA   = 5
+	EAI_NODATA   = 7
 	EAI_NONAME   = 8
 	EAI_SYSTEM   = 11
 	EAI_OVERFLOW = 14

--- a/src/net/cgo_unix.go
+++ b/src/net/cgo_unix.go
@@ -166,7 +166,7 @@ func cgoLookupHostIP(network, name string) (addrs []IPAddr, err error) {
 				// comes up again. golang.org/issue/6232.
 				err = syscall.EMFILE
 			}
-		case _C_EAI_NONAME:
+		case _C_EAI_NONAME, _C_EAI_NODATA:
 			err = errNoSuchHost
 			isErrorNoSuchHost = true
 		default:

--- a/src/net/cgo_unix_cgo.go
+++ b/src/net/cgo_unix_cgo.go
@@ -7,6 +7,8 @@
 package net
 
 /*
+#define _GNU_SOURCE
+
 #cgo CFLAGS: -fno-stack-protector
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -15,6 +17,10 @@ package net
 #include <unistd.h>
 #include <string.h>
 #include <stdlib.h>
+
+#ifndef EAI_NODATA
+#define EAI_NODATA -5
+#endif
 
 // If nothing else defined EAI_OVERFLOW, make sure it has a value.
 #ifndef EAI_OVERFLOW
@@ -29,6 +35,7 @@ const (
 	_C_AF_INET6     = C.AF_INET6
 	_C_AF_UNSPEC    = C.AF_UNSPEC
 	_C_EAI_AGAIN    = C.EAI_AGAIN
+	_C_EAI_NODATA   = C.EAI_NODATA
 	_C_EAI_NONAME   = C.EAI_NONAME
 	_C_EAI_OVERFLOW = C.EAI_OVERFLOW
 	_C_EAI_SYSTEM   = C.EAI_SYSTEM

--- a/src/net/cgo_unix_syscall.go
+++ b/src/net/cgo_unix_syscall.go
@@ -19,6 +19,7 @@ const (
 	_C_AF_UNSPEC    = syscall.AF_UNSPEC
 	_C_EAI_AGAIN    = unix.EAI_AGAIN
 	_C_EAI_NONAME   = unix.EAI_NONAME
+	_C_EAI_NODATA   = unix.EAI_NODATA
 	_C_EAI_OVERFLOW = unix.EAI_OVERFLOW
 	_C_EAI_SYSTEM   = unix.EAI_SYSTEM
 	_C_IPPROTO_TCP  = syscall.IPPROTO_TCP

--- a/src/net/lookup_test.go
+++ b/src/net/lookup_test.go
@@ -1425,7 +1425,7 @@ func testLookupNoData(t *testing.T, prefix string) {
 	for {
 		// Domain that doesn't have any A/AAAA RRs, but has different one (in this case a TXT),
 		// so that it returns an empty response without any error codes (NXDOMAIN).
-		_, err := LookupHost("_dmarc.google.com")
+		_, err := LookupHost("golang.rsc.io")
 		if err == nil {
 			t.Errorf("%v: unexpected success", prefix)
 			return

--- a/src/net/lookup_test.go
+++ b/src/net/lookup_test.go
@@ -1401,6 +1401,10 @@ func TestDNSTimeout(t *testing.T) {
 }
 
 func TestLookupNoData(t *testing.T) {
+	if runtime.GOOS == "plan9" {
+		t.Skip("not supported yet")
+	}
+
 	mustHaveExternalNetwork(t)
 
 	testLookupNoData(t, "default resolver")

--- a/src/net/lookup_test.go
+++ b/src/net/lookup_test.go
@@ -1402,7 +1402,7 @@ func TestDNSTimeout(t *testing.T) {
 
 func TestLookupNoData(t *testing.T) {
 	if runtime.GOOS == "plan9" {
-		t.Skip("not supported yet")
+		t.Skip("not supported on plan9")
 	}
 
 	mustHaveExternalNetwork(t)


### PR DESCRIPTION
man getaddrinfo:
EAI_NODATA
              The specified network host exists, but does not have any
              network addresses defined.

In the go resolver we treat this kind of error as nosuchhost.
