### PR TITLE
fmt: clear width and precision in fmt.init

### DIFF
--- a/src/fmt/format.go
+++ b/src/fmt/format.go
@@ -57,6 +57,8 @@ func (f *fmt) clearflags() {
 
 func (f *fmt) init(buf *buffer) {
 	f.buf = buf
+	f.wid = 0
+	f.prec = 0
 	f.clearflags()
 }
 


### PR DESCRIPTION
width and precision may be abnormally large when missing args.
it case unnecessary large mem alloc, as follows:

func test() {
	var m runtime.MemStats
	runtime.ReadMemStats(&m)
	fmt.Printf("1. mem init: %+v\n", m.TotalAlloc)
	fmt.Printf("2. fault print: %.9000000f\n", "aaa")
	fmt.Printf("3. normal print %02d%02d\n", 1, 1)
	runtime.ReadMemStats(&m)
	fmt.Printf("4. mem after: %+v\n", m.TotalAlloc)
}
// 1. mem init: 105856
// 2. fault print: %!f(string=aaa)
// 3. normal print 0101
// 4. mem after: 18123680

