### PR TITLE
archive/tar: use explicit verb for headerError's Error

### DIFF
--- a/src/archive/tar/common.go
+++ b/src/archive/tar/common.go
@@ -53,7 +53,7 @@ func (he headerError) Error() string {
 	if len(ss) == 0 {
 		return prefix
 	}
-	return fmt.Sprintf("%s: %v", prefix, strings.Join(ss, "; and "))
+	return fmt.Sprintf("%s: %s", prefix, strings.Join(ss, "; and "))
 }
 
 // Type flags for Header.Typeflag.


### PR DESCRIPTION
Since strings.Join returns a string, use the explicit verb "%s"
instead of "%v" to keep the same style as the previous "prefix".
