### PR TITLE
net: use the lookupOrder for go resolver LookupAddr

### DIFF
--- a/src/net/dnsclient_unix.go
+++ b/src/net/dnsclient_unix.go
@@ -810,15 +810,18 @@ func (r *Resolver) goLookupCNAME(ctx context.Context, host string, order hostLoo
 }
 
 // goLookupPTR is the native Go implementation of LookupAddr.
-// Used only if cgoLookupPTR refuses to handle the request (that is,
-// only if cgoLookupPTR is the stub in cgo_stub.go).
-// Normally we let cgo use the C library resolver instead of depending
-// on our lookup code, so that Go and C get the same answers.
-func (r *Resolver) goLookupPTR(ctx context.Context, addr string, conf *dnsConfig) ([]string, error) {
-	names := lookupStaticAddr(addr)
-	if len(names) > 0 {
-		return names, nil
+func (r *Resolver) goLookupPTR(ctx context.Context, addr string, order hostLookupOrder, conf *dnsConfig) ([]string, error) {
+	if order == hostLookupFiles || order == hostLookupFilesDNS {
+		names := lookupStaticAddr(addr)
+		if len(names) > 0 {
+			return names, nil
+		}
+
+		if order == hostLookupFiles {
+			return nil, &DNSError{Err: errNoSuchHost.Error(), Name: addr, IsNotFound: true}
+		}
 	}
+
 	arpa, err := reverseaddr(addr)
 	if err != nil {
 		return nil, err
@@ -862,5 +865,17 @@ func (r *Resolver) goLookupPTR(ctx context.Context, addr string, conf *dnsConfig
 		ptrs = append(ptrs, ptr.PTR.String())
 
 	}
-	return ptrs, nil
+
+	if len(ptrs) > 0 {
+		return ptrs, nil
+	}
+
+	if order == hostLookupDNSFiles {
+		names := lookupStaticAddr(addr)
+		if len(names) > 0 {
+			return names, nil
+		}
+	}
+
+	return nil, &DNSError{Err: errNoSuchHost.Error(), Name: addr, IsNotFound: true}
 }

--- a/src/net/lookup_plan9.go
+++ b/src/net/lookup_plan9.go
@@ -361,8 +361,8 @@ func (r *Resolver) lookupTXT(ctx context.Context, name string) (txt []string, er
 }
 
 func (r *Resolver) lookupAddr(ctx context.Context, addr string) (name []string, err error) {
-	if _, conf, preferGo := r.preferGoOverPlan9WithOrderAndConf(); preferGo {
-		return r.goLookupPTR(ctx, addr, conf)
+	if order, conf, preferGo := r.preferGoOverPlan9WithOrderAndConf(); preferGo {
+		return r.goLookupPTR(ctx, addr, order, conf)
 	}
 	arpa, err := reverseaddr(addr)
 	if err != nil {

--- a/src/net/lookup_unix.go
+++ b/src/net/lookup_unix.go
@@ -121,7 +121,7 @@ func (r *Resolver) lookupAddr(ctx context.Context, addr string) ([]string, error
 	if order == hostLookupCgo {
 		return cgoLookupPTR(ctx, addr)
 	}
-	return r.goLookupPTR(ctx, addr, conf)
+	return r.goLookupPTR(ctx, addr, order, conf)
 }
 
 // concurrentThreadsLimit returns the number of threads we permit to

--- a/src/net/lookup_windows.go
+++ b/src/net/lookup_windows.go
@@ -374,8 +374,8 @@ func (r *Resolver) lookupTXT(ctx context.Context, name string) ([]string, error)
 }
 
 func (r *Resolver) lookupAddr(ctx context.Context, addr string) ([]string, error) {
-	if r.preferGoOverWindows() {
-		return r.goLookupPTR(ctx, addr, nil)
+	if order, conf := systemConf().hostLookupOrder(r, ""); order != hostLookupCgo {
+		return r.goLookupPTR(ctx, addr, order, conf)
 	}
 
 	// TODO(bradfitz): finish ctx plumbing. Nothing currently depends on this.


### PR DESCRIPTION
To mach the cgo version behaviour and the LookupHost (go resolver).