### PR TITLE
flag: continue parsing arguments when using ContinueOnError

### DIFF
--- a/src/flag/flag.go
+++ b/src/flag/flag.go
@@ -1114,7 +1114,7 @@ func (f *FlagSet) Parse(arguments []string) error {
 		}
 		switch f.errorHandling {
 		case ContinueOnError:
-			return err
+			continue
 		case ExitOnError:
 			if err == ErrHelp {
 				os.Exit(0)


### PR DESCRIPTION
Fixes #15352

Go's flag.FlagSet struct has ErrorHandling support with three values: ContinueOnError, ExitOnError, and PanicOnError. ExitOnError and PanicOnError are straightforward, but ContinueOnError stops processing arguments if an error is encountered.

This commit changes the behavior of ContinueOnError to "continue" parsing arguments. Errors are not returned and are silently dropped.
