### PR TITLE
testing: improve the usage message of -benchtime

### DIFF
--- a/src/testing/benchmark.go
+++ b/src/testing/benchmark.go
@@ -25,7 +25,7 @@ import (
 func initBenchmarkFlags() {
 	matchBenchmarks = flag.String("test.bench", "", "run only benchmarks matching `regexp`")
 	benchmarkMemory = flag.Bool("test.benchmem", false, "print memory allocations for benchmarks")
-	flag.Var(&benchTime, "test.benchtime", "run each benchmark for duration `d`")
+	flag.Var(&benchTime, "test.benchtime", "run each benchmark for duration `d` or N times if `d` is of the form Nx")
 }
 
 var (


### PR DESCRIPTION
Specify that -benchtime can take the form Nx.