### PR TITLE
doc/go1.20: fix links to new strings functions

### DIFF
--- a/doc/go1.20.html
+++ b/doc/go1.20.html
@@ -1121,10 +1121,10 @@ proxyHandler := &httputil.ReverseProxy{
   <dd>
     <p><!-- CL 407176, https://go.dev/issue/42537 -->
       The new
-      <a href="/pkg/bytes/#CutPrefix"><code>CutPrefix</code></a> and
-      <a href="/pkg/bytes/#CutSuffix"><code>CutSuffix</code></a> functions
-      are like <a href="/pkg/bytes/#TrimPrefix"><code>TrimPrefix</code></a>
-      and <a href="/pkg/bytes/#TrimSuffix"><code>TrimSuffix</code></a>
+      <a href="/pkg/strings/#CutPrefix"><code>CutPrefix</code></a> and
+      <a href="/pkg/strings/#CutSuffix"><code>CutSuffix</code></a> functions
+      are like <a href="/pkg/strings/#TrimPrefix"><code>TrimPrefix</code></a>
+      and <a href="/pkg/strings/#TrimSuffix"><code>TrimSuffix</code></a>
       but also report whether the string was trimmed.
     </p>
 


### PR DESCRIPTION
Links under strings package were linking to the bytes versions of the functions.

