### PR TITLE
net/dial: only request DNS A record when IPv6 not support

### DIFF
--- a/src/net/dial.go
+++ b/src/net/dial.go
@@ -419,7 +419,14 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (Conn
 		resolveCtx = context.WithValue(resolveCtx, nettrace.TraceKey{}, &shadow)
 	}
 
-	addrs, err := d.resolver().resolveAddrList(resolveCtx, "dial", network, address, d.LocalAddr)
+	networkForResolve := network
+	switch network {
+	case "tcp", "udp":
+		if !supportsIPv6() {
+			networkForResolve = network + "4"
+		}
+	}
+	addrs, err := d.resolver().resolveAddrList(resolveCtx, "dial", networkForResolve, address, d.LocalAddr)
 	if err != nil {
 		return nil, &OpError{Op: "dial", Net: network, Source: nil, Addr: nil, Err: err}
 	}


### PR DESCRIPTION
only request DNS A record when IPv6 not support, when use `net` or `net/http` start reqeust to domain name

Fixes [58995](https://github.com/golang/go/issues/58995)