### PR TITLE
cmd/compile: allow self referencing-constraint

### DIFF
--- a/src/cmd/compile/internal/types2/decl.go
+++ b/src/cmd/compile/internal/types2/decl.go
@@ -227,20 +227,12 @@ func (check *Checker) validCycle(obj Object) (valid bool) {
 	tparCycle := false // if set, the cycle is through a type parameter list
 	nval := 0          // number of (constant or variable) values in the cycle; valid if !generic
 	ndef := 0          // number of type definitions in the cycle; valid if !generic
-loop:
+
 	for _, obj := range cycle {
 		switch obj := obj.(type) {
 		case *Const, *Var:
 			nval++
 		case *TypeName:
-			// If we reach a generic type that is part of a cycle
-			// and we are in a type parameter list, we have a cycle
-			// through a type parameter list, which is invalid.
-			if check.inTParamList && isGeneric(obj.typ) {
-				tparCycle = true
-				break loop
-			}
-
 			// Determine if the type name is an alias or not. For
 			// package-level objects, use the object map which
 			// provides syntactic information (which doesn't rely

--- a/src/cmd/compile/testdata/issue49439/should_pass.go
+++ b/src/cmd/compile/testdata/issue49439/should_pass.go
@@ -1,0 +1,11 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+type T0[P any, P1 T0[P,P1]] any
+type T1[P any, P1 *T1[P,P1]] any
+
+
+//TODO: current implementation doesn't allow this due to lack of applications for this syntax.


### PR DESCRIPTION
allow: self referencing-constraints

fix: invalid recursive type: T0 refers to itself

reverting some changes made as fix  for  #49439

Relates to #60880
Relates to #60817
