### PR TITLE
net: centralize resolver selection logic

### DIFF
--- a/src/net/conf.go
+++ b/src/net/conf.go
@@ -184,7 +184,7 @@ func goosPrefersCgo() bool {
 // mustUseGoResolver reports whether a DNS lookup of any sort is
 // required to use the go resolver. The provided Resolver is optional.
 // This will report true if the cgo resolver is not available.
-func (c *conf) mustUseGoResolver(r *Resolver) (ret bool) {
+func (c *conf) mustUseGoResolver(r *Resolver) bool {
 	if !cgoAvailable {
 		return true
 	}

--- a/src/net/conf.go
+++ b/src/net/conf.go
@@ -208,10 +208,10 @@ func (c *conf) isGoResolverForced(r *Resolver) bool {
 // mustUseGoResolver determines whether the use of the Go resolver for
 // non-hostname and non-address resolutions (e.g., DNS, port lookup) is required.
 // The provided Resolver is optional. nil means to not consider its options.
-func (c *conf) mustUseGoResolver(r *Resolver, qType, host string) (ret bool) {
+func (c *conf) mustUseGoResolver(r *Resolver) (ret bool) {
 	if c.dnsDebugLevel > 1 {
 		defer func() {
-			print("go package net: mustUseGoResolver(", qType, ", ", host, ") = ", ret, "\n")
+			print("go package net: mustUseGoResolver() = ", ret, "\n")
 		}()
 	}
 	return c.isGoResolverForced(r)

--- a/src/net/conf.go
+++ b/src/net/conf.go
@@ -181,10 +181,10 @@ func goosPrefersCgo() bool {
 	}
 }
 
-// isGoResolverForced reports whether a DNS lookup of any sort is
+// mustUseGoResolver reports whether a DNS lookup of any sort is
 // required to use the go resolver. The provided Resolver is optional.
 // This will report true if the cgo resolver is not available.
-func (c *conf) isGoResolverForced(r *Resolver) bool {
+func (c *conf) mustUseGoResolver(r *Resolver) (ret bool) {
 	if !cgoAvailable {
 		return true
 	}
@@ -203,18 +203,6 @@ func (c *conf) isGoResolverForced(r *Resolver) bool {
 	}
 
 	return c.netGo || r.preferGo()
-}
-
-// mustUseGoResolver determines whether the use of the Go resolver for
-// non-hostname and non-address resolutions (e.g., DNS, port lookup) is required.
-// The provided Resolver is optional. nil means to not consider its options.
-func (c *conf) mustUseGoResolver(r *Resolver) (ret bool) {
-	if c.dnsDebugLevel > 1 {
-		defer func() {
-			print("go package net: mustUseGoResolver() = ", ret, "\n")
-		}()
-	}
-	return c.isGoResolverForced(r)
 }
 
 // addrLookupOrder determines which strategy to use to resolve addresses.
@@ -246,7 +234,7 @@ func (c *conf) lookupOrder(r *Resolver, hostname string) (ret hostLookupOrder, d
 	var fallbackOrder hostLookupOrder
 
 	var canUseCgo bool
-	if c.isGoResolverForced(r) {
+	if c.mustUseGoResolver(r) {
 		// Go resolver was explicitly requested
 		// or cgo resolver is not available.
 		// Figure out the order below.

--- a/src/net/conf.go
+++ b/src/net/conf.go
@@ -205,7 +205,7 @@ func (c *conf) isGoResolverForced(r *Resolver) bool {
 	return c.netGo || r.preferGo()
 }
 
-// mustUseGoResolver determines whether to use of the Go resolver for
+// mustUseGoResolver determines whether the use of the Go resolver for
 // non-hostname and non-address resolutions (e.g., DNS, port lookup) is required.
 // The provided Resolver is optional. nil means to not consider its options.
 func (c *conf) mustUseGoResolver(r *Resolver, qType, host string) (ret bool) {

--- a/src/net/dnsclient_unix.go
+++ b/src/net/dnsclient_unix.go
@@ -606,8 +606,7 @@ func goLookupIPFiles(name string) (addrs []IPAddr, canonical string) {
 
 // goLookupIP is the native Go implementation of LookupIP.
 // The libc versions are in cgo_*.go.
-func (r *Resolver) goLookupIP(ctx context.Context, network, host string) (addrs []IPAddr, err error) {
-	order, conf := systemConf().hostLookupOrder(r, host)
+func (r *Resolver) goLookupIP(ctx context.Context, network, host string, order hostLookupOrder, conf *dnsConfig) (addrs []IPAddr, err error) {
 	addrs, _, err = r.goLookupIPCNAMEOrder(ctx, network, host, order, conf)
 	return
 }

--- a/src/net/lookup_plan9.go
+++ b/src/net/lookup_plan9.go
@@ -254,7 +254,7 @@ func (r *Resolver) lookupCNAME(ctx context.Context, name string) (cname string, 
 }
 
 func (r *Resolver) lookupSRV(ctx context.Context, service, proto, name string) (cname string, addrs []*SRV, err error) {
-	if systemConf().mustUseGoResolver(r, "SRV", name) {
+	if systemConf().mustUseGoResolver(r) {
 		return r.goLookupSRV(ctx, service, proto, name)
 	}
 	var target string
@@ -286,7 +286,7 @@ func (r *Resolver) lookupSRV(ctx context.Context, service, proto, name string) (
 }
 
 func (r *Resolver) lookupMX(ctx context.Context, name string) (mx []*MX, err error) {
-	if systemConf().mustUseGoResolver(r, "MX", name) {
+	if systemConf().mustUseGoResolver(r) {
 		return r.goLookupMX(ctx, name)
 	}
 	lines, err := queryDNS(ctx, name, "mx")
@@ -307,7 +307,7 @@ func (r *Resolver) lookupMX(ctx context.Context, name string) (mx []*MX, err err
 }
 
 func (r *Resolver) lookupNS(ctx context.Context, name string) (ns []*NS, err error) {
-	if systemConf().mustUseGoResolver(r, "NS", name) {
+	if systemConf().mustUseGoResolver(r) {
 		return r.goLookupNS(ctx, name)
 	}
 	lines, err := queryDNS(ctx, name, "ns")
@@ -325,7 +325,7 @@ func (r *Resolver) lookupNS(ctx context.Context, name string) (ns []*NS, err err
 }
 
 func (r *Resolver) lookupTXT(ctx context.Context, name string) (txt []string, err error) {
-	if systemConf().mustUseGoResolver(r, "TXT", name) {
+	if systemConf().mustUseGoResolver(r) {
 		return r.goLookupTXT(ctx, name)
 	}
 	lines, err := queryDNS(ctx, name, "txt")

--- a/src/net/lookup_plan9.go
+++ b/src/net/lookup_plan9.go
@@ -184,31 +184,11 @@ loop:
 	return
 }
 
-// preferGoOverPlan9 reports whether the resolver should use the
-// "PreferGo" implementation rather than asking plan9 services
-// for the answers.
-func (r *Resolver) preferGoOverPlan9() bool {
-	_, _, res := r.preferGoOverPlan9WithOrderAndConf()
-	return res
-}
-
-func (r *Resolver) preferGoOverPlan9WithOrderAndConf() (hostLookupOrder, *dnsConfig, bool) {
-	order, conf := systemConf().hostLookupOrder(r, "") // name is unused
-
-	// TODO(bradfitz): for now we only permit use of the PreferGo
-	// implementation when there's a non-nil Resolver with a
-	// non-nil Dialer. This is a sign that they the code is trying
-	// to use their DNS-speaking net.Conn (such as an in-memory
-	// DNS cache) and they don't want to actually hit the network.
-	// Once we add support for looking the default DNS servers
-	// from plan9, though, then we can relax this.
-	return order, conf, order != hostLookupCgo && r != nil && r.Dial != nil
-}
-
 func (r *Resolver) lookupIP(ctx context.Context, network, host string) (addrs []IPAddr, err error) {
-	if r.preferGoOverPlan9() {
-		return r.goLookupIP(ctx, network, host)
+	if order, conf := systemConf().hostLookupOrder(r, host); order != hostLookupCgo {
+		return r.goLookupIP(ctx, network, host, order, conf)
 	}
+
 	lits, err := r.lookupHost(ctx, host)
 	if err != nil {
 		return
@@ -253,7 +233,7 @@ func (*Resolver) lookupPort(ctx context.Context, network, service string) (port 
 }
 
 func (r *Resolver) lookupCNAME(ctx context.Context, name string) (cname string, err error) {
-	if order, conf, preferGo := r.preferGoOverPlan9WithOrderAndConf(); preferGo {
+	if order, conf := systemConf().hostLookupOrder(r, name); order != hostLookupCgo {
 		return r.goLookupCNAME(ctx, name, order, conf)
 	}
 
@@ -274,7 +254,7 @@ func (r *Resolver) lookupCNAME(ctx context.Context, name string) (cname string, 
 }
 
 func (r *Resolver) lookupSRV(ctx context.Context, service, proto, name string) (cname string, addrs []*SRV, err error) {
-	if r.preferGoOverPlan9() {
+	if systemConf().mustUseGoResolver(r, "SRV", name) {
 		return r.goLookupSRV(ctx, service, proto, name)
 	}
 	var target string
@@ -306,7 +286,7 @@ func (r *Resolver) lookupSRV(ctx context.Context, service, proto, name string) (
 }
 
 func (r *Resolver) lookupMX(ctx context.Context, name string) (mx []*MX, err error) {
-	if r.preferGoOverPlan9() {
+	if systemConf().mustUseGoResolver(r, "MX", name) {
 		return r.goLookupMX(ctx, name)
 	}
 	lines, err := queryDNS(ctx, name, "mx")
@@ -327,7 +307,7 @@ func (r *Resolver) lookupMX(ctx context.Context, name string) (mx []*MX, err err
 }
 
 func (r *Resolver) lookupNS(ctx context.Context, name string) (ns []*NS, err error) {
-	if r.preferGoOverPlan9() {
+	if systemConf().mustUseGoResolver(r, "NS", name) {
 		return r.goLookupNS(ctx, name)
 	}
 	lines, err := queryDNS(ctx, name, "ns")
@@ -345,7 +325,7 @@ func (r *Resolver) lookupNS(ctx context.Context, name string) (ns []*NS, err err
 }
 
 func (r *Resolver) lookupTXT(ctx context.Context, name string) (txt []string, err error) {
-	if r.preferGoOverPlan9() {
+	if systemConf().mustUseGoResolver(r, "TXT", name) {
 		return r.goLookupTXT(ctx, name)
 	}
 	lines, err := queryDNS(ctx, name, "txt")
@@ -361,7 +341,7 @@ func (r *Resolver) lookupTXT(ctx context.Context, name string) (txt []string, er
 }
 
 func (r *Resolver) lookupAddr(ctx context.Context, addr string) (name []string, err error) {
-	if order, conf, preferGo := r.preferGoOverPlan9WithOrderAndConf(); preferGo {
+	if order, conf := systemConf().addrLookupOrder(r, addr); order != hostLookupCgo {
 		return r.goLookupPTR(ctx, addr, order, conf)
 	}
 	arpa, err := reverseaddr(addr)

--- a/src/net/lookup_unix.go
+++ b/src/net/lookup_unix.go
@@ -62,9 +62,6 @@ func (r *Resolver) lookupHost(ctx context.Context, host string) (addrs []string,
 }
 
 func (r *Resolver) lookupIP(ctx context.Context, network, host string) (addrs []IPAddr, err error) {
-	if r.preferGo() {
-		return r.goLookupIP(ctx, network, host)
-	}
 	order, conf := systemConf().hostLookupOrder(r, host)
 	if order == hostLookupCgo {
 		return cgoLookupIP(ctx, network, host)
@@ -76,7 +73,7 @@ func (r *Resolver) lookupIP(ctx context.Context, network, host string) (addrs []
 func (r *Resolver) lookupPort(ctx context.Context, network, service string) (int, error) {
 	// Port lookup is not a DNS operation.
 	// Prefer the cgo resolver if possible.
-	if !systemConf().mustUseGoResolver(r) {
+	if !systemConf().mustUseGoResolver(r, "port", service) {
 		port, err := cgoLookupPort(ctx, network, service)
 		if err != nil {
 			// Issue 18213: if cgo fails, first check to see whether we

--- a/src/net/lookup_unix.go
+++ b/src/net/lookup_unix.go
@@ -73,7 +73,7 @@ func (r *Resolver) lookupIP(ctx context.Context, network, host string) (addrs []
 func (r *Resolver) lookupPort(ctx context.Context, network, service string) (int, error) {
 	// Port lookup is not a DNS operation.
 	// Prefer the cgo resolver if possible.
-	if !systemConf().mustUseGoResolver(r, "port", service) {
+	if !systemConf().mustUseGoResolver(r) {
 		port, err := cgoLookupPort(ctx, network, service)
 		if err != nil {
 			// Issue 18213: if cgo fails, first check to see whether we

--- a/src/net/lookup_windows.go
+++ b/src/net/lookup_windows.go
@@ -91,19 +91,11 @@ func (r *Resolver) lookupHost(ctx context.Context, name string) ([]string, error
 	return addrs, nil
 }
 
-// preferGoOverWindows reports whether the resolver should use the
-// pure Go implementation rather than making win32 calls to ask the
-// kernel for its answer.
-func (r *Resolver) preferGoOverWindows() bool {
-	conf := systemConf()
-	order, _ := conf.hostLookupOrder(r, "") // name is unused
-	return order != hostLookupCgo
-}
-
 func (r *Resolver) lookupIP(ctx context.Context, network, name string) ([]IPAddr, error) {
-	if r.preferGoOverWindows() {
-		return r.goLookupIP(ctx, network, name)
+	if order, conf := systemConf().hostLookupOrder(r, name); order != hostLookupCgo {
+		return r.goLookupIP(ctx, network, name, order, conf)
 	}
+
 	// TODO(bradfitz,brainman): use ctx more. See TODO below.
 
 	var family int32 = syscall.AF_UNSPEC
@@ -200,7 +192,7 @@ func (r *Resolver) lookupIP(ctx context.Context, network, name string) ([]IPAddr
 }
 
 func (r *Resolver) lookupPort(ctx context.Context, network, service string) (int, error) {
-	if r.preferGoOverWindows() {
+	if systemConf().mustUseGoResolver(r, "port", service) {
 		return lookupPortMap(network, service)
 	}
 
@@ -249,7 +241,7 @@ func (r *Resolver) lookupPort(ctx context.Context, network, service string) (int
 }
 
 func (r *Resolver) lookupCNAME(ctx context.Context, name string) (string, error) {
-	if order, conf := systemConf().hostLookupOrder(r, ""); order != hostLookupCgo {
+	if order, conf := systemConf().hostLookupOrder(r, name); order != hostLookupCgo {
 		return r.goLookupCNAME(ctx, name, order, conf)
 	}
 
@@ -274,7 +266,7 @@ func (r *Resolver) lookupCNAME(ctx context.Context, name string) (string, error)
 }
 
 func (r *Resolver) lookupSRV(ctx context.Context, service, proto, name string) (string, []*SRV, error) {
-	if r.preferGoOverWindows() {
+	if systemConf().mustUseGoResolver(r, "SRV", name) {
 		return r.goLookupSRV(ctx, service, proto, name)
 	}
 	// TODO(bradfitz): finish ctx plumbing. Nothing currently depends on this.
@@ -303,7 +295,7 @@ func (r *Resolver) lookupSRV(ctx context.Context, service, proto, name string) (
 }
 
 func (r *Resolver) lookupMX(ctx context.Context, name string) ([]*MX, error) {
-	if r.preferGoOverWindows() {
+	if systemConf().mustUseGoResolver(r, "MX", name) {
 		return r.goLookupMX(ctx, name)
 	}
 	// TODO(bradfitz): finish ctx plumbing. Nothing currently depends on this.
@@ -326,7 +318,7 @@ func (r *Resolver) lookupMX(ctx context.Context, name string) ([]*MX, error) {
 }
 
 func (r *Resolver) lookupNS(ctx context.Context, name string) ([]*NS, error) {
-	if r.preferGoOverWindows() {
+	if systemConf().mustUseGoResolver(r, "NS", name) {
 		return r.goLookupNS(ctx, name)
 	}
 	// TODO(bradfitz): finish ctx plumbing. Nothing currently depends on this.
@@ -348,7 +340,7 @@ func (r *Resolver) lookupNS(ctx context.Context, name string) ([]*NS, error) {
 }
 
 func (r *Resolver) lookupTXT(ctx context.Context, name string) ([]string, error) {
-	if r.preferGoOverWindows() {
+	if systemConf().mustUseGoResolver(r, "TXT", name) {
 		return r.goLookupTXT(ctx, name)
 	}
 	// TODO(bradfitz): finish ctx plumbing. Nothing currently depends on this.
@@ -374,7 +366,7 @@ func (r *Resolver) lookupTXT(ctx context.Context, name string) ([]string, error)
 }
 
 func (r *Resolver) lookupAddr(ctx context.Context, addr string) ([]string, error) {
-	if order, conf := systemConf().hostLookupOrder(r, ""); order != hostLookupCgo {
+	if order, conf := systemConf().addrLookupOrder(r, addr); order != hostLookupCgo {
 		return r.goLookupPTR(ctx, addr, order, conf)
 	}
 

--- a/src/net/lookup_windows.go
+++ b/src/net/lookup_windows.go
@@ -192,7 +192,7 @@ func (r *Resolver) lookupIP(ctx context.Context, network, name string) ([]IPAddr
 }
 
 func (r *Resolver) lookupPort(ctx context.Context, network, service string) (int, error) {
-	if systemConf().mustUseGoResolver(r, "port", service) {
+	if systemConf().mustUseGoResolver(r) {
 		return lookupPortMap(network, service)
 	}
 
@@ -266,7 +266,7 @@ func (r *Resolver) lookupCNAME(ctx context.Context, name string) (string, error)
 }
 
 func (r *Resolver) lookupSRV(ctx context.Context, service, proto, name string) (string, []*SRV, error) {
-	if systemConf().mustUseGoResolver(r, "SRV", name) {
+	if systemConf().mustUseGoResolver(r) {
 		return r.goLookupSRV(ctx, service, proto, name)
 	}
 	// TODO(bradfitz): finish ctx plumbing. Nothing currently depends on this.
@@ -295,7 +295,7 @@ func (r *Resolver) lookupSRV(ctx context.Context, service, proto, name string) (
 }
 
 func (r *Resolver) lookupMX(ctx context.Context, name string) ([]*MX, error) {
-	if systemConf().mustUseGoResolver(r, "MX", name) {
+	if systemConf().mustUseGoResolver(r) {
 		return r.goLookupMX(ctx, name)
 	}
 	// TODO(bradfitz): finish ctx plumbing. Nothing currently depends on this.
@@ -318,7 +318,7 @@ func (r *Resolver) lookupMX(ctx context.Context, name string) ([]*MX, error) {
 }
 
 func (r *Resolver) lookupNS(ctx context.Context, name string) ([]*NS, error) {
-	if systemConf().mustUseGoResolver(r, "NS", name) {
+	if systemConf().mustUseGoResolver(r) {
 		return r.goLookupNS(ctx, name)
 	}
 	// TODO(bradfitz): finish ctx plumbing. Nothing currently depends on this.
@@ -340,7 +340,7 @@ func (r *Resolver) lookupNS(ctx context.Context, name string) ([]*NS, error) {
 }
 
 func (r *Resolver) lookupTXT(ctx context.Context, name string) ([]string, error) {
-	if systemConf().mustUseGoResolver(r, "TXT", name) {
+	if systemConf().mustUseGoResolver(r) {
 		return r.goLookupTXT(ctx, name)
 	}
 	// TODO(bradfitz): finish ctx plumbing. Nothing currently depends on this.


### PR DESCRIPTION
This change removes the per GOOS hostLookupOrder wrappers.
passes the correct hostname to hostLookupOrder (windows,
plan9), so that the netdns+2 GODEBUG doesn't show empty 
hostnames.

Uses the mustUseGoResolver instead of hostLookupOrder,
hostLookupOrder should only be used for hostname resolution,
not for lookups that do only DNS.