### PR TITLE
crypto/x509: use the RFC 6125 terminology in the VerifyHostname docs

### DIFF
--- a/src/crypto/x509/verify.go
+++ b/src/crypto/x509/verify.go
@@ -1081,7 +1081,7 @@ func toLowerCaseASCII(in string) string {
 // IP addresses can be optionally enclosed in square brackets and are checked
 // against the IPAddresses field. Other names are checked case insensitively
 // against the DNSNames field. If the names are valid hostnames, the certificate
-// fields can have a wildcard as the left-most label.
+// fields can have a wildcard as the complete left-most label (e.g. *.example.com).
 //
 // Note that the legacy Common Name field is ignored.
 func (c *Certificate) VerifyHostname(h string) error {


### PR DESCRIPTION
RFC6125 uses the "complete left-most label" to describe star and full stop wildcards.