### PR TITLE
crypto/tls: set const maxUselessRecords to 32 (the same with OpenSSL)

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -42,7 +42,7 @@ const (
 	maxCiphertextTLS13 = 16384 + 256  // maximum ciphertext length in TLS 1.3
 	recordHeaderLen    = 5            // record header length
 	maxHandshake       = 65536        // maximum handshake we support (protocol max is 16 MB)
-	maxUselessRecords  = 16           // maximum number of consecutive non-advancing records
+	maxUselessRecords  = 32           // maximum number of consecutive non-advancing records
 )
 
 // TLS record types.


### PR DESCRIPTION
In OpenSSL:

https://github.com/openssl/openssl/blob/ac57336cd258e0432ffa485615d11c7c7ecfe81a/ssl/record/methods/tls_common.c#L513

In BoringSSL:

https://github.com/google/boringssl/blob/082e953a134ad423a00b8859f9daf5708e729260/ssl/tls_record.cc#L128