### PR TITLE
net/http/httptest: remove unnecessary creation of http.Transport

### DIFF
--- a/src/net/http/httptest/server.go
+++ b/src/net/http/httptest/server.go
@@ -144,7 +144,7 @@ func (s *Server) StartTLS() {
 		panic("Server already started")
 	}
 	if s.client == nil {
-		s.client = &http.Client{Transport: &http.Transport{}}
+		s.client = &http.Client{}
 	}
 	cert, err := tls.X509KeyPair(testcert.LocalhostCert, testcert.LocalhostKey)
 	if err != nil {


### PR DESCRIPTION
In (*Server).StartTLS, it's unnecessary to create an http.Client
with a Transport, because a new one will be created with the
TLSClientConfig later.