### PR TITLE
Add description field for windows adapters

### DIFF
--- a/src/net/interface_windows.go
+++ b/src/net/interface_windows.go
@@ -57,8 +57,9 @@ func interfaceTable(ifindex int) ([]Interface, error) {
 		}
 		if ifindex == 0 || ifindex == int(index) {
 			ifi := Interface{
-				Index: int(index),
-				Name:  windows.UTF16PtrToString(aa.FriendlyName),
+				Index:       int(index),
+				Description: windows.UTF16PtrToString(aa.Description),
+				Name:        windows.UTF16PtrToString(aa.FriendlyName),
 			}
 			if aa.OperStatus == windows.IfOperStatusUp {
 				ifi.Flags |= FlagUp


### PR DESCRIPTION
Adds the description field for the Windows adapters objects. Currently only returns the FriendlyName, but the Description field is what is logged with things like Windows Performance Counters. This makes it easier to correlate performance statistics directly back to interfaces.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
