### PR TITLE
cmd: fix typo in webhtml.go

### DIFF
--- a/src/cmd/vendor/github.com/google/pprof/internal/driver/webhtml.go
+++ b/src/cmd/vendor/github.com/google/pprof/internal/driver/webhtml.go
@@ -56,7 +56,7 @@ func addTemplates(templates *template.Template) {
 	def("d3flamegraphscript", d3flamegraph.JSSource)
 	def("d3flamegraphcss", d3flamegraph.CSSSource)
 
-	// Embeded files.
+	// Embedded files.
 	def("css", loadCSS("html/common.css"))
 	def("header", loadFile("html/header.html"))
 	def("graph", loadFile("html/graph.html"))


### PR DESCRIPTION
Embeded -> Embedded
