### PR TITLE
net: clear /etc/hosts cache on fs.ErrNotExist and fs.ErrPermission errors 

### DIFF
--- a/src/net/hosts.go
+++ b/src/net/hosts.go
@@ -7,7 +7,6 @@ package net
 import (
 	"errors"
 	"internal/bytealg"
-	"io/fs"
 	"net/netip"
 	"sync"
 	"time"
@@ -67,12 +66,10 @@ func readHosts() {
 
 	file, err := open(hp)
 	if err != nil {
-		// Return only on temporary errors, so that
-		// the hosts cache gets cleaned up on errors
-		// like: access, file not exist errors.
-		var pathError *fs.PathError
+		// Return only on temporary errors (EMFILE, ENFILE), so that
+		// the hosts cache gets cleaned up on errors like: access, file not exist.
 		var temporary interface{ Temporary() bool }
-		if errors.As(err, &pathError) && errors.As(pathError.Err, &temporary) && temporary.Temporary() {
+		if errors.As(err, &temporary) && temporary.Temporary() {
 			return
 		}
 	}

--- a/src/net/hosts.go
+++ b/src/net/hosts.go
@@ -5,7 +5,9 @@
 package net
 
 import (
+	"errors"
 	"internal/bytealg"
+	"io/fs"
 	"net/netip"
 	"sync"
 	"time"
@@ -63,48 +65,52 @@ func readHosts() {
 	hs := make(map[string]byName)
 	is := make(map[string][]string)
 
-	var file *file
-	if file, _ = open(hp); file == nil {
+	file, err := open(hp)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return
 	}
-	for line, ok := file.readLine(); ok; line, ok = file.readLine() {
-		if i := bytealg.IndexByteString(line, '#'); i >= 0 {
-			// Discard comments.
-			line = line[0:i]
-		}
-		f := getFields(line)
-		if len(f) < 2 {
-			continue
-		}
-		addr := parseLiteralIP(f[0])
-		if addr == "" {
-			continue
-		}
 
-		var canonical string
-		for i := 1; i < len(f); i++ {
-			name := absDomainName(f[i])
-			h := []byte(f[i])
-			lowerASCIIBytes(h)
-			key := absDomainName(string(h))
-
-			if i == 1 {
-				canonical = key
+	if file != nil {
+		defer file.close()
+		for line, ok := file.readLine(); ok; line, ok = file.readLine() {
+			if i := bytealg.IndexByteString(line, '#'); i >= 0 {
+				// Discard comments.
+				line = line[0:i]
 			}
-
-			is[addr] = append(is[addr], name)
-
-			if v, ok := hs[key]; ok {
-				hs[key] = byName{
-					addrs:         append(v.addrs, addr),
-					canonicalName: v.canonicalName,
-				}
+			f := getFields(line)
+			if len(f) < 2 {
+				continue
+			}
+			addr := parseLiteralIP(f[0])
+			if addr == "" {
 				continue
 			}
 
-			hs[key] = byName{
-				addrs:         []string{addr},
-				canonicalName: canonical,
+			var canonical string
+			for i := 1; i < len(f); i++ {
+				name := absDomainName(f[i])
+				h := []byte(f[i])
+				lowerASCIIBytes(h)
+				key := absDomainName(string(h))
+
+				if i == 1 {
+					canonical = key
+				}
+
+				is[addr] = append(is[addr], name)
+
+				if v, ok := hs[key]; ok {
+					hs[key] = byName{
+						addrs:         append(v.addrs, addr),
+						canonicalName: v.canonicalName,
+					}
+					continue
+				}
+
+				hs[key] = byName{
+					addrs:         []string{addr},
+					canonicalName: canonical,
+				}
 			}
 		}
 	}
@@ -115,7 +121,6 @@ func readHosts() {
 	hosts.byAddr = is
 	hosts.mtime = mtime
 	hosts.size = size
-	file.close()
 }
 
 // lookupStaticHost looks up the addresses and the canonical name for the given host from /etc/hosts.

--- a/src/net/hosts.go
+++ b/src/net/hosts.go
@@ -7,6 +7,7 @@ package net
 import (
 	"errors"
 	"internal/bytealg"
+	"io/fs"
 	"net/netip"
 	"sync"
 	"time"
@@ -66,10 +67,7 @@ func readHosts() {
 
 	file, err := open(hp)
 	if err != nil {
-		// Return only on temporary errors (EMFILE, ENFILE), so that
-		// the hosts cache gets cleaned up on errors like: access, file not exist.
-		var temporary interface{ Temporary() bool }
-		if errors.As(err, &temporary) && temporary.Temporary() {
+		if !errors.Is(err, fs.ErrNotExist) && !errors.Is(err, fs.ErrPermission) {
 			return
 		}
 	}

--- a/src/net/hosts.go
+++ b/src/net/hosts.go
@@ -66,8 +66,15 @@ func readHosts() {
 	is := make(map[string][]string)
 
 	file, err := open(hp)
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return
+	if err != nil {
+		// Return only on temporary errors, so that
+		// the hosts cache gets cleaned up on errors
+		// like: access, file not exist errors.
+		var pathError *fs.PathError
+		var temporary interface{ Temporary() bool }
+		if errors.As(err, &pathError) && errors.As(pathError.Err, &temporary) && temporary.Temporary() {
+			return
+		}
 	}
 
 	if file != nil {


### PR DESCRIPTION
This was also the cause of my issues in CL 455275

Before:
root@arch:~/aa# $(time sleep 5 && mv /etc/hosts /tmp/hosts) &
[1] 2214
root@arch:~/aa# go run main.go
[232.223.232.123] <nil>
[232.223.232.123] <nil>
[232.223.232.123] <nil>
[232.223.232.123] <nil>
[232.223.232.123] <nil>
[232.223.232.123] <nil>
(....)

After: 
root@arch:~/aa# $(time sleep 5 && mv /etc/hosts /tmp/hosts) &
[1] 2284
root@arch:~/aa# go run main.go
[232.223.232.123] <nil>
[232.223.232.123] <nil>
[232.223.232.123] <nil>
[232.223.232.123] <nil>
[232.223.232.123] <nil>
[] lookup sth on 127.0.0.53:53: server misbehaving
[] lookup sth on 127.0.0.53:53: server misbehaving

