### PR TITLE
doc: correct spelling on placeholder

### DIFF
--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -2647,7 +2647,7 @@ TypeParamDecl   = IdentifierList TypeConstraint .
 <p>
 All non-blank names in the list must be unique.
 Each name declares a type parameter, which is a new and different <a href="#Types">named type</a>
-that acts as a place holder for an (as of yet) unknown type in the declaration.
+that acts as a placeholder for an (as of yet) unknown type in the declaration.
 The type parameter is replaced with a <i>type argument</i> upon
 <a href="#Instantiations">instantiation</a> of the generic function or type.
 </p>


### PR DESCRIPTION
"placeholder" (no space) is already used in the spec and seems to be
the preferred option.

Removed space from "place holder".
