### PR TITLE
runtime: add a alignment check

### DIFF
--- a/src/runtime/mem_linux.go
+++ b/src/runtime/mem_linux.go
@@ -92,6 +92,11 @@ func sysHugePageOS(v unsafe.Pointer, n uintptr) {
 }
 
 func sysNoHugePageOS(v unsafe.Pointer, n uintptr) {
+	if uintptr(v)&(physPageSize-1) != 0 {
+		// The Linux implementation requires that the address
+		// addr be page-aligned, and allows length to be zero.
+		throw("unaligned sysNoHugePageOS")
+	}
 	madvise(v, n, _MADV_NOHUGEPAGE)
 }
 


### PR DESCRIPTION
The Linux implementation requires that the address addr be
page-aligned, and allows length to be zero.

See Linux notes:
https://man7.org/linux/man-pages/man2/madvise.2.html