### PR TITLE
cmd/compile/internal/liveness: remove excess bits for stackmap

### DIFF
--- a/src/cmd/compile/internal/liveness/plive.go
+++ b/src/cmd/compile/internal/liveness/plive.go
@@ -1485,7 +1485,7 @@ func WriteFuncMap(fn *ir.Func, abiInfo *abi.ABIParamResultInfo) {
 		return
 	}
 	nptr := int(abiInfo.ArgWidth() / int64(types.PtrSize))
-	bv := bitvec.New(int32(nptr) * 2)
+	bv := bitvec.New(int32(nptr))
 
 	for _, p := range abiInfo.InParams() {
 		typebits.SetNoCheck(p.Type, p.FrameOffset(abiInfo), bv)


### PR DESCRIPTION
ArgWidth() already includes the stack space required for
input parameters and return values, so their offset will
not exceed the value of ArgWidth(), so there is no need
to double it.