### PR TITLE
os: add a FindProcess implementation for UNIX

### DIFF
--- a/src/os/exec.go
+++ b/src/os/exec.go
@@ -84,9 +84,6 @@ func Getppid() int { return syscall.Getppid() }
 //
 // The Process it returns can be used to obtain information
 // about the underlying operating system process.
-//
-// On Unix systems, FindProcess always succeeds and returns a Process
-// for the given pid, regardless of whether the process exists.
 func FindProcess(pid int) (*Process, error) {
 	return findProcess(pid)
 }

--- a/src/os/exec_unix.go
+++ b/src/os/exec_unix.go
@@ -92,9 +92,15 @@ func (p *Process) release() error {
 	return nil
 }
 
-func findProcess(pid int) (p *Process, err error) {
-	// NOOP for unix.
-	return newProcess(pid, 0), nil
+func findProcess(pid int) (*Process, error) {
+	proc := newProcess(pid, 0)
+	// The POSIX standard specifies that a null-signal can be sent to check
+	// whether a PID is valid.
+	err := proc.Signal(syscall.Signal(0))
+	if err != nil {
+		return nil, err
+	}
+	return proc, nil
 }
 
 func (p *ProcessState) userTime() time.Duration {


### PR DESCRIPTION
The current implementation of always returning a process can lead to unexpected behavior and is generally not very helpful.

This commit adds a simple check whether the process is still alive or not, as described in the POSIX standard, by attempting to send a null signal to the process.

Fixes #34396

Link: https://pubs.opengroup.org/onlinepubs/9699919799/functions/kill.html