### PR TITLE
database/sql: wake cleaner if maxIdleTime set to less than maxLifetime

### DIFF
--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -1007,7 +1007,7 @@ func (db *DB) SetConnMaxLifetime(d time.Duration) {
 	}
 	db.mu.Lock()
 	// Wake cleaner up when lifetime is shortened.
-	if d > 0 && d < db.maxLifetime && db.cleanerCh != nil {
+	if d > 0 && d < db.shortestIdleTimeLocked() && db.cleanerCh != nil {
 		select {
 		case db.cleanerCh <- struct{}{}:
 		default:
@@ -1031,7 +1031,7 @@ func (db *DB) SetConnMaxIdleTime(d time.Duration) {
 	defer db.mu.Unlock()
 
 	// Wake cleaner up when idle time is shortened.
-	if d > 0 && d < db.maxIdleTime && db.cleanerCh != nil {
+	if d > 0 && d < db.shortestIdleTimeLocked() && db.cleanerCh != nil {
 		select {
 		case db.cleanerCh <- struct{}{}:
 		default:


### PR DESCRIPTION
The existing implementation wouldn't wake the connection cleaner if
maxIdleTime was set to a value less than maxLifetime while an existing
connection was open - resulting in idle connections not being discarded
until after the first maxLifetime had passed.

Fixes #45993
