### PR TITLE
encoding/asn1: improve memory efficiency of ObjectIdentifier.String

### DIFF
--- a/src/encoding/asn1/asn1.go
+++ b/src/encoding/asn1/asn1.go
@@ -26,6 +26,7 @@ import (
 	"math/big"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 	"unicode/utf16"
 	"unicode/utf8"
@@ -236,16 +237,17 @@ func (oi ObjectIdentifier) Equal(other ObjectIdentifier) bool {
 }
 
 func (oi ObjectIdentifier) String() string {
-	var s string
+	var s strings.Builder
+	s.Grow(32)
 
 	for i, v := range oi {
 		if i > 0 {
-			s += "."
+			s.WriteByte('.')
 		}
-		s += strconv.Itoa(v)
+		s.Write(strconv.AppendInt(make([]byte, 0, 16), int64(v), 10))
 	}
 
-	return s
+	return s.String()
 }
 
 // parseObjectIdentifier parses an OBJECT IDENTIFIER from the given bytes and

--- a/src/encoding/asn1/asn1.go
+++ b/src/encoding/asn1/asn1.go
@@ -245,7 +245,7 @@ func (oi ObjectIdentifier) String() string {
 		if i > 0 {
 			s.WriteByte('.')
 		}
-		s.Write(strconv.AppendInt(buf[:0], int64(v), 10))
+		s.Write(strconv.AppendInt(buf, int64(v), 10))
 	}
 
 	return s.String()

--- a/src/encoding/asn1/asn1.go
+++ b/src/encoding/asn1/asn1.go
@@ -240,11 +240,12 @@ func (oi ObjectIdentifier) String() string {
 	var s strings.Builder
 	s.Grow(32)
 
+	buf := make([]byte, 0, 19)
 	for i, v := range oi {
 		if i > 0 {
 			s.WriteByte('.')
 		}
-		s.Write(strconv.AppendInt(make([]byte, 0, 16), int64(v), 10))
+		s.Write(strconv.AppendInt(buf[:0], int64(v), 10))
 	}
 
 	return s.String()

--- a/src/encoding/asn1/asn1_test.go
+++ b/src/encoding/asn1/asn1_test.go
@@ -1164,3 +1164,10 @@ func TestNonMinimalEncodedOID(t *testing.T) {
 		t.Fatalf("accepted non-minimally encoded oid")
 	}
 }
+
+func BenchmarkObjectIdentifierString(b *testing.B) {
+	oidPublicKeyRSA := ObjectIdentifier{1, 2, 840, 113549, 1, 1, 1}
+	for i := 0; i < b.N; i++ {
+		_ = oidPublicKeyRSA.String()
+	}
+}


### PR DESCRIPTION
name                      old time/op    new time/op    delta
ObjectIdentifierString-4     670ns ± 9%     157ns ±14%  -76.59%  (p=0.000 n=10+9)

name                      old alloc/op   new alloc/op   delta
ObjectIdentifierString-4      184B ± 0%       32B ± 0%  -82.61%  (p=0.000 n=10+10)

name                      old allocs/op  new allocs/op  delta
ObjectIdentifierString-4      14.0 ± 0%       1.0 ± 0%  -92.86%  (p=0.000 n=10+10)

This also improves the x509 certificate parser performance by ~12-15%

name                           old time/op    new time/op    delta
ParseCertificate/ecdsa_leaf-4    24.5µs ± 8%    20.9µs ±11%  -14.66%  (p=0.000 n=10+10)
ParseCertificate/rsa_leaf-4      26.6µs ± 5%    23.5µs ± 7%  -11.83%  (p=0.000 n=8+10)

name                           old alloc/op   new alloc/op   delta
ParseCertificate/ecdsa_leaf-4    12.5kB ± 0%    12.0kB ± 0%   -3.72%  (p=0.000 n=10+10)
ParseCertificate/rsa_leaf-4      13.9kB ± 0%    13.4kB ± 0%   -3.34%  (p=0.000 n=10+10)

name                           old allocs/op  new allocs/op  delta
ParseCertificate/ecdsa_leaf-4       238 ± 0%       165 ± 0%  -30.67%  (p=0.000 n=10+10)
ParseCertificate/rsa_leaf-4         262 ± 0%       189 ± 0%  -27.86%  (p=0.000 n=10+10)
