### PR TITLE
cmd/go/internal/vcweb, os, os/exec: clarify usage of os.ErrProcessDone

### DIFF
--- a/src/cmd/go/internal/vcweb/hg.go
+++ b/src/cmd/go/internal/vcweb/hg.go
@@ -7,7 +7,6 @@ package vcweb
 import (
 	"bufio"
 	"context"
-	"errors"
 	"io"
 	"log"
 	"net/http"
@@ -59,7 +58,7 @@ func (h *hgHandler) Handler(dir string, env []string, logger *log.Logger) (http.
 
 		cmd.Cancel = func() error {
 			err := cmd.Process.Signal(os.Interrupt)
-			if err != nil && !errors.Is(err, os.ErrProcessDone) {
+			if err != nil && err != os.ErrProcessDone {
 				err = cmd.Process.Kill()
 			}
 			return err

--- a/src/os/exec.go
+++ b/src/os/exec.go
@@ -15,6 +15,9 @@ import (
 )
 
 // ErrProcessDone indicates a Process has finished.
+//
+// When Cancel of os/exec.Cmd is called, errors will be checked using errors.Is,
+// since an error may wrap ErrProcessDone.
 var ErrProcessDone = errors.New("os: process already finished")
 
 // Process stores the information about a process created by StartProcess.

--- a/src/os/exec/exec.go
+++ b/src/os/exec/exec.go
@@ -771,7 +771,7 @@ func (c *Cmd) watchCtx(resultc chan<- ctxResult) {
 		// exit, and if that does happen we shouldn't report a spurious error,
 		// so don't set err to anything here.
 		killed = true
-	} else if !errors.Is(killErr, os.ErrProcessDone) {
+	} else if killErr != os.ErrProcessDone {
 		err = wrappedError{
 			prefix: "exec: killing Cmd",
 			err:    killErr,


### PR DESCRIPTION
Recently I'm confused about using "errors.Is(err, os.ErrProcessDone)" because there is no documentation on how to use os.ErrProcessDone.

"Cancel" func of "os/exec.Cmd" says it may return error that wraps os.ErrProcessDone, however TestErrProcessDone uses "got != ErrProcessDone". I searched all the usages of os.ErrProcessDone, found that std-lib also uses "errors.Is" to check it when calling Process.Signal().

I think we shouldn't abuse "errors.Is", since Signal() doesn't return an error which wraps os.ErrProcessDone or implements the Is(error) bool method.