### PR TITLE
fix/fuzz: output int32(v)/rune(q) in failing log

### DIFF
--- a/src/internal/fuzz/encoding.go
+++ b/src/internal/fuzz/encoding.go
@@ -81,7 +81,7 @@ func marshalCorpusFile(vals ...any) []byte {
 			// We arbitrarily draw the line at UTF-8 validity, which biases toward the
 			// "rune" interpretation. (However, we accept either format as input.)
 			if utf8.ValidRune(t) {
-				fmt.Fprintf(b, "rune(%q)\n", t)
+				fmt.Fprintf(b, "int32(%v)/rune(%q)\n", t, t)
 			} else {
 				fmt.Fprintf(b, "int32(%v)\n", t)
 			}
@@ -116,6 +116,12 @@ func unmarshalCorpusFile(b []byte) ([]any, error) {
 		line = bytes.TrimSpace(line)
 		if len(line) == 0 {
 			continue
+		}
+		if bytes.HasPrefix(line, []byte("int32")) ||
+			bytes.HasPrefix(line, []byte("rune")) {
+			if idx := bytes.IndexByte(line, '/'); idx != -1 {
+				line = line[:idx]
+			}
 		}
 		v, err := parseCorpusValue(line)
 		if err != nil {


### PR DESCRIPTION
When fuzz testing outputs failing input into testdata/<log>, it needs to
marshal the input, In go, int32 and rune are the same datatype, so it
cannot differentiate the two types in typeswitch.

Before, when the data is a valid unicode point, it will outputs rune(%q)
in the log, but the real datatype maybe a int32. In this case, we have
to query the ASCII or unicode table to get the int32 value. It's
inconvenient.

So, here we output int32(%v)/rune(%q) to solve this.

Fixes #58824.