### PR TITLE
cmd/go: mod vendor: fixed checking for vendor directory

### DIFF
--- a/src/cmd/go/internal/modcmd/vendor.go
+++ b/src/cmd/go/internal/modcmd/vendor.go
@@ -211,7 +211,7 @@ func moduleLine(m, r module.Version) string {
 		b.WriteString(m.Version)
 	}
 	if r.Path != "" {
-		if strings.HasPrefix(r.Path, "./vendor") || strings.HasPrefix(r.Path, ".\vendor") {
+		if strings.HasPrefix(r.Path, "./vendor/") || strings.HasPrefix(r.Path, ".\vendor\") {
 			base.Fatalf("go: replacement path %s inside vendor directory", r.Path)
 		}
 		b.WriteString(" => ")

--- a/src/cmd/go/internal/modcmd/vendor.go
+++ b/src/cmd/go/internal/modcmd/vendor.go
@@ -211,7 +211,7 @@ func moduleLine(m, r module.Version) string {
 		b.WriteString(m.Version)
 	}
 	if r.Path != "" {
-		if strings.HasPrefix(r.Path, "./vendor/") || strings.HasPrefix(r.Path, ".\vendor\") {
+		if str.HasFilePathPrefix(filepath.Clean(r.Path), "vendor") {
 			base.Fatalf("go: replacement path %s inside vendor directory", r.Path)
 		}
 		b.WriteString(" => ")


### PR DESCRIPTION
In our case I was using a "vendor-replace" directory which was incorrectly flagged as being in the vendor directory.