### PR TITLE
cmd/link: fix incorrect DOS header on Windows binaries

### DIFF
--- a/src/cmd/link/internal/ld/pe.go
+++ b/src/cmd/link/internal/ld/pe.go
@@ -152,6 +152,7 @@ const (
 
 // DOS stub that prints out
 // "This program cannot be run in DOS mode."
+// See IMAGE_DOS_HEADER in the Windows SDK for the format of the header used here.
 var dosstub = []uint8{
 	0x4d,
 	0x5a,
@@ -159,9 +160,9 @@ var dosstub = []uint8{
 	0x00,
 	0x03,
 	0x00,
+	0x00,
+	0x00,
 	0x04,
-	0x00,
-	0x00,
 	0x00,
 	0x00,
 	0x00,


### PR DESCRIPTION
The previous DOS header placed on Windows binaries was incorrect, as it had e_crlc (number of relocations) set to 4, instead of e_cparhdr (size of header in 16-bit words) set to 4. This resulted in execution starting at the beginning of the file, instead of where the DOS stub code actually exists.

Fixes #57834
