### PR TITLE
syscall/js: correct the wrong name in error for Value.Length method

### DIFF
--- a/src/syscall/js/js.go
+++ b/src/syscall/js/js.go
@@ -362,7 +362,7 @@ func makeArgs(args []any) ([]Value, []ref) {
 // It panics if v is not a JavaScript object.
 func (v Value) Length() int {
 	if vType := v.Type(); !vType.isObject() {
-		panic(&ValueError{"Value.SetIndex", vType})
+		panic(&ValueError{"Value.Length", vType})
 	}
 	r := valueLength(v.ref)
 	runtime.KeepAlive(v)


### PR DESCRIPTION
when i call "Length" method on a js.Value object, and an error results, that error claims to originate from the "SetIndex" method, which is incorrect. instead, it actually originates from the "Length" method. thus, i changed the string from "Value.SetIndex" to "Value.Length". thanks for considering!