### PR TITLE
net/http: declare publicErr as a constant

### DIFF
--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -1971,7 +1971,7 @@ func (c *conn) serve(ctx context.Context) {
 					fmt.Fprintf(c.rwc, "HTTP/1.1 %d %s: %s%s%d %s: %s", v.code, StatusText(v.code), v.text, errorHeaders, v.code, StatusText(v.code), v.text)
 					return
 				}
-				publicErr := "400 Bad Request"
+				const publicErr = "400 Bad Request"
 				fmt.Fprintf(c.rwc, "HTTP/1.1 "+publicErr+errorHeaders+publicErr)
 				return
 			}


### PR DESCRIPTION
Do the same as the code above: "case err == errTooLarge", declare
publicErr as a constant to avoid runtime calls.