### PR TITLE
cmd/compile: expose -ptabs flag to force compiler to emit ptabs

### DIFF
--- a/src/cmd/compile/internal/base/flag.go
+++ b/src/cmd/compile/internal/base/flag.go
@@ -105,7 +105,8 @@ type CmdFlags struct {
 	JSON               string       "help:\"version,file for JSON compiler/optimizer detail output\""
 	Lang               string       "help:\"Go language version source code expects\""
 	LinkObj            string       "help:\"write linker-specific object to `file`\""
-	LinkShared         *bool        "help:\"generate code that will be linked against Go shared libraries\"" // &Ctxt.Flag_linkshared, set below
+	LinkShared         *bool        "help:\"generate code that will be linked against Go shared libraries\""          // &Ctxt.Flag_linkshared, set below
+	Ptabs              *bool        "help:\"generate and ptabs to encode type information for all exported symbols\"" // &Ctxt.Flag_emitptabs, set below
 	Live               CountFlag    "help:\"debug liveness analysis\""
 	MSan               bool         "help:\"build code compatible with C/C++ memory sanitizer\""
 	MemProfile         string       "help:\"write memory profile to `file`\""
@@ -162,6 +163,7 @@ func ParseFlags() {
 	Flag.ImportCfg = readImportCfg
 	Flag.CoverageCfg = readCoverageCfg
 	Flag.LinkShared = &Ctxt.Flag_linkshared
+	Flag.Ptabs = &Ctxt.Flag_ptabs
 	Flag.Shared = &Ctxt.Flag_shared
 	Flag.WB = true
 	Flag.WrapGlobalMapInit = true

--- a/src/cmd/compile/internal/reflectdata/reflect.go
+++ b/src/cmd/compile/internal/reflectdata/reflect.go
@@ -816,7 +816,7 @@ func TypeSymPrefix(prefix string, t *types.Type) *types.Sym {
 	NeedRuntimeType(t)
 	signatmu.Unlock()
 
-	//print("algsym: %s -> %+S\n", p, s);
+	// print("algsym: %s -> %+S\n", p, s);
 
 	return s
 }
@@ -1356,7 +1356,7 @@ func writeITab(lsym *obj.LSym, typ, iface *types.Type, allowNonImplement bool) {
 
 func WriteTabs() {
 	// process ptabs
-	if types.LocalPkg.Name == "main" && len(ptabs) > 0 {
+	if (types.LocalPkg.Name == "main" || base.Ctxt.Flag_ptabs) && len(ptabs) > 0 {
 		ot := 0
 		s := base.Ctxt.Lookup("go:plugin.tabs")
 		for _, p := range ptabs {
@@ -1757,7 +1757,7 @@ func ZeroAddr(size int64) ir.Node {
 }
 
 func CollectPTabs() {
-	if !base.Ctxt.Flag_dynlink || types.LocalPkg.Name != "main" {
+	if (!base.Ctxt.Flag_dynlink || types.LocalPkg.Name != "main") && !base.Ctxt.Flag_ptabs {
 		return
 	}
 	for _, exportn := range typecheck.Target.Exports {
@@ -1773,7 +1773,7 @@ func CollectPTabs() {
 		if !types.IsExported(s.Name) {
 			continue
 		}
-		if s.Pkg.Name != "main" {
+		if s.Pkg.Name != "main" && !base.Ctxt.Flag_ptabs {
 			continue
 		}
 		ptabs = append(ptabs, n)

--- a/src/cmd/internal/obj/link.go
+++ b/src/cmd/internal/obj/link.go
@@ -903,6 +903,7 @@ type Link struct {
 	Flag_shared        bool
 	Flag_dynlink       bool
 	Flag_linkshared    bool
+	Flag_ptabs         bool
 	Flag_optimize      bool
 	Flag_locationlists bool
 	Flag_noRefName     bool   // do not include referenced symbol names in object file


### PR DESCRIPTION
Implements https://github.com/golang/go/issues/58567

Currently compiler only emits ptabs for package `main` with `-dynlink`, for `-buildmode=plugin`. This PR exposes a flag `-ptabs` to force the ptabs to be emitted with other buildmodes