### PR TITLE
net: add the "Description" field for interfaces on Windows hosts

### DIFF
--- a/src/net/interface.go
+++ b/src/net/interface.go
@@ -32,6 +32,7 @@ type Interface struct {
 	Index        int          // positive integer that starts at one, zero is never used
 	MTU          int          // maximum transmission unit
 	Name         string       // e.g., "en0", "lo0", "eth0.100"
+	Description  string       // e.g., "Software Loopback Interface 1", "Intel(R) 82574L Gigabit Network Connection"
 	HardwareAddr HardwareAddr // IEEE MAC-48, EUI-48 and EUI-64 form
 	Flags        Flags        // e.g., FlagUp, FlagLoopback, FlagMulticast
 }

--- a/src/net/interface_windows.go
+++ b/src/net/interface_windows.go
@@ -57,8 +57,9 @@ func interfaceTable(ifindex int) ([]Interface, error) {
 		}
 		if ifindex == 0 || ifindex == int(index) {
 			ifi := Interface{
-				Index: int(index),
-				Name:  windows.UTF16PtrToString(aa.FriendlyName),
+				Index:       int(index),
+				Name:        windows.UTF16PtrToString(aa.FriendlyName),
+				Description: windows.UTF16PtrToString(aa.Description),
 			}
 			if aa.OperStatus == windows.IfOperStatusUp {
 				ifi.Flags |= FlagUp


### PR DESCRIPTION
This change modifies Go to add the "Description" field for interfaces on Windows hosts. 

The "Description" field, rather than "FriendlyName", is used by Windows Performance Monitor and others when identifying interfaces. Making both fields accessible makes correlating back to specific interfaces easier.