### PR TITLE
log: support millisecond timestamp resolution

### DIFF
--- a/src/log/log.go
+++ b/src/log/log.go
@@ -47,6 +47,7 @@ const (
 	Lshortfile                    // final file name element and line number: d.go:23. overrides Llongfile
 	LUTC                          // if Ldate or Ltime is set, use UTC rather than the local time zone
 	Lmsgprefix                    // move the "prefix" from the beginning of the line to before the message
+	Lmilliseconds                 // millisecond resolution: 01:23:23.123.  assumes Ltime.
 	LstdFlags     = Ldate | Ltime // initial values for the standard logger
 )
 
@@ -115,7 +116,7 @@ func formatHeader(buf *[]byte, t time.Time, prefix string, flag int, file string
 	if flag&Lmsgprefix == 0 {
 		*buf = append(*buf, prefix...)
 	}
-	if flag&(Ldate|Ltime|Lmicroseconds) != 0 {
+	if flag&(Ldate|Ltime|Lmicroseconds|Lmilliseconds) != 0 {
 		if flag&LUTC != 0 {
 			t = t.UTC()
 		}
@@ -128,7 +129,7 @@ func formatHeader(buf *[]byte, t time.Time, prefix string, flag int, file string
 			itoa(buf, day, 2)
 			*buf = append(*buf, ' ')
 		}
-		if flag&(Ltime|Lmicroseconds) != 0 {
+		if flag&(Ltime|Lmicroseconds|Lmilliseconds) != 0 {
 			hour, min, sec := t.Clock()
 			itoa(buf, hour, 2)
 			*buf = append(*buf, ':')
@@ -138,6 +139,9 @@ func formatHeader(buf *[]byte, t time.Time, prefix string, flag int, file string
 			if flag&Lmicroseconds != 0 {
 				*buf = append(*buf, '.')
 				itoa(buf, t.Nanosecond()/1e3, 6)
+			} else if flag&Lmilliseconds != 0 {
+				*buf = append(*buf, '.')
+				itoa(buf, t.Nanosecond()/1e6, 3)
 			}
 			*buf = append(*buf, ' ')
 		}

--- a/src/log/log_test.go
+++ b/src/log/log_test.go
@@ -23,7 +23,8 @@ const (
 	Rdate         = `[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9]`
 	Rtime         = `[0-9][0-9]:[0-9][0-9]:[0-9][0-9]`
 	Rmicroseconds = `\.[0-9][0-9][0-9][0-9][0-9][0-9]`
-	Rline         = `(63|65):` // must update if the calls to l.Printf / l.Print below move
+	Rmilliseconds = `\.[0-9][0-9][0-9]`
+	Rline         = `(70|72):` // must update if the calls to l.Printf / l.Print below move
 	Rlongfile     = `.*/[A-Za-z0-9_\-]+\.go:` + Rline
 	Rshortfile    = `[A-Za-z0-9_\-]+\.go:` + Rline
 )
@@ -43,6 +44,8 @@ var tests = []tester{
 	{Ltime | Lmsgprefix, "XXX", Rtime + " XXX"},
 	{Ltime | Lmicroseconds, "", Rtime + Rmicroseconds + " "},
 	{Lmicroseconds, "", Rtime + Rmicroseconds + " "}, // microsec implies time
+	{Ltime | Lmilliseconds, "", Rtime + Rmilliseconds + " "},
+	{Lmilliseconds, "", Rtime + Rmilliseconds + " "}, // millisec implies time
 	{Llongfile, "", Rlongfile + " "},
 	{Lshortfile, "", Rshortfile + " "},
 	{Llongfile | Lshortfile, "", Rshortfile + " "}, // shortfile overrides longfile
@@ -51,6 +54,10 @@ var tests = []tester{
 	{Ldate | Ltime | Lmicroseconds | Lshortfile, "XXX", "XXX" + Rdate + " " + Rtime + Rmicroseconds + " " + Rshortfile + " "},
 	{Ldate | Ltime | Lmicroseconds | Llongfile | Lmsgprefix, "XXX", Rdate + " " + Rtime + Rmicroseconds + " " + Rlongfile + " XXX"},
 	{Ldate | Ltime | Lmicroseconds | Lshortfile | Lmsgprefix, "XXX", Rdate + " " + Rtime + Rmicroseconds + " " + Rshortfile + " XXX"},
+	{Ldate | Ltime | Lmilliseconds | Llongfile, "XXX", "XXX" + Rdate + " " + Rtime + Rmilliseconds + " " + Rlongfile + " "},
+	{Ldate | Ltime | Lmilliseconds | Lshortfile, "XXX", "XXX" + Rdate + " " + Rtime + Rmilliseconds + " " + Rshortfile + " "},
+	{Ldate | Ltime | Lmilliseconds | Llongfile | Lmsgprefix, "XXX", Rdate + " " + Rtime + Rmilliseconds + " " + Rlongfile + " XXX"},
+	{Ldate | Ltime | Lmilliseconds | Lshortfile | Lmsgprefix, "XXX", Rdate + " " + Rtime + Rmilliseconds + " " + Rshortfile + " XXX"},
 }
 
 // Test using Println("hello", 23, "world") or using Printf("hello %d world", 23)


### PR DESCRIPTION
Existing implementation had only microsecond or second resolution, but microsecond resolution could be seen as too precise (access to logs could be used for side channel attacks) while second resolution is not precise enough.

This adds Lmilliseconds flag.

Fixes #60249