### PR TITLE
cmd/dist: set buildvcs=false when building go-bootstrap

### DIFF
--- a/src/cmd/dist/buildtool.go
+++ b/src/cmd/dist/buildtool.go
@@ -244,6 +244,10 @@ func bootstrapBuildTools() {
 	cmd := []string{
 		pathf("%s/bin/go", goroot_bootstrap),
 		"install",
+		// In case we are bootstrapping from a source tarball instead of a VCS checkout,
+		// ignore any VCS roots found in parent directories of the bootstrap module.
+		// See https://go.dev/issue/54852 and https://go.dev/issue/61620.
+		"-buildvcs=false",
 		"-tags=math_big_pure_go compiler_bootstrap purego",
 	}
 	if vflag > 0 {

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2510,12 +2510,6 @@ func (p *Package) setBuildInfo(ctx context.Context, f *modfetch.Fetcher, autoVCS
 	}
 
 	if wantVCS && p.Module != nil && p.Module.Version == "" && !p.Standard {
-		if p.Module.Path == "bootstrap" && cfg.GOROOT == os.Getenv("GOROOT_BOOTSTRAP") {
-			// During bootstrapping, the bootstrap toolchain is built in module
-			// "bootstrap" (instead of "std"), with GOROOT set to GOROOT_BOOTSTRAP
-			// (so the bootstrap toolchain packages don't even appear to be in GOROOT).
-			goto omitVCS
-		}
 		repoDir, vcsCmd, err = vcs.FromDir(base.Cwd(), "")
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			setVCSError(err)

--- a/src/cmd/internal/bootstrap_test/reboot_test.go
+++ b/src/cmd/internal/bootstrap_test/reboot_test.go
@@ -31,14 +31,14 @@ func TestRepeatBootstrap(t *testing.T) {
 	realGoroot := testenv.GOROOT(t)
 
 	// To ensure that bootstrapping doesn't unexpectedly depend
-	// on the Go repo's git metadata, add a fake (unreadable) git
-	// directory above the simulated GOROOT.
-	// This mimics the configuration one much have when
+	// on the Go repo's git metadata, add a fake .git file that
+	// points to a nonexistent gitdir above the simulated GOROOT.
+	// This mimics the configuration one might have when
 	// building from distro-packaged source code
-	// (see https://go.dev/issue/54852).
+	// (see https://go.dev/issue/54852 and https://go.dev/issue/61620).
 	parent := t.TempDir()
 	dotGit := filepath.Join(parent, ".git")
-	if err := os.Mkdir(dotGit, 000); err != nil {
+	if err := os.WriteFile(dotGit, []byte("gitdir: ../nonexistent/.git\n"), 0666); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
When building go-bootstrap as part of the make.bash process, the cmd/dist invokes the bootstrap Go compiler to build the go_bootstrap tool:

${GOROOT_BOOTSTRAP}/bin/go install -tags=math_big_pure_go compiler_bootstrap purego bootstrap/cmd/...

If there is an invalid .git directory in a parent of ${GOROOT_BOOTSTRAP}, make.bash will fail. Reproduction of the issue:

  mkdir go-issue-61620
  cd ./go-issue-61620
  wget https://go.dev/dl/go1.19.11.src.tar.gz
  mkdir go-bootstrap
  tar -xf go1.19.11.src.tar.gz -C ./go-bootstrap --strip-components=1
  cd ./go-bootstrap/src/
  bash make.bash
  cd ../../
  wget https://go.dev/dl/go1.20.6.src.tar.gz
  mkdir go
  tar -xf go1.20.6.src.tar.gz -C ./go/ --strip-components=1
  printf "gitdir: ../../does/not/exist/.git" > ./.git
  cd ./go/src/
  GOROOT_BOOTSTRAP=$(pwd)/../../go-bootstrap/ bash make.bash

The build fails with the following error:

  Building Go toolchain1 using [snip]/go-1.19.10.
  error obtaining VCS status: exit status 128
    Use -buildvcs=false to disable VCS stamping.
  go tool dist: FAILED: [snip]/go-1.19.10/bin/go install -tags=math_big_pure_go \
    compiler_bootstrap purego bootstrap/cmd/...: exit status 1

This change unconditionally sets -buildvcs=false when compiling go-bootstrap. We don't need the revision information in those binaries anyway. Setting this flag was previously not done as we were unsure if the go-bootstrap compiler would be new enough to support the buildvcs build flag. However, since Go 1.20.x, Go 1.19.x is the minimum version for go-bootstrap, and supports -buildvcs=false. We can now set -buildvcs=false without worrying about compatibility.

Related: #54852
Fixes: #61620
