### PR TITLE
testing: enforce -skip in example tests

### DIFF
--- a/src/cmd/go/testdata/script/test_skip.txt
+++ b/src/cmd/go/testdata/script/test_skip.txt
@@ -13,13 +13,19 @@ stdout RUN.*Test2/3
 go test -v -skip 2/3 skip_test.go
 stdout RUN.*Test1
 stdout RUN.*Test2
+stdout RUN.*ExampleTest1
 ! stdout Test2/3
 
 go test -v -skip 2/4 skip_test.go
 stdout RUN.*Test1
 stdout RUN.*Test2
 stdout RUN.*Test2/3
+stdout RUN.*ExampleTest1
 
+go test -v -skip Example skip_test.go
+stdout RUN.*Test1
+stdout RUN.*Test2
+stdout RUN.*Test2/3
 
 -- skip_test.go --
 package skip_test
@@ -31,4 +37,8 @@ func Test1(t *testing.T) {
 
 func Test2(t *testing.T) {
 	t.Run("3", func(t *testing.T) {})
+}
+
+func ExampleTest1() {
+	// Output:
 }

--- a/src/testing/example.go
+++ b/src/testing/example.go
@@ -6,7 +6,6 @@ package testing
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -29,14 +28,11 @@ func RunExamples(matchString func(pat, str string) (bool, error), examples []Int
 func runExamples(matchString func(pat, str string) (bool, error), examples []InternalExample) (ran, ok bool) {
 	ok = true
 
-	var eg InternalExample
+	m := newMatcher(matchString, *match, "-test.run", *skip)
 
+	var eg InternalExample
 	for _, eg = range examples {
-		matched, err := matchString(*match, eg.Name)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "testing: invalid regexp for -test.run: %s\n", err)
-			os.Exit(1)
-		}
+		_, matched, _ := m.fullName(nil, eg.Name)
 		if !matched {
 			continue
 		}


### PR DESCRIPTION
The go test flag -skip had no effect in example tests.

Fixes #61482 
