### PR TITLE
cmd/cgo: include seed string with -frandom-seed for lto

### DIFF
--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -39,6 +39,7 @@ import (
 	"cmd/go/internal/slices"
 	"cmd/go/internal/str"
 	"cmd/go/internal/trace"
+	"cmd/internal/buildid"
 	"cmd/internal/quoted"
 	"cmd/internal/sys"
 )
@@ -2542,6 +2543,12 @@ func (b *Builder) ccompile(a *Action, p *load.Package, outfile string, flags []s
 			}
 			flags = append(slices.Clip(flags), "-fdebug-prefix-map="+from+"="+to)
 		}
+	}
+
+	// Tell gcc to not insert truly random numbers into the build process
+	// this ensures LTO won't create random numbers for symbols.
+	if b.gccSupportsFlag(compiler, "-frandom-seed=1") {
+		flags = append(flags, "-frandom-seed="+buildid.HashToString(a.actionID))
 	}
 
 	overlayPath := file


### PR DESCRIPTION
cgo is built with -flto the symbols in runtime/cgo is going to include random numbers which would make builds unreproducible.

Settings -frandom-seeds ensures this is consistent across builds, and to ensure we always use a reproducible seed across builds we use the actionID as the seed string.

runtime/cgo built with "-frandom-seed=OFEc9OKoUMJwh3-5yFCH" would output the following:

    $ strings --all --bytes=8 $WORK/b055/_pkg_.a | grep "gnu.lto_.profile"
    .gnu.lto_.profile.8403a797
    .gnu.lto_.profile.8403a797
    .gnu.lto_.profile.8403a797
    .gnu.lto_.profile.8403a797
    .gnu.lto_.profile.8403a797
    .gnu.lto_.profile.8403a797
    .gnu.lto_.profile.8403a797
    .gnu.lto_.profile.8403a797
    .gnu.lto_.profile.8403a797
    .gnu.lto_.profile.8403a797
    .gnu.lto_.profile.8403a797
    .gnu.lto_.profile.8403a797