### PR TITLE
runtime: Use doas -n in TestSUID on OpenBSD

### DIFF
--- a/src/runtime/security_test.go
+++ b/src/runtime/security_test.go
@@ -27,6 +27,8 @@ func privesc(command string, args ...string) error {
 	var cmd *exec.Cmd
 	if runtime.GOOS == "darwin" {
 		cmd = exec.CommandContext(ctx, "sudo", append([]string{"-n", command}, args...)...)
+	} else if runtime.GOOS == "openbsd" {
+		cmd = exec.CommandContext(ctx, "doas", append([]string{"-n", command}, args...)...)
 	} else {
 		cmd = exec.CommandContext(ctx, "su", highPrivUser, "-c", fmt.Sprintf("%s %s", command, strings.Join(args, " ")))
 	}


### PR DESCRIPTION
This prevents a hang at a su password prompt when running this test on
OpenBSD.

Fixes #60690.