### PR TITLE
encoding/xml: overriding by empty namespace when no new name declaration

### DIFF
--- a/src/encoding/xml/marshal.go
+++ b/src/encoding/xml/marshal.go
@@ -545,6 +545,7 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 
 	// If a name was found, namespace is overridden with an empty space
 	if tinfo.xmlname != nil && start.Name.Space == "" &&
+		tinfo.xmlname.xmlns == "" && tinfo.xmlname.name == "" &&
 		len(p.tags) != 0 && p.tags[len(p.tags)-1].Space != "" {
 		start.Attr = append(start.Attr, Attr{Name{"", xmlnsPrefix}, ""})
 	}

--- a/src/encoding/xml/marshal.go
+++ b/src/encoding/xml/marshal.go
@@ -543,7 +543,7 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 		}
 	}
 
-	// If a name was found, namespace is overridden with an empty space
+	// If a empty name was found, namespace is overridden with an empty space
 	if tinfo.xmlname != nil && start.Name.Space == "" &&
 		tinfo.xmlname.xmlns == "" && tinfo.xmlname.name == "" &&
 		len(p.tags) != 0 && p.tags[len(p.tags)-1].Space != "" {

--- a/src/encoding/xml/xml_test.go
+++ b/src/encoding/xml/xml_test.go
@@ -1064,14 +1064,19 @@ func TestIssue7113(t *testing.T) {
 		XMLName Name `xml:""` // Sets empty namespace
 	}
 
+	type D struct {
+		XMLName Name `xml:"D"`
+	}
+
 	type A struct {
 		XMLName Name `xml:""`
 		C       C    `xml:""`
+		D       D
 	}
 
 	var a A
 	structSpace := "b"
-	xmlTest := `<A xmlns="` + structSpace + `"><C xmlns=""></C></A>`
+	xmlTest := `<A xmlns="` + structSpace + `"><C xmlns=""></C><D></D></A>`
 	t.Log(xmlTest)
 	err := Unmarshal([]byte(xmlTest), &a)
 	if err != nil {

--- a/src/encoding/xml/xml_test.go
+++ b/src/encoding/xml/xml_test.go
@@ -1065,7 +1065,7 @@ func TestIssue7113(t *testing.T) {
 	}
 
 	type D struct {
-		XMLName Name `xml:"D"`
+		XMLName Name `xml:"d"`
 	}
 
 	type A struct {
@@ -1076,7 +1076,7 @@ func TestIssue7113(t *testing.T) {
 
 	var a A
 	structSpace := "b"
-	xmlTest := `<A xmlns="` + structSpace + `"><C xmlns=""></C><D></D></A>`
+	xmlTest := `<A xmlns="` + structSpace + `"><C xmlns=""></C><d></d></A>`
 	t.Log(xmlTest)
 	err := Unmarshal([]byte(xmlTest), &a)
 	if err != nil {


### PR DESCRIPTION
The unmarshal and marshal XML text should be consistent if not modified deserialize variable.

Fixes #61881