### PR TITLE
cryptobyte: disambiguate empty fields from errors

### DIFF
--- a/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go
+++ b/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go
@@ -421,6 +421,7 @@ func (s *String) ReadASN1Enum(out *int) bool {
 func (s *String) readBase128Int(out *int) bool {
 	ret := 0
 	for i := 0; len(*s) > 0; i++ {
+		var b byte
 		if i == 5 {
 			return false
 		}
@@ -430,7 +431,10 @@ func (s *String) readBase128Int(out *int) bool {
 			return false
 		}
 		ret <<= 7
-		b := s.read(1)[0]
+		c, ok := s.read(1)
+		if ok {
+			b = c[0]
+		}
 		ret |= int(b & 0x7f)
 		if b&0x80 == 0 {
 			*out = ret

--- a/src/vendor/golang.org/x/crypto/cryptobyte/string.go
+++ b/src/vendor/golang.org/x/crypto/cryptobyte/string.go
@@ -23,25 +23,26 @@ type String []byte
 
 // read advances a String by n bytes and returns them. If less than n bytes
 // remain, it returns nil.
-func (s *String) read(n int) []byte {
+func (s *String) read(n int) ([]byte, bool) {
 	if len(*s) < n || n < 0 {
-		return nil
+		return nil, false
 	}
 	v := (*s)[:n]
 	*s = (*s)[n:]
-	return v
+	return v, true
 }
 
 // Skip advances the String by n byte and reports whether it was successful.
 func (s *String) Skip(n int) bool {
-	return s.read(n) != nil
+	_, ok := s.read(n)
+	return ok
 }
 
 // ReadUint8 decodes an 8-bit value into out and advances over it.
 // It reports whether the read was successful.
 func (s *String) ReadUint8(out *uint8) bool {
-	v := s.read(1)
-	if v == nil {
+	v, ok := s.read(1)
+	if !ok {
 		return false
 	}
 	*out = uint8(v[0])
@@ -51,8 +52,8 @@ func (s *String) ReadUint8(out *uint8) bool {
 // ReadUint16 decodes a big-endian, 16-bit value into out and advances over it.
 // It reports whether the read was successful.
 func (s *String) ReadUint16(out *uint16) bool {
-	v := s.read(2)
-	if v == nil {
+	v, ok := s.read(2)
+	if !ok {
 		return false
 	}
 	*out = uint16(v[0])<<8 | uint16(v[1])
@@ -62,8 +63,8 @@ func (s *String) ReadUint16(out *uint16) bool {
 // ReadUint24 decodes a big-endian, 24-bit value into out and advances over it.
 // It reports whether the read was successful.
 func (s *String) ReadUint24(out *uint32) bool {
-	v := s.read(3)
-	if v == nil {
+	v, ok := s.read(3)
+	if !ok {
 		return false
 	}
 	*out = uint32(v[0])<<16 | uint32(v[1])<<8 | uint32(v[2])
@@ -73,8 +74,8 @@ func (s *String) ReadUint24(out *uint32) bool {
 // ReadUint32 decodes a big-endian, 32-bit value into out and advances over it.
 // It reports whether the read was successful.
 func (s *String) ReadUint32(out *uint32) bool {
-	v := s.read(4)
-	if v == nil {
+	v, ok := s.read(4)
+	if !ok {
 		return false
 	}
 	*out = uint32(v[0])<<24 | uint32(v[1])<<16 | uint32(v[2])<<8 | uint32(v[3])
@@ -84,8 +85,8 @@ func (s *String) ReadUint32(out *uint32) bool {
 // ReadUint64 decodes a big-endian, 64-bit value into out and advances over it.
 // It reports whether the read was successful.
 func (s *String) ReadUint64(out *uint64) bool {
-	v := s.read(8)
-	if v == nil {
+	v, ok := s.read(8)
+	if !ok {
 		return false
 	}
 	*out = uint64(v[0])<<56 | uint64(v[1])<<48 | uint64(v[2])<<40 | uint64(v[3])<<32 | uint64(v[4])<<24 | uint64(v[5])<<16 | uint64(v[6])<<8 | uint64(v[7])
@@ -93,8 +94,8 @@ func (s *String) ReadUint64(out *uint64) bool {
 }
 
 func (s *String) readUnsigned(out *uint32, length int) bool {
-	v := s.read(length)
-	if v == nil {
+	v, ok := s.read(length)
+	if !ok {
 		return false
 	}
 	var result uint32
@@ -107,8 +108,8 @@ func (s *String) readUnsigned(out *uint32, length int) bool {
 }
 
 func (s *String) readLengthPrefixed(lenLen int, outChild *String) bool {
-	lenBytes := s.read(lenLen)
-	if lenBytes == nil {
+	lenBytes, ok := s.read(lenLen)
+	if !ok {
 		return false
 	}
 	var length uint32
@@ -116,8 +117,8 @@ func (s *String) readLengthPrefixed(lenLen int, outChild *String) bool {
 		length = length << 8
 		length = length | uint32(b)
 	}
-	v := s.read(int(length))
-	if v == nil {
+	v, ok := s.read(int(length))
+	if !ok {
 		return false
 	}
 	*outChild = v
@@ -147,8 +148,8 @@ func (s *String) ReadUint24LengthPrefixed(out *String) bool {
 // ReadBytes reads n bytes into out and advances over them. It reports
 // whether the read was successful.
 func (s *String) ReadBytes(out *[]byte, n int) bool {
-	v := s.read(n)
-	if v == nil {
+	v, ok := s.read(n)
+	if !ok {
 		return false
 	}
 	*out = v
@@ -159,8 +160,8 @@ func (s *String) ReadBytes(out *[]byte, n int) bool {
 // whether the copy operation was successful
 func (s *String) CopyBytes(out []byte) bool {
 	n := len(out)
-	v := s.read(n)
-	if v == nil {
+	v, ok := s.read(n)
+	if !ok {
 		return false
 	}
 	return copy(out, v) == n


### PR DESCRIPTION
The `read()` function underpins many of the other functions within `cryptobyte`.  However it returned only `[]byte`, which in come cases (i.e. a zero length field) could be empty despite there being no error (such as running out of bytes to process).  Many functions (e.g. `ReadUint16LengthPrefixed`) only perform a check for `nil` or similar to determine a success/fail state, and so would return failure (`bool == false`) in the event of cases such as a zero length field, when there is still more data to follow.

When processing something such as a TLS handshake, for example, it is not uncommon to encounter a 0 length field, with valid data following.  However when using `cryptobyte` to check this the `bool` will be set to false, and there is no other form of error checking available.

Therefore the supplied patch modifies the `read()` function to return `([]byte, error)` instead, so that an empty `[]byte` can be returned along with a success status for such cases.  The rest of the suggested change consists of modifications to the rest of the package to account for this change.

These changes are self contained within the package and so should merely fix the bug without changes required elsewhere.