### PR TITLE
reflect: deprecate PtrTo

### DIFF
--- a/api/next/59599.txt
+++ b/api/next/59599.txt
@@ -1,0 +1,1 @@
+pkg reflect, func PtrTo //deprecated #59599

--- a/src/cmd/compile/internal/reflectdata/reflect.go
+++ b/src/cmd/compile/internal/reflectdata/reflect.go
@@ -1224,7 +1224,7 @@ func writeType(t *types.Type) *obj.LSym {
 	keep := base.Ctxt.Flag_dynlink
 	if !keep && t.Sym() == nil {
 		// For an unnamed type, we only need the link if the type can
-		// be created at run time by reflect.PtrTo and similar
+		// be created at run time by reflect.PointerTo and similar
 		// functions. If the type exists in the program, those
 		// functions must return the existing type structure rather
 		// than creating a new one.

--- a/src/encoding/gob/decode.go
+++ b/src/encoding/gob/decode.go
@@ -656,7 +656,7 @@ func (dec *Decoder) decodeSlice(state *decoderState, value reflect.Value, elemOp
 		errorf("%s slice too big: %d elements of %d bytes", typ.Elem(), u, size)
 	}
 	if value.Cap() < n {
-		safe := saferio.SliceCap(reflect.Zero(reflect.PtrTo(typ.Elem())).Interface(), uint64(n))
+		safe := saferio.SliceCap(reflect.Zero(reflect.PointerTo(typ.Elem())).Interface(), uint64(n))
 		if safe < 0 {
 			errorf("%s slice too big: %d elements of %d bytes", typ.Elem(), u, size)
 		}

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -1171,6 +1171,8 @@ var ptrMap sync.Map // map[*rtype]*ptrType
 //
 // PtrTo is the old spelling of PointerTo.
 // The two functions behave identically.
+//
+// Deprecated: Superseded by [PointerTo].
 func PtrTo(t Type) Type { return PointerTo(t) }
 
 // PointerTo returns the pointer type with element t.


### PR DESCRIPTION
Replace reflect.PtrTo with reflect.PointerTo.

Fixes #59599

Change-Id: I49407193e2050543ef983cd637703acc682d9f51
