### PR TITLE
cmd/go: reject import paths with suffix .test

### DIFF
--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2807,6 +2807,10 @@ type PackageOpts struct {
 	SuppressEmbedFiles bool
 }
 
+type KnownError struct {
+	Err error
+}
+
 // PackagesAndErrors returns the packages named by the command line arguments
 // 'patterns'. If a named package cannot be loaded, PackagesAndErrors returns
 // a *Package with the Error field describing the failure. If errors are found
@@ -2861,6 +2865,10 @@ func PackagesAndErrors(ctx context.Context, opts PackageOpts, patterns []string)
 		for _, pkg := range m.Pkgs {
 			if pkg == "" {
 				panic(fmt.Sprintf("ImportPaths returned empty package for pattern %s", m.Pattern()))
+			}
+			if strings.HasSuffix(pkg, ".test") {
+				panic(KnownError{Err: fmt.Errorf("Reject %s because the import path suffix cannot be .test", pkg)})
+				continue
 			}
 			mode := cmdlinePkg
 			if m.IsLiteral() {

--- a/src/cmd/go/main.go
+++ b/src/cmd/go/main.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"cmd/go/internal/load"
 	"cmd/go/internal/toolchain"
 	"cmd/go/internal/workcmd"
 	"context"
@@ -261,6 +262,15 @@ func invoke(cmd *base.Command, args []string) {
 
 	ctx := maybeStartTrace(context.Background())
 	ctx, span := trace.StartSpan(ctx, fmt.Sprint("Running ", cmd.Name(), " command"))
+	defer func() {
+		if err := recover(); err != nil {
+			if e, ok := err.(load.KnownError); ok {
+				log.Fatal(e.Err.Error())
+			} else {
+				panic(err)
+			}
+		}
+	}()
 	cmd.Run(ctx, cmd, args)
 	span.Done()
 }


### PR DESCRIPTION
This CL implementation rejects the import path suffix .test .

Fixes #60454.