### PR TITLE
run.bash: ignore os generated files

### DIFF
--- a/src/cmd/go/internal/vcweb/vcstest/vcstest_test.go
+++ b/src/cmd/go/internal/vcweb/vcstest/vcstest_test.go
@@ -140,6 +140,9 @@ func TestScripts(t *testing.T) {
 		if rel == "README" {
 			return nil
 		}
+		if rel == ".DS_Store" {
+			return nil
+		}
 
 		t.Run(filepath.ToSlash(rel), func(t *testing.T) {
 			t.Parallel()

--- a/src/go/types/check_test.go
+++ b/src/go/types/check_test.go
@@ -398,6 +398,10 @@ func testDirFiles(t *testing.T, dir string, manual bool) {
 		if fi.IsDir() {
 			testDir(t, path, manual)
 		} else {
+			if !strings.HasSuffix(path, ".go") {
+				// ignores os generated files like .DS_Store,*.ini
+				continue
+			}
 			t.Run(filepath.Base(path), func(t *testing.T) {
 				testPkg(t, []string{path}, manual)
 			})
@@ -414,8 +418,11 @@ func testDir(t *testing.T, dir string, manual bool) {
 		return
 	}
 
-	var filenames []string
+	filenames := make([]string, 0, len(fis))
 	for _, fi := range fis {
+		if !strings.HasSuffix(fi.Name(), ".go") {
+			continue
+		}
 		filenames = append(filenames, filepath.Join(dir, fi.Name()))
 	}
 


### PR DESCRIPTION
ignore os generated files like *.ini, .DS_Store while testing