### PR TITLE
cmd/internal/obj/riscv: fix typos

### DIFF
--- a/src/cmd/internal/obj/riscv/obj.go
+++ b/src/cmd/internal/obj/riscv/obj.go
@@ -1869,7 +1869,7 @@ func instructionsForMOV(p *obj.Prog) []*instruction {
 			return nil
 		}
 
-		// MOV $c, R -> ADD $c, ZERO, R
+		// MOV $c, R -> ADDI $c, ZERO, R
 		ins.as, ins.rs1, ins.rs2, ins.imm = AADDI, REG_ZERO, obj.REG_NONE, low
 
 		// LUI is only necessary if the constant does not fit in 12 bits.
@@ -1881,7 +1881,7 @@ func instructionsForMOV(p *obj.Prog) []*instruction {
 		}
 
 		// LUI top20bits(c), R
-		// ADD bottom12bits(c), R, R
+		// ADDIW bottom12bits(c), R, R
 		insLUI := &instruction{as: ALUI, rd: ins.rd, imm: high}
 		inss = []*instruction{insLUI}
 		if low != 0 {


### PR DESCRIPTION
Fix the comments in riscv/obj.go to make it in step with the code below.