### PR TITLE
encoding/hex: optimizations to EncodeToString

### DIFF
--- a/src/encoding/hex/hex.go
+++ b/src/encoding/hex/hex.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unsafe"
 )
 
 const (
@@ -104,9 +105,12 @@ func Decode(dst, src []byte) (int, error) {
 
 // EncodeToString returns the hexadecimal encoding of src.
 func EncodeToString(src []byte) string {
+	if len(src) == 0 {
+		return ""
+	}
 	dst := make([]byte, EncodedLen(len(src)))
 	Encode(dst, src)
-	return string(dst)
+	return unsafe.String(&dst[0], len(dst))
 }
 
 // DecodeString returns the bytes represented by the hexadecimal string s.

--- a/src/encoding/hex/hex_test.go
+++ b/src/encoding/hex/hex_test.go
@@ -236,7 +236,7 @@ var expectedHexDump = []byte(`00000000  1e 1f 20 21 22 23 24 25  26 27 28 29 2a 
 var sink []byte
 
 func BenchmarkEncode(b *testing.B) {
-	for _, size := range []int{256, 1024, 4096, 16384} {
+	for _, size := range []int{0, 256, 1024, 4096, 16384} {
 		src := bytes.Repeat([]byte{2, 3, 5, 7, 9, 11, 13, 17}, size/8)
 		sink = make([]byte, 2*size)
 
@@ -244,6 +244,19 @@ func BenchmarkEncode(b *testing.B) {
 			b.SetBytes(int64(size))
 			for i := 0; i < b.N; i++ {
 				Encode(sink, src)
+			}
+		})
+	}
+}
+
+func BenchmarkEncodeToString(b *testing.B) {
+	for _, size := range []int{0, 256, 1024, 4096, 16384} {
+		src := bytes.Repeat([]byte{2, 3, 5, 7, 9, 11, 13, 17}, size/8)
+
+		b.Run(fmt.Sprintf("%v", size), func(b *testing.B) {
+			b.SetBytes(int64(size))
+			for i := 0; i < b.N; i++ {
+				EncodeToString(src)
 			}
 		})
 	}


### PR DESCRIPTION
Currently, a string alloc/copy happens for the result value,
but we can wrap the buffer instead. Additionally, we can skip it all
for empty input.

name                     old time/op   new time/op    delta
EncodeToString/0-10       4.66ns ± 0%    0.31ns ± 0%   ~     (p=1.000 n=1+1)
EncodeToString/256-10      321ns ± 0%     267ns ± 0%   ~     (p=1.000 n=1+1)
EncodeToString/1024-10    1.20µs ± 0%    1.04µs ± 0%   ~     (p=1.000 n=1+1)
EncodeToString/4096-10    4.83µs ± 0%    4.23µs ± 0%   ~     (p=1.000 n=1+1)
EncodeToString/16384-10   18.0µs ± 0%    16.0µs ± 0%   ~     (p=1.000 n=1+1)

name                     old speed     new speed      delta
EncodeToString/256-10    797MB/s ± 0%   960MB/s ± 0%   ~     (p=1.000 n=1+1)
EncodeToString/1024-10   855MB/s ± 0%   983MB/s ± 0%   ~     (p=1.000 n=1+1)
EncodeToString/4096-10   849MB/s ± 0%   969MB/s ± 0%   ~     (p=1.000 n=1+1)
EncodeToString/16384-10  912MB/s ± 0%  1022MB/s ± 0%   ~     (p=1.000 n=1+1)
