### PR TITLE
net/rpc: use conventional `err` in example

### DIFF
--- a/src/net/rpc/server.go
+++ b/src/net/rpc/server.go
@@ -86,9 +86,9 @@ The server calls (for HTTP service):
 	arith := new(Arith)
 	rpc.Register(arith)
 	rpc.HandleHTTP()
-	l, e := net.Listen("tcp", ":1234")
-	if e != nil {
-		log.Fatal("listen error:", e)
+	l, err := net.Listen("tcp", ":1234")
+	if err != nil {
+		log.Fatal("listen error:", err)
 	}
 	go http.Serve(l, nil)
 

--- a/src/net/rpc/server_test.go
+++ b/src/net/rpc/server_test.go
@@ -110,9 +110,9 @@ func (BuiltinTypes) Array(args *Args, reply *[2]int) error {
 }
 
 func listenTCP() (net.Listener, string) {
-	l, e := net.Listen("tcp", "127.0.0.1:0") // any available address
-	if e != nil {
-		log.Fatalf("net.Listen tcp :0: %v", e)
+	l, err := net.Listen("tcp", "127.0.0.1:0") // any available address
+	if err != nil {
+		log.Fatalf("net.Listen tcp :0: %v", err)
 	}
 	return l, l.Addr().String()
 }


### PR DESCRIPTION
It is conventional to use `err` for error variables, so change the example to use `err` instead of `e`.