### PR TITLE
regexp/syntax: accept (?<name>...) syntax as valid capture

### DIFF
--- a/src/regexp/syntax/doc.go
+++ b/src/regexp/syntax/doc.go
@@ -56,6 +56,7 @@ Grouping:
 
 	(re)           numbered capturing group (submatch)
 	(?P<name>re)   named & numbered capturing group (submatch)
+	(?<name>re)    named & numbered capturing group (submatch)
 	(?:re)         non-capturing group
 	(?flags)       set flags within current group; non-capturing
 	(?flags:re)    set flags during re; non-capturing

--- a/src/regexp/syntax/parse_test.go
+++ b/src/regexp/syntax/parse_test.go
@@ -160,6 +160,7 @@ var parseTests = []parseTest{
 
 	// Test named captures
 	{`(?P<name>a)`, `cap{name:lit{a}}`},
+	{`(?<name>a)`, `cap{name:lit{a}}`},
 
 	// Case-folded literals
 	{`[Aa]`, `litfold{A}`},
@@ -482,6 +483,11 @@ var invalidRegexps = []string{
 	`(?P<name`,
 	`(?P<x y>a)`,
 	`(?P<>a)`,
+	`(?<name>a`,
+	`(?<name>`,
+	`(?<name`,
+	`(?<x y>a)`,
+	`(?<>a)`,
 	`[a-Z]`,
 	`(?i)[a-Z]`,
 	`\Q\E*`,


### PR DESCRIPTION
Currently the only named capture supported by regexp is (?P<name>a).

The syntax (?<name>a) is also widely used and there is currently an effort from
 the Rust regex and RE2 teams to also accept this syntax.

Fixes #58458