### PR TITLE
net/http: use initial request protocol version for redirect requests

### DIFF
--- a/src/net/http/client.go
+++ b/src/net/http/client.go
@@ -651,13 +651,16 @@ func (c *Client) do(req *Request) (retres *Response, reterr error) {
 			}
 			ireq := reqs[0]
 			req = &Request{
-				Method:   redirectMethod,
-				Response: resp,
-				URL:      u,
-				Header:   make(Header),
-				Host:     host,
-				Cancel:   ireq.Cancel,
-				ctx:      ireq.ctx,
+				Method:     redirectMethod,
+				Response:   resp,
+				URL:        u,
+				Proto:      ireq.Proto,
+				ProtoMajor: ireq.ProtoMajor,
+				ProtoMinor: ireq.ProtoMinor,
+				Header:     make(Header),
+				Host:       host,
+				Cancel:     ireq.Cancel,
+				ctx:        ireq.ctx,
 			}
 			if includeBody && ireq.GetBody != nil {
 				req.Body, err = ireq.GetBody()


### PR DESCRIPTION
This is useful for a logging RoundTripper that uses httputil.DumpRequest and it also matches NewRequest behavior.
