### PR TITLE
net: restrict cgo_stub.go netgo with unix build tag

### DIFF
--- a/src/net/cgo_stub.go
+++ b/src/net/cgo_stub.go
@@ -9,7 +9,7 @@
 // Darwin is exempted because it always provides the cgo routines,
 // in cgo_unix_syscall.go.
 
-//go:build netgo || (!cgo && unix && !darwin) || wasip1
+//go:build (unix && netgo) || (!cgo && unix && !darwin) || wasip1
 
 package net
 


### PR DESCRIPTION
Fixes #61153