### PR TITLE
doc update: https://go.dev/ref/spec#Size_and_alignment_guarantees

### DIFF
--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -8389,5 +8389,5 @@ The following minimal alignment properties are guaranteed:
 </ol>
 
 <p>
-A struct or array type has size zero if it contains no fields (or elements, respectively) that have a size greater than zero. Two distinct zero-size variables may have the same address in memory.
+A struct or array type has size zero if it contains no fields (or elements, respectively) that have a size greater than zero. Two distinct zero-size variables may have the same address in memory. It is advisable to arrange fields of struct in order of size for memory efficient struct.
 </p>


### PR DESCRIPTION
Adds info in the doc about advisable order of fields in struct for memory efficient code. Example cases here:- https://go.dev/play/p/97P05PazlKQ

Fixes #60638