### PR TITLE
cmd/go: don't compute Embed fields if they're not needed

### DIFF
--- a/src/cmd/go/internal/list/list.go
+++ b/src/cmd/go/internal/list/list.go
@@ -602,8 +602,9 @@ func runList(ctx context.Context, cmd *base.Command, args []string) {
 		// for test variants of packages and users who have been providing format strings
 		// might not expect those errors to stop showing up.
 		// See issue #52443.
-		SuppressDeps:      !listJsonFields.needAny("Deps", "DepsErrors"),
-		SuppressBuildInfo: !listJsonFields.needAny("Stale", "StaleReason"),
+		SuppressDeps:       !listJsonFields.needAny("Deps", "DepsErrors"),
+		SuppressBuildInfo:  !listJsonFields.needAny("Stale", "StaleReason"),
+		SuppressEmbedFiles: !listJsonFields.needAny("EmbedFiles", "TestEmbedFiles", "XTestEmbedFiles"),
 	}
 	pkgs := load.PackagesAndErrors(ctx, pkgOpts, args)
 	if !*listE {

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -1919,12 +1919,14 @@ func (p *Package) load(ctx context.Context, opts PackageOpts, path string, stk *
 		p.Module = modload.PackageModuleInfo(ctx, pkgPath)
 	}
 
-	p.EmbedFiles, p.Internal.Embed, err = resolveEmbed(p.Dir, p.EmbedPatterns)
-	if err != nil {
-		p.Incomplete = true
-		setError(err)
-		embedErr := err.(*EmbedError)
-		p.Error.setPos(p.Internal.Build.EmbedPatternPos[embedErr.Pattern])
+	if !opts.SuppressEmbedFiles {
+		p.EmbedFiles, p.Internal.Embed, err = resolveEmbed(p.Dir, p.EmbedPatterns)
+		if err != nil {
+			p.Incomplete = true
+			setError(err)
+			embedErr := err.(*EmbedError)
+			p.Error.setPos(p.Internal.Build.EmbedPatternPos[embedErr.Pattern])
+		}
 	}
 
 	// Check for case-insensitive collision of input files.
@@ -2774,6 +2776,10 @@ type PackageOpts struct {
 	// SuppressBuildInfo is true if the caller does not need p.Stale, p.StaleReason, or p.Internal.BuildInfo
 	// to be populated on the package.
 	SuppressBuildInfo bool
+
+	// SuppressEmbedFiles is true if the caller does not need any embed files to be populated on the
+	// package.
+	SuppressEmbedFiles bool
 }
 
 // PackagesAndErrors returns the packages named by the command line arguments

--- a/src/cmd/go/testdata/script/list_json_fields.txt
+++ b/src/cmd/go/testdata/script/list_json_fields.txt
@@ -26,6 +26,21 @@ go list -json=Deps
 stdout '"Deps": \['
 stdout '"errors",'
 
+# Test -json=<field> with *EmbedPatterns outputs embed patterns.
+cd embed
+go list -json=EmbedPatterns,TestEmbedPatterns,XTestEmbedPatterns
+stdout '"EmbedPatterns": \['
+stdout '"TestEmbedPatterns": \['
+stdout '"XTestEmbedPatterns": \['
+# Test -json=<field> with *EmbedFiles fails due to broken file reference.
+! go list -json=EmbedFiles
+stderr 'no matching files found'
+! go list -json=TestEmbedFiles
+stderr 'no matching files found'
+! go list -json=XTestEmbedFiles
+stderr 'no matching files found'
+cd ..
+
 [!git] skip
 
 # Test -json=<field> without Stale skips computing buildinfo
@@ -73,3 +88,26 @@ module example.com/repo
 package main
 
 func main() {}
+-- embed/go.mod --
+module example.com/embed
+-- embed/embed.go --
+package embed
+
+import _ "embed"
+
+//go:embed non-existing-file.txt
+var s string
+-- embed/embed_test.go --
+package embed
+
+import _ "embed"
+
+//go:embed non-existing-file.txt
+var s string
+-- embed/embed_xtest_test.go --
+package embed_test
+
+import _ "embed"
+
+//go:embed non-existing-file.txt
+var s string


### PR DESCRIPTION
If the user provides the -json flag to explicitly specify fields, but doesn't specify any *Embed* field, skip computing the embed fields.

This enhances the initial implementation of #29666.
