### PR TITLE
net/http: fix the error that causes panic on arm32 architecture

### DIFF
--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -251,6 +251,8 @@ var (
 
 // A conn represents the server side of an HTTP connection.
 type conn struct {
+	curState atomic.Uint64 // packed (unixtime<<8|uint8(ConnState))
+
 	// server is the server on which the connection arrived.
 	// Immutable; never nil.
 	server *Server
@@ -294,8 +296,6 @@ type conn struct {
 	lastMethod string
 
 	curReq atomic.Pointer[response] // (which has a Request in it)
-
-	curState atomic.Uint64 // packed (unixtime<<8|uint8(ConnState))
 
 	// mu guards hijackedv
 	mu sync.Mutex


### PR DESCRIPTION
To avoid panicking on arm32 due to a bug in atomic, it's necessary to place the `curState atomic.Uint64` at the top of the struct.

Ref: https://pkg.go.dev/sync/atomic#pkg-note-BUG