### PR TITLE
testing: clarify comments on runCleanup

### DIFF
--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -1300,7 +1300,7 @@ func (c *common) Setenv(key, value string) {
 	}
 }
 
-// panicHanding is an argument to runCleanup.
+// panicHanding controls the panic handling used by runCleanup.
 type panicHandling int
 
 const (
@@ -1309,7 +1309,7 @@ const (
 )
 
 // runCleanup is called at the end of the test.
-// If catchPanic is true, this will catch panics, and return the recovered
+// If panicHandling == recoverAndReturnPanic, it will catch panics, and return the recovered
 // value if any.
 func (c *common) runCleanup(ph panicHandling) (panicVal any) {
 	c.cleanupStarted.Store(true)


### PR DESCRIPTION
The comment on runCleanup states "If catchPanic is true ...", but there is no catchPanic argument or variable. This was introduced in commit 998cbe29832a, which also introduced the panicHandling type. This was changed during code review, but the comment was missed. See:

https://go-review.googlesource.com/c/go/+/214822/4..6/src/testing/testing.go#b797
