### PR TITLE
errors: clarify Join documentation

### DIFF
--- a/src/errors/join.go
+++ b/src/errors/join.go
@@ -6,7 +6,7 @@ package errors
 
 // Join returns an error that wraps the given errors.
 // Any nil error values are discarded.
-// Join returns nil if errs consists entirely of nil values.
+// Join returns nil if every value in errs is nil.
 // The error formats as the concatenation of the strings obtained
 // by calling the Error method of each element of errs, with a newline
 // between each string.

--- a/src/errors/join.go
+++ b/src/errors/join.go
@@ -6,7 +6,7 @@ package errors
 
 // Join returns an error that wraps the given errors.
 // Any nil error values are discarded.
-// Join returns nil if errs consists entirely of non-nil values.
+// Join returns nil if errs consists entirely of nil values.
 // The error formats as the concatenation of the strings obtained
 // by calling the Error method of each element of errs, with a newline
 // between each string.

--- a/src/errors/join.go
+++ b/src/errors/join.go
@@ -6,7 +6,7 @@ package errors
 
 // Join returns an error that wraps the given errors.
 // Any nil error values are discarded.
-// Join returns nil if errs contains no non-nil values.
+// Join returns nil if errs consists entirely of non-nil values.
 // The error formats as the concatenation of the strings obtained
 // by calling the Error method of each element of errs, with a newline
 // between each string.


### PR DESCRIPTION
The previous documentation used a double-negative in describing Join behavior; this use of language could be confusing.

This update removes the double-negative.
