### PR TITLE
image/png: add HuffmanOnly compression level

### DIFF
--- a/src/image/png/fuzz.go
+++ b/src/image/png/fuzz.go
@@ -28,6 +28,7 @@ func Fuzz(data []byte) int {
 		NoCompression,
 		BestSpeed,
 		BestCompression,
+		HuffmanOnly,
 	}
 	for _, l := range levels {
 		var w bytes.Buffer

--- a/src/image/png/fuzz_test.go
+++ b/src/image/png/fuzz_test.go
@@ -50,6 +50,7 @@ func FuzzDecode(f *testing.F) {
 			NoCompression,
 			BestSpeed,
 			BestCompression,
+			HuffmanOnly,
 		}
 		for _, l := range levels {
 			var w bytes.Buffer

--- a/src/image/png/writer.go
+++ b/src/image/png/writer.go
@@ -59,6 +59,7 @@ const (
 	NoCompression      CompressionLevel = -1
 	BestSpeed          CompressionLevel = -2
 	BestCompression    CompressionLevel = -3
+	HuffmanOnly        CompressionLevel = -4
 
 	// Positive CompressionLevel values are reserved to mean a numeric zlib
 	// compression level, although that is not implemented yet.
@@ -578,6 +579,8 @@ func levelToZlib(l CompressionLevel) int {
 		return zlib.BestSpeed
 	case BestCompression:
 		return zlib.BestCompression
+	case HuffmanOnly:
+		return zlib.HuffmanOnly
 	default:
 		return zlib.DefaultCompression
 	}


### PR DESCRIPTION
Add the HuffmanOnly compression level to png,
which was only supported by the zlib library.

Closes #59023 