### PR TITLE
bufio.Reset: when argument io.Reader is nil, Reader initializes the internal buffer to the default size

### DIFF
--- a/src/bufio/bufio.go
+++ b/src/bufio/bufio.go
@@ -70,6 +70,8 @@ func (b *Reader) Size() int { return len(b.buf) }
 // the buffered reader to read from r.
 // Calling Reset on the zero value of Reader initializes the internal buffer
 // to the default size.
+// If the argument io.Reader is nil, Reader initializes the internal buffer
+// to the default size.
 // Calling b.Reset(b) (that is, resetting a Reader to itself) does nothing.
 func (b *Reader) Reset(r io.Reader) {
 	// If a Reader r is passed to NewReader, NewReader will return r.
@@ -78,7 +80,7 @@ func (b *Reader) Reset(r io.Reader) {
 	if b == r {
 		return
 	}
-	if b.buf == nil {
+	if b.buf == nil || r == nil {
 		b.buf = make([]byte, defaultBufSize)
 	}
 	b.reset(b.buf, r)

--- a/src/bufio/bufio_test.go
+++ b/src/bufio/bufio_test.go
@@ -1514,6 +1514,12 @@ func TestReaderReset(t *testing.T) {
 	r.Reset(strings.NewReader("recur2"))
 	r2.Reset(r)
 	checkAll(r2, "recur2")
+
+	// reset the underline reader provided by the client
+	r.Reset(nil)
+	if got := r.Size(); got != DefaultBufSize {
+		t.Errorf("NewReader's Reader.Size = %d; want %d", DefaultBufSize, got)
+	}
 }
 
 func TestWriterReset(t *testing.T) {


### PR DESCRIPTION
When the Reset function is called with a nil argument, The underlying reader's buffer using the defaultBufSize should be reset.