### PR TITLE
syscall: add support for setns after fork

### DIFF
--- a/src/syscall/syscall_linux_386.go
+++ b/src/syscall/syscall_linux_386.go
@@ -11,6 +11,7 @@ const (
 	_SYS_clone3     = 435
 	_SYS_faccessat2 = 439
 	_SYS_fchmodat2  = 452
+	_SYS_setns      = SYS_SETNS
 )
 
 func setTimespec(sec, nsec int64) Timespec {

--- a/src/syscall/syscall_linux_amd64.go
+++ b/src/syscall/syscall_linux_amd64.go
@@ -13,6 +13,7 @@ const (
 	_SYS_clone3     = 435
 	_SYS_faccessat2 = 439
 	_SYS_fchmodat2  = 452
+	_SYS_setns      = 308
 )
 
 //sys	Dup2(oldfd int, newfd int) (err error)

--- a/src/syscall/syscall_linux_arm.go
+++ b/src/syscall/syscall_linux_arm.go
@@ -11,6 +11,7 @@ const (
 	_SYS_clone3     = 435
 	_SYS_faccessat2 = 439
 	_SYS_fchmodat2  = 452
+	_SYS_setns      = SYS_SETNS
 )
 
 func setTimespec(sec, nsec int64) Timespec {

--- a/src/syscall/syscall_linux_arm64.go
+++ b/src/syscall/syscall_linux_arm64.go
@@ -11,6 +11,7 @@ const (
 	_SYS_clone3     = 435
 	_SYS_faccessat2 = 439
 	_SYS_fchmodat2  = 452
+	_SYS_setns      = SYS_SETNS
 )
 
 //sys	EpollWait(epfd int, events []EpollEvent, msec int) (n int, err error) = SYS_EPOLL_PWAIT

--- a/src/syscall/syscall_linux_loong64.go
+++ b/src/syscall/syscall_linux_loong64.go
@@ -11,6 +11,7 @@ const (
 	_SYS_clone3     = 435
 	_SYS_faccessat2 = 439
 	_SYS_fchmodat2  = 452
+	_SYS_setns      = SYS_SETNS
 )
 
 //sys	EpollWait(epfd int, events []EpollEvent, msec int) (n int, err error) = SYS_EPOLL_PWAIT

--- a/src/syscall/syscall_linux_mips64x.go
+++ b/src/syscall/syscall_linux_mips64x.go
@@ -15,6 +15,7 @@ const (
 	_SYS_clone3     = 5435
 	_SYS_faccessat2 = 5439
 	_SYS_fchmodat2  = 5452
+	_SYS_setns      = SYS_SETNS
 )
 
 //sys	Dup2(oldfd int, newfd int) (err error)

--- a/src/syscall/syscall_linux_mipsx.go
+++ b/src/syscall/syscall_linux_mipsx.go
@@ -13,6 +13,7 @@ const (
 	_SYS_clone3     = 4435
 	_SYS_faccessat2 = 4439
 	_SYS_fchmodat2  = 4452
+	_SYS_setns      = SYS_SETNS
 )
 
 func Syscall9(trap, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2 uintptr, err Errno)

--- a/src/syscall/syscall_linux_ppc64x.go
+++ b/src/syscall/syscall_linux_ppc64x.go
@@ -15,6 +15,7 @@ const (
 	_SYS_clone3     = 435
 	_SYS_faccessat2 = 439
 	_SYS_fchmodat2  = 452
+	_SYS_setns      = SYS_SETNS
 )
 
 //sys	Dup2(oldfd int, newfd int) (err error)

--- a/src/syscall/syscall_linux_riscv64.go
+++ b/src/syscall/syscall_linux_riscv64.go
@@ -11,6 +11,7 @@ const (
 	_SYS_clone3     = 435
 	_SYS_faccessat2 = 439
 	_SYS_fchmodat2  = 452
+	_SYS_setns      = SYS_SETNS
 )
 
 //sys	EpollWait(epfd int, events []EpollEvent, msec int) (n int, err error) = SYS_EPOLL_PWAIT

--- a/src/syscall/syscall_linux_s390x.go
+++ b/src/syscall/syscall_linux_s390x.go
@@ -11,6 +11,7 @@ const (
 	_SYS_clone3     = 435
 	_SYS_faccessat2 = 439
 	_SYS_fchmodat2  = 452
+	_SYS_setns      = SYS_SETNS
 )
 
 //sys	Dup2(oldfd int, newfd int) (err error)


### PR DESCRIPTION
This adds a Namespaces field to Linux's SysProcAttr type.
When set, these namespaces will be entered after fork and before exec.
The format for this is [ns name]=[path], e.g. mnt=/some/path.
    
This allows users to exec a new process in a pre-defined set of
namespaces without having to resort to hacks or re-execs to bootstrap
these namespaces.

Closes #56680