### PR TITLE
log/slog: Reorder doc comment for level constants

### DIFF
--- a/src/log/slog/level.go
+++ b/src/log/slog/level.go
@@ -16,6 +16,8 @@ import (
 // The higher the level, the more important or severe the event.
 type Level int
 
+// Names for common levels.
+//
 // Level numbers are inherently arbitrary,
 // but we picked them to satisfy three constraints.
 // Any system can map them to another numbering scheme if it wishes.
@@ -38,8 +40,6 @@ type Level int
 // Level range. OpenTelemetry also has the names TRACE and FATAL, which slog
 // does not. But those OpenTelemetry levels can still be represented as slog
 // Levels by using the appropriate integers.
-//
-// Names for common levels.
 const (
 	LevelDebug Level = -4
 	LevelInfo  Level = 0


### PR DESCRIPTION
pkgsite and go doc print the doc comment *after* the code, resulting in:

    const (
            LevelDebug Level = -4
            ...
    )

    Many paragraphs...

    Names for common levels.

The "Names for common levels." feels out of place and confusing at the bottom.

This is also consistent with the recommendation for the first sentence in doc comments to be the "summary".