### PR TITLE
os/exec: use pidfd for waiting and signaling of processes

### DIFF
--- a/src/os/exec.go
+++ b/src/os/exec.go
@@ -85,7 +85,7 @@ func Getppid() int { return syscall.Getppid() }
 // The Process it returns can be used to obtain information
 // about the underlying operating system process.
 //
-// On Unix systems, FindProcess always succeeds and returns a Process
+// On non-Linux Unix systems, FindProcess always succeeds and returns a Process
 // for the given pid, regardless of whether the process exists.
 func FindProcess(pid int) (*Process, error) {
 	return findProcess(pid)

--- a/src/os/exec_unix.go
+++ b/src/os/exec_unix.go
@@ -11,7 +11,63 @@ import (
 	"runtime"
 	"syscall"
 	"time"
+	"unsafe"
 )
+
+const CLD_EXITED = 1
+const CLD_KILLED = 2
+const CLD_DUMPED = 3
+const CLD_TRAPPED = 4
+const CLD_STOPPED = 5
+const CLD_CONTINUED = 6
+
+type Siginfo struct {
+	Signo int32
+	Errno int32
+	Code  int32
+	_     int32
+	_     [112]byte
+}
+
+func (s Siginfo) Exited() bool { return s.Code == CLD_EXITED }
+
+func (s Siginfo) Signaled() bool { return s.Code == CLD_KILLED }
+
+func (s Siginfo) Stopped() bool { return s.Code == CLD_STOPPED }
+
+func (s Siginfo) Trapped() bool { return s.Code == CLD_TRAPPED }
+
+func (s Siginfo) Continued() bool { return s.Code == CLD_CONTINUED }
+
+func (s Siginfo) CoreDump() bool { return s.Code == CLD_DUMPED }
+
+func (s Siginfo) ExitStatus() int {
+	if !s.Exited() {
+		return -1
+	}
+	return int(s.Errno)
+}
+
+func (s Siginfo) Signal() syscall.Signal {
+	if !s.Signaled() {
+		return -1
+	}
+	return syscall.Signal(s.Errno)
+}
+
+func (s Siginfo) StopSignal() syscall.Signal {
+	if !s.Stopped() {
+		return -1
+	}
+	return syscall.Signal(s.Errno)
+}
+
+func (s Siginfo) TrapCause() int {
+	if !s.Trapped() {
+		return -1
+	}
+	return int(s.Errno)
+}
 
 func (p *Process) wait() (ps *ProcessState, err error) {
 	if p.Pid == -1 {
@@ -34,27 +90,37 @@ func (p *Process) wait() (ps *ProcessState, err error) {
 	}
 
 	var (
-		status syscall.WaitStatus
-		rusage syscall.Rusage
-		pid1   int
-		e      error
+		siginfo Siginfo
+		rusage  syscall.Rusage
+		e       syscall.Errno
 	)
 	for {
-		pid1, e = syscall.Wait4(p.Pid, &status, 0, &rusage)
-		if e != syscall.EINTR {
+		_, _, e = syscall.Syscall6(syscall.SYS_WAITID, _P_PIDFD, p.handle, uintptr(unsafe.Pointer(&siginfo)), syscall.WEXITED, uintptr(unsafe.Pointer(&rusage)), 0)
+		if e == syscall.EINTR {
+			continue
+		} else if e == syscall.ENOSYS {
+			// waitid has been available since Linux 2.6.9, but
+			// reportedly is not available in Ubuntu on Windows.
+			// See issue 16610.
+			panic("TODO: Implement fallback")
+		} else if e != 0 {
+			break
+		}
+		// During ptrace the wait might return also for non-exit reasons. In that case we retry.
+		// See: https://lwn.net/Articles/688624/
+		if siginfo.Exited() || siginfo.Signaled() || siginfo.CoreDump() {
 			break
 		}
 	}
-	if e != nil {
-		return nil, NewSyscallError("wait", e)
+	runtime.KeepAlive(p)
+	if e != 0 {
+		return nil, NewSyscallError("waitid", e)
 	}
-	if pid1 != 0 {
-		p.setDone()
-	}
+	p.setDone()
 	ps = &ProcessState{
-		pid:    pid1,
-		status: status,
-		rusage: &rusage,
+		pid:     p.Pid,
+		siginfo: siginfo,
+		rusage:  &rusage,
 	}
 	return ps, nil
 }
@@ -75,17 +141,22 @@ func (p *Process) signal(sig Signal) error {
 	if !ok {
 		return errors.New("os: unsupported signal type")
 	}
-	if e := syscall.Kill(p.Pid, s); e != nil {
+	if _, _, e := syscall.RawSyscall6(syscall.SYS_PIDFD_SEND_SIGNAL, p.handle, uintptr(s), 0, 0, 0, 0); e != 0 {
 		if e == syscall.ESRCH {
 			return ErrProcessDone
 		}
-		return e
+		return NewSyscallError("pidfd_send_signal", e)
 	}
+	runtime.KeepAlive(p)
 	return nil
 }
 
 func (p *Process) release() error {
-	// NOOP for unix.
+	e := syscall.Close(int(p.handle))
+	if e != nil {
+		return NewSyscallError("close", e)
+
+	}
 	p.Pid = -1
 	// no need for a finalizer anymore
 	runtime.SetFinalizer(p, nil)
@@ -93,8 +164,12 @@ func (p *Process) release() error {
 }
 
 func findProcess(pid int) (p *Process, err error) {
-	// NOOP for unix.
-	return newProcess(pid, 0), nil
+	fd, _, e := syscall.Syscall(syscall.SYS_PIDFD_OPEN, uintptr(pid), 0, 0)
+	runtime.KeepAlive(p)
+	if e != 0 {
+		return nil, NewSyscallError("pidfd_open", e)
+	}
+	return newProcess(pid, fd), nil
 }
 
 func (p *ProcessState) userTime() time.Duration {


### PR DESCRIPTION
Using pidfd allows us to have a handle on the process and poll the handle to non-blocking wait for the process to exit.

Fixes #34396
Fixes #60321
Fixes #60320