### PR TITLE
runtime/pprof: update outdated google/pprof GitHub link

### DIFF
--- a/src/runtime/pprof/pprof.go
+++ b/src/runtime/pprof/pprof.go
@@ -69,7 +69,7 @@
 // all pprof commands.
 //
 // For more information about pprof, see
-// https://github.com/google/pprof/blob/master/doc/README.md.
+// https://github.com/google/pprof/blob/main/doc/README.md.
 package pprof
 
 import (


### PR DESCRIPTION
Google/pprof changed the master branch to main, so it might be better to update it to the latest.
