### PR TITLE
doc: clarify the description of the receive operator

### DIFF
--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -1735,8 +1735,8 @@ A channel may be closed with the built-in function
 <a href="#Close"><code>close</code></a>.
 The multi-valued assignment form of the
 <a href="#Receive_operator">receive operator</a>
-reports whether a received value was sent before
-the channel was closed.
+reports whether a received value was delivered by a successful send operation or
+is a zero value generated because the channel is closed and empty.
 </p>
 
 <p>


### PR DESCRIPTION
The description in the "Channel types" section is a little misleading:
  The multi-valued assignment form of the receive operator reports
  whether a received value was sent before the channel was closed.

It could be interpreted as:
  a value could be sent **after** the channel was closed.

The description in the "Receive operator" section is more clearer:
  The value of ok is true if the value received was delivered by a
  successful send operation to the channel, or false if it is a zero
  value generated because the channel is closed and empty.

This CL copies the the description from the "Receive operator" section
to the "Channel types" section (with a little modification).