### PR TITLE
net: support go resolver for LookupHost and LookupPort on plan9

### DIFF
--- a/src/net/lookup_plan9.go
+++ b/src/net/lookup_plan9.go
@@ -148,7 +148,11 @@ func lookupProtocol(ctx context.Context, name string) (proto int, err error) {
 	return 0, UnknownNetworkError(name)
 }
 
-func (*Resolver) lookupHost(ctx context.Context, host string) (addrs []string, err error) {
+func (r *Resolver) lookupHost(ctx context.Context, host string) (addrs []string, err error) {
+	if order, conf, preferGo := r.preferGoOverPlan9WithOrderAndConf(); preferGo {
+		return r.goLookupHostOrder(ctx, host, order, conf)
+	}
+
 	// Use netdir/cs instead of netdir/dns because cs knows about
 	// host names in local network (e.g. from /lib/ndb/local)
 	lines, err := queryCS(ctx, "net", host, "1")

--- a/src/net/lookup_plan9.go
+++ b/src/net/lookup_plan9.go
@@ -207,7 +207,11 @@ func (r *Resolver) lookupIP(ctx context.Context, network, host string) (addrs []
 	return
 }
 
-func (*Resolver) lookupPort(ctx context.Context, network, service string) (port int, err error) {
+func (r *Resolver) lookupPort(ctx context.Context, network, service string) (port int, err error) {
+	if r.preferGoOverPlan9() {
+		return lookupPortMap(network, service)
+	}
+
 	switch network {
 	case "tcp4", "tcp6":
 		network = "tcp"

--- a/src/net/lookup_plan9.go
+++ b/src/net/lookup_plan9.go
@@ -149,7 +149,7 @@ func lookupProtocol(ctx context.Context, name string) (proto int, err error) {
 }
 
 func (r *Resolver) lookupHost(ctx context.Context, host string) (addrs []string, err error) {
-	if order, conf, preferGo := r.preferGoOverPlan9WithOrderAndConf(); preferGo {
+	if order, conf := systemConf().hostLookupOrder(r, host); order != hostLookupCgo {
 		return r.goLookupHostOrder(ctx, host, order, conf)
 	}
 
@@ -208,7 +208,7 @@ func (r *Resolver) lookupIP(ctx context.Context, network, host string) (addrs []
 }
 
 func (r *Resolver) lookupPort(ctx context.Context, network, service string) (port int, err error) {
-	if r.preferGoOverPlan9() {
+	if systemConf().mustUseGoResolver(r) {
 		return lookupPortMap(network, service)
 	}
 


### PR DESCRIPTION
All other lookup methods on plan 9 support the go resolver, I don't 
see any reason for which the LookupHost shouldn't support it.