### PR TITLE
net/http: use cancelKey to cancel request

### DIFF
--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -2248,7 +2248,7 @@ func (pc *persistConn) readLoop() {
 			}
 		case <-rc.req.Cancel:
 			alive = false
-			pc.t.CancelRequest(rc.req)
+			pc.t.cancelRequest(rc.cancelKey, errRequestCanceled)
 		case <-rc.req.Context().Done():
 			alive = false
 			pc.t.cancelRequest(rc.cancelKey, rc.req.Context().Err())


### PR DESCRIPTION
Follows up on CL 245357 and adds missing returns in waitCondition (CL 477196)

Fixes #51354
