### PR TITLE
reflect: add Value.Caller to minimise allocations

### DIFF
--- a/api/next/49340.txt
+++ b/api/next/49340.txt
@@ -1,0 +1,5 @@
+pkg reflect, method (*Caller) Call([]Value, []Value) #49340
+pkg reflect, method (*Caller) CallSlice([]Value, []Value) #49340
+pkg reflect, method (*Caller) Type() Type #49340
+pkg reflect, method (Value) Caller() *Caller #49340
+pkg reflect, type Caller struct #49340

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -8410,3 +8410,19 @@ func TestClear(t *testing.T) {
 		})
 	}
 }
+
+func TestCaller_CallReusesOutValues(t *testing.T) {
+	fn := func() int {
+		return 27
+	}
+
+	var i int
+	v := ValueOf(&i).Elem()
+	out := []Value{v}
+
+	ValueOf(fn).Caller().Call([]Value{}, out)
+
+	if i != 27 {
+		t.Errorf("unexpected result for output value; got %d, want 27", i)
+	}
+}

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -8410,19 +8410,3 @@ func TestClear(t *testing.T) {
 		})
 	}
 }
-
-func TestCaller_CallReusesOutValues(t *testing.T) {
-	fn := func() int {
-		return 27
-	}
-
-	var i int
-	v := ValueOf(&i).Elem()
-	out := []Value{v}
-
-	ValueOf(fn).Caller().Call([]Value{}, out)
-
-	if i != 27 {
-		t.Errorf("unexpected result for output value; got %d, want 27", i)
-	}
-}

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -3990,8 +3990,8 @@ func TestValuePanic(t *testing.T) {
 	shouldPanic("reflect.Value.Addr of unaddressable value", func() { vo(0).Addr() })
 	shouldPanic("call of reflect.Value.Bool on float64 Value", func() { vo(0.0).Bool() })
 	shouldPanic("call of reflect.Value.Bytes on string Value", func() { vo("").Bytes() })
-	shouldPanic("call of reflect.Value.Call on bool Value", func() { vo(true).Call(nil) })
-	shouldPanic("call of reflect.Value.CallSlice on int Value", func() { vo(0).CallSlice(nil) })
+	shouldPanic("call of reflect.Value.Caller on bool Value", func() { vo(true).Call(nil) })
+	shouldPanic("call of reflect.Value.Caller on int Value", func() { vo(0).CallSlice(nil) })
 	shouldPanic("call of reflect.Value.Close on string Value", func() { vo("").Close() })
 	shouldPanic("call of reflect.Value.Complex on float64 Value", func() { vo(0.0).Complex() })
 	shouldPanic("call of reflect.Value.Elem on bool Value", func() { vo(false).Elem() })
@@ -8408,5 +8408,21 @@ func TestClear(t *testing.T) {
 				t.Errorf("unexpected result for value.Clear(): %value", tc.value)
 			}
 		})
+	}
+}
+
+func TestCaller_CallReusesOutValues(t *testing.T) {
+	fn := func() int {
+		return 27
+	}
+
+	var i int
+	v := ValueOf(&i).Elem()
+	out := []Value{v}
+
+	ValueOf(fn).Caller().Call([]Value{}, out)
+
+	if i != 27 {
+		t.Errorf("unexpected result for output value; got %d, want 27", i)
 	}
 }

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -3990,8 +3990,8 @@ func TestValuePanic(t *testing.T) {
 	shouldPanic("reflect.Value.Addr of unaddressable value", func() { vo(0).Addr() })
 	shouldPanic("call of reflect.Value.Bool on float64 Value", func() { vo(0.0).Bool() })
 	shouldPanic("call of reflect.Value.Bytes on string Value", func() { vo("").Bytes() })
-	shouldPanic("call of reflect.Value.Caller on bool Value", func() { vo(true).Call(nil) })
-	shouldPanic("call of reflect.Value.Caller on int Value", func() { vo(0).CallSlice(nil) })
+	shouldPanic("call of reflect.Value.Call on bool Value", func() { vo(true).Call(nil) })
+	shouldPanic("call of reflect.Value.CallSlice on int Value", func() { vo(0).CallSlice(nil) })
 	shouldPanic("call of reflect.Value.Close on string Value", func() { vo("").Close() })
 	shouldPanic("call of reflect.Value.Complex on float64 Value", func() { vo(0.0).Complex() })
 	shouldPanic("call of reflect.Value.Elem on bool Value", func() { vo(false).Elem() })
@@ -8425,4 +8425,17 @@ func TestCaller_CallReusesOutValues(t *testing.T) {
 	if i != 27 {
 		t.Errorf("unexpected result for output value; got %d, want 27", i)
 	}
+}
+
+func TestCaller_CallAllocations(t *testing.T) {
+	fn := func() int {
+		return 27
+	}
+	c := ValueOf(fn).Caller()
+
+	out := make([]Value, c.Type().NumOut())
+
+	noAlloc(t, 100, func(int) {
+		c.Call([]Value{}, out)
+	})
 }

--- a/src/reflect/benchmark_test.go
+++ b/src/reflect/benchmark_test.go
@@ -197,6 +197,19 @@ func BenchmarkCall(b *testing.B) {
 	})
 }
 
+func BenchmarkCallerCall(b *testing.B) {
+	fv := ValueOf(func(a, b string) {})
+	c := fv.Caller()
+	out := make([]Value, c.Type().NumOut())
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		args := []Value{ValueOf("a"), ValueOf("b")}
+		for pb.Next() {
+			c.Call(args, out)
+		}
+	})
+}
+
 type myint int64
 
 func (i *myint) inc() {
@@ -210,6 +223,17 @@ func BenchmarkCallMethod(b *testing.B) {
 	v := ValueOf(z.inc)
 	for i := 0; i < b.N; i++ {
 		v.Call(nil)
+	}
+}
+
+func BenchmarkCallerCallMethod(b *testing.B) {
+	b.ReportAllocs()
+	z := new(myint)
+
+	v := ValueOf(z.inc)
+	c := v.Caller()
+	for i := 0; i < b.N; i++ {
+		c.Call(nil, nil)
 	}
 }
 

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -688,14 +688,7 @@ func (c *Caller) call(op string, in, out []Value) {
 		}
 
 		// All that's left is values passed in registers that we need to
-		// create space for and copy values back into.
-		//
-		// TODO(mknyszek): We make a new allocation for each register-allocated
-		// value, but previously we could always point into the heap-allocated
-		// stack frame. This is a regression that could be fixed by adding
-		// additional space to the allocated stack frame and storing the
-		// register-allocated return values into the allocated stack frame and
-		// referring there in the resulting Value.
+		// potentially create space for and copy values back into.
 		if s == nil || v.flag&flagIndir == 0 {
 			s = unsafe_New(tv.common())
 			out[i] = Value{tv.common(), s, flagIndir | flag(tv.Kind())}

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -443,18 +443,18 @@ func (c *Caller) Type() Type {
 }
 
 // Call calls the function c with the input arguments in and output result slice out.
-// For example, if len(in) == 3, v.Call(in) represents the Go call v(in[0], in[1], in[2]).
+// For example, if len(in) == 3, c.Call(in) represents the Go call c(in[0], in[1], in[2]).
 // As in Go, each input argument must be assignable to the
 // type of the function's corresponding input parameter.
-// If v is a variadic function, Call creates the variadic slice parameter
+// If c is a variadic function, Call creates the variadic slice parameter
 // itself, copying in the corresponding values.
 func (c *Caller) Call(in, out []Value) {
 	c.call("Call", in, out)
 }
 
 // CallSlice calls the variadic function c with the input arguments in and output result slice out,
-// assigning the slice in[len(in)-1] to v's final variadic argument.
-// For example, if len(in) == 3, v.CallSlice(in) represents the Go call v(in[0], in[1], in[2]...).
+// assigning the slice in[len(in)-1] to c's final variadic argument.
+// For example, if len(in) == 3, c.CallSlice(in) represents the Go call c(in[0], in[1], in[2]...).
 // As in Go, each input argument must be assignable to the
 // type of the function's corresponding input parameter.
 func (c *Caller) CallSlice(in, out []Value) {

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -529,7 +529,6 @@ func (c *Caller) call(op string, in, out []Value) {
 	if nin != c.t.NumIn() {
 		panic("reflect.Caller.Call: wrong argument count")
 	}
-	nout := c.t.NumOut()
 
 	// Register argument space.
 	var regArgs abi.RegArgs
@@ -537,13 +536,7 @@ func (c *Caller) call(op string, in, out []Value) {
 	// Allocate a chunk of memory for frame if needed.
 	var stackArgs unsafe.Pointer
 	if c.frametype.size != 0 {
-		if nout == 0 {
-			stackArgs = c.framePool.Get().(unsafe.Pointer)
-		} else {
-			// Can't use pool if the function has return values.
-			// We will leak pointer to args in ret, so its lifetime is not scoped.
-			stackArgs = unsafe_New(c.frametype)
-		}
+		stackArgs = c.framePool.Get().(unsafe.Pointer)
 	}
 	frameSize := c.frametype.size
 
@@ -652,86 +645,83 @@ func (c *Caller) call(op string, in, out []Value) {
 		runtime.GC()
 	}
 
-	if nout == 0 {
-		if stackArgs != nil {
-			typedmemclr(c.frametype, stackArgs)
-			c.framePool.Put(stackArgs)
-		}
-	} else {
-		if stackArgs != nil {
-			// Zero the now unused input area of args,
-			// because the Values returned by this function contain pointers to the args object,
-			// and will thus keep the args object alive indefinitely.
-			typedmemclrpartial(c.frametype, stackArgs, 0, c.abid.retOffset)
+	// Wrap Values around return values in args.
+	for i, v := range out {
+		tv := c.t.Out(i)
+		if tv.Size() == 0 {
+			// For zero-sized return value, args+off may point to the next object.
+			// In this case, return the zero value instead.
+			out[i] = Zero(tv)
+			continue
 		}
 
-		// Wrap Values around return values in args.
-		for i := 0; i < nout; i++ {
-			tv := c.t.Out(i)
-			if tv.Size() == 0 {
-				// For zero-sized return value, args+off may point to the next object.
-				// In this case, return the zero value instead.
-				out[i] = Zero(tv)
-				continue
-			}
-			steps := c.abid.ret.stepsForValue(i)
-			if st := steps[0]; st.kind == abiStepStack {
-				// This value is on the stack. If part of a value is stack
-				// allocated, the entire value is according to the ABI. So
-				// just make an indirection into the allocated frame.
-				fl := flagIndir | flag(tv.Kind())
-				out[i] = Value{tv.common(), add(stackArgs, st.stkOff, "tv.Size() != 0"), fl}
-				// Note: this does introduce false sharing between results -
-				// if any result is live, they are all live.
-				// (And the space for the args is live as well, but as we've
-				// cleared that space it isn't as big a deal.)
-				continue
-			}
+		s := v.ptr
+		if s != nil && v.typ != tv {
+			panic("reflect: cannot use " + v.typ.String() + " as type " + tv.String() + " in " + op)
+		}
 
-			// Handle pointers passed in registers.
-			if !ifaceIndir(tv.common()) {
-				// Pointer-valued data gets put directly
-				// into v.ptr.
-				if steps[0].kind != abiStepPointer {
-					print("kind=", steps[0].kind, ", type=", tv.String(), "\n")
-					panic("mismatch between ABI description and types")
-				}
-				out[i] = Value{tv.common(), regArgs.Ptrs[steps[0].ireg], flag(tv.Kind())}
-				continue
-			}
-
-			// All that's left is values passed in registers that we need to
-			// create space for and copy values back into.
-			//
-			// TODO(mknyszek): We make a new allocation for each register-allocated
-			// value, but previously we could always point into the heap-allocated
-			// stack frame. This is a regression that could be fixed by adding
-			// additional space to the allocated stack frame and storing the
-			// register-allocated return values into the allocated stack frame and
-			// referring there in the resulting Value.
-			s := out[i].ptr
-			if out[i].typ != tv || out[i].flag&flagIndir != flagIndir || s == nil {
+		steps := c.abid.ret.stepsForValue(i)
+		if st := steps[0]; st.kind == abiStepStack {
+			// This value is on the stack. If part of a value is stack
+			// allocated, the entire value is according to the ABI.
+			addr := add(stackArgs, st.stkOff, "tv.Size() != 0")
+			if s == nil || out[i].flag&flagIndir == 0 {
+				// Make space for the value to be copied into so the stack
+				// can be reused.
 				s = unsafe_New(tv.common())
 				out[i] = Value{tv.common(), s, flagIndir | flag(tv.Kind())}
 			}
-			for _, st := range steps {
-				switch st.kind {
-				case abiStepIntReg:
-					offset := add(s, st.offset, "precomputed value offset")
-					intFromReg(&regArgs, st.ireg, st.size, offset)
-				case abiStepPointer:
-					s := add(s, st.offset, "precomputed value offset")
-					*((*unsafe.Pointer)(s)) = regArgs.Ptrs[st.ireg]
-				case abiStepFloatReg:
-					offset := add(s, st.offset, "precomputed value offset")
-					floatFromReg(&regArgs, st.freg, st.size, offset)
-				case abiStepStack:
-					panic("register-based return value has stack component")
-				default:
-					panic("unknown ABI part kind")
-				}
+			typedmemmove(c.t.Out(i).(*rtype), s, addr)
+			continue
+		}
+
+		// Handle pointers passed in registers.
+		if !ifaceIndir(tv.common()) {
+			// Pointer-valued data gets put directly
+			// into v.ptr.
+			if steps[0].kind != abiStepPointer {
+				print("kind=", steps[0].kind, ", type=", tv.String(), "\n")
+				panic("mismatch between ABI description and types")
+			}
+			out[i] = Value{tv.common(), regArgs.Ptrs[steps[0].ireg], flag(tv.Kind())}
+			continue
+		}
+
+		// All that's left is values passed in registers that we need to
+		// create space for and copy values back into.
+		//
+		// TODO(mknyszek): We make a new allocation for each register-allocated
+		// value, but previously we could always point into the heap-allocated
+		// stack frame. This is a regression that could be fixed by adding
+		// additional space to the allocated stack frame and storing the
+		// register-allocated return values into the allocated stack frame and
+		// referring there in the resulting Value.
+		if s == nil || v.flag&flagIndir == 0 {
+			s = unsafe_New(tv.common())
+			out[i] = Value{tv.common(), s, flagIndir | flag(tv.Kind())}
+		}
+		for _, st := range steps {
+			switch st.kind {
+			case abiStepIntReg:
+				offset := add(s, st.offset, "precomputed value offset")
+				intFromReg(&regArgs, st.ireg, st.size, offset)
+			case abiStepPointer:
+				s := add(s, st.offset, "precomputed value offset")
+				*((*unsafe.Pointer)(s)) = regArgs.Ptrs[st.ireg]
+			case abiStepFloatReg:
+				offset := add(s, st.offset, "precomputed value offset")
+				floatFromReg(&regArgs, st.freg, st.size, offset)
+			case abiStepStack:
+				panic("register-based return value has stack component")
+			default:
+				panic("unknown ABI part kind")
 			}
 		}
+	}
+
+	if stackArgs != nil {
+		typedmemclr(c.frametype, stackArgs)
+		c.framePool.Put(stackArgs)
 	}
 }
 


### PR DESCRIPTION
This adds the Caller struct that makes calling functions allocation free. Value.Call and Value.CallSlice now
internally use Caller, as well as adding Value.Caller to access the Caller directly.

Fixes #49340
