### PR TITLE
net: respect netCgo set by forceCgoDNS() in hostLookupOrder

### DIFF
--- a/src/net/conf.go
+++ b/src/net/conf.go
@@ -143,7 +143,7 @@ func (c *conf) hostLookupOrder(r *Resolver, hostname string) (ret hostLookupOrde
 			fallbackOrder = hostLookupFilesDNS
 		}
 	}
-	if c.forceCgoLookupHost || c.goos == "android" || c.goos == "windows" || c.goos == "plan9" {
+	if c.forceCgoLookupHost || c.netCgo || c.goos == "android" || c.goos == "windows" || c.goos == "plan9" {
 		return fallbackOrder, nil
 	}
 	if bytealg.IndexByteString(hostname, '\\') != -1 || bytealg.IndexByteString(hostname, '%') != -1 {

--- a/src/net/main_conf_test.go
+++ b/src/net/main_conf_test.go
@@ -6,6 +6,8 @@
 
 package net
 
+import "testing"
+
 // forceGoDNS forces the resolver configuration to use the pure Go resolver
 // and returns a fixup function to restore the old settings.
 func forceGoDNS() func() {
@@ -35,4 +37,20 @@ func forceCgoDNS() func() {
 	c.netGo = false
 	c.netCgo = true
 	return fixup
+}
+
+func TestForceCgoDNS(t *testing.T) {
+	defer forceCgoDNS()()
+	order, _ := systemConf().hostLookupOrder(nil, "go.dev")
+	if order != hostLookupCgo {
+		t.Fatalf("expected cgo hostLookuporder got: %v", order)
+	}
+}
+
+func TestForceGoDNS(t *testing.T) {
+	defer forceGoDNS()()
+	order, _ := systemConf().hostLookupOrder(nil, "go.dev")
+	if !(order == hostLookupFiles || order == hostLookupFilesDNS || order == hostLookupDNSFiles || order == hostLookupDNS) {
+		t.Fatalf("expected go hostLookuporder got: %v", order)
+	}
 }

--- a/src/net/main_conf_test.go
+++ b/src/net/main_conf_test.go
@@ -43,7 +43,7 @@ func TestForceCgoDNS(t *testing.T) {
 	defer forceCgoDNS()()
 	order, _ := systemConf().hostLookupOrder(nil, "go.dev")
 	if order != hostLookupCgo {
-		t.Fatalf("expected cgo hostLookuporder got: %v", order)
+		t.Fatalf("expected cgo hostLookupOrder got: %v", order)
 	}
 }
 
@@ -51,6 +51,6 @@ func TestForceGoDNS(t *testing.T) {
 	defer forceGoDNS()()
 	order, _ := systemConf().hostLookupOrder(nil, "go.dev")
 	if !(order == hostLookupFiles || order == hostLookupFilesDNS || order == hostLookupDNSFiles || order == hostLookupDNS) {
-		t.Fatalf("expected go hostLookuporder got: %v", order)
+		t.Fatalf("expected go hostLookupOrder got: %v", order)
 	}
 }


### PR DESCRIPTION
forceCgoDNS sets netCgo to true, but the hostLookupOrder didn't use that field.