### PR TITLE
cmd/compile/internal/staticinit: fix panic in interface conversion

### DIFF
--- a/test/fixedbugs/issue58339.dir/a.go
+++ b/test/fixedbugs/issue58339.dir/a.go
@@ -1,0 +1,17 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package a
+
+func Assert(msgAndArgs ...any) {
+}
+
+func Run() int {
+	Assert("%v")
+	return 0
+}
+
+func Run2() int {
+	return Run()
+}

--- a/test/fixedbugs/issue58339.dir/b.go
+++ b/test/fixedbugs/issue58339.dir/b.go
@@ -1,0 +1,9 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package b
+
+import "./a"
+
+var A = a.Run2()

--- a/test/fixedbugs/issue58339.go
+++ b/test/fixedbugs/issue58339.go
@@ -1,0 +1,7 @@
+// compiledir
+
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ignored


### PR DESCRIPTION
This patch fixes a panic from incorrect interface conversion from
*ir.BasicLit to *ir.ConstExpr. This only occurs when nounified
GOEXPERIMENT is set, so ideally it should be backported to Go
1.20 and removed from master.

Fixes #58339 