### PR TITLE
io: prevent seeking to position prior to offsetwrite.base

### DIFF
--- a/src/io/io.go
+++ b/src/io/io.go
@@ -575,6 +575,10 @@ func (o *OffsetWriter) Write(p []byte) (n int, err error) {
 }
 
 func (o *OffsetWriter) WriteAt(p []byte, off int64) (n int, err error) {
+	if off < 0 {
+		return 0, errOffset
+	}
+
 	off += o.base
 	return o.w.WriteAt(p, off)
 }

--- a/src/io/io_test.go
+++ b/src/io/io_test.go
@@ -608,6 +608,26 @@ func TestOffsetWriter_WriteAt(t *testing.T) {
 	}
 }
 
+func TestWriteAt_PositionPriorToBase(t *testing.T) {
+	tmpdir := t.TempDir()
+	tmpfilename := "TestOffsetWriter_WriteAt"
+	tmpfile, err := os.CreateTemp(tmpdir, tmpfilename)
+	if err != nil {
+		t.Fatalf("CreateTemp(%s) failed: %v", tmpfilename, err)
+	}
+	defer tmpfile.Close()
+
+	// start writing position in OffsetWriter
+	offset := int64(10)
+	// position we want to write to the tmpfile
+	at := int64(-1)
+	w := NewOffsetWriter(tmpfile, offset)
+	_, e := w.WriteAt([]byte("hello"), at)
+	if e == nil {
+		t.Errorf("error expected to be not nil")
+	}
+}
+
 func TestOffsetWriter_Write(t *testing.T) {
 	const content = "0123456789ABCDEF"
 	contentSize := len(content)


### PR DESCRIPTION
We don't want to permit writing before the start of an OffsetWriter.

One of the goals of OffsetWriter is to restrict where data 
can be written. 

However, this rule can be violated by WriteAt() method of OffsetWriter
as the following code shows:

f, _ := os.Create("file.txt")
owr := io.NewOffsetWriter(f, 10)
owr.Write([]byte("world"))
owr.WriteAt([]byte("hello"), -10)
