### PR TITLE
strings: correct NewReader documentation

### DIFF
--- a/src/strings/reader.go
+++ b/src/strings/reader.go
@@ -156,5 +156,5 @@ func (r *Reader) WriteTo(w io.Writer) (n int64, err error) {
 func (r *Reader) Reset(s string) { *r = Reader{s, 0, -1} }
 
 // NewReader returns a new Reader reading from s.
-// It is similar to bytes.NewBufferString but more efficient and read-only.
+// It is similar to bytes.NewBufferString but more efficient and non-writable.
 func NewReader(s string) *Reader { return &Reader{s, 0, -1} }


### PR DESCRIPTION
The provided description for `NewReader` says that the underlying string is read-only. but the following example shows that this is not the case. 
<br />

rd := strings.NewReader("this is a text")
 
rd.Reset("new text") <--- underlying string gets updated here
