### PR TITLE
internal/trace: reduce if statement

### DIFF
--- a/src/internal/trace/parser.go
+++ b/src/internal/trace/parser.go
@@ -517,11 +517,10 @@ func parseEvents(ver int, rawEvents []rawEvent, strings map[uint64]string) (even
 	for _, ev := range events {
 		ev.Ts = int64(float64(ev.Ts-minTs) * freq)
 		// Move timers and syscalls to separate fake Ps.
-		if timerGoids[ev.G] && ev.Type == EvGoUnblock {
-			ev.P = TimerP
-		}
 		if ev.Type == EvGoSysExit {
 			ev.P = SyscallP
+		} else if timerGoids[ev.G] && ev.Type == EvGoUnblock {
+			ev.P = TimerP
 		}
 	}
 


### PR DESCRIPTION
Since "if ev.Type == EvGoSysExit" must be executed,
use if-elsif to reduce the other if statement in the case of "ev.Type == EvGoSysExit"
when assigning to ev.P.