### PR TITLE
slices: make Clone preallocate and copy instead of solely invoking append

### DIFF
--- a/src/slices/slices.go
+++ b/src/slices/slices.go
@@ -340,7 +340,9 @@ func Clone[S ~[]E, E any](s S) S {
 	if s == nil {
 		return nil
 	}
-	return append(S([]E{}), s...)
+	t := make([]E, len(s))
+	copy(t, s)
+	return t
 }
 
 // Compact replaces consecutive runs of equal elements with a single copy.

--- a/src/slices/slices_benchmark_test.go
+++ b/src/slices/slices_benchmark_test.go
@@ -1,0 +1,56 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package slices
+
+import (
+	"testing"
+)
+
+var sink any = nil
+
+func BenchmarkIntClone_10B(b *testing.B) {
+	benchmarkClone[int](b, 10)
+}
+
+func BenchmarkIntClone_1Kb(b *testing.B) {
+	benchmarkClone[int](b, 1<<10)
+}
+
+func BenchmarkIntClone_10Kb(b *testing.B) {
+	benchmarkClone[int](b, 10<<10)
+}
+
+func BenchmarkIntClone_1Mb(b *testing.B) {
+	benchmarkClone[int](b, 1<<20)
+}
+
+func BenchmarkIntClone_10Mb(b *testing.B) {
+	benchmarkClone[int](b, 10<<20)
+}
+
+func BenchmarkByteClone_10B(b *testing.B) {
+	benchmarkClone[byte](b, 10)
+}
+
+func BenchmarkByteClone_10Kb(b *testing.B) {
+	benchmarkClone[byte](b, 10<<10)
+}
+
+func benchmarkClone[T int | byte](b *testing.B, n int) {
+	s1 := make([]T, n)
+	for i := 0; i < n/2; i++ {
+		s1[i] = T(i)
+		s1[n-i-1] = T(i * 2)
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		sink = Clone(s1)
+	}
+	if sink == nil {
+		b.Fatal("Benchmark did not run!")
+	}
+	sink = nil
+}


### PR DESCRIPTION
slices: make Clone preallocate and copy instead of solely invoking append

By preallocating a slice of equal size then invoking copy, this
change results in a speedup:

```
                  │   old.txt    │               new.txt                │
                  │    sec/op    │    sec/op     vs base                │
IntClone_10B-12     41.18n ±  1%   34.07n ±  1%  -17.26% (p=0.000 n=10)
IntClone_1Kb-12     719.5n ±  2%   718.9n ±  2%        ~ (p=0.912 n=10)
IntClone_10Kb-12    7.032µ ± 29%   6.946µ ± 14%        ~ (p=1.000 n=10)
IntClone_1Mb-12     239.6µ ±  1%   238.9µ ±  1%        ~ (p=0.353 n=10)
IntClone_10Mb-12    2.431m ±  1%   2.418m ±  1%        ~ (p=0.143 n=10)
ByteClone_10B-12    35.86n ±  0%   29.43n ±  0%  -17.92% (p=0.000 n=10)
ByteClone_10Kb-12   689.2n ±  6%   694.3n ±  3%        ~ (p=0.912 n=10)
geomean             3.138µ         2.964µ         -5.56%

                  │   old.txt    │                new.txt                │
                  │     B/op     │     B/op      vs base                 │
IntClone_10B-12       104.0 ± 0%     104.0 ± 0%       ~ (p=1.000 n=10) ¹
IntClone_1Kb-12     8.023Ki ± 0%   8.023Ki ± 0%       ~ (p=1.000 n=10) ¹
IntClone_10Kb-12    80.02Ki ± 0%   80.02Ki ± 0%       ~ (p=1.000 n=10) ¹
IntClone_1Mb-12     8.000Mi ± 0%   8.000Mi ± 0%       ~ (p=0.350 n=10)
IntClone_10Mb-12    80.00Mi ± 0%   80.00Mi ± 0%       ~ (p=0.173 n=10)
ByteClone_10B-12      40.00 ± 0%     40.00 ± 0%       ~ (p=1.000 n=10) ¹
ByteClone_10Kb-12   10.02Ki ± 0%   10.02Ki ± 0%       ~ (p=1.000 n=10) ¹
geomean             28.97Ki        28.97Ki       -0.00%
¹ all samples are equal

                  │  old.txt   │               new.txt               │
                  │ allocs/op  │ allocs/op   vs base                 │
IntClone_10B-12     2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
IntClone_1Kb-12     2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
IntClone_10Kb-12    2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
IntClone_1Mb-12     2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
IntClone_10Mb-12    2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
ByteClone_10B-12    2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
ByteClone_10Kb-12   2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean             2.000        2.000       +0.00%
¹ all samples are equal

```