### PR TITLE
errors: improve the godoc for Join and Unwrap

### DIFF
--- a/src/errors/join.go
+++ b/src/errors/join.go
@@ -10,6 +10,8 @@ package errors
 // The error formats as the concatenation of the strings obtained
 // by calling the Error method of each element of errs, with a newline
 // between each string.
+//
+// A non-nil error returned by Join implements the Unwrap() []error method.
 func Join(errs ...error) error {
 	n := 0
 	for _, err := range errs {

--- a/src/errors/wrap.go
+++ b/src/errors/wrap.go
@@ -12,7 +12,8 @@ import (
 // type contains an Unwrap method returning error.
 // Otherwise, Unwrap returns nil.
 //
-// Unwrap returns nil if the Unwrap method returns []error.
+// Unwrap only calls a method of the form "Unwrap() error".
+// In particular Unwrap does not unwrap errors returned by [Join].
 func Unwrap(err error) error {
 	u, ok := err.(interface {
 		Unwrap() error


### PR DESCRIPTION
Document that errors returned by Join always implement Unwrap []error.

Explicitly state that Unwrap does not unwrap errors
with an Unwrap() []error method.