### PR TITLE
os: update tempDir for cross-platform get temp directory

### DIFF
--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -341,7 +341,7 @@ func tempDir() string {
 	switch runtime.GOOS {
 	case "windows":
 		if dir = Getenv("TEMP"); dir == "" {
-			dir = "%USERPROFILE%/AppData/Local/Temp"
+			dir = "%USERPROFILE%\\AppData\\Local\\Temp"
 		}
 	case "darwin":
 		if dir = Getenv("TMPDIR"); dir == "" {

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -336,14 +336,23 @@ func Remove(name string) error {
 }
 
 func tempDir() string {
-	dir := Getenv("TMPDIR")
-	if dir == "" {
-		if runtime.GOOS == "android" {
-			dir = "/data/local/tmp"
-		} else {
+	var dir string
+
+	switch runtime.GOOS {
+	case "windows":
+		if dir = Getenv("TEMP"); dir == "" {
+			dir = "%USERPROFILE%/AppData/Local/Temp"
+		}
+	case "darwin":
+		if dir = Getenv("TMPDIR"); dir == "" {
 			dir = "/tmp"
 		}
+	case "android":
+		dir = "/data/local/tmp"
+	default: // unix
+		dir = "/tmp"
 	}
+
 	return dir
 }
 

--- a/src/os/os_test.go
+++ b/src/os/os_test.go
@@ -2943,3 +2943,20 @@ func TestPipeCloseRace(t *testing.T) {
 		t.Errorf("got nils %d errs %d, want 2 2", nils, errs)
 	}
 }
+
+func TestTempDir(t *testing.T) {
+	dir := TempDir()
+
+	if dir == "" {
+		t.Fatalf("dir is empty string")
+	}
+
+	dirStat, err := Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !dirStat.IsDir() {
+		t.Fatalf("dir %s is not directory; type = %v", dir, dirStat.Mode())
+	}
+}


### PR DESCRIPTION
older tempDir just get dir path for linux and android now we can get tempDir for windows and darwin.

OS X generates a programmatic directory stored in /private/var and defines the $TMPDIR environment variable for locating the system temporary folder.

