### PR TITLE
net: support forceCgoDNS and forceGoDns on windows

### DIFF
--- a/src/net/main_conf_test.go
+++ b/src/net/main_conf_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !js && !plan9 && !windows
+//go:build !js && !plan9
 
 package net
 

--- a/src/net/main_noconf_test.go
+++ b/src/net/main_noconf_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (js && wasm) || plan9 || windows
+//go:build (js && wasm) || plan9
 
 package net
 
@@ -11,7 +11,7 @@ import "runtime"
 // See main_conf_test.go for what these (don't) do.
 func forceGoDNS() func() {
 	switch runtime.GOOS {
-	case "plan9", "windows":
+	case "plan9":
 		return func() {}
 	default:
 		return nil


### PR DESCRIPTION
Windows is able to use the go resolver now, so let the forceCgoDNS and forceGoDns work.