### PR TITLE
[perf][queue] Replace %s with copy.

### DIFF
--- a/src/internal/fuzz/queue.go
+++ b/src/internal/fuzz/queue.go
@@ -32,9 +32,9 @@ func (q *queue) grow() {
 	}
 	newElems := make([]any, newCap)
 	oldLen := q.len
-	for i := 0; i < oldLen; i++ {
-		newElems[i] = q.elems[(q.head+i)%oldCap]
-	}
+	copy(newElems, q.elems[q.head:])
+	wrote := oldLen - q.head
+	copy(newElems[wrote:], q.elems[:q.head])
 	q.elems = newElems
 	q.head = 0
 }

--- a/src/internal/fuzz/queue.go
+++ b/src/internal/fuzz/queue.go
@@ -31,9 +31,7 @@ func (q *queue) grow() {
 		newCap = 8
 	}
 	newElems := make([]any, newCap)
-	oldLen := q.len
-	copy(newElems, q.elems[q.head:])
-	wrote := oldLen - q.head
+	wrote := copy(newElems, q.elems[q.head:])
 	copy(newElems[wrote:], q.elems[:q.head])
 	q.elems = newElems
 	q.head = 0


### PR DESCRIPTION
This avoids relatively expensive `%` operations and `copy` is much easier to optimize.

I've used https://gist.github.com/ttsugriy/45db22b2564745bedda05574c033c0b0 to get benchmark results below:
```
% go test -benchmem -run=^$ -bench ^Benchmark bench.com/b
goos: darwin
goarch: arm64
pkg: bench.com/b
BenchmarkModClone-8       903997              1123 ns/op            3200 B/op         20 allocs/op
BenchmarkCopyClone-8     1337074               890.6 ns/op          3200 B/op         20 allocs/op
PASS
ok      bench.com/b     3.266s
```

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
