### PR TITLE
reflect: panic on recv channel close

### DIFF
--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -1708,8 +1708,8 @@ func TestChan(t *testing.T) {
 		}
 		// Closing a read-only channel
 		shouldPanic("", func() {
-			rc := make(<-chan int, 1)
-			cv := ValueOf(rc)
+			c := make(<-chan int, 1)
+			cv := ValueOf(c)
 			cv.Close()
 		})
 	}

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -1706,6 +1706,12 @@ func TestChan(t *testing.T) {
 		if i, ok := cv.Recv(); i.Int() != 0 || ok {
 			t.Errorf("after close Recv %d, %t", i.Int(), ok)
 		}
+		// Closing a read-only channel
+		shouldPanic("", func() {
+			rc := make(<-chan int, 1)
+			cv := ValueOf(rc)
+			cv.Close()
+		})
 	}
 
 	// check creation of unbuffered channel

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -1187,16 +1187,11 @@ func (v Value) capNonSlice() int {
 }
 
 // Close closes the channel v.
-// It panics if v's Kind is not Chan.
+// It panics if v's Kind is not Chan or
+// v is a recv-only channel.
 func (v Value) Close() {
 	v.mustBe(Chan)
 	v.mustBeExported()
-	v.close()
-}
-
-// internal close
-// v is known to be a channel.
-func (v Value) close() {
 	tt := (*chanType)(unsafe.Pointer(v.typ()))
 	if ChanDir(tt.Dir)&SendDir == 0 {
 		panic("reflect: close on receive-only channel")

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -1194,7 +1194,7 @@ func (v Value) Close() {
 	v.mustBeExported()
 	tt := (*chanType)(unsafe.Pointer(v.typ()))
 	if ChanDir(tt.Dir)&SendDir == 0 {
-		panic("reflect: close on receive-only channel")
+		panic("reflect: close of receive-only channel")
 	}
 
 	chanclose(v.pointer())

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -1191,6 +1191,17 @@ func (v Value) capNonSlice() int {
 func (v Value) Close() {
 	v.mustBe(Chan)
 	v.mustBeExported()
+	v.close()
+}
+
+// internal close
+// v is known to be a channel.
+func (v Value) close() {
+	tt := (*chanType)(unsafe.Pointer(v.typ()))
+	if ChanDir(tt.Dir)&SendDir == 0 {
+		panic("reflect: close on receive-only channel")
+	}
+
 	chanclose(v.pointer())
 }
 

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -1188,7 +1188,7 @@ func (v Value) capNonSlice() int {
 
 // Close closes the channel v.
 // It panics if v's Kind is not Chan or
-// v is a recv-only channel.
+// v is a receive-only channel.
 func (v Value) Close() {
 	v.mustBe(Chan)
 	v.mustBeExported()


### PR DESCRIPTION
It is possible to call reflect.ValueOf(ch).Close() on a recv-only channel,
 while close(ch) is a compile-time error. Following the same reflect 
semantics as send and recv this should result in a panic.

Fixes #61445