### PR TITLE
io/copybuffer: use bitwise instead of multiplication

### DIFF
--- a/src/io/io.go
+++ b/src/io/io.go
@@ -413,7 +413,7 @@ func copyBuffer(dst Writer, src Reader, buf []byte) (written int64, err error) {
 		return rt.ReadFrom(src)
 	}
 	if buf == nil {
-		size := 32 * 1024
+		size := 1 << 15
 		if l, ok := src.(*LimitedReader); ok && int64(size) > l.N {
 			if l.N < 1 {
 				size = 1


### PR DESCRIPTION
Reasons for this change: 
- The number(size) being expressed is the power of two.
- This approach is more consistent across the `src/io/io.go` file.
- This approach is slightly faster based on my benchmarks
`goos: linux`
`goarch: amd64`
`cpu: 12th Gen Intel(R) Core(TM) i9-12900HK`
BenchmarkPerformance/LeftShift-20                    1000000000               0.1042 ns/op
BenchmarkPerformance/Multiplication-20           1000000000               0.1054 ns/op
BenchmarkPerformance/LeftShift#01-20             1000000000               0.1168 ns/op
BenchmarkPerformance/Multiplication#01-20    1000000000               0.1102 ns/op
BenchmarkPerformance/LeftShift#02-20              1000000000               0.1084 ns/op
BenchmarkPerformance/Multiplication#02-20    1000000000               0.1174 ns/op
BenchmarkPerformance/LeftShift#03-20              1000000000               0.1141 ns/op
BenchmarkPerformance/Multiplication#03-20    1000000000               0.1353 ns/op
BenchmarkPerformance/LeftShift#04-20              1000000000               0.1030 ns/op
BenchmarkPerformance/Multiplication#04-20    1000000000               0.1276 ns/op
BenchmarkPerformance/LeftShift#05-20              1000000000               0.1028 ns/op
BenchmarkPerformance/Multiplication#05-20    1000000000               0.1446 ns/op
BenchmarkPerformance/LeftShift#06-20             1000000000               0.1241 ns/op
BenchmarkPerformance/Multiplication#06-20    1000000000               0.1418 ns/op
BenchmarkPerformance/LeftShift#07-20            1000000000               0.1108 ns/op
BenchmarkPerformance/Multiplication#07-20   1000000000               0.1121 ns/op
BenchmarkPerformance/LeftShift#08-20            1000000000               0.1177 ns/op
BenchmarkPerformance/Multiplication#08-20  1000000000               0.1069 ns/op
BenchmarkPerformance/LeftShift#09-20            1000000000               0.1089 ns/op
BenchmarkPerformance/Multiplication#09-20   1000000000               0.1076 ns/op