### PR TITLE
crypto/tls: add `certout`, `keyout` options

### DIFF
--- a/src/crypto/tls/generate_cert.go
+++ b/src/crypto/tls/generate_cert.go
@@ -5,7 +5,7 @@
 //go:build ignore
 
 // Generate a self-signed X.509 certificate for a TLS server. Outputs to
-// 'cert.pem' and 'key.pem' and will overwrite existing files.
+// 'cert.pem' and 'key.pem' in default and will overwrite existing files.
 
 package main
 
@@ -35,6 +35,8 @@ var (
 	rsaBits    = flag.Int("rsa-bits", 2048, "Size of RSA key to generate. Ignored if --ecdsa-curve is set")
 	ecdsaCurve = flag.String("ecdsa-curve", "", "ECDSA curve to use to generate a key. Valid values are P224, P256 (recommended), P384, P521")
 	ed25519Key = flag.Bool("ed25519", false, "Generate an Ed25519 key")
+	certName   = flag.String("certout", "cert.pem", "File name of generated cert")
+	keyName    = flag.String("keyout", "key.pem", "File name of generated key")
 )
 
 func publicKey(priv any) any {
@@ -141,31 +143,31 @@ func main() {
 		log.Fatalf("Failed to create certificate: %v", err)
 	}
 
-	certOut, err := os.Create("cert.pem")
+	certOut, err := os.Create(*certName)
 	if err != nil {
-		log.Fatalf("Failed to open cert.pem for writing: %v", err)
+		log.Fatalf("Failed to open %s for writing: %v", *certName, err)
 	}
 	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
-		log.Fatalf("Failed to write data to cert.pem: %v", err)
+		log.Fatalf("Failed to write data to %s: %v", *certName, err)
 	}
 	if err := certOut.Close(); err != nil {
-		log.Fatalf("Error closing cert.pem: %v", err)
+		log.Fatalf("Error closing %s: %v", *certName, err)
 	}
-	log.Print("wrote cert.pem\n")
+	log.Printf("wrote %s\n", *certName)
 
-	keyOut, err := os.OpenFile("key.pem", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	keyOut, err := os.OpenFile(*keyName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		log.Fatalf("Failed to open key.pem for writing: %v", err)
+		log.Fatalf("Failed to open %s for writing: %v", *keyName, err)
 	}
 	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
 	if err != nil {
 		log.Fatalf("Unable to marshal private key: %v", err)
 	}
 	if err := pem.Encode(keyOut, &pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}); err != nil {
-		log.Fatalf("Failed to write data to key.pem: %v", err)
+		log.Fatalf("Failed to write data to %s: %v", *keyName, err)
 	}
 	if err := keyOut.Close(); err != nil {
-		log.Fatalf("Error closing key.pem: %v", err)
+		log.Fatalf("Error closing %s: %v", *keyName, err)
 	}
-	log.Print("wrote key.pem\n")
+	log.Printf("wrote %s\n", *keyName)
 }


### PR DESCRIPTION
```zsh
~/Desktop/go 
$ go run ./src/crypto/tls/generate_cert.go --host localhost        
2023/01/16 21:43:54 wrote cert.pem
2023/01/16 21:43:54 wrote key.pem

~/Desktop/go 
$ go run ./src/crypto/tls/generate_cert.go --host localhost --certout server.crt --keyout server.key
2023/01/16 21:55:14 wrote server.crt
2023/01/16 21:55:14 wrote server.key
```