### PR TITLE
crypto/aes: reduce allocations in NewCipher

### DIFF
--- a/src/crypto/aes/aes_test.go
+++ b/src/crypto/aes/aes_test.go
@@ -384,11 +384,11 @@ func BenchmarkExpand(b *testing.B) {
 
 func BenchmarkNewEncrypt(b *testing.B) {
 	tt := encryptTests[0]
-	out := make([]byte, len(tt.out))
+	out := make([]byte, len(tt.in))
 	b.SetBytes(int64(len(out)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		c, _ := NewCipher(tt.key)
-		c.Decrypt(out, tt.out)
+		c.Encrypt(out, tt.in)
 	}
 }

--- a/src/crypto/aes/aes_test.go
+++ b/src/crypto/aes/aes_test.go
@@ -381,3 +381,14 @@ func BenchmarkExpand(b *testing.B) {
 		expandKey(tt.key, c.enc, c.dec)
 	}
 }
+
+func BenchmarkNewEncrypt(b *testing.B) {
+	tt := encryptTests[0]
+	out := make([]byte, len(tt.out))
+	b.SetBytes(int64(len(out)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c, _ := NewCipher(tt.key)
+		c.Decrypt(out, tt.out)
+	}
+}

--- a/src/crypto/aes/cipher.go
+++ b/src/crypto/aes/cipher.go
@@ -48,7 +48,8 @@ func NewCipher(key []byte) (cipher.Block, error) {
 // implemented in pure Go.
 func newCipherGeneric(key []byte) (cipher.Block, error) {
 	n := len(key) + 28
-	c := aesCipher{make([]uint32, n), make([]uint32, n)}
+	buf := make([]uint32, n*2)
+	c := aesCipher{buf[:n:n], buf[n:]}
 	expandKeyGo(key, c.enc, c.dec)
 	return &c, nil
 }

--- a/src/crypto/aes/cipher_asm.go
+++ b/src/crypto/aes/cipher_asm.go
@@ -45,7 +45,7 @@ func newCipher(key []byte) (cipher.Block, error) {
 		return newCipherGeneric(key)
 	}
 	n := len(key) + 28
-	c := aesCipherAsm{aesCipher{make([]uint32, n), make([]uint32, n)}}
+	c := aesCipherGCM{aesCipherAsm{aesCipher{make([]uint32, n), make([]uint32, n)}}}
 	var rounds int
 	switch len(key) {
 	case 128 / 8:
@@ -60,9 +60,9 @@ func newCipher(key []byte) (cipher.Block, error) {
 
 	expandKeyAsm(rounds, &key[0], &c.enc[0], &c.dec[0])
 	if supportsAES && supportsGFMUL {
-		return &aesCipherGCM{c}, nil
+		return &c, nil
 	}
-	return &c, nil
+	return &c.aesCipherAsm, nil
 }
 
 func (c *aesCipherAsm) BlockSize() int { return BlockSize }

--- a/src/crypto/aes/cipher_asm.go
+++ b/src/crypto/aes/cipher_asm.go
@@ -44,8 +44,10 @@ func newCipher(key []byte) (cipher.Block, error) {
 	if !supportsAES {
 		return newCipherGeneric(key)
 	}
+
 	n := len(key) + 28
-	c := aesCipherGCM{aesCipherAsm{aesCipher{make([]uint32, n), make([]uint32, n)}}}
+	buf := make([]uint32, n*2)
+	c := aesCipherGCM{aesCipherAsm{aesCipher{buf[:n:n], buf[n:]}}}
 	var rounds int
 	switch len(key) {
 	case 128 / 8:


### PR DESCRIPTION
&aesCipherGCM{c} causes a copy + allocation, even though
c is already heap allocated.

name          old time/op    new time/op    delta
Encrypt-4       15.5ns ± 2%    15.5ns ± 2%     ~     (p=0.153 n=20+20)
Decrypt-4       15.4ns ± 2%    15.5ns ± 1%     ~     (p=0.102 n=20+20)
Expand-4        43.1ns ± 1%    43.1ns ± 2%     ~     (p=0.655 n=19+17)
NewEncrypt-4     891ns ±12%     630ns ±13%  -29.27%  (p=0.000 n=20+19)

name          old speed      new speed      delta
Encrypt-4     1.03GB/s ± 2%  1.03GB/s ± 2%     ~     (p=0.136 n=20+20)
Decrypt-4     1.04GB/s ± 2%  1.03GB/s ± 1%     ~     (p=0.108 n=20+20)
NewEncrypt-4  18.0MB/s ±13%  25.3MB/s ± 9%  +40.12%  (p=0.000 n=20+18)

name          old alloc/op   new alloc/op   delta
Encrypt-4        0.00B          0.00B          ~     (all equal)
Decrypt-4        0.00B          0.00B          ~     (all equal)
Expand-4         0.00B          0.00B          ~     (all equal)
NewEncrypt-4      448B ± 0%      400B ± 0%  -10.71%  (p=0.000 n=20+20)

name          old allocs/op  new allocs/op  delta
Encrypt-4         0.00           0.00          ~     (all equal)
Decrypt-4         0.00           0.00          ~     (all equal)
Expand-4          0.00           0.00          ~     (all equal)
NewEncrypt-4      4.00 ± 0%      2.00 ± 0%  -50.00%  (p=0.000 n=20+20)
