### PR TITLE
cmd/go: enable fuzz testing on OpenBSD

### DIFF
--- a/src/internal/fuzz/counters_supported.go
+++ b/src/internal/fuzz/counters_supported.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (darwin || linux || windows || freebsd) && (amd64 || arm64)
+//go:build (darwin || linux || windows || freebsd || openbsd) && (amd64 || arm64)
 
 package fuzz
 

--- a/src/internal/fuzz/counters_unsupported.go
+++ b/src/internal/fuzz/counters_unsupported.go
@@ -8,7 +8,7 @@
 //
 // If you update this constraint, also update internal/platform.FuzzInstrumeted.
 //
-//go:build !((darwin || linux || windows || freebsd) && (amd64 || arm64))
+//go:build !((darwin || linux || windows || freebsd || openbsd) && (amd64 || arm64))
 
 package fuzz
 

--- a/src/internal/fuzz/minimize_test.go
+++ b/src/internal/fuzz/minimize_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build darwin || freebsd || linux || windows
+//go:build darwin || freebsd || linux || openbsd || windows
 
 package fuzz
 

--- a/src/internal/fuzz/sys_posix.go
+++ b/src/internal/fuzz/sys_posix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build darwin || freebsd || linux
+//go:build darwin || freebsd || linux || openbsd
 
 package fuzz
 

--- a/src/internal/fuzz/sys_unimplemented.go
+++ b/src/internal/fuzz/sys_unimplemented.go
@@ -4,7 +4,7 @@
 
 // If you update this constraint, also update internal/platform.FuzzSupported.
 //
-//go:build !darwin && !freebsd && !linux && !windows
+//go:build !darwin && !freebsd && !linux && !openbsd && !windows
 
 package fuzz
 

--- a/src/internal/platform/supported.go
+++ b/src/internal/platform/supported.go
@@ -50,7 +50,7 @@ func ASanSupported(goos, goarch string) bool {
 // ('go test -fuzz=.').
 func FuzzSupported(goos, goarch string) bool {
 	switch goos {
-	case "darwin", "freebsd", "linux", "windows":
+	case "darwin", "freebsd", "linux", "openbsd", "windows":
 		return true
 	default:
 		return false


### PR DESCRIPTION
This change provides support for -fuzz flag on OpenBSD. According to #46554 the flag was unsupported on some OSes due to lack of proper testing.

Fixes: #60491
