### PR TITLE
cmd/internal/cov: fix typo in readcovdata.go

### DIFF
--- a/src/cmd/internal/cov/readcovdata.go
+++ b/src/cmd/internal/cov/readcovdata.go
@@ -108,7 +108,7 @@ type CovDataVisitor interface {
 	EndCounters()
 
 	// Invoked for each package in the meta-data file for the pod,
-	// first the 'begin' method when processinf of hte package starts,
+	// first the 'begin' method when processinf of the package starts,
 	// then the 'end' method when we're done
 	BeginPackage(pd *decodemeta.CoverageMetaDataDecoder, pkgIdx uint32)
 	EndPackage(pd *decodemeta.CoverageMetaDataDecoder, pkgIdx uint32)


### PR DESCRIPTION
hte -> the