### PR TITLE
os: use GetTempPath2 on Windows if available

### DIFF
--- a/src/internal/syscall/windows/syscall_windows.go
+++ b/src/internal/syscall/windows/syscall_windows.go
@@ -151,6 +151,7 @@ const (
 //sys	GetModuleFileName(module syscall.Handle, fn *uint16, len uint32) (n uint32, err error) = kernel32.GetModuleFileNameW
 //sys	SetFileInformationByHandle(handle syscall.Handle, fileInformationClass uint32, buf uintptr, bufsize uint32) (err error) = kernel32.SetFileInformationByHandle
 //sys	VirtualQuery(address uintptr, buffer *MemoryBasicInformation, length uintptr) (err error) = kernel32.VirtualQuery
+//sys	GetTempPath2(buflen uint32, buf *uint16) (n uint32, err error) = GetTempPath2W
 
 const (
 	// flags for CreateToolhelp32Snapshot
@@ -361,6 +362,10 @@ const (
 
 func LoadGetFinalPathNameByHandle() error {
 	return procGetFinalPathNameByHandleW.Find()
+}
+
+func ErrorLoadingGetTempPath2() error {
+	return procGetTempPath2W.Find()
 }
 
 //sys	CreateEnvironmentBlock(block **uint16, token syscall.Token, inheritExisting bool) (err error) = userenv.CreateEnvironmentBlock

--- a/src/internal/syscall/windows/zsyscall_windows.go
+++ b/src/internal/syscall/windows/zsyscall_windows.go
@@ -62,6 +62,7 @@ var (
 	procGetFinalPathNameByHandleW     = modkernel32.NewProc("GetFinalPathNameByHandleW")
 	procGetModuleFileNameW            = modkernel32.NewProc("GetModuleFileNameW")
 	procGetVolumeInformationByHandleW = modkernel32.NewProc("GetVolumeInformationByHandleW")
+	procGetTempPath2W                 = modkernel32.NewProc("GetTempPath2W")
 	procLockFileEx                    = modkernel32.NewProc("LockFileEx")
 	procModule32FirstW                = modkernel32.NewProc("Module32FirstW")
 	procModule32NextW                 = modkernel32.NewProc("Module32NextW")
@@ -213,6 +214,15 @@ func GetFinalPathNameByHandle(file syscall.Handle, filePath *uint16, filePathSiz
 
 func GetModuleFileName(module syscall.Handle, fn *uint16, len uint32) (n uint32, err error) {
 	r0, _, e1 := syscall.Syscall(procGetModuleFileNameW.Addr(), 3, uintptr(module), uintptr(unsafe.Pointer(fn)), uintptr(len))
+	n = uint32(r0)
+	if n == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func GetTempPath2(buflen uint32, buf *uint16) (n uint32, err error) {
+	r0, _, e1 := syscall.Syscall(procGetTempPath2W.Addr(), 2, uintptr(buflen), uintptr(unsafe.Pointer(buf)), 0)
 	n = uint32(r0)
 	if n == 0 {
 		err = errnoErr(e1)


### PR DESCRIPTION
This generates GetTempPath2. Go now tries to determine if the windows it runs on has GetTempPath2 by finding it only once at the loading time. If GetTempPath2 exists, it sets the flag so that any calls to tempDir will use it. If it doesn't exist, Go then uses GetTempPath.

GetTempPath2 was generated into internal/syscall/windows since syscall is locked down.


Fixes #56899