### PR TITLE
cmd/compile: fix location lists that extend over stack growth code

### DIFF
--- a/src/cmd/compile/internal/dwarfgen/dwarf.go
+++ b/src/cmd/compile/internal/dwarfgen/dwarf.go
@@ -517,7 +517,7 @@ func createComplexVar(fnsym *obj.LSym, fn *ir.Func, varID ssa.VarID) *dwarf.Var 
 	list := debug.LocationLists[varID]
 	if len(list) != 0 {
 		dvar.PutLocationList = func(listSym, startPC dwarf.Sym) {
-			debug.PutLocationList(list, base.Ctxt, listSym.(*obj.LSym), startPC.(*obj.LSym))
+			debug.PutLocationList(list, base.Ctxt, listSym.(*obj.LSym), startPC.(*obj.LSym), dvar.StackOffset)
 		}
 	}
 	return dvar

--- a/src/cmd/compile/internal/ir/abi.go
+++ b/src/cmd/compile/internal/ir/abi.go
@@ -16,7 +16,7 @@ import (
 // InitLSym must be called exactly once per function and must be
 // called for both functions with bodies and functions without bodies.
 // For body-less functions, we only create the LSym; for functions
-// with bodies call a helper to setup up / populate the LSym.
+// with bodies call a helper to set up / populate the LSym.
 func InitLSym(f *Func, hasBody bool) {
 	if f.LSym != nil {
 		base.FatalfAt(f.Pos(), "InitLSym called twice on %v", f)

--- a/src/cmd/compile/internal/ssa/debug.go
+++ b/src/cmd/compile/internal/ssa/debug.go
@@ -42,7 +42,10 @@ type FuncDebug struct {
 	OptDcl []*ir.Name
 
 	// Filled in by the user. Translates Block and Value ID to PC.
-	GetPC func(ID, ID) int64
+	//
+	// NOTE: block is only used if value is BlockStart.ID or BlockEnd.ID.
+	// Otherwise, it is ignored.
+	GetPC func(block, value ID) int64
 }
 
 type BlockDebug struct {
@@ -1368,7 +1371,7 @@ func (state *debugState) buildLocationLists(blockLocs []*BlockDebug) {
 
 	// Flush any leftover entries live at the end of the last block.
 	for varID := range state.lists {
-		state.writePendingEntry(VarID(varID), state.f.Blocks[len(state.f.Blocks)-1].ID, FuncEnd.ID)
+		state.writePendingEntry(VarID(varID), -1, FuncEnd.ID)
 		list := state.lists[varID]
 		if state.loggingLevel > 0 {
 			if len(list) == 0 {

--- a/src/cmd/compile/internal/ssagen/ssa.go
+++ b/src/cmd/compile/internal/ssagen/ssa.go
@@ -7319,9 +7319,9 @@ func genssa(f *ssa.Func, pp *objw.Progs) {
 		for i, b := range f.Blocks {
 			idToIdx[b.ID] = i
 		}
-		// Note that at this moment, Prog.Pc is a sequence number; it's
-		// not a real PC until after assembly, so this mapping has to
-		// be done later.
+		// Register a callback that will be used later to fill in PC's into location
+		// lists. At the moment, Prog.Pc is a sequence number; it's not a real PC
+		// until after assembly, so the translation needs to be deferred.
 		debugInfo.GetPC = func(b, v ssa.ID) int64 {
 			switch v {
 			case ssa.BlockStart.ID:

--- a/src/cmd/internal/dwarf/dwarf.go
+++ b/src/cmd/internal/dwarf/dwarf.go
@@ -1429,7 +1429,7 @@ func PutConcreteFunc(ctxt Context, s *FnState, isWrapper bool) error {
 // routine records).
 func PutDefaultFunc(ctxt Context, s *FnState, isWrapper bool) error {
 	if logDwarf {
-		ctxt.Logf("PutDefaultFunc(%v)\n", s.Info)
+		ctxt.Logf("PutDefaultFunc(%s - %v)\n", s.Name, s.Info)
 	}
 	abbrev := DW_ABRV_FUNCTION
 	if isWrapper {

--- a/src/cmd/internal/obj/link.go
+++ b/src/cmd/internal/obj/link.go
@@ -480,6 +480,22 @@ type FuncInfo struct {
 	InlMarks  []InlMark
 	spills    []RegSpill
 
+	// The first instruction in the trailing code dealing with growing the stack
+	// on function entry. This code is placed at the end of the function, but it
+	// is logically part of the function's epilogue. This is used when
+	// generating DWARF location data for the function arguments, which are
+	// alive when this trailing code executes.
+	// Nil if the function doesn't have a stack-growth layer. Also, not all
+	// architectures set it when producing the stack growth code; if not set,
+	// the location lists for variables that are alive at "the end of the
+	// function" will erroneously include the trailing code even though the
+	// variable might not be alive when that code executes.
+	StackGrowthTrailerStart *Prog
+	// StackGrowthCall points to the instruction for actually calling the
+	// runtime stack growth function. The call is a few instructions after
+	// StackGrowthTrailerStart, after the registers have been spilled.
+	StackGrowthCall *Prog
+
 	dwarfInfoSym       *LSym
 	dwarfLocSym        *LSym
 	dwarfRangesSym     *LSym

--- a/src/cmd/internal/obj/x86/obj6.go
+++ b/src/cmd/internal/obj/x86/obj6.go
@@ -1198,12 +1198,16 @@ func stacksplit(ctxt *obj.Link, cursym *obj.LSym, p *obj.Prog, newprog obj.ProgA
 	spfix := obj.Appendp(last, newprog)
 	spfix.As = obj.ANOP
 	spfix.Spadj = -framesize
+	// Remember where this trailing code starts; we'll use this information when
+	// generating DWARF location lists for function arguments.
+	cursym.Func().StackGrowthTrailerStart = spfix
 
 	pcdata := ctxt.EmitEntryStackMap(cursym, spfix, newprog)
 	spill := ctxt.StartUnsafePoint(pcdata, newprog)
 	pcdata = cursym.Func().SpillRegisterArgs(spill, newprog)
 
 	call := obj.Appendp(pcdata, newprog)
+	cursym.Func().StackGrowthCall = call
 	call.Pos = cursym.Func().Text.Pos
 	call.As = obj.ACALL
 	call.To.Type = obj.TYPE_BRANCH


### PR DESCRIPTION
This patch fixes some incorrect DWARF location lists. Before this patch,
a location list for a variable that was available until the "end of its
function" erroneously extended over trailing code that dealt with the
stack growth code. The code in question is placed at the end of the
function, but it is morally part of the function's prologue (the
prologue jumps to it if stack growth is needed, and this trailer then
jumps back to the prologue). Thus, for the purposes of the location
lists, it should be treated more like the beginning of the function than
the end of the function; instructions for reading variables at the end
of the function do not apply in this code region.

The patch makes the loclists for regular variable not expand over this
trailing code, as they do not yet exist when this code runs. Function
arguments are special though - they do exist when the stack growth code
runs, and generally can be read. For function arguments, this patch
"fixes up" the location lists generated by the compiler after the linker
has inserted the stack growth code, as described below:

The layout of a function's code is as follows:

<function prologue jumps to the stack growth trailer>
<regular function code>
...
ret
movq    %rax, 0x38(%rsp)                  <- FuncLogicalEnd
movq    %rbx, 0x40(%rsp)
...
callq   <runtime.morestack_noctxt.abi0>   <- StackGrowthCall
movq    0x38(%rsp), %rax
movq    0x40(%rsp), %rbx
...
jmp     <beginning of function>
int3                                      <- FuncPhysicalEndA

The stack growth trailer consists of register spilling (starting at
FuncLogicalEnd), a call to the runtime stack growth function (marked by
StackGrowthCall), and then register unspilling (up until
FuncPhysicalEnd).
A variable that's available at the beginning of the function (i.e. a function
argument) is available in between [FuncLogicalEnd,StackGrowthCall) using the
same DWARF instructions as the ones used at the beginning of the function.
The variable is then available in between [StackGrowthCall,FuncPhysicalEnd)
with new instructions referencing the stack location where the variable was
spilled to.

The patch only performs this fixup for function arguments on amd64; the
tracking that linker needs to do for identifying FuncLoficalEnd and
StackGrowthCall is architecture-specific and I didn't go through the
trouble of doing it outside amd64.

Fixes https://github.com/golang/go/issues/60493