### PR TITLE
os: use t.Fatalf instead of t.Errorf in TestErrProcessDone

### DIFF
--- a/src/os/exec_unix_test.go
+++ b/src/os/exec_unix_test.go
@@ -19,7 +19,7 @@ func TestErrProcessDone(t *testing.T) {
 
 	p, err := StartProcess(testenv.GoToolPath(t), []string{"go"}, &ProcAttr{})
 	if err != nil {
-		t.Skipf("starting test process: %v", err)
+		t.Fatalf("starting test process: %v", err)
 	}
 	p.Wait()
 	if got := p.Signal(Kill); got != ErrProcessDone {

--- a/src/os/exec_unix_test.go
+++ b/src/os/exec_unix_test.go
@@ -19,7 +19,7 @@ func TestErrProcessDone(t *testing.T) {
 
 	p, err := StartProcess(testenv.GoToolPath(t), []string{"go"}, &ProcAttr{})
 	if err != nil {
-		t.Errorf("starting test process: %v", err)
+		t.Skipf("starting test process: %v", err)
 	}
 	p.Wait()
 	if got := p.Signal(Kill); got != ErrProcessDone {


### PR DESCRIPTION
If err is non-nil, use t.Fatalf to avoid panic when calling p.Wait().
