### PR TITLE
modget: fix typo `-v` to `-x`

### DIFF
--- a/src/cmd/go/internal/modget/get.go
+++ b/src/cmd/go/internal/modget/get.go
@@ -53,7 +53,7 @@ import (
 var CmdGet = &base.Command{
 	// Note: flags below are listed explicitly because they're the most common.
 	// Do not send CLs removing them because they're covered by [get flags].
-	UsageLine: "go get [-t] [-u] [-v] [build flags] [packages]",
+	UsageLine: "go get [-t] [-u] [-x] [build flags] [packages]",
 	Short:     "add dependencies to current module and install them",
 	Long: `
 Get resolves its command-line arguments to packages at specific module versions,


### PR DESCRIPTION
Fix typo on UsageLine's text. To match with long description of debug flag `-x`. The `-v` flag doesn't effect.

The `-v` flag not working sample is below
https://gist.github.com/miyataka/8af12f126943dcd8c6022251fdce1b71