### PR TITLE
encoding/xml: wrap charsetReader errors

### DIFF
--- a/src/encoding/xml/xml.go
+++ b/src/encoding/xml/xml.go
@@ -262,6 +262,9 @@ func NewTokenDecoder(t TokenReader) *Decoder {
 // or EOF before all expected end elements,
 // it will return an error.
 //
+// If CharsetReader is called and returns an error,
+// the error is wrapped and returned.
+//
 // Token implements XML name spaces as described by
 // https://www.w3.org/TR/REC-xml-names/. Each of the
 // Name structures contained in the Token has the Space
@@ -634,7 +637,7 @@ func (d *Decoder) rawToken() (Token, error) {
 				}
 				newr, err := d.CharsetReader(enc, d.r.(io.Reader))
 				if err != nil {
-					d.err = fmt.Errorf("xml: opening charset %q: %v", enc, err)
+					d.err = fmt.Errorf("xml: opening charset %q: %w", enc, err)
 					return nil, d.err
 				}
 				if newr == nil {


### PR DESCRIPTION
This change wraps the errors from the CharsetReader function so the caller can distinguish different error conditions.

Context: I have an XML file with an unknown encoding which I like to handle separately. I like to use the CharsetReader for this but the error type has not been forwarded.
