### PR TITLE
os/exec: avoid calling LookPath in cmd.Start for resolved paths

### DIFF
--- a/src/os/exec/lp_plan9.go
+++ b/src/os/exec/lp_plan9.go
@@ -64,3 +64,9 @@ func LookPath(file string) (string, error) {
 	}
 	return "", &Error{file, ErrNotFound}
 }
+
+// lookExtensions is a no-op on non-Windows platforms, since
+// they do not restrict executables to specific extensions.
+func lookExtensions(path, dir string) (string, error) {
+	return path, nil
+}

--- a/src/os/exec/lp_unix.go
+++ b/src/os/exec/lp_unix.go
@@ -80,3 +80,9 @@ func LookPath(file string) (string, error) {
 	}
 	return "", &Error{file, ErrNotFound}
 }
+
+// lookExtensions is a no-op on non-Windows platforms, since
+// they do not restrict executables to specific extensions.
+func lookExtensions(path, dir string) (string, error) {
+	return path, nil
+}

--- a/src/os/exec/lp_wasm.go
+++ b/src/os/exec/lp_wasm.go
@@ -21,3 +21,9 @@ func LookPath(file string) (string, error) {
 	// Wasm can not execute processes, so act as if there are no executables at all.
 	return "", &Error{file, ErrNotFound}
 }
+
+// lookExtensions is a no-op on non-Windows platforms, since
+// they do not restrict executables to specific extensions.
+func lookExtensions(path, dir string) (string, error) {
+	return path, nil
+}

--- a/src/os/exec/lp_windows.go
+++ b/src/os/exec/lp_windows.go
@@ -63,6 +63,45 @@ func findExecutable(file string, exts []string) (string, error) {
 // As of Go 1.19, LookPath will instead return that path along with an error satisfying
 // errors.Is(err, ErrDot). See the package documentation for more details.
 func LookPath(file string) (string, error) {
+	return lookPath(file, pathExt())
+}
+
+// lookExtensions finds windows executable by its dir and path.
+// It uses LookPath to try appropriate extensions.
+// lookExtensions does not search PATH, instead it converts `prog` into `.\prog`.
+func lookExtensions(path, dir string) (string, error) {
+	if filepath.Base(path) == path {
+		path = "." + string(filepath.Separator) + path
+	}
+	exts := pathExt()
+	if ext := filepath.Ext(path); ext != "" {
+		for _, e := range exts {
+			if strings.EqualFold(ext, e) {
+				// Assume that path has already been resolved.
+				return path, nil
+			}
+		}
+	}
+	if dir == "" {
+		return lookPath(path, exts)
+	}
+	if filepath.VolumeName(path) != "" {
+		return lookPath(path, exts)
+	}
+	if len(path) > 1 && os.IsPathSeparator(path[0]) {
+		return lookPath(path, exts)
+	}
+	dirandpath := filepath.Join(dir, path)
+	// We assume that LookPath will only add file extension.
+	lp, err := lookPath(dirandpath, exts)
+	if err != nil {
+		return "", err
+	}
+	ext := strings.TrimPrefix(lp, dirandpath)
+	return path + ext, nil
+}
+
+func pathExt() []string {
 	var exts []string
 	x := os.Getenv(`PATHEXT`)
 	if x != "" {
@@ -78,7 +117,11 @@ func LookPath(file string) (string, error) {
 	} else {
 		exts = []string{".com", ".exe", ".bat", ".cmd"}
 	}
+	return exts
+}
 
+// lookPath implements LookPath for the given PATHEXT list.
+func lookPath(file string, exts []string) (string, error) {
 	if strings.ContainsAny(file, `:\/`) {
 		f, err := findExecutable(file, exts)
 		if err == nil {


### PR DESCRIPTION
Follow up on CL 511458, see https://go-review.googlesource.com/c/go/+/511458/2..4/src/cmd/go/main.go#b270 .

For #36768.

Change-Id: Icc2a4dbb1219b1d69dd10a900478957b0e975847