### PR TITLE
net/http: move mux.mu.RLock() and mux.mu.RUnlock to shouldRedirectRLocked method

### DIFF
--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -2391,9 +2391,7 @@ func (mux *ServeMux) match(path string) (h Handler, pattern string) {
 // not for path itself. If the path needs appending to, it creates a new
 // URL, setting the path to u.Path + "/" and returning true to indicate so.
 func (mux *ServeMux) redirectToPathSlash(host, path string, u *url.URL) (*url.URL, bool) {
-	mux.mu.RLock()
 	shouldRedirect := mux.shouldRedirectRLocked(host, path)
-	mux.mu.RUnlock()
 	if !shouldRedirect {
 		return u, false
 	}
@@ -2406,6 +2404,8 @@ func (mux *ServeMux) redirectToPathSlash(host, path string, u *url.URL) (*url.UR
 // path+"/". This should happen if a handler is registered for path+"/" but
 // not path -- see comments at ServeMux.
 func (mux *ServeMux) shouldRedirectRLocked(host, path string) bool {
+	mux.mu.RLock()
+	defer mux.mu.RUnlock()
 	p := []string{path, host + path}
 
 	for _, c := range p {

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -2391,7 +2391,7 @@ func (mux *ServeMux) match(path string) (h Handler, pattern string) {
 // not for path itself. If the path needs appending to, it creates a new
 // URL, setting the path to u.Path + "/" and returning true to indicate so.
 func (mux *ServeMux) redirectToPathSlash(host, path string, u *url.URL) (*url.URL, bool) {
-	shouldRedirect := mux.shouldRedirectRLocked(host, path)
+	shouldRedirect := mux.shouldRedirect(host, path)
 	if !shouldRedirect {
 		return u, false
 	}
@@ -2400,14 +2400,14 @@ func (mux *ServeMux) redirectToPathSlash(host, path string, u *url.URL) (*url.UR
 	return u, true
 }
 
-// shouldRedirectRLocked reports whether the given path and host should be redirected to
+// shouldRedirect reports whether the given path and host should be redirected to
 // path+"/". This should happen if a handler is registered for path+"/" but
 // not path -- see comments at ServeMux.
-func (mux *ServeMux) shouldRedirectRLocked(host, path string) bool {
+func (mux *ServeMux) shouldRedirect(host, path string) bool {
 	mux.mu.RLock()
 	defer mux.mu.RUnlock()
 	p := []string{path, host + path}
-
+	
 	for _, c := range p {
 		if _, exist := mux.m[c]; exist {
 			return false

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -2407,7 +2407,7 @@ func (mux *ServeMux) shouldRedirect(host, path string) bool {
 	mux.mu.RLock()
 	defer mux.mu.RUnlock()
 	p := []string{path, host + path}
-	
+
 	for _, c := range p {
 		if _, exist := mux.m[c]; exist {
 			return false


### PR DESCRIPTION
Update shouldRedirectRLocked method

`RLock` and `Runlock` move to `shouldRedirectRLocked`
renamed `shouldRedirectRLocked` to `shouldRedirect`


Benchmark:

BenchmarkServeMux-8
old    26017 ns/op	   17280 B/op	     360 allocs/op
new    25420 ns/op	   17280 B/op	     360 allocs/op

BenchmarkServeMux_SkipServe-8
old 14834 ns/op
new 15386 ns/op
