### PR TITLE
crypto: support errors.Unwrap() for more crypto errors

### DIFF
--- a/src/crypto/tls/handshake_client.go
+++ b/src/crypto/tls/handshake_client.go
@@ -108,14 +108,14 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *ecdh.PrivateKey, error) {
 
 	_, err := io.ReadFull(config.rand(), hello.random)
 	if err != nil {
-		return nil, nil, errors.New("tls: short read from Rand: " + err.Error())
+		return nil, nil, fmt.Errorf("tls: short read from Rand: %w", err)
 	}
 
 	// A random session ID is used to detect when the server accepted a ticket
 	// and is resuming a session (see RFC 5077). In TLS 1.3, it's always set as
 	// a compatibility measure (see RFC 8446, Section 4.1.2).
 	if _, err := io.ReadFull(config.rand(), hello.sessionId); err != nil {
-		return nil, nil, errors.New("tls: short read from Rand: " + err.Error())
+		return nil, nil, fmt.Errorf("tls: short read from Rand: %w", err)
 	}
 
 	if hello.vers >= VersionTLS12 {
@@ -649,7 +649,7 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 	hs.masterSecret = masterFromPreMasterSecret(c.vers, hs.suite, preMasterSecret, hs.hello.random, hs.serverHello.random)
 	if err := c.config.writeKeyLog(keyLogLabelTLS12, hs.hello.random, hs.masterSecret); err != nil {
 		c.sendAlert(alertInternalError)
-		return errors.New("tls: failed to write to key log: " + err.Error())
+		return fmt.Errorf("tls: failed to write to key log: %w", err)
 	}
 
 	hs.finishedHash.discardHandshakeBuffer()
@@ -855,7 +855,7 @@ func (c *Conn) verifyServerCertificate(certificates [][]byte) error {
 		cert, err := clientCertCache.newCert(asn1Data)
 		if err != nil {
 			c.sendAlert(alertBadCertificate)
-			return errors.New("tls: failed to parse certificate from server: " + err.Error())
+			return fmt.Errorf("tls: failed to parse certificate from server: %w", err)
 		}
 		activeHandles[i] = cert
 		certs[i] = cert.cert

--- a/src/crypto/tls/handshake_client_tls13.go
+++ b/src/crypto/tls/handshake_client_tls13.go
@@ -12,6 +12,7 @@ import (
 	"crypto/hmac"
 	"crypto/rsa"
 	"errors"
+	"fmt"
 	"hash"
 	"time"
 )
@@ -495,7 +496,7 @@ func (hs *clientHandshakeStateTLS13) readServerCertificate() error {
 	if err := verifyHandshakeSignature(sigType, c.peerCertificates[0].PublicKey,
 		sigHash, signed, certVerify.signature); err != nil {
 		c.sendAlert(alertDecryptError)
-		return errors.New("tls: invalid signature by the server certificate: " + err.Error())
+		return fmt.Errorf("tls: invalid signature by the server certificate: %w", err)
 	}
 
 	hs.transcript.Write(certVerify.marshal())
@@ -606,7 +607,7 @@ func (hs *clientHandshakeStateTLS13) sendClientCertificate() error {
 	sig, err := cert.PrivateKey.(crypto.Signer).Sign(c.config.rand(), signed, signOpts)
 	if err != nil {
 		c.sendAlert(alertInternalError)
-		return errors.New("tls: failed to sign handshake: " + err.Error())
+		return fmt.Errorf("tls: failed to sign handshake: %w", err)
 	}
 	certVerifyMsg.signature = sig
 

--- a/src/crypto/tls/handshake_server.go
+++ b/src/crypto/tls/handshake_server.go
@@ -670,7 +670,7 @@ func (hs *serverHandshakeState) doFullHandshake() error {
 		signed := hs.finishedHash.hashForClientCertificate(sigType, sigHash)
 		if err := verifyHandshakeSignature(sigType, pub, sigHash, signed, certVerify.signature); err != nil {
 			c.sendAlert(alertDecryptError)
-			return errors.New("tls: invalid signature by the client certificate: " + err.Error())
+			return fmt.Errorf("tls: invalid signature by the client certificate: %w", err)
 		}
 
 		hs.finishedHash.Write(certVerify.marshal())
@@ -807,7 +807,7 @@ func (c *Conn) processCertsFromClient(certificate Certificate) error {
 	for i, asn1Data := range certificates {
 		if certs[i], err = x509.ParseCertificate(asn1Data); err != nil {
 			c.sendAlert(alertBadCertificate)
-			return errors.New("tls: failed to parse client certificate: " + err.Error())
+			return fmt.Errorf("tls: failed to parse client certificate: %w", err)
 		}
 	}
 

--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -12,6 +12,7 @@ import (
 	"crypto/rsa"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"hash"
 	"io"
 	"time"
@@ -637,7 +638,7 @@ func (hs *serverHandshakeStateTLS13) sendServerCertificate() error {
 		} else {
 			c.sendAlert(alertInternalError)
 		}
-		return errors.New("tls: failed to sign handshake: " + err.Error())
+		return fmt.Errorf("tls: failed to sign handshake: %w", err)
 	}
 	certVerifyMsg.signature = sig
 
@@ -840,7 +841,7 @@ func (hs *serverHandshakeStateTLS13) readClientCertificate() error {
 		if err := verifyHandshakeSignature(sigType, c.peerCertificates[0].PublicKey,
 			sigHash, signed, certVerify.signature); err != nil {
 			c.sendAlert(alertDecryptError)
-			return errors.New("tls: invalid signature by the client certificate: " + err.Error())
+			return fmt.Errorf("tls: invalid signature by the client certificate: %w", err)
 		}
 
 		hs.transcript.Write(certVerify.marshal())

--- a/src/crypto/tls/key_agreement.go
+++ b/src/crypto/tls/key_agreement.go
@@ -232,7 +232,7 @@ func (ka *ecdheKeyAgreement) generateServerKeyExchange(config *Config, cert *Cer
 	}
 	sig, err := priv.Sign(config.rand(), signed, signOpts)
 	if err != nil {
-		return nil, errors.New("tls: failed to sign ECDHE parameters: " + err.Error())
+		return nil, fmt.Errorf("tls: failed to sign ECDHE parameters: %w", err)
 	}
 
 	skx := new(serverKeyExchangeMsg)
@@ -352,7 +352,7 @@ func (ka *ecdheKeyAgreement) processServerKeyExchange(config *Config, clientHell
 
 	signed := hashForServerKeyExchange(sigType, sigHash, ka.version, clientHello.random, serverHello.random, serverECDHEParams)
 	if err := verifyHandshakeSignature(sigType, cert.PublicKey, sigHash, signed, sig); err != nil {
-		return errors.New("tls: invalid signature by the server certificate: " + err.Error())
+		return fmt.Errorf("tls: invalid signature by the server certificate: %w", err)
 	}
 	return nil
 }

--- a/src/crypto/tls/ticket.go
+++ b/src/crypto/tls/ticket.go
@@ -12,6 +12,7 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"errors"
+	"fmt"
 	"io"
 
 	"golang.org/x/crypto/cryptobyte"
@@ -133,7 +134,7 @@ func (c *Conn) encryptTicket(state []byte) ([]byte, error) {
 	copy(keyName, key.keyName[:])
 	block, err := aes.NewCipher(key.aesKey[:])
 	if err != nil {
-		return nil, errors.New("tls: failed to create cipher while encrypting ticket: " + err.Error())
+		return nil, fmt.Errorf("tls: failed to create cipher while encrypting ticket: %w", err)
 	}
 	cipher.NewCTR(block, iv).XORKeyStream(encrypted[ticketKeyNameLen+aes.BlockSize:], state)
 

--- a/src/crypto/x509/parser.go
+++ b/src/crypto/x509/parser.go
@@ -535,7 +535,7 @@ func parseNameConstraintsExtension(out *Certificate, e pkix.Extension) (unhandle
 			case dnsTag:
 				domain := string(value)
 				if err := isIA5String(domain); err != nil {
-					return nil, nil, nil, nil, errors.New("x509: invalid constraint value: " + err.Error())
+					return nil, nil, nil, nil, fmt.Errorf("x509: invalid constraint value: %w", err)
 				}
 
 				trimmedDomain := domain
@@ -577,7 +577,7 @@ func parseNameConstraintsExtension(out *Certificate, e pkix.Extension) (unhandle
 			case emailTag:
 				constraint := string(value)
 				if err := isIA5String(constraint); err != nil {
-					return nil, nil, nil, nil, errors.New("x509: invalid constraint value: " + err.Error())
+					return nil, nil, nil, nil, fmt.Errorf("x509: invalid constraint value: %w", err)
 				}
 
 				// If the constraint contains an @ then
@@ -601,7 +601,7 @@ func parseNameConstraintsExtension(out *Certificate, e pkix.Extension) (unhandle
 			case uriTag:
 				domain := string(value)
 				if err := isIA5String(domain); err != nil {
-					return nil, nil, nil, nil, errors.New("x509: invalid constraint value: " + err.Error())
+					return nil, nil, nil, nil, fmt.Errorf("x509: invalid constraint value: %w", err)
 				}
 
 				if net.ParseIP(domain) != nil {

--- a/src/crypto/x509/pem_decrypt.go
+++ b/src/crypto/x509/pem_decrypt.go
@@ -16,6 +16,7 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 )
@@ -199,7 +200,7 @@ func EncryptPEMBlock(rand io.Reader, blockType string, data, password []byte, al
 	}
 	iv := make([]byte, ciph.blockSize)
 	if _, err := io.ReadFull(rand, iv); err != nil {
-		return nil, errors.New("x509: cannot generate IV: " + err.Error())
+		return nil, fmt.Errorf("x509: cannot generate IV: %w", err)
 	}
 	// The salt is the first 8 bytes of the initialization vector,
 	// matching the key derivation in DecryptPEMBlock.

--- a/src/crypto/x509/pkcs8.go
+++ b/src/crypto/x509/pkcs8.go
@@ -47,7 +47,7 @@ func ParsePKCS8PrivateKey(der []byte) (key any, err error) {
 	case privKey.Algo.Algorithm.Equal(oidPublicKeyRSA):
 		key, err = ParsePKCS1PrivateKey(privKey.PrivateKey)
 		if err != nil {
-			return nil, errors.New("x509: failed to parse RSA private key embedded in PKCS#8: " + err.Error())
+			return nil, fmt.Errorf("x509: failed to parse RSA private key embedded in PKCS#8: %w", err)
 		}
 		return key, nil
 
@@ -59,7 +59,7 @@ func ParsePKCS8PrivateKey(der []byte) (key any, err error) {
 		}
 		key, err = parseECPrivateKey(namedCurveOID, privKey.PrivateKey)
 		if err != nil {
-			return nil, errors.New("x509: failed to parse EC private key embedded in PKCS#8: " + err.Error())
+			return nil, fmt.Errorf("x509: failed to parse EC private key embedded in PKCS#8: %w", err)
 		}
 		return key, nil
 
@@ -116,7 +116,7 @@ func MarshalPKCS8PrivateKey(key any) ([]byte, error) {
 		}
 		oidBytes, err := asn1.Marshal(oid)
 		if err != nil {
-			return nil, errors.New("x509: failed to marshal curve OID: " + err.Error())
+			return nil, fmt.Errorf("x509: failed to marshal curve OID: %w", err)
 		}
 		privKey.Algo = pkix.AlgorithmIdentifier{
 			Algorithm: oidPublicKeyECDSA,
@@ -125,7 +125,7 @@ func MarshalPKCS8PrivateKey(key any) ([]byte, error) {
 			},
 		}
 		if privKey.PrivateKey, err = marshalECPrivateKeyWithOID(k, nil); err != nil {
-			return nil, errors.New("x509: failed to marshal EC private key while building PKCS#8: " + err.Error())
+			return nil, fmt.Errorf("x509: failed to marshal EC private key while building PKCS#8: %w", err)
 		}
 
 	case ed25519.PrivateKey:
@@ -154,7 +154,7 @@ func MarshalPKCS8PrivateKey(key any) ([]byte, error) {
 			}
 			oidBytes, err := asn1.Marshal(oid)
 			if err != nil {
-				return nil, errors.New("x509: failed to marshal curve OID: " + err.Error())
+				return nil, fmt.Errorf("x509: failed to marshal curve OID: %w", err)
 			}
 			privKey.Algo = pkix.AlgorithmIdentifier{
 				Algorithm: oidPublicKeyECDSA,
@@ -163,7 +163,7 @@ func MarshalPKCS8PrivateKey(key any) ([]byte, error) {
 				},
 			}
 			if privKey.PrivateKey, err = marshalECDHPrivateKey(k); err != nil {
-				return nil, errors.New("x509: failed to marshal EC private key while building PKCS#8: " + err.Error())
+				return nil, fmt.Errorf("x509: failed to marshal EC private key while building PKCS#8: %w", err)
 			}
 		}
 

--- a/src/crypto/x509/sec1.go
+++ b/src/crypto/x509/sec1.go
@@ -90,7 +90,7 @@ func parseECPrivateKey(namedCurveOID *asn1.ObjectIdentifier, der []byte) (key *e
 		if _, err := asn1.Unmarshal(der, &pkcs1PrivateKey{}); err == nil {
 			return nil, errors.New("x509: failed to parse private key (use ParsePKCS1PrivateKey instead for this key format)")
 		}
-		return nil, errors.New("x509: failed to parse EC private key: " + err.Error())
+		return nil, fmt.Errorf("x509: failed to parse EC private key: %w", err)
 	}
 	if privKey.Version != ecPrivKeyVersion {
 		return nil, fmt.Errorf("x509: unknown EC private key version %d", privKey.Version)

--- a/src/crypto/x509/x509.go
+++ b/src/crypto/x509/x509.go
@@ -2023,7 +2023,7 @@ func CreateCertificateRequest(rand io.Reader, template *CertificateRequest, priv
 
 		b, err := asn1.Marshal(attr)
 		if err != nil {
-			return nil, errors.New("x509: failed to serialise extensions attribute: " + err.Error())
+			return nil, fmt.Errorf("x509: failed to serialise extensions attribute: %w", err)
 		}
 
 		var rawValue asn1.RawValue


### PR DESCRIPTION
This allows more errors in crypto packages to be unwrapped so the inner error can be accessed.

This should help avoid some error string comparison some consumers may currently need.

Fixes #58365.