### PR TITLE
text/template: clarify the definition of immediate text for trimming

### DIFF
--- a/src/text/template/doc.go
+++ b/src/text/template/doc.go
@@ -62,16 +62,13 @@ the generated output would be
 For this trimming, the definition of white space characters is the same as in Go:
 space, horizontal tab, carriage return, and newline.
 
-Another example is
+Another example, when executing the template whose source is
 
 	"some   {{ "   " }}   {{- " leading spaces" }}"
 
-which would output
+the generated output would be
 
 	"some       leading spaces"
-
-Noting that the white spaces in "some    " and in "{{ "   " }}" would not be
-trimmed as they do not immediately precede "{{- " leading spaces" }}".
 
 Actions
 

--- a/src/text/template/doc.go
+++ b/src/text/template/doc.go
@@ -70,8 +70,8 @@ which would output
 
 	"some       leading spaces"
 
-Noting that the white space in "some    " would not be trimmed as it does not
-immediately precedes "{{- " spaces" }}".
+Noting that the white spaces in "some    " and in "{{ "   " }}" would not be
+trimmed as they do not immediately precede "{{- " spaces" }}".
 
 Actions
 

--- a/src/text/template/doc.go
+++ b/src/text/template/doc.go
@@ -62,6 +62,17 @@ the generated output would be
 For this trimming, the definition of white space characters is the same as in Go:
 space, horizontal tab, carriage return, and newline.
 
+Another example is
+
+	"some   {{ "   " }}   {{- " leading spaces" }}"
+
+which would output
+
+	"some       leading spaces"
+
+Noting that the white space in "some    " would not be trimmed as it does not
+immediately precedes "{{- " spaces" }}".
+
 Actions
 
 Here is the list of actions. "Arguments" and "pipelines" are evaluations of

--- a/src/text/template/doc.go
+++ b/src/text/template/doc.go
@@ -71,7 +71,7 @@ which would output
 	"some       leading spaces"
 
 Noting that the white spaces in "some    " and in "{{ "   " }}" would not be
-trimmed as they do not immediately precede "{{- " spaces" }}".
+trimmed as they do not immediately precede "{{- " leading spaces" }}".
 
 Actions
 


### PR DESCRIPTION
With an example that makes it clear that immediate text is, at most, the text until the closure or opening of another template expression.