### PR TITLE
runtime: do nothing if madvise is nonexistent

### DIFF
--- a/src/runtime/mem_linux.go
+++ b/src/runtime/mem_linux.go
@@ -12,6 +12,7 @@ import (
 const (
 	_EACCES = 13
 	_EINVAL = 22
+	_ENOSYS = 38
 )
 
 // Don't split the stack as this method may be invoked without a valid G, which
@@ -34,7 +35,10 @@ func sysAllocOS(n uintptr) unsafe.Pointer {
 	return p
 }
 
-var adviseUnused = uint32(_MADV_FREE)
+var (
+	adviseUnused = uint32(_MADV_FREE)
+	madviseNX    uint32
+)
 
 func sysUnusedOS(v unsafe.Pointer, n uintptr) {
 	if uintptr(v)&(physPageSize-1) != 0 || n&(physPageSize-1) != 0 {
@@ -44,17 +48,25 @@ func sysUnusedOS(v unsafe.Pointer, n uintptr) {
 		throw("unaligned sysUnused")
 	}
 
-	var advise uint32
-	if debug.madvdontneed != 0 {
-		advise = _MADV_DONTNEED
-	} else {
-		advise = atomic.Load(&adviseUnused)
-	}
-	if errno := madvise(v, n, int32(advise)); advise == _MADV_FREE && errno != 0 {
-		// MADV_FREE was added in Linux 4.5. Fall back to MADV_DONTNEED if it is
-		// not supported.
-		atomic.Store(&adviseUnused, _MADV_DONTNEED)
-		madvise(v, n, _MADV_DONTNEED)
+	// Since Linux 3.18, support for madvise is optional.
+	if atomic.Load(&madviseNX) == 0 {
+		var advise uint32
+		if debug.madvdontneed != 0 {
+			advise = _MADV_DONTNEED
+		} else {
+			advise = atomic.Load(&adviseUnused)
+		}
+		if errno := madvise(v, n, int32(advise)); errno != 0 {
+			if errno == _ENOSYS {
+				// Since Linux 3.18, support for madvise is optional.
+				atomic.Store(&madviseNX, 1)
+			} else if advise == _MADV_FREE {
+				// MADV_FREE was added in Linux 4.5. Fall back to MADV_DONTNEED if it is
+				// not supported.
+				atomic.Store(&adviseUnused, _MADV_DONTNEED)
+				madvise(v, n, _MADV_DONTNEED)
+			}
+		}
 	}
 
 	if debug.harddecommit > 0 {


### PR DESCRIPTION
madvise is not specified by any standards.

Since Linux 3.18, support for this system call is optional,
depending on the setting of the CONFIG_ADVISE_SYSCALLS
configuration option. See https://github.com/torvalds/linux/commit/d3ac21cacc24790eb45d735769f35753f5b56ceb

If we attempt to invoke a nonexistent system call, then it
will return -1, and errno will be set to ENOSYS. See https://github.com/torvalds/linux/blob/2af3e53a4dc08657f1b46f97f04ff4a0ab3cad8d/include/uapi/asm-generic/errno.h#L18