### PR TITLE
cmd/go/internal/generate: error if failed to find a package

### DIFF
--- a/src/cmd/go/internal/generate/generate.go
+++ b/src/cmd/go/internal/generate/generate.go
@@ -210,6 +210,13 @@ func runGenerate(ctx context.Context, cmd *base.Command, args []string) {
 			continue
 		}
 
+		if pkg.Error != nil && len(pkg.InternalAllGoFiles()) == 0 {
+			// A directory only contains a Go package if it has at least
+			// one .go source file, so the fact that there are no files
+			// implies that the package couldn't be found.
+			base.Errorf("%v", pkg.Error)
+		}
+
 		for _, file := range pkg.InternalGoFiles() {
 			if !generate(file) {
 				break
@@ -222,6 +229,7 @@ func runGenerate(ctx context.Context, cmd *base.Command, args []string) {
 			}
 		}
 	}
+	base.ExitIfErrors()
 }
 
 // generate runs the generation directives for a single file.

--- a/src/cmd/go/testdata/script/generate_invalid.txt
+++ b/src/cmd/go/testdata/script/generate_invalid.txt
@@ -6,8 +6,13 @@ go install echo.go
 env PATH=$GOBIN${:}$PATH
 
 # Test go generate for directory with no go files
-go generate ./nogo
+! go generate ./nogo
 ! stdout 'Fail'
+stderr 'no Go files'
+
+# Test go  generate for module which doesn't exist should fail
+! go generate foo.bar/nothing
+stderr 'no required module provides package foo.bar/nothing'
 
 # Test go generate for package where all .go files are excluded by build
 # constraints


### PR DESCRIPTION
Add check for package loader to print error and fail `go generate` command,
if package can not be found.

Fixes #60079