### PR TITLE
net: return fallbackOrder immediately for some GOOS

### DIFF
--- a/src/net/conf.go
+++ b/src/net/conf.go
@@ -238,6 +238,11 @@ func (c *conf) hostLookupOrder(r *Resolver, hostname string) (ret hostLookupOrde
 		canUseCgo = true
 	}
 
+	if c.goos == "windows" || c.goos == "plan9" || c.goos == "android" ||
+		c.goos == "ios" || c.goos == "darwin" {
+		return fallbackOrder, nil
+	}
+
 	// Try to figure out the order to use for searches.
 	// If we don't recognize something, use fallbackOrder.
 	// That will use cgo unless the Go resolver was explicitly requested.

--- a/src/net/conf.go
+++ b/src/net/conf.go
@@ -238,8 +238,9 @@ func (c *conf) hostLookupOrder(r *Resolver, hostname string) (ret hostLookupOrde
 		canUseCgo = true
 	}
 
-	if c.goos == "windows" || c.goos == "plan9" || c.goos == "android" ||
-		c.goos == "ios" || c.goos == "darwin" {
+	// On systems that don't use /etc/resolv.conf or /etc/nsswitch.conf, we are done.
+	switch c.goos {
+	case "windows", "plan9", "android", "ios":
 		return fallbackOrder, nil
 	}
 


### PR DESCRIPTION
We don't need to check resolv.conf, nsswitch.conf on these systems.
Seems like this was the behaviour before CL 487196.