### PR TITLE
net/http: fix doc comment on FormValue function

### DIFF
--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -1339,7 +1339,7 @@ func (r *Request) ParseMultipartForm(maxMemory int64) error {
 }
 
 // FormValue returns the first value for the named component of the query.
-// POST and PUT body parameters take precedence over URL query string values.
+// POST, PUT, and PATCH body parameters take precedence over URL query string values.
 // FormValue calls ParseMultipartForm and ParseForm if necessary and ignores
 // any errors returned by these functions.
 // If key is not present, FormValue returns the empty string.
@@ -1356,7 +1356,7 @@ func (r *Request) FormValue(key string) string {
 }
 
 // PostFormValue returns the first value for the named component of the POST,
-// PATCH, or PUT request body. URL query parameters are ignored.
+// PUT, or PATCH request body. URL query parameters are ignored.
 // PostFormValue calls ParseMultipartForm and ParseForm if necessary and ignores
 // any errors returned by these functions.
 // If key is not present, PostFormValue returns the empty string.


### PR DESCRIPTION
This function checks Request.Form, which now includes values parsed from a PATCH request.

Fixes #60585