### PR TITLE
log/slog: fix the wrapping anti-example

### DIFF
--- a/src/log/slog/doc.go
+++ b/src/log/slog/doc.go
@@ -231,8 +231,8 @@ and line number of the logging call within the application. This can produce
 incorrect source information for functions that wrap slog. For instance, if you
 define this function in file mylog.go:
 
-	func Infof(format string, args ...any) {
-	    slog.Default().Info(fmt.Sprintf(format, args...))
+	func Infof(logger *slog.Logger, format string, args ...any) {
+	    logger.Info(fmt.Sprintf(format, args...))
 	}
 
 and you call it like this in main.go:


### PR DESCRIPTION
The new logger parameter is the same as the one in the example
"wrapping".

Fixes: f67b0a73e30d ("log/slog: initial commit")
