### PR TITLE
cmd/asm: add PCALIGN support on 386/amd64

### DIFF
--- a/src/cmd/internal/obj/x86/asm6.go
+++ b/src/cmd/internal/obj/x86/asm6.go
@@ -2146,11 +2146,6 @@ func span6(ctxt *obj.Link, s *obj.LSym, newprog obj.ProgAlloc) {
 					fillnop(s.P[c:], int(v))
 				}
 
-				// Update the current text symbol alignment value.
-				if int32(v) > s.Func().Align {
-					s.Func().Align = int32(v)
-				}
-
 				c += int32(v)
 				pPrev = p
 				continue

--- a/src/cmd/internal/obj/x86/asm_test.go
+++ b/src/cmd/internal/obj/x86/asm_test.go
@@ -298,11 +298,7 @@ func TestRegIndex(t *testing.T) {
 // code can be aligned to the alignment value.
 func TestPCALIGN(t *testing.T) {
 	testenv.MustHaveGoBuild(t)
-	dir, err := os.MkdirTemp("", "testpcalign")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	tmpfile := filepath.Join(dir, "test.s")
 	tmpout := filepath.Join(dir, "test.o")
 

--- a/src/cmd/internal/obj/x86/asm_test.go
+++ b/src/cmd/internal/obj/x86/asm_test.go
@@ -306,23 +306,25 @@ func TestPCALIGN(t *testing.T) {
 	tmpfile := filepath.Join(dir, "test.s")
 	tmpout := filepath.Join(dir, "test.o")
 
-	code1 := []byte("TEXT ·foo(SB),$0-0\nMOVQ $0, AX\nPCALIGN $8\nMOVQ $1, BX\nRET\n")
-	code2 := []byte("TEXT ·foo(SB),$0-0\nMOVQ $0, AX\nPCALIGN $16\nMOVQ $2, CX\nRET\n")
-	// If the output contains this pattern, the pc-offsite of "MOVQ $1, AX" is 8 bytes aligned.
-	out1 := `0x0008\s00008\s\(.*\)\tMOVQ\t\$1,\sBX`
-	// If the output contains this pattern, the pc-offsite of "MOVQ $2, CX" is 16 bytes aligned.
-	out2 := `0x0010\s00016\s\(.*\)\tMOVQ\t\$2,\sCX`
 	var testCases = []struct {
 		name string
-		code []byte
+		code string
 		out  string
 	}{
-		{"8-byte alignment", code1, out1},
-		{"16-byte alignment", code2, out2},
+		{
+			name: "8-byte alignment",
+			code: `TEXT ·foo(SB),$0-0\nMOVQ $0, AX\nPCALIGN $8\nMOVQ $1, BX\nRET\n`,
+			out:  `0x0008\s00008\s\(.*\)\tMOVQ\t\$1,\sBX`,
+		},
+		{
+			name: "16-byte alignment",
+			code: `TEXT ·foo(SB),$0-0\nMOVQ $0, AX\nPCALIGN $16\nMOVQ $2, CX\nRET\n`,
+			out:  `0x0010\s00016\s\(.*\)\tMOVQ\t\$2,\sCX`,
+		},
 	}
 
 	for _, test := range testCases {
-		if err := os.WriteFile(tmpfile, test.code, 0644); err != nil {
+		if err := os.WriteFile(tmpfile, []byte(test.code), 0644); err != nil {
 			t.Fatal(err)
 		}
 		cmd := testenv.Command(t, testenv.GoToolPath(t), "tool", "asm", "-S", "-o", tmpout, tmpfile)

--- a/src/cmd/internal/obj/x86/asm_test.go
+++ b/src/cmd/internal/obj/x86/asm_test.go
@@ -313,12 +313,12 @@ func TestPCALIGN(t *testing.T) {
 	}{
 		{
 			name: "8-byte alignment",
-			code: `TEXT ·foo(SB),$0-0\nMOVQ $0, AX\nPCALIGN $8\nMOVQ $1, BX\nRET\n`,
+			code: "TEXT ·foo(SB),$0-0\nMOVQ $0, AX\nPCALIGN $8\nMOVQ $1, BX\nRET\n",
 			out:  `0x0008\s00008\s\(.*\)\tMOVQ\t\$1,\sBX`,
 		},
 		{
 			name: "16-byte alignment",
-			code: `TEXT ·foo(SB),$0-0\nMOVQ $0, AX\nPCALIGN $16\nMOVQ $2, CX\nRET\n`,
+			code: "TEXT ·foo(SB),$0-0\nMOVQ $0, AX\nPCALIGN $16\nMOVQ $2, CX\nRET\n",
 			out:  `0x0010\s00016\s\(.*\)\tMOVQ\t\$2,\sCX`,
 		},
 	}


### PR DESCRIPTION
The PCALIGN asm directive was not supported on 386/amd64,
causing a compile-time error when used. The same directive
is currently supported on arm64, loong64 and ppc64 architectures.

This has potential for noticeable performance improvements on 
amd64 across multiple packages, I did a quick test aligning a hot 
loop on bytes.IndexByte:

```
IndexByte/10-16                 3.477n ± ∞ ¹   3.462n ± ∞ ¹        ~ (p=0.198 n=5)
IndexByte/32-16                 4.675n ± ∞ ¹   4.834n ± ∞ ¹   +3.40% (p=0.008 n=5)
IndexByte/4K-16                 67.47n ± ∞ ¹   44.44n ± ∞ ¹  -34.13% (p=0.008 n=5)
IndexByte/4M-16                 61.98µ ± ∞ ¹   45.07µ ± ∞ ¹  -27.28% (p=0.008 n=5)
IndexByte/64M-16               1206.6µ ± ∞ ¹   940.9µ ± ∞ ¹  -22.02% (p=0.008 n=5)
IndexBytePortable/10-16         4.064n ± ∞ ¹   4.044n ± ∞ ¹        ~ (p=0.325 n=5)
IndexBytePortable/32-16         9.999n ± ∞ ¹   9.934n ± ∞ ¹        ~ (p=0.151 n=5)
IndexBytePortable/4K-16         975.8n ± ∞ ¹   965.5n ± ∞ ¹        ~ (p=0.151 n=5)
IndexBytePortable/4M-16         973.3µ ± ∞ ¹   972.3µ ± ∞ ¹        ~ (p=0.222 n=5)
IndexBytePortable/64M-16        15.68m ± ∞ ¹   15.89m ± ∞ ¹        ~ (p=0.310 n=5)
geomean                         1.478µ         1.342µ         -9.20%

IndexByte/10-16                2.678Gi ± ∞ ¹   2.690Gi ± ∞ ¹        ~ (p=0.151 n=5)
IndexByte/32-16                6.375Gi ± ∞ ¹   6.165Gi ± ∞ ¹   -3.30% (p=0.008 n=5)
IndexByte/4K-16                56.54Gi ± ∞ ¹   85.85Gi ± ∞ ¹  +51.83% (p=0.008 n=5)
IndexByte/4M-16                63.03Gi ± ∞ ¹   86.68Gi ± ∞ ¹  +37.52% (p=0.008 n=5)
IndexByte/64M-16               51.80Gi ± ∞ ¹   66.42Gi ± ∞ ¹  +28.23% (p=0.008 n=5)
IndexBytePortable/10-16        2.291Gi ± ∞ ¹   2.303Gi ± ∞ ¹        ~ (p=0.421 n=5)
IndexBytePortable/32-16        2.980Gi ± ∞ ¹   3.000Gi ± ∞ ¹        ~ (p=0.151 n=5)
IndexBytePortable/4K-16        3.909Gi ± ∞ ¹   3.951Gi ± ∞ ¹        ~ (p=0.151 n=5)
IndexBytePortable/4M-16        4.013Gi ± ∞ ¹   4.017Gi ± ∞ ¹        ~ (p=0.222 n=5)
IndexBytePortable/64M-16       3.987Gi ± ∞ ¹   3.933Gi ± ∞ ¹        ~ (p=0.310 n=5)
geomean                        8.183Gi         9.013Gi        +10.14%
```

Fixes #56474