### PR TITLE
os: avoid creating a new file in Truncate on Windows

### DIFF
--- a/src/os/file_windows.go
+++ b/src/os/file_windows.go
@@ -160,7 +160,7 @@ func (f *File) seek(offset int64, whence int) (ret int64, err error) {
 // Truncate changes the size of the named file.
 // If the file is a symbolic link, it changes the size of the link's target.
 func Truncate(name string, size int64) error {
-	f, e := OpenFile(name, O_WRONLY|O_CREATE, 0666)
+	f, e := OpenFile(name, O_WRONLY, 0666)
 	if e != nil {
 		return e
 	}

--- a/src/os/os_test.go
+++ b/src/os/os_test.go
@@ -1335,6 +1335,26 @@ func TestTruncate(t *testing.T) {
 	}
 }
 
+func TestTruncateNonexistentFile(t *testing.T) {
+	t.Parallel()
+
+	assertPathError := func(t testing.TB, path string, err error) {
+		t.Helper()
+		if pe, ok := err.(*os.PathError); !ok || !os.IsNotExist(err) || pe.Path != path {
+			t.Errorf("got error: %v\nwant an ErrNotExist PathError with path %q", err, path)
+		}
+	}
+
+	path := filepath.Join(t.TempDir(), "nonexistent")
+
+	err := os.Truncate(path, 1)
+	assertPathError(t, path, err)
+
+	// Truncate shouldn't create any new file.
+	_, err = os.Stat(path)
+	assertPathError(t, path, err)
+}
+
 // Use TempDir (via newFile) to make sure we're on a local file system,
 // so that timings are not distorted by latency and caching.
 // On NFS, timings can be off due to caching of meta-data on


### PR DESCRIPTION
Truncate() a non existent file on Windows currently creates a new blank
file. This behavior is not consistent with other OSes where a file not
found error would instead be returned. This change makes Truncate on
Windows return a file-not-found error when the specified file doesn't
exist, bringing the behavior consistent.

New test cases have been added to prevent a regression.

Fixes #58977