### PR TITLE
doc: normalize proposal-process links

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,5 +1,5 @@
 Unlike many projects on GitHub, the Go project does not use its bug tracker for general discussion or asking questions.
-We only use our bug tracker for tracking bugs and tracking proposals going through the [Proposal Process](https://golang.org/s/proposal-process).
+We only use our bug tracker for tracking bugs and tracking proposals going through the [Proposal Process](https://go.dev/s/proposal-process).
 
 For asking questions, see:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Otherwise, when filing an issue, make sure to answer these five questions:
 4. What did you expect to see?
 5. What did you see instead?
 
-For change proposals, see [Proposing Changes To Go](https://github.com/golang/proposal/).
+For change proposals, see [Proposing Changes To Go](https://go.dev/s/proposal-process).
 
 ## Contributing code
 


### PR DESCRIPTION
The docs in .github & CONTRIBUTING.md have three different links to the same place. I have picked the one from "10-proposal.md" as the canonical url as it uses the normal go website shortener service (thus centralizing any future maintenance of this location), uses the new public domain (go.dev over golang.org), and also picks up the readme URI fragment from the shortener redirect which allows the doc links to be cleaner, but also the convenience for the reader starting directly at the human readable parsed README.md.

Should also cut down on confusion like I had reading documentation about why there were multiple proposal sites, which turned out all to be the same place.

Update all proposal-process links to the same URL.