### PR TITLE
archive: error check when parse archive

### DIFF
--- a/src/cmd/internal/archive/archive.go
+++ b/src/cmd/internal/archive/archive.go
@@ -368,7 +368,10 @@ func (r *objReader) parseArchive(verbose bool) error {
 			if bytes.Equal(p, goobjHeader) {
 				typ = EntryGoObj
 				o = &GoObj{}
-				r.parseObject(o, size)
+				err := r.parseObject(o, size)
+				if err != nil {
+					return err
+				}
 			} else {
 				typ = EntryNativeObj
 				r.skip(size)


### PR DESCRIPTION
Add error check when call `r.parseObject` in `parseArchive`.
