### PR TITLE
archive/zip: reject non-regular files in AddFS

### DIFF
--- a/src/archive/zip/writer.go
+++ b/src/archive/zip/writer.go
@@ -504,6 +504,9 @@ func (w *Writer) AddFS(fsys fs.FS) error {
 		if err != nil {
 			return err
 		}
+		if !info.Mode().IsRegular() {
+			return errors.New("zip: cannot add non-regular file")
+		}
 		h, err := FileInfoHeader(info)
 		if err != nil {
 			return err

--- a/src/archive/zip/writer_test.go
+++ b/src/archive/zip/writer_test.go
@@ -648,3 +648,26 @@ func TestWriterAddFS(t *testing.T) {
 		testReadFile(t, r.File[i], &wt)
 	}
 }
+
+func TestIssue61875(t *testing.T) {
+	buf := new(bytes.Buffer)
+	w := NewWriter(buf)
+	tests := []WriteTest{
+		{
+			Name:   "symlink",
+			Data:   []byte("../link/target"),
+			Method: Deflate,
+			Mode:   0755 | fs.ModeSymlink,
+		},
+		{
+			Name:   "device",
+			Data:   []byte(""),
+			Method: Deflate,
+			Mode:   0755 | fs.ModeDevice,
+		},
+	}
+	err := w.AddFS(writeTestsToFS(tests))
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+}


### PR DESCRIPTION
When a filesystem with non-regular files is used
the resulting files inside the zip archive are empty.

In this case we can be explicit and return an error.

Fixes #61875