### PR TITLE
errors: clarify that Join doesn't extend already-joined errors

### DIFF
--- a/src/errors/join.go
+++ b/src/errors/join.go
@@ -12,6 +12,11 @@ package errors
 // between each string.
 //
 // A non-nil error returned by Join implements the Unwrap() []error method.
+//
+// Calling Join on an error that was previously returned by Join wraps
+// the error again. Consequently, calling Unwrap() []error on the result
+// of Join(Join(err1, err2), err3) returns a slice with 2 items, of which
+// the first one implements Unwrap() []error too.
 func Join(errs ...error) error {
 	n := 0
 	for _, err := range errs {


### PR DESCRIPTION
Updates the documentation for Join to explain that it does not append to an existing joinError (i.e. the result of calling Join), and if one of the errors is a joinError, it will be wrapped again. Fixes #60209

It also adds a test to provide an example of said behavior, as well as formalizing it in the API's contract.