### PR TITLE
net/http: improve Error and implement Errorf

### DIFF
--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -2137,11 +2137,31 @@ func (f HandlerFunc) ServeHTTP(w ResponseWriter, r *Request) {
 // It does not otherwise end the request; the caller should ensure no further
 // writes are done to w.
 // The error message should be plain text.
-func Error(w ResponseWriter, error string, code int) {
+func Error(w ResponseWriter, err any, code int) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(code)
-	fmt.Fprintln(w, error)
+
+	var msg string
+	switch v := err.(type) {
+	case error:
+		msg = v.Error()
+	case string:
+		msg = v
+	default:
+		msg = fmt.Sprintf("%v", v)
+	}
+	fmt.Fprintln(w, msg)
+}
+
+// Errorf replies to the request with the formatted error and HTTP code.
+// It does not otherwise end the request; the caller should ensure no further
+// writes are done to w. The formatted error message should be plain text.
+func Errorf(w ResponseWriter, code int, format string, args ...any) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(code)
+	fmt.Fprintf(w, format, args...)
 }
 
 // NotFound replies to the request with an HTTP 404 not found error.


### PR DESCRIPTION
Improves `Error` by modifying param type to `any` so developers can pass `error` type, or `string` etc..

Also implements `http.Errorf` to support error messages w/formatting directives.