### PR TITLE
make.bat: support existing toolchain paths with spaces

### DIFF
--- a/src/make.bat
+++ b/src/make.bat
@@ -73,7 +73,7 @@ if not exist ..\bin\tool mkdir ..\bin\tool
 if not "x%GOROOT_BOOTSTRAP%"=="x" goto bootstrapset
 for /f "tokens=*" %%g in ('where go 2^>nul') do (
 	if "x%GOROOT_BOOTSTRAP%"=="x" (
-		for /f "tokens=*" %%i in ('%%g env GOROOT 2^>nul') do (
+		for /f "tokens=*" %%i in ('"%%g" env GOROOT 2^>nul') do (
 			if /I not "%%i"=="%GOROOT_TEMP%" (
 				set GOROOT_BOOTSTRAP=%%i
 			)


### PR DESCRIPTION
Previously if the default go toolchain (from "where go") contained spaces, then running make.bat would fail.

Fixes it to correctly treat paths with spaces. This is especially useful given that the default Go install path is under "C:\Program Files".

Fixes #57918