### PR TITLE
doc/go1.20: fix typo

### DIFF
--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -2759,7 +2759,7 @@ However, they <a href="#Satisfying_a_type_constraint">satisfy</a> <code>comparab
 int                          // implements comparable (int is strictly comparable)
 []byte                       // does not implement comparable (slices cannot be compared)
 interface{}                  // does not implement comparable (see above)
-interface{ ~int | ~string }  // type parameter only: implements comparable (int, string types are stricly comparable)
+interface{ ~int | ~string }  // type parameter only: implements comparable (int, string types are strictly comparable)
 interface{ comparable }      // type parameter only: implements comparable (comparable implements itself)
 interface{ ~int | ~[]byte }  // type parameter only: does not implement comparable (slices are not comparable)
 interface{ ~struct{ any } }  // type parameter only: does not implement comparable (field any is not strictly comparable)
@@ -2802,7 +2802,7 @@ A type T <i>satisfies</i> a constraint <code>C</code> if
 type argument      type constraint                // constraint satisfaction
 
 int                interface{ ~int }              // satisfied: int implements interface{ ~int }
-string             comparable                     // satisfied: string implements comparable (string is stricty comparable)
+string             comparable                     // satisfied: string implements comparable (string is strictly comparable)
 []byte             comparable                     // not satisfied: slices are not comparable
 any                interface{ comparable; int }   // not satisfied: any does not implement interface{ int }
 any                comparable                     // satisfied: any is comparable and implements the basic interface any


### PR DESCRIPTION
Fixed typo in go_spec.html.