### PR TITLE
cmd/compile: fix duplicated dwarf parameters for some functions

### DIFF
--- a/src/cmd/internal/dwarf/dwarf.go
+++ b/src/cmd/internal/dwarf/dwarf.go
@@ -1204,11 +1204,21 @@ func putPrunedScopes(ctxt Context, s *FnState, fnabbrev int) error {
 	}
 	scopes := make([]Scope, len(s.Scopes), len(s.Scopes))
 	pvars := inlinedVarTable(&s.InlCalls)
+	dedupvars := make(map[string]bool)
 	for k, s := range s.Scopes {
 		var pruned Scope = Scope{Parent: s.Parent, Ranges: s.Ranges}
 		for i := 0; i < len(s.Vars); i++ {
+			// FIXME: This map was added to deduplicate the list of variables.
+			// When generating the formal parameters from the symbols some variables
+			// were added to the scope more than once.
+			_, dup := dedupvars[s.Vars[i].Name]
+			if dup {
+				continue
+			}
+
 			_, found := pvars[s.Vars[i]]
 			if !found {
+				dedupvars[s.Vars[i].Name] = true
 				pruned.Vars = append(pruned.Vars, s.Vars[i])
 			}
 		}

--- a/src/cmd/link/internal/ld/dwarf_test.go
+++ b/src/cmd/link/internal/ld/dwarf_test.go
@@ -1628,7 +1628,7 @@ func processParams(die *dwarf.Entry, ex *dwtest.Examiner) string {
 			}
 			if name, ok := child.Val(dwarf.AttrName).(string); ok {
 				if _, ok := foundParams[name]; ok {
-					panic(fmt.Sprintf("Found duplicated child parameter %s while parsing dwarf entry %s", name, entryName))
+					panic(fmt.Sprintf("Found duplicated child parameter %s while parsing dwarf entry %s\n", name, entryName))
 				}
 				foundParams[name] = fmt.Sprintf("%d:%d", idx, st)
 				idx++


### PR DESCRIPTION
Dwarf formal parameters appear more than once in the
final dwarf symbols for some functions. I believe there is an error
up the chain where the vars are created and some of them are pushed
more than once to the list.

I ended up implementing a simple dedup mechanism to get rid of the
duplicates up the chain, but this should be investigated deeper in
a follow up ticket in order to find the root cause.

The testing routine `findSubprogramDIE` was updated to panic in case it
received duplicated formal parameters since this bug probably existed
for quite a while and it was never discovered since this function
basically pushes into a map indexed by the var name, overwriting the 
last value.

A test has been added to cover this case as reported in the original
issue ticket.

Fixes #61357