### PR TITLE
runtime: reduce overhead for alignment check

### DIFF
--- a/src/runtime/mem_linux.go
+++ b/src/runtime/mem_linux.go
@@ -37,7 +37,7 @@ func sysAllocOS(n uintptr) unsafe.Pointer {
 var adviseUnused = uint32(_MADV_FREE)
 
 func sysUnusedOS(v unsafe.Pointer, n uintptr) {
-	if uintptr(v)&(physPageSize-1) != 0 || n&(physPageSize-1) != 0 {
+	if (uintptr(v)|n)&(physPageSize-1) != 0 {
 		// madvise will round this to any physical page
 		// *covered* by this range, so an unaligned madvise
 		// will release more memory than intended.


### PR DESCRIPTION
If one of address v or n is not page-aligned, then the value 
of v|n is still not page-aligned.

In most cases, this alignment check will execute fewer 
instructions than before.