### PR TITLE
errors: optimize *joinError's Error method for less allocation and faster execution

### DIFF
--- a/src/errors/join.go
+++ b/src/errors/join.go
@@ -38,11 +38,14 @@ type joinError struct {
 }
 
 func (e *joinError) Error() string {
-	var b []byte
-	for i, err := range e.errs {
-		if i > 0 {
-			b = append(b, '\n')
-		}
+	// Assert len(e.errs) > 0.
+	if len(e.errs) == 1 {
+		return e.errs[0].Error()
+	}
+
+	b := []byte(e.errs[0].Error())
+	for _, err := range e.errs[1:] {
+		b = append(b, '\n')
 		b = append(b, err.Error()...)
 	}
 	return string(b)

--- a/src/errors/join.go
+++ b/src/errors/join.go
@@ -42,18 +42,17 @@ type joinError struct {
 }
 
 func (e *joinError) Error() string {
-	nerrs := len(e.errs)
 	// Since Join returns nil if every value in errs is nil,
 	// e.errs cannot be empty.
 	// TODO: get rid of case 0
-	switch nerrs {
+	switch len(e.errs) {
 	case 0: // Impossible but handle.
 		return "<nil>"
 	case 1:
 		return e.errs[0].Error()
 	}
 
-	// To avoid doubling the number of Error calls, skip preallocating 
+	// To avoid doubling the number of Error calls, skip preallocating
 	// the slice on overflow and let the runtime handle the panic.
 	b := []byte(e.errs[0].Error())
 	for _, err := range e.errs[1:] {

--- a/src/errors/join.go
+++ b/src/errors/join.go
@@ -53,19 +53,9 @@ func (e *joinError) Error() string {
 		return e.errs[0].Error()
 	}
 
-	const maxInt = int(^uint(0) >> 1)
-
-	n := nerrs - 1
-	for _, err := range e.errs {
-		nstr := len(err.Error())
-		if nstr > maxInt-n {
-			panic("errors: Join output length overflow")
-		}
-		n += nstr
-	}
-
-	b := make([]byte, 0, n)
-	b = append(b, e.errs[0].Error()...)
+	// To avoid doubling the number of Error calls, skip preallocating 
+	// the slice on overflow and let the runtime handle the panic.
+	b := []byte(e.errs[0].Error())
 	for _, err := range e.errs[1:] {
 		b = append(b, '\n')
 		b = append(b, err.Error()...)

--- a/src/errors/join.go
+++ b/src/errors/join.go
@@ -4,6 +4,10 @@
 
 package errors
 
+import (
+	"unsafe"
+)
+
 // Join returns an error that wraps the given errors.
 // Any nil error values are discarded.
 // Join returns nil if every value in errs is nil.
@@ -38,7 +42,8 @@ type joinError struct {
 }
 
 func (e *joinError) Error() string {
-	// Assert len(e.errs) > 0.
+	// Since "Join returns nil if every value in errs is nil",
+	// "errs" in a *joinErr is certainly non-empty.
 	if len(e.errs) == 1 {
 		return e.errs[0].Error()
 	}
@@ -48,7 +53,9 @@ func (e *joinError) Error() string {
 		b = append(b, '\n')
 		b = append(b, err.Error()...)
 	}
-	return string(b)
+	// At this point, b has at least one byte '\n', so that
+	// b is certainly non-empty.
+	return unsafe.String(&b[0], len(b))
 }
 
 func (e *joinError) Unwrap() []error {

--- a/src/errors/join.go
+++ b/src/errors/join.go
@@ -44,24 +44,17 @@ type joinError struct {
 func (e *joinError) Error() string {
 	// Since Join returns nil if every value in errs is nil,
 	// e.errs cannot be empty.
-	// TODO: get rid of case 0
-	switch len(e.errs) {
-	case 0: // Impossible but handle.
-		return "<nil>"
-	case 1:
+	if len(e.errs) == 1 {
 		return e.errs[0].Error()
 	}
 
-	// To avoid doubling the number of Error calls, skip preallocating
-	// the slice on overflow and let the runtime handle the panic.
 	b := []byte(e.errs[0].Error())
 	for _, err := range e.errs[1:] {
 		b = append(b, '\n')
 		b = append(b, err.Error()...)
 	}
 	// At this point, b has at least one byte '\n'.
-	// TODO: replace with unsafe.String(&b[0], len(b))
-	return unsafe.String(unsafe.SliceData(b), len(b))
+	return unsafe.String(&b[0], len(b))
 }
 
 func (e *joinError) Unwrap() []error {

--- a/src/errors/join.go
+++ b/src/errors/join.go
@@ -43,7 +43,7 @@ type joinError struct {
 
 func (e *joinError) Error() string {
 	// Since "Join returns nil if every value in errs is nil",
-	// "errs" in a *joinErr is certainly non-empty.
+	// "errs" in a *joinError is certainly non-empty.
 	if len(e.errs) == 1 {
 		return e.errs[0].Error()
 	}


### PR DESCRIPTION
Handle the case of one error at the beginning.
Use unsafe.String to avoid memory allocation when converting byte slice to string.