### PR TITLE
net: use avoidDNS for search suffixes

### DIFF
--- a/src/net/dnsclient_unix.go
+++ b/src/net/dnsclient_unix.go
@@ -501,7 +501,7 @@ func (conf *dnsConfig) nameList(name string) []string {
 	// Build list of search choices.
 	names := make([]string, 0, 1+len(conf.search))
 	// If name has enough dots, try unsuffixed first.
-	if !avoidDNS(name) && hasNdots {
+	if hasNdots && !avoidDNS(name) {
 		names = append(names, name)
 	}
 	// Try suffixes that are not too long (see isDomainName).
@@ -512,7 +512,7 @@ func (conf *dnsConfig) nameList(name string) []string {
 		}
 	}
 	// Try unsuffixed, if not tried first above.
-	if !avoidDNS(name) && !hasNdots {
+	if !hasNdots && !avoidDNS(name) {
 		names = append(names, name)
 	}
 	return names

--- a/src/net/dnsclient_unix.go
+++ b/src/net/dnsclient_unix.go
@@ -479,10 +479,6 @@ func avoidDNS(name string) bool {
 
 // nameList returns a list of names for sequential DNS queries.
 func (conf *dnsConfig) nameList(name string) []string {
-	if avoidDNS(name) {
-		return nil
-	}
-
 	// Check name length (see isDomainName).
 	l := len(name)
 	rooted := l > 0 && name[l-1] == '.'
@@ -492,6 +488,9 @@ func (conf *dnsConfig) nameList(name string) []string {
 
 	// If name is rooted (trailing dot), try only that name.
 	if rooted {
+		if avoidDNS(name) {
+			return nil
+		}
 		return []string{name}
 	}
 
@@ -502,17 +501,18 @@ func (conf *dnsConfig) nameList(name string) []string {
 	// Build list of search choices.
 	names := make([]string, 0, 1+len(conf.search))
 	// If name has enough dots, try unsuffixed first.
-	if hasNdots {
+	if !avoidDNS(name) && hasNdots {
 		names = append(names, name)
 	}
 	// Try suffixes that are not too long (see isDomainName).
 	for _, suffix := range conf.search {
-		if l+len(suffix) <= 254 {
-			names = append(names, name+suffix)
+		fqdn := name + suffix
+		if !avoidDNS(fqdn) && len(fqdn) <= 254 {
+			names = append(names, fqdn)
 		}
 	}
 	// Try unsuffixed, if not tried first above.
-	if !hasNdots {
+	if !avoidDNS(name) && !hasNdots {
 		names = append(names, name)
 	}
 	return names

--- a/src/net/dnsclient_unix_test.go
+++ b/src/net/dnsclient_unix_test.go
@@ -199,6 +199,11 @@ func TestNameListAvoidDNS(t *testing.T) {
 	if !slices.Equal(got, []string{"www.", "www.go.dev."}) {
 		t.Fatalf("unexpected nameList return: %v", got)
 	}
+
+	got = c.nameList("www.onion")
+	if !slices.Equal(got, []string{"www.onion.go.dev."}) {
+		t.Fatalf("unexpected nameList return: %v", got)
+	}
 }
 
 var fakeDNSServerSuccessful = fakeDNSServer{rh: func(_, _ string, q dnsmessage.Message, _ time.Time) (dnsmessage.Message, error) {

--- a/src/net/dnsclient_unix_test.go
+++ b/src/net/dnsclient_unix_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"slices"
+
 	"golang.org/x/net/dns/dnsmessage"
 )
 
@@ -188,6 +190,14 @@ func TestAvoidDNSName(t *testing.T) {
 		if got != tt.avoid {
 			t.Errorf("avoidDNS(%q) = %v; want %v", tt.name, got, tt.avoid)
 		}
+	}
+}
+
+func TestNameListAvoidDNS(t *testing.T) {
+	c := &dnsConfig{search: []string{"go.dev.", "onion."}}
+	got := c.nameList("www")
+	if !slices.Equal(got, []string{"www.", "www.go.dev."}) {
+		t.Fatalf("unexpected nameList return: %v", got)
 	}
 }
 

--- a/src/net/dnsclient_unix_test.go
+++ b/src/net/dnsclient_unix_test.go
@@ -197,12 +197,12 @@ func TestNameListAvoidDNS(t *testing.T) {
 	c := &dnsConfig{search: []string{"go.dev.", "onion."}}
 	got := c.nameList("www")
 	if !slices.Equal(got, []string{"www.", "www.go.dev."}) {
-		t.Fatalf("unexpected nameList return: %v", got)
+		t.Fatalf("nameList(\"www\") = %v, want \"www\", \"www.go.dev\"", got)
 	}
 
 	got = c.nameList("www.onion")
 	if !slices.Equal(got, []string{"www.onion.go.dev."}) {
-		t.Fatalf("unexpected nameList return: %v", got)
+		t.Fatalf("nameList(\"www.onion\") = %v, want \"www.onion.go.dev\"", got)
 	}
 }
 

--- a/src/net/dnsclient_unix_test.go
+++ b/src/net/dnsclient_unix_test.go
@@ -231,7 +231,7 @@ var fakeDNSServerSuccessful = fakeDNSServer{rh: func(_, _ string, q dnsmessage.M
 func TestLookupTorOnion(t *testing.T) {
 	defer dnsWaitGroup.Wait()
 	r := Resolver{PreferGo: true, Dial: fakeDNSServerSuccessful.DialContext}
-	addrs, err := r.LookupIPAddr(context.Background(), "foo.onion")
+	addrs, err := r.LookupIPAddr(context.Background(), "foo.onion.")
 	if err != nil {
 		t.Fatalf("lookup = %v; want nil", err)
 	}

--- a/src/net/dnsclient_unix_test.go
+++ b/src/net/dnsclient_unix_test.go
@@ -16,13 +16,12 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"slices"
 
 	"golang.org/x/net/dns/dnsmessage"
 )
@@ -197,12 +196,12 @@ func TestNameListAvoidDNS(t *testing.T) {
 	c := &dnsConfig{search: []string{"go.dev.", "onion."}}
 	got := c.nameList("www")
 	if !slices.Equal(got, []string{"www.", "www.go.dev."}) {
-		t.Fatalf("nameList(\"www\") = %v, want \"www\", \"www.go.dev\"", got)
+		t.Fatalf(`nameList("www") = %v, want "www.", "www.go.dev."`, got)
 	}
 
 	got = c.nameList("www.onion")
 	if !slices.Equal(got, []string{"www.onion.go.dev."}) {
-		t.Fatalf("nameList(\"www.onion\") = %v, want \"www.onion.go.dev\"", got)
+		t.Fatalf(`nameList("www.onion") = %v, want "www.onion.go.dev."`, got)
 	}
 }
 


### PR DESCRIPTION
The go resolver shouldn't attempt to query .onion domains, but
the restriction was not restricted for search domains.

Also before this change query for "sth.onion" would
not be suffixed with any search domain (for "go.dev" search 
domain, it should query fine the "std.onion.go.dev" domain).