### PR TITLE
net/http: check RemoteAddr isn't nil before dereferencing

### DIFF
--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -1856,7 +1856,9 @@ func isCommonNetReadError(err error) bool {
 
 // Serve a new connection.
 func (c *conn) serve(ctx context.Context) {
-	c.remoteAddr = c.rwc.RemoteAddr().String()
+	if ra := c.rwc.RemoteAddr(); ra != nil {
+		c.remoteAddr = ra.String()
+	}
 	ctx = context.WithValue(ctx, LocalAddrContextKey, c.rwc.LocalAddr())
 	var inFlightResponse *response
 	defer func() {


### PR DESCRIPTION
RemoteAddr can return nil in some cases, this fix prevents a panic.

I chatted with @neild about this beforehand, but what's happening in our
case is that a connection comes in to the HTTP server which is then
immediately closed (we discovered this issue by accident using nmap).
The network implementation that we're using (it happens to be gVisor
via its gonet adaptor) is returning nil from RemoteAddr(), presumably
as there is no remote at that point.

But, ultimately, since RemoteAddr returns an interface it is always
possible for it to return nil, and indeed conn.RemoteAddr in this file
does exactly that if the conn is not ok.