### PR TITLE
runtime/cgo: fix calls from C to go on linux/ppc64

### DIFF
--- a/src/cmd/link/internal/ld/config.go
+++ b/src/cmd/link/internal/ld/config.go
@@ -211,10 +211,5 @@ func determineLinkMode(ctxt *Link) {
 		if extNeeded {
 			Exitf("internal linking requested %sbut external linking required: %s", via, extReason)
 		}
-	case LinkExternal:
-		switch {
-		case buildcfg.GOARCH == "ppc64" && buildcfg.GOOS != "aix":
-			Exitf("external linking not supported for %s/ppc64", buildcfg.GOOS)
-		}
 	}
 }

--- a/src/runtime/cgo/asm_ppc64x.s
+++ b/src/runtime/cgo/asm_ppc64x.s
@@ -30,10 +30,11 @@ TEXT crosscall2(SB),NOSPLIT|NOFRAME,$0
 	BL	runtime·reginit(SB)
 	BL	runtime·load_g(SB)
 
-#ifdef GOARCH_ppc64
+#ifdef GOOS_aix
 	// ppc64 use elf ABI v1. we must get the real entry address from
 	// first slot of the function descriptor before call.
-	// Same for AIX.
+	// This applies only for AIX; on Linux go functions are represented
+	// by a raw pointer regardless of elf ABI version
 	MOVD	8(R3), R2
 	MOVD	(R3), R3
 #endif


### PR DESCRIPTION
This fix makes cgo work correctly on linux/ppc64 (big endian).  I tested it on Gentoo linux/ppc64 (ELF ABI v1)
with https://github.com/andreiavrammsd/cgo-examples.git and with Docker.

While I can't test if the removed code was somehow correct for the AIX case, I very much doubt that would be the case.
