### PR TITLE
cmd/link/internal/ld: pass correct offset to codesign.Sign

### DIFF
--- a/src/cmd/link/internal/ld/macho.go
+++ b/src/cmd/link/internal/ld/macho.go
@@ -710,6 +710,7 @@ func asmbMacho(ctxt *Link) {
 	/* text */
 	v := Rnd(int64(uint64(HEADR)+Segtext.Length), int64(*FlagRound))
 
+	var mstext *MachoSeg
 	if ctxt.LinkMode != LinkExternal {
 		ms = newMachoSeg("__TEXT", 20)
 		ms.vaddr = uint64(va)
@@ -718,6 +719,7 @@ func asmbMacho(ctxt *Link) {
 		ms.filesize = uint64(v)
 		ms.prot1 = 7
 		ms.prot2 = 5
+		mstext = ms
 	}
 
 	for _, sect := range Segtext.Sections {
@@ -868,7 +870,7 @@ func asmbMacho(ctxt *Link) {
 		if int64(len(data)) != codesigOff {
 			panic("wrong size")
 		}
-		codesign.Sign(ldr.Data(cs), bytes.NewReader(data), "a.out", codesigOff, int64(Segtext.Fileoff), int64(Segtext.Filelen), ctxt.IsExe() || ctxt.IsPIE())
+		codesign.Sign(ldr.Data(cs), bytes.NewReader(data), "a.out", codesigOff, int64(mstext.fileoffset), int64(mstext.filesize), ctxt.IsExe() || ctxt.IsPIE())
 		ctxt.Out.SeekSet(codesigOff)
 		ctxt.Out.Write(ldr.Data(cs))
 	}


### PR DESCRIPTION
Previously, codesign.Sign was called with Segtext.Fileoff and
Segtext.Filelen. However, both variables do not contain the
complete __TEXT segment, as it excludes padding and header. 
Therefore, we now store a reference to the complete segment 
in mstext when it is created and pass its offset (which should
always be 0) and filesize to codesign.Sign.

Fixes #59555