### PR TITLE
crypto/tls: reject change_cipher_spec record after handshake in TLS 1.3

### DIFF
--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -728,7 +728,7 @@ func (c *Conn) readRecordOrCCS(expectChangeCipherSpec bool) error {
 		// 5, a server can send a ChangeCipherSpec before its ServerHello, when
 		// c.vers is still unset. That's not useful though and suspicious if the
 		// server then selects a lower protocol version, so don't allow that.
-		if c.vers == VersionTLS13 {
+		if c.vers == VersionTLS13 && !handshakeComplete {
 			return c.retryReadRecord(expectChangeCipherSpec)
 		}
 		if !expectChangeCipherSpec {


### PR DESCRIPTION
This change fixes a non-urgent security issue in Golang's implementation of TLS 1.3.

Currently, when using Go crypto/tls, the middleman is able to insert garbage change_cipher_spec records between application_data records without breaking the TLS 1.3 connection. To test it, for example, insert the following code in func writeRecordLocked():

```go
	if typ == recordTypeApplicationData && c.vers == VersionTLS13 {
		c.write([]byte{20, 3, 3, 0, 1, 1})
	}
```

If the peer is Go crypto/tls, it will ignore these bytes and increase `c.retryCount`, instead of sending an alert immediately.
With `maxUselessRecords = 16`, this bug can be used to detect whether an application_data record is empty or not.

---

In Golang's existing comment:

https://github.com/golang/go/blob/84609d874e19e9d2419e07b72e8c8e2d24dcfc3a/src/crypto/tls/conn.go#L726-L727

In RFC 8446, Appendix D.4:

> Either side can send change_cipher_spec at any time **during the handshake**

In OpenSSL:

https://github.com/openssl/openssl/blob/ac57336cd258e0432ffa485615d11c7c7ecfe81a/ssl/record/methods/tls_common.c#L728

In BoringSSL:

https://github.com/google/boringssl/blob/082e953a134ad423a00b8859f9daf5708e729260/ssl/tls_record.cc#L257