### PR TITLE
cmd/go/internal/modfetch: fix retractions slice initial length not zero

### DIFF
--- a/src/cmd/go/internal/modfetch/coderepo.go
+++ b/src/cmd/go/internal/modfetch/coderepo.go
@@ -1011,7 +1011,7 @@ func (r *codeRepo) retractedVersions(ctx context.Context) (func(string) bool, er
 	if err != nil {
 		return nil, err
 	}
-	retractions := make([]modfile.VersionInterval, len(f.Retract))
+	retractions := make([]modfile.VersionInterval, 0, len(f.Retract))
 	for _, r := range f.Retract {
 		retractions = append(retractions, r.VersionInterval)
 	}


### PR DESCRIPTION
When make slice of retractions, it should have initial length zero, to append more VersionIntervals.

Currently without the zero length, the capacity used will be doubled after the appending, looks like a bug.



