### PR TITLE
net/url: simplify values Get

### DIFF
--- a/src/net/url/url.go
+++ b/src/net/url/url.go
@@ -883,14 +883,10 @@ type Values map[string][]string
 // the empty string. To access multiple values, use the map
 // directly.
 func (v Values) Get(key string) string {
-	if v == nil {
-		return ""
+	if vs := v[key]; len(vs) != 0 {
+		return vs[0]
 	}
-	vs := v[key]
-	if len(vs) == 0 {
-		return ""
-	}
-	return vs[0]
+	return ""
 }
 
 // Set sets the key to value. It replaces any existing

--- a/src/net/url/url.go
+++ b/src/net/url/url.go
@@ -883,10 +883,11 @@ type Values map[string][]string
 // the empty string. To access multiple values, use the map
 // directly.
 func (v Values) Get(key string) string {
-	if vs := v[key]; len(vs) != 0 {
-		return vs[0]
+	vs := v[key]
+	if len(vs) == 0 {
+		return ""
 	}
-	return ""
+	return vs[0]
 }
 
 // Set sets the key to value. It replaces any existing


### PR DESCRIPTION
Checking if v == nil is unnecessary, nil map always return the zero value of the value type.