### PR TITLE
strconv: Improved ParseBool Function for Better True/False Recognition

### DIFF
--- a/src/strconv/atob.go
+++ b/src/strconv/atob.go
@@ -5,13 +5,13 @@
 package strconv
 
 // ParseBool returns the boolean value represented by the string.
-// It accepts 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False.
+// It accepts 1, t, T, TRUE, true, True, y, Y, yes, YES, 0, f, F, FALSE, false, False, n, N, no, NO.
 // Any other value returns an error.
 func ParseBool(str string) (bool, error) {
 	switch str {
-	case "1", "t", "T", "true", "TRUE", "True":
+	case "1", "t", "T", "true", "TRUE", "True", "y", "Y", "yes", "YES":
 		return true, nil
-	case "0", "f", "F", "false", "FALSE", "False":
+	case "0", "f", "F", "false", "FALSE", "False", "n", "N", "no", "NO":
 		return false, nil
 	}
 	return false, syntaxError("ParseBool", str)

--- a/src/strconv/atob_test.go
+++ b/src/strconv/atob_test.go
@@ -25,12 +25,20 @@ var atobtests = []atobTest{
 	{"FALSE", false, nil},
 	{"false", false, nil},
 	{"False", false, nil},
+	{"n", false, nil},
+	{"N", false, nil},
+	{"no", false, nil},
+	{"NO", false, nil},
 	{"1", true, nil},
 	{"t", true, nil},
 	{"T", true, nil},
 	{"TRUE", true, nil},
 	{"true", true, nil},
 	{"True", true, nil},
+	{"y", true, nil},
+	{"Y", true, nil},
+	{"yes", true, nil},
+	{"YES", true, nil},
 }
 
 func TestParseBool(t *testing.T) {


### PR DESCRIPTION
Makes the ParseBool function in the strconv package more versatile. It now accepts additional words to represent true values: "y," "Y," "yes," and "YES." Similarly, you can use "n," "N," "no," and "NO" to indicate false values.