### PR TITLE
os: remove executable bits from os.OpenFile example

### DIFF
--- a/src/os/example_test.go
+++ b/src/os/example_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func ExampleOpenFile() {
-	f, err := os.OpenFile("notes.txt", os.O_RDWR|os.O_CREATE, 0755)
+	f, err := os.OpenFile("notes.txt", os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
The mode used in the os.OpenFile example (0755) has all executable bits set.  
I suspect that this ill-advised usage propagates to other codebases (by means of people carelessly copying the usage example), which is why I suggest modifying the example.