### PR TITLE
runtime: fall back on mmap if madvise is nonexistent

### DIFF
--- a/src/runtime/mem_linux.go
+++ b/src/runtime/mem_linux.go
@@ -12,6 +12,7 @@ import (
 const (
 	_EACCES = 13
 	_EINVAL = 22
+	_ENOSYS = 38
 )
 
 // Don't split the stack as this method may be invoked without a valid G, which
@@ -34,7 +35,10 @@ func sysAllocOS(n uintptr) unsafe.Pointer {
 	return p
 }
 
-var adviseUnused = uint32(_MADV_FREE)
+var (
+	adviseUnused = uint32(_MADV_FREE)
+	madviseNX    uint32
+)
 
 func sysUnusedOS(v unsafe.Pointer, n uintptr) {
 	if uintptr(v)&(physPageSize-1) != 0 || n&(physPageSize-1) != 0 {
@@ -44,17 +48,32 @@ func sysUnusedOS(v unsafe.Pointer, n uintptr) {
 		throw("unaligned sysUnused")
 	}
 
-	var advise uint32
-	if debug.madvdontneed != 0 {
-		advise = _MADV_DONTNEED
+	if atomic.Load(&madviseNX) == 1 {
+		// Since Linux 3.18, support for madvise is optional.
+		// Fall back on mmap if it is nonexistent.
+		// _MAP_ANON|_MAP_FIXED|_MAP_PRIVATE will unmap all the
+		// pages in the old mapping, and remap the memory region.
+		mmap(v, n, _PROT_READ|_PROT_WRITE, _MAP_ANON|_MAP_FIXED|_MAP_PRIVATE, -1, 0)
 	} else {
-		advise = atomic.Load(&adviseUnused)
-	}
-	if errno := madvise(v, n, int32(advise)); advise == _MADV_FREE && errno != 0 {
-		// MADV_FREE was added in Linux 4.5. Fall back to MADV_DONTNEED if it is
-		// not supported.
-		atomic.Store(&adviseUnused, _MADV_DONTNEED)
-		madvise(v, n, _MADV_DONTNEED)
+		var advise uint32
+		if debug.madvdontneed != 0 {
+			advise = _MADV_DONTNEED
+		} else {
+			advise = atomic.Load(&adviseUnused)
+		}
+		if errno := madvise(v, n, int32(advise)); errno != 0 {
+			if errno == _ENOSYS {
+				// Since Linux 3.18, support for madvise is optional.
+				// Fall back on mmap if it is nonexistent.
+				atomic.Store(&madviseNX, 1)
+				mmap(v, n, _PROT_READ|_PROT_WRITE, _MAP_ANON|_MAP_FIXED|_MAP_PRIVATE, -1, 0)
+			} else if advise == _MADV_FREE {
+				// MADV_FREE was added in Linux 4.5. Fall back to MADV_DONTNEED if it is
+				// not supported.
+				atomic.Store(&adviseUnused, _MADV_DONTNEED)
+				madvise(v, n, _MADV_DONTNEED)
+			}
+		}
 	}
 
 	if debug.harddecommit > 0 {


### PR DESCRIPTION
Since Linux 3.18, support for this system call is optional,
depending on the setting of the CONFIG_ADVISE_SYSCALLS
configuration option.

The Go runtime currently assumes in several places that we 
do not unmap heap memory; that needs to remain true. So, if 
madvise is nonexistent, we cannot fall back on munmap. AFAIK, 
the only way to free pages is to remap the memory region.

For the x86, the system call mmap() is implemented by sys_mmap2() 
which calls do_mmap2() directly with the same parameters. The main 
call trace for 
mmap(v, n, PROT_READ|PROT_WRITE, MAP_ANON|MAP_FIXED|MAP_PRIVATE, -1, 0)
is as follows:

```
do_mmap2()
    \- do_mmap_pgoff()
        \- get_unmapped_area()
        \- find_vma_prepare()
				
        // If a VMA was found and it is part of the new mmaping, remove 
        // the old mapping as the new one will cover both.
        // Unmap all the pages in the region to be unmapped.
        \- do_munmap()
				
        // Allocate a VMA from the slab allocator.
        \- kmem_cache_alloc()
				
        // Link in the new vm_area_struct.
        \- vma_link()
```	
So, it's safe to fall back on mmap().
See D.2 https://www.kernel.org/doc/gorman/html/understand/understand021.html