### PR TITLE
net: root the nodata test domain to avoid search domains

### DIFF
--- a/src/net/lookup_test.go
+++ b/src/net/lookup_test.go
@@ -1425,7 +1425,7 @@ func testLookupNoData(t *testing.T, prefix string) {
 	for {
 		// Domain that doesn't have any A/AAAA RRs, but has different one (in this case a TXT),
 		// so that it returns an empty response without any error codes (NXDOMAIN).
-		_, err := LookupHost("golang.rsc.io")
+		_, err := LookupHost("golang.rsc.io.")
 		if err == nil {
 			t.Errorf("%v: unexpected success", prefix)
 			return


### PR DESCRIPTION
I came across similar issue in CL 455275. 
Without rooting this, the search domains might affect 
the query, so the test might not prove the right thing.
The search domain will cause a change from no data
to NXDOMAIN error.