### PR TITLE
syscall: update windows zsyscalls to use SyscallN

### DIFF
--- a/src/syscall/zsyscall_windows.go
+++ b/src/syscall/zsyscall_windows.go
@@ -200,7 +200,7 @@ var (
 )
 
 func ConvertSidToStringSid(sid *SID, stringSid **uint16) (err error) {
-	r1, _, e1 := Syscall(procConvertSidToStringSidW.Addr(), 2, uintptr(unsafe.Pointer(sid)), uintptr(unsafe.Pointer(stringSid)), 0)
+	r1, _, e1 := SyscallN(procConvertSidToStringSidW.Addr(), uintptr(unsafe.Pointer(sid)), uintptr(unsafe.Pointer(stringSid)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -208,7 +208,7 @@ func ConvertSidToStringSid(sid *SID, stringSid **uint16) (err error) {
 }
 
 func ConvertStringSidToSid(stringSid *uint16, sid **SID) (err error) {
-	r1, _, e1 := Syscall(procConvertStringSidToSidW.Addr(), 2, uintptr(unsafe.Pointer(stringSid)), uintptr(unsafe.Pointer(sid)), 0)
+	r1, _, e1 := SyscallN(procConvertStringSidToSidW.Addr(), uintptr(unsafe.Pointer(stringSid)), uintptr(unsafe.Pointer(sid)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -216,7 +216,7 @@ func ConvertStringSidToSid(stringSid *uint16, sid **SID) (err error) {
 }
 
 func CopySid(destSidLen uint32, destSid *SID, srcSid *SID) (err error) {
-	r1, _, e1 := Syscall(procCopySid.Addr(), 3, uintptr(destSidLen), uintptr(unsafe.Pointer(destSid)), uintptr(unsafe.Pointer(srcSid)))
+	r1, _, e1 := SyscallN(procCopySid.Addr(), uintptr(destSidLen), uintptr(unsafe.Pointer(destSid)), uintptr(unsafe.Pointer(srcSid)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -228,7 +228,7 @@ func CreateProcessAsUser(token Token, appName *uint16, commandLine *uint16, proc
 	if inheritHandles {
 		_p0 = 1
 	}
-	r1, _, e1 := Syscall12(procCreateProcessAsUserW.Addr(), 11, uintptr(token), uintptr(unsafe.Pointer(appName)), uintptr(unsafe.Pointer(commandLine)), uintptr(unsafe.Pointer(procSecurity)), uintptr(unsafe.Pointer(threadSecurity)), uintptr(_p0), uintptr(creationFlags), uintptr(unsafe.Pointer(env)), uintptr(unsafe.Pointer(currentDir)), uintptr(unsafe.Pointer(startupInfo)), uintptr(unsafe.Pointer(outProcInfo)), 0)
+	r1, _, e1 := SyscallN(procCreateProcessAsUserW.Addr(), uintptr(token), uintptr(unsafe.Pointer(appName)), uintptr(unsafe.Pointer(commandLine)), uintptr(unsafe.Pointer(procSecurity)), uintptr(unsafe.Pointer(threadSecurity)), uintptr(_p0), uintptr(creationFlags), uintptr(unsafe.Pointer(env)), uintptr(unsafe.Pointer(currentDir)), uintptr(unsafe.Pointer(startupInfo)), uintptr(unsafe.Pointer(outProcInfo)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -236,7 +236,7 @@ func CreateProcessAsUser(token Token, appName *uint16, commandLine *uint16, proc
 }
 
 func CryptAcquireContext(provhandle *Handle, container *uint16, provider *uint16, provtype uint32, flags uint32) (err error) {
-	r1, _, e1 := Syscall6(procCryptAcquireContextW.Addr(), 5, uintptr(unsafe.Pointer(provhandle)), uintptr(unsafe.Pointer(container)), uintptr(unsafe.Pointer(provider)), uintptr(provtype), uintptr(flags), 0)
+	r1, _, e1 := SyscallN(procCryptAcquireContextW.Addr(), uintptr(unsafe.Pointer(provhandle)), uintptr(unsafe.Pointer(container)), uintptr(unsafe.Pointer(provider)), uintptr(provtype), uintptr(flags))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -244,7 +244,7 @@ func CryptAcquireContext(provhandle *Handle, container *uint16, provider *uint16
 }
 
 func CryptGenRandom(provhandle Handle, buflen uint32, buf *byte) (err error) {
-	r1, _, e1 := Syscall(procCryptGenRandom.Addr(), 3, uintptr(provhandle), uintptr(buflen), uintptr(unsafe.Pointer(buf)))
+	r1, _, e1 := SyscallN(procCryptGenRandom.Addr(), uintptr(provhandle), uintptr(buflen), uintptr(unsafe.Pointer(buf)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -252,7 +252,7 @@ func CryptGenRandom(provhandle Handle, buflen uint32, buf *byte) (err error) {
 }
 
 func CryptReleaseContext(provhandle Handle, flags uint32) (err error) {
-	r1, _, e1 := Syscall(procCryptReleaseContext.Addr(), 2, uintptr(provhandle), uintptr(flags), 0)
+	r1, _, e1 := SyscallN(procCryptReleaseContext.Addr(), uintptr(provhandle), uintptr(flags))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -260,13 +260,13 @@ func CryptReleaseContext(provhandle Handle, flags uint32) (err error) {
 }
 
 func GetLengthSid(sid *SID) (len uint32) {
-	r0, _, _ := Syscall(procGetLengthSid.Addr(), 1, uintptr(unsafe.Pointer(sid)), 0, 0)
+	r0, _, _ := SyscallN(procGetLengthSid.Addr(), uintptr(unsafe.Pointer(sid)))
 	len = uint32(r0)
 	return
 }
 
 func GetTokenInformation(t Token, infoClass uint32, info *byte, infoLen uint32, returnedLen *uint32) (err error) {
-	r1, _, e1 := Syscall6(procGetTokenInformation.Addr(), 5, uintptr(t), uintptr(infoClass), uintptr(unsafe.Pointer(info)), uintptr(infoLen), uintptr(unsafe.Pointer(returnedLen)), 0)
+	r1, _, e1 := SyscallN(procGetTokenInformation.Addr(), uintptr(t), uintptr(infoClass), uintptr(unsafe.Pointer(info)), uintptr(infoLen), uintptr(unsafe.Pointer(returnedLen)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -274,7 +274,7 @@ func GetTokenInformation(t Token, infoClass uint32, info *byte, infoLen uint32, 
 }
 
 func LookupAccountName(systemName *uint16, accountName *uint16, sid *SID, sidLen *uint32, refdDomainName *uint16, refdDomainNameLen *uint32, use *uint32) (err error) {
-	r1, _, e1 := Syscall9(procLookupAccountNameW.Addr(), 7, uintptr(unsafe.Pointer(systemName)), uintptr(unsafe.Pointer(accountName)), uintptr(unsafe.Pointer(sid)), uintptr(unsafe.Pointer(sidLen)), uintptr(unsafe.Pointer(refdDomainName)), uintptr(unsafe.Pointer(refdDomainNameLen)), uintptr(unsafe.Pointer(use)), 0, 0)
+	r1, _, e1 := SyscallN(procLookupAccountNameW.Addr(), uintptr(unsafe.Pointer(systemName)), uintptr(unsafe.Pointer(accountName)), uintptr(unsafe.Pointer(sid)), uintptr(unsafe.Pointer(sidLen)), uintptr(unsafe.Pointer(refdDomainName)), uintptr(unsafe.Pointer(refdDomainNameLen)), uintptr(unsafe.Pointer(use)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -282,7 +282,7 @@ func LookupAccountName(systemName *uint16, accountName *uint16, sid *SID, sidLen
 }
 
 func LookupAccountSid(systemName *uint16, sid *SID, name *uint16, nameLen *uint32, refdDomainName *uint16, refdDomainNameLen *uint32, use *uint32) (err error) {
-	r1, _, e1 := Syscall9(procLookupAccountSidW.Addr(), 7, uintptr(unsafe.Pointer(systemName)), uintptr(unsafe.Pointer(sid)), uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(nameLen)), uintptr(unsafe.Pointer(refdDomainName)), uintptr(unsafe.Pointer(refdDomainNameLen)), uintptr(unsafe.Pointer(use)), 0, 0)
+	r1, _, e1 := SyscallN(procLookupAccountSidW.Addr(), uintptr(unsafe.Pointer(systemName)), uintptr(unsafe.Pointer(sid)), uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(nameLen)), uintptr(unsafe.Pointer(refdDomainName)), uintptr(unsafe.Pointer(refdDomainNameLen)), uintptr(unsafe.Pointer(use)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -290,7 +290,7 @@ func LookupAccountSid(systemName *uint16, sid *SID, name *uint16, nameLen *uint3
 }
 
 func OpenProcessToken(h Handle, access uint32, token *Token) (err error) {
-	r1, _, e1 := Syscall(procOpenProcessToken.Addr(), 3, uintptr(h), uintptr(access), uintptr(unsafe.Pointer(token)))
+	r1, _, e1 := SyscallN(procOpenProcessToken.Addr(), uintptr(h), uintptr(access), uintptr(unsafe.Pointer(token)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -298,7 +298,7 @@ func OpenProcessToken(h Handle, access uint32, token *Token) (err error) {
 }
 
 func RegCloseKey(key Handle) (regerrno error) {
-	r0, _, _ := Syscall(procRegCloseKey.Addr(), 1, uintptr(key), 0, 0)
+	r0, _, _ := SyscallN(procRegCloseKey.Addr(), uintptr(key))
 	if r0 != 0 {
 		regerrno = Errno(r0)
 	}
@@ -306,7 +306,7 @@ func RegCloseKey(key Handle) (regerrno error) {
 }
 
 func regEnumKeyEx(key Handle, index uint32, name *uint16, nameLen *uint32, reserved *uint32, class *uint16, classLen *uint32, lastWriteTime *Filetime) (regerrno error) {
-	r0, _, _ := Syscall9(procRegEnumKeyExW.Addr(), 8, uintptr(key), uintptr(index), uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(nameLen)), uintptr(unsafe.Pointer(reserved)), uintptr(unsafe.Pointer(class)), uintptr(unsafe.Pointer(classLen)), uintptr(unsafe.Pointer(lastWriteTime)), 0)
+	r0, _, _ := SyscallN(procRegEnumKeyExW.Addr(), uintptr(key), uintptr(index), uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(nameLen)), uintptr(unsafe.Pointer(reserved)), uintptr(unsafe.Pointer(class)), uintptr(unsafe.Pointer(classLen)), uintptr(unsafe.Pointer(lastWriteTime)))
 	if r0 != 0 {
 		regerrno = Errno(r0)
 	}
@@ -314,7 +314,7 @@ func regEnumKeyEx(key Handle, index uint32, name *uint16, nameLen *uint32, reser
 }
 
 func RegOpenKeyEx(key Handle, subkey *uint16, options uint32, desiredAccess uint32, result *Handle) (regerrno error) {
-	r0, _, _ := Syscall6(procRegOpenKeyExW.Addr(), 5, uintptr(key), uintptr(unsafe.Pointer(subkey)), uintptr(options), uintptr(desiredAccess), uintptr(unsafe.Pointer(result)), 0)
+	r0, _, _ := SyscallN(procRegOpenKeyExW.Addr(), uintptr(key), uintptr(unsafe.Pointer(subkey)), uintptr(options), uintptr(desiredAccess), uintptr(unsafe.Pointer(result)))
 	if r0 != 0 {
 		regerrno = Errno(r0)
 	}
@@ -322,7 +322,7 @@ func RegOpenKeyEx(key Handle, subkey *uint16, options uint32, desiredAccess uint
 }
 
 func RegQueryInfoKey(key Handle, class *uint16, classLen *uint32, reserved *uint32, subkeysLen *uint32, maxSubkeyLen *uint32, maxClassLen *uint32, valuesLen *uint32, maxValueNameLen *uint32, maxValueLen *uint32, saLen *uint32, lastWriteTime *Filetime) (regerrno error) {
-	r0, _, _ := Syscall12(procRegQueryInfoKeyW.Addr(), 12, uintptr(key), uintptr(unsafe.Pointer(class)), uintptr(unsafe.Pointer(classLen)), uintptr(unsafe.Pointer(reserved)), uintptr(unsafe.Pointer(subkeysLen)), uintptr(unsafe.Pointer(maxSubkeyLen)), uintptr(unsafe.Pointer(maxClassLen)), uintptr(unsafe.Pointer(valuesLen)), uintptr(unsafe.Pointer(maxValueNameLen)), uintptr(unsafe.Pointer(maxValueLen)), uintptr(unsafe.Pointer(saLen)), uintptr(unsafe.Pointer(lastWriteTime)))
+	r0, _, _ := SyscallN(procRegQueryInfoKeyW.Addr(), uintptr(key), uintptr(unsafe.Pointer(class)), uintptr(unsafe.Pointer(classLen)), uintptr(unsafe.Pointer(reserved)), uintptr(unsafe.Pointer(subkeysLen)), uintptr(unsafe.Pointer(maxSubkeyLen)), uintptr(unsafe.Pointer(maxClassLen)), uintptr(unsafe.Pointer(valuesLen)), uintptr(unsafe.Pointer(maxValueNameLen)), uintptr(unsafe.Pointer(maxValueLen)), uintptr(unsafe.Pointer(saLen)), uintptr(unsafe.Pointer(lastWriteTime)))
 	if r0 != 0 {
 		regerrno = Errno(r0)
 	}
@@ -330,7 +330,7 @@ func RegQueryInfoKey(key Handle, class *uint16, classLen *uint32, reserved *uint
 }
 
 func RegQueryValueEx(key Handle, name *uint16, reserved *uint32, valtype *uint32, buf *byte, buflen *uint32) (regerrno error) {
-	r0, _, _ := Syscall6(procRegQueryValueExW.Addr(), 6, uintptr(key), uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(reserved)), uintptr(unsafe.Pointer(valtype)), uintptr(unsafe.Pointer(buf)), uintptr(unsafe.Pointer(buflen)))
+	r0, _, _ := SyscallN(procRegQueryValueExW.Addr(), uintptr(key), uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(reserved)), uintptr(unsafe.Pointer(valtype)), uintptr(unsafe.Pointer(buf)), uintptr(unsafe.Pointer(buflen)))
 	if r0 != 0 {
 		regerrno = Errno(r0)
 	}
@@ -338,7 +338,7 @@ func RegQueryValueEx(key Handle, name *uint16, reserved *uint32, valtype *uint32
 }
 
 func CertAddCertificateContextToStore(store Handle, certContext *CertContext, addDisposition uint32, storeContext **CertContext) (err error) {
-	r1, _, e1 := Syscall6(procCertAddCertificateContextToStore.Addr(), 4, uintptr(store), uintptr(unsafe.Pointer(certContext)), uintptr(addDisposition), uintptr(unsafe.Pointer(storeContext)), 0, 0)
+	r1, _, e1 := SyscallN(procCertAddCertificateContextToStore.Addr(), uintptr(store), uintptr(unsafe.Pointer(certContext)), uintptr(addDisposition), uintptr(unsafe.Pointer(storeContext)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -346,7 +346,7 @@ func CertAddCertificateContextToStore(store Handle, certContext *CertContext, ad
 }
 
 func CertCloseStore(store Handle, flags uint32) (err error) {
-	r1, _, e1 := Syscall(procCertCloseStore.Addr(), 2, uintptr(store), uintptr(flags), 0)
+	r1, _, e1 := SyscallN(procCertCloseStore.Addr(), uintptr(store), uintptr(flags))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -354,7 +354,7 @@ func CertCloseStore(store Handle, flags uint32) (err error) {
 }
 
 func CertCreateCertificateContext(certEncodingType uint32, certEncoded *byte, encodedLen uint32) (context *CertContext, err error) {
-	r0, _, e1 := Syscall(procCertCreateCertificateContext.Addr(), 3, uintptr(certEncodingType), uintptr(unsafe.Pointer(certEncoded)), uintptr(encodedLen))
+	r0, _, e1 := SyscallN(procCertCreateCertificateContext.Addr(), uintptr(certEncodingType), uintptr(unsafe.Pointer(certEncoded)), uintptr(encodedLen))
 	context = (*CertContext)(unsafe.Pointer(r0))
 	if context == nil {
 		err = errnoErr(e1)
@@ -363,7 +363,7 @@ func CertCreateCertificateContext(certEncodingType uint32, certEncoded *byte, en
 }
 
 func CertEnumCertificatesInStore(store Handle, prevContext *CertContext) (context *CertContext, err error) {
-	r0, _, e1 := Syscall(procCertEnumCertificatesInStore.Addr(), 2, uintptr(store), uintptr(unsafe.Pointer(prevContext)), 0)
+	r0, _, e1 := SyscallN(procCertEnumCertificatesInStore.Addr(), uintptr(store), uintptr(unsafe.Pointer(prevContext)))
 	context = (*CertContext)(unsafe.Pointer(r0))
 	if context == nil {
 		err = errnoErr(e1)
@@ -372,12 +372,12 @@ func CertEnumCertificatesInStore(store Handle, prevContext *CertContext) (contex
 }
 
 func CertFreeCertificateChain(ctx *CertChainContext) {
-	Syscall(procCertFreeCertificateChain.Addr(), 1, uintptr(unsafe.Pointer(ctx)), 0, 0)
+	SyscallN(procCertFreeCertificateChain.Addr(), uintptr(unsafe.Pointer(ctx)))
 	return
 }
 
 func CertFreeCertificateContext(ctx *CertContext) (err error) {
-	r1, _, e1 := Syscall(procCertFreeCertificateContext.Addr(), 1, uintptr(unsafe.Pointer(ctx)), 0, 0)
+	r1, _, e1 := SyscallN(procCertFreeCertificateContext.Addr(), uintptr(unsafe.Pointer(ctx)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -385,7 +385,7 @@ func CertFreeCertificateContext(ctx *CertContext) (err error) {
 }
 
 func CertGetCertificateChain(engine Handle, leaf *CertContext, time *Filetime, additionalStore Handle, para *CertChainPara, flags uint32, reserved uintptr, chainCtx **CertChainContext) (err error) {
-	r1, _, e1 := Syscall9(procCertGetCertificateChain.Addr(), 8, uintptr(engine), uintptr(unsafe.Pointer(leaf)), uintptr(unsafe.Pointer(time)), uintptr(additionalStore), uintptr(unsafe.Pointer(para)), uintptr(flags), uintptr(reserved), uintptr(unsafe.Pointer(chainCtx)), 0)
+	r1, _, e1 := SyscallN(procCertGetCertificateChain.Addr(), uintptr(engine), uintptr(unsafe.Pointer(leaf)), uintptr(unsafe.Pointer(time)), uintptr(additionalStore), uintptr(unsafe.Pointer(para)), uintptr(flags), uintptr(reserved), uintptr(unsafe.Pointer(chainCtx)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -393,7 +393,7 @@ func CertGetCertificateChain(engine Handle, leaf *CertContext, time *Filetime, a
 }
 
 func CertOpenStore(storeProvider uintptr, msgAndCertEncodingType uint32, cryptProv uintptr, flags uint32, para uintptr) (handle Handle, err error) {
-	r0, _, e1 := Syscall6(procCertOpenStore.Addr(), 5, uintptr(storeProvider), uintptr(msgAndCertEncodingType), uintptr(cryptProv), uintptr(flags), uintptr(para), 0)
+	r0, _, e1 := SyscallN(procCertOpenStore.Addr(), uintptr(storeProvider), uintptr(msgAndCertEncodingType), uintptr(cryptProv), uintptr(flags), uintptr(para))
 	handle = Handle(r0)
 	if handle == 0 {
 		err = errnoErr(e1)
@@ -402,7 +402,7 @@ func CertOpenStore(storeProvider uintptr, msgAndCertEncodingType uint32, cryptPr
 }
 
 func CertOpenSystemStore(hprov Handle, name *uint16) (store Handle, err error) {
-	r0, _, e1 := Syscall(procCertOpenSystemStoreW.Addr(), 2, uintptr(hprov), uintptr(unsafe.Pointer(name)), 0)
+	r0, _, e1 := SyscallN(procCertOpenSystemStoreW.Addr(), uintptr(hprov), uintptr(unsafe.Pointer(name)))
 	store = Handle(r0)
 	if store == 0 {
 		err = errnoErr(e1)
@@ -411,7 +411,7 @@ func CertOpenSystemStore(hprov Handle, name *uint16) (store Handle, err error) {
 }
 
 func CertVerifyCertificateChainPolicy(policyOID uintptr, chain *CertChainContext, para *CertChainPolicyPara, status *CertChainPolicyStatus) (err error) {
-	r1, _, e1 := Syscall6(procCertVerifyCertificateChainPolicy.Addr(), 4, uintptr(policyOID), uintptr(unsafe.Pointer(chain)), uintptr(unsafe.Pointer(para)), uintptr(unsafe.Pointer(status)), 0, 0)
+	r1, _, e1 := SyscallN(procCertVerifyCertificateChainPolicy.Addr(), uintptr(policyOID), uintptr(unsafe.Pointer(chain)), uintptr(unsafe.Pointer(para)), uintptr(unsafe.Pointer(status)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -419,7 +419,7 @@ func CertVerifyCertificateChainPolicy(policyOID uintptr, chain *CertChainContext
 }
 
 func DnsNameCompare(name1 *uint16, name2 *uint16) (same bool) {
-	r0, _, _ := Syscall(procDnsNameCompare_W.Addr(), 2, uintptr(unsafe.Pointer(name1)), uintptr(unsafe.Pointer(name2)), 0)
+	r0, _, _ := SyscallN(procDnsNameCompare_W.Addr(), uintptr(unsafe.Pointer(name1)), uintptr(unsafe.Pointer(name2)))
 	same = r0 != 0
 	return
 }
@@ -434,7 +434,7 @@ func DnsQuery(name string, qtype uint16, options uint32, extra *byte, qrs **DNSR
 }
 
 func _DnsQuery(name *uint16, qtype uint16, options uint32, extra *byte, qrs **DNSRecord, pr *byte) (status error) {
-	r0, _, _ := Syscall6(procDnsQuery_W.Addr(), 6, uintptr(unsafe.Pointer(name)), uintptr(qtype), uintptr(options), uintptr(unsafe.Pointer(extra)), uintptr(unsafe.Pointer(qrs)), uintptr(unsafe.Pointer(pr)))
+	r0, _, _ := SyscallN(procDnsQuery_W.Addr(), uintptr(unsafe.Pointer(name)), uintptr(qtype), uintptr(options), uintptr(unsafe.Pointer(extra)), uintptr(unsafe.Pointer(qrs)), uintptr(unsafe.Pointer(pr)))
 	if r0 != 0 {
 		status = Errno(r0)
 	}
@@ -442,12 +442,12 @@ func _DnsQuery(name *uint16, qtype uint16, options uint32, extra *byte, qrs **DN
 }
 
 func DnsRecordListFree(rl *DNSRecord, freetype uint32) {
-	Syscall(procDnsRecordListFree.Addr(), 2, uintptr(unsafe.Pointer(rl)), uintptr(freetype), 0)
+	SyscallN(procDnsRecordListFree.Addr(), uintptr(unsafe.Pointer(rl)), uintptr(freetype))
 	return
 }
 
 func GetAdaptersInfo(ai *IpAdapterInfo, ol *uint32) (errcode error) {
-	r0, _, _ := Syscall(procGetAdaptersInfo.Addr(), 2, uintptr(unsafe.Pointer(ai)), uintptr(unsafe.Pointer(ol)), 0)
+	r0, _, _ := SyscallN(procGetAdaptersInfo.Addr(), uintptr(unsafe.Pointer(ai)), uintptr(unsafe.Pointer(ol)))
 	if r0 != 0 {
 		errcode = Errno(r0)
 	}
@@ -455,7 +455,7 @@ func GetAdaptersInfo(ai *IpAdapterInfo, ol *uint32) (errcode error) {
 }
 
 func GetIfEntry(pIfRow *MibIfRow) (errcode error) {
-	r0, _, _ := Syscall(procGetIfEntry.Addr(), 1, uintptr(unsafe.Pointer(pIfRow)), 0, 0)
+	r0, _, _ := SyscallN(procGetIfEntry.Addr(), uintptr(unsafe.Pointer(pIfRow)))
 	if r0 != 0 {
 		errcode = Errno(r0)
 	}
@@ -463,7 +463,7 @@ func GetIfEntry(pIfRow *MibIfRow) (errcode error) {
 }
 
 func CancelIo(s Handle) (err error) {
-	r1, _, e1 := Syscall(procCancelIo.Addr(), 1, uintptr(s), 0, 0)
+	r1, _, e1 := SyscallN(procCancelIo.Addr(), uintptr(s))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -471,7 +471,7 @@ func CancelIo(s Handle) (err error) {
 }
 
 func CancelIoEx(s Handle, o *Overlapped) (err error) {
-	r1, _, e1 := Syscall(procCancelIoEx.Addr(), 2, uintptr(s), uintptr(unsafe.Pointer(o)), 0)
+	r1, _, e1 := SyscallN(procCancelIoEx.Addr(), uintptr(s), uintptr(unsafe.Pointer(o)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -479,7 +479,7 @@ func CancelIoEx(s Handle, o *Overlapped) (err error) {
 }
 
 func CloseHandle(handle Handle) (err error) {
-	r1, _, e1 := Syscall(procCloseHandle.Addr(), 1, uintptr(handle), 0, 0)
+	r1, _, e1 := SyscallN(procCloseHandle.Addr(), uintptr(handle))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -487,7 +487,7 @@ func CloseHandle(handle Handle) (err error) {
 }
 
 func CreateDirectory(path *uint16, sa *SecurityAttributes) (err error) {
-	r1, _, e1 := Syscall(procCreateDirectoryW.Addr(), 2, uintptr(unsafe.Pointer(path)), uintptr(unsafe.Pointer(sa)), 0)
+	r1, _, e1 := SyscallN(procCreateDirectoryW.Addr(), uintptr(unsafe.Pointer(path)), uintptr(unsafe.Pointer(sa)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -495,7 +495,7 @@ func CreateDirectory(path *uint16, sa *SecurityAttributes) (err error) {
 }
 
 func CreateFileMapping(fhandle Handle, sa *SecurityAttributes, prot uint32, maxSizeHigh uint32, maxSizeLow uint32, name *uint16) (handle Handle, err error) {
-	r0, _, e1 := Syscall6(procCreateFileMappingW.Addr(), 6, uintptr(fhandle), uintptr(unsafe.Pointer(sa)), uintptr(prot), uintptr(maxSizeHigh), uintptr(maxSizeLow), uintptr(unsafe.Pointer(name)))
+	r0, _, e1 := SyscallN(procCreateFileMappingW.Addr(), uintptr(fhandle), uintptr(unsafe.Pointer(sa)), uintptr(prot), uintptr(maxSizeHigh), uintptr(maxSizeLow), uintptr(unsafe.Pointer(name)))
 	handle = Handle(r0)
 	if handle == 0 {
 		err = errnoErr(e1)
@@ -504,7 +504,7 @@ func CreateFileMapping(fhandle Handle, sa *SecurityAttributes, prot uint32, maxS
 }
 
 func CreateFile(name *uint16, access uint32, mode uint32, sa *SecurityAttributes, createmode uint32, attrs uint32, templatefile int32) (handle Handle, err error) {
-	r0, _, e1 := Syscall9(procCreateFileW.Addr(), 7, uintptr(unsafe.Pointer(name)), uintptr(access), uintptr(mode), uintptr(unsafe.Pointer(sa)), uintptr(createmode), uintptr(attrs), uintptr(templatefile), 0, 0)
+	r0, _, e1 := SyscallN(procCreateFileW.Addr(), uintptr(unsafe.Pointer(name)), uintptr(access), uintptr(mode), uintptr(unsafe.Pointer(sa)), uintptr(createmode), uintptr(attrs), uintptr(templatefile))
 	handle = Handle(r0)
 	if handle == InvalidHandle {
 		err = errnoErr(e1)
@@ -513,7 +513,7 @@ func CreateFile(name *uint16, access uint32, mode uint32, sa *SecurityAttributes
 }
 
 func CreateHardLink(filename *uint16, existingfilename *uint16, reserved uintptr) (err error) {
-	r1, _, e1 := Syscall(procCreateHardLinkW.Addr(), 3, uintptr(unsafe.Pointer(filename)), uintptr(unsafe.Pointer(existingfilename)), uintptr(reserved))
+	r1, _, e1 := SyscallN(procCreateHardLinkW.Addr(), uintptr(unsafe.Pointer(filename)), uintptr(unsafe.Pointer(existingfilename)), uintptr(reserved))
 	if r1&0xff == 0 {
 		err = errnoErr(e1)
 	}
@@ -521,7 +521,7 @@ func CreateHardLink(filename *uint16, existingfilename *uint16, reserved uintptr
 }
 
 func createIoCompletionPort(filehandle Handle, cphandle Handle, key uintptr, threadcnt uint32) (handle Handle, err error) {
-	r0, _, e1 := Syscall6(procCreateIoCompletionPort.Addr(), 4, uintptr(filehandle), uintptr(cphandle), uintptr(key), uintptr(threadcnt), 0, 0)
+	r0, _, e1 := SyscallN(procCreateIoCompletionPort.Addr(), uintptr(filehandle), uintptr(cphandle), uintptr(key), uintptr(threadcnt))
 	handle = Handle(r0)
 	if handle == 0 {
 		err = errnoErr(e1)
@@ -530,7 +530,7 @@ func createIoCompletionPort(filehandle Handle, cphandle Handle, key uintptr, thr
 }
 
 func CreatePipe(readhandle *Handle, writehandle *Handle, sa *SecurityAttributes, size uint32) (err error) {
-	r1, _, e1 := Syscall6(procCreatePipe.Addr(), 4, uintptr(unsafe.Pointer(readhandle)), uintptr(unsafe.Pointer(writehandle)), uintptr(unsafe.Pointer(sa)), uintptr(size), 0, 0)
+	r1, _, e1 := SyscallN(procCreatePipe.Addr(), uintptr(unsafe.Pointer(readhandle)), uintptr(unsafe.Pointer(writehandle)), uintptr(unsafe.Pointer(sa)), uintptr(size))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -542,7 +542,7 @@ func CreateProcess(appName *uint16, commandLine *uint16, procSecurity *SecurityA
 	if inheritHandles {
 		_p0 = 1
 	}
-	r1, _, e1 := Syscall12(procCreateProcessW.Addr(), 10, uintptr(unsafe.Pointer(appName)), uintptr(unsafe.Pointer(commandLine)), uintptr(unsafe.Pointer(procSecurity)), uintptr(unsafe.Pointer(threadSecurity)), uintptr(_p0), uintptr(creationFlags), uintptr(unsafe.Pointer(env)), uintptr(unsafe.Pointer(currentDir)), uintptr(unsafe.Pointer(startupInfo)), uintptr(unsafe.Pointer(outProcInfo)), 0, 0)
+	r1, _, e1 := SyscallN(procCreateProcessW.Addr(), uintptr(unsafe.Pointer(appName)), uintptr(unsafe.Pointer(commandLine)), uintptr(unsafe.Pointer(procSecurity)), uintptr(unsafe.Pointer(threadSecurity)), uintptr(_p0), uintptr(creationFlags), uintptr(unsafe.Pointer(env)), uintptr(unsafe.Pointer(currentDir)), uintptr(unsafe.Pointer(startupInfo)), uintptr(unsafe.Pointer(outProcInfo)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -550,7 +550,7 @@ func CreateProcess(appName *uint16, commandLine *uint16, procSecurity *SecurityA
 }
 
 func CreateSymbolicLink(symlinkfilename *uint16, targetfilename *uint16, flags uint32) (err error) {
-	r1, _, e1 := Syscall(procCreateSymbolicLinkW.Addr(), 3, uintptr(unsafe.Pointer(symlinkfilename)), uintptr(unsafe.Pointer(targetfilename)), uintptr(flags))
+	r1, _, e1 := SyscallN(procCreateSymbolicLinkW.Addr(), uintptr(unsafe.Pointer(symlinkfilename)), uintptr(unsafe.Pointer(targetfilename)), uintptr(flags))
 	if r1&0xff == 0 {
 		err = errnoErr(e1)
 	}
@@ -558,7 +558,7 @@ func CreateSymbolicLink(symlinkfilename *uint16, targetfilename *uint16, flags u
 }
 
 func CreateToolhelp32Snapshot(flags uint32, processId uint32) (handle Handle, err error) {
-	r0, _, e1 := Syscall(procCreateToolhelp32Snapshot.Addr(), 2, uintptr(flags), uintptr(processId), 0)
+	r0, _, e1 := SyscallN(procCreateToolhelp32Snapshot.Addr(), uintptr(flags), uintptr(processId))
 	handle = Handle(r0)
 	if handle == InvalidHandle {
 		err = errnoErr(e1)
@@ -567,7 +567,7 @@ func CreateToolhelp32Snapshot(flags uint32, processId uint32) (handle Handle, er
 }
 
 func DeleteFile(path *uint16) (err error) {
-	r1, _, e1 := Syscall(procDeleteFileW.Addr(), 1, uintptr(unsafe.Pointer(path)), 0, 0)
+	r1, _, e1 := SyscallN(procDeleteFileW.Addr(), uintptr(unsafe.Pointer(path)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -575,12 +575,12 @@ func DeleteFile(path *uint16) (err error) {
 }
 
 func deleteProcThreadAttributeList(attrlist *_PROC_THREAD_ATTRIBUTE_LIST) {
-	Syscall(procDeleteProcThreadAttributeList.Addr(), 1, uintptr(unsafe.Pointer(attrlist)), 0, 0)
+	SyscallN(procDeleteProcThreadAttributeList.Addr(), uintptr(unsafe.Pointer(attrlist)))
 	return
 }
 
 func DeviceIoControl(handle Handle, ioControlCode uint32, inBuffer *byte, inBufferSize uint32, outBuffer *byte, outBufferSize uint32, bytesReturned *uint32, overlapped *Overlapped) (err error) {
-	r1, _, e1 := Syscall9(procDeviceIoControl.Addr(), 8, uintptr(handle), uintptr(ioControlCode), uintptr(unsafe.Pointer(inBuffer)), uintptr(inBufferSize), uintptr(unsafe.Pointer(outBuffer)), uintptr(outBufferSize), uintptr(unsafe.Pointer(bytesReturned)), uintptr(unsafe.Pointer(overlapped)), 0)
+	r1, _, e1 := SyscallN(procDeviceIoControl.Addr(), uintptr(handle), uintptr(ioControlCode), uintptr(unsafe.Pointer(inBuffer)), uintptr(inBufferSize), uintptr(unsafe.Pointer(outBuffer)), uintptr(outBufferSize), uintptr(unsafe.Pointer(bytesReturned)), uintptr(unsafe.Pointer(overlapped)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -592,7 +592,7 @@ func DuplicateHandle(hSourceProcessHandle Handle, hSourceHandle Handle, hTargetP
 	if bInheritHandle {
 		_p0 = 1
 	}
-	r1, _, e1 := Syscall9(procDuplicateHandle.Addr(), 7, uintptr(hSourceProcessHandle), uintptr(hSourceHandle), uintptr(hTargetProcessHandle), uintptr(unsafe.Pointer(lpTargetHandle)), uintptr(dwDesiredAccess), uintptr(_p0), uintptr(dwOptions), 0, 0)
+	r1, _, e1 := SyscallN(procDuplicateHandle.Addr(), uintptr(hSourceProcessHandle), uintptr(hSourceHandle), uintptr(hTargetProcessHandle), uintptr(unsafe.Pointer(lpTargetHandle)), uintptr(dwDesiredAccess), uintptr(_p0), uintptr(dwOptions))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -600,12 +600,12 @@ func DuplicateHandle(hSourceProcessHandle Handle, hSourceHandle Handle, hTargetP
 }
 
 func ExitProcess(exitcode uint32) {
-	Syscall(procExitProcess.Addr(), 1, uintptr(exitcode), 0, 0)
+	SyscallN(procExitProcess.Addr(), uintptr(exitcode))
 	return
 }
 
 func FindClose(handle Handle) (err error) {
-	r1, _, e1 := Syscall(procFindClose.Addr(), 1, uintptr(handle), 0, 0)
+	r1, _, e1 := SyscallN(procFindClose.Addr(), uintptr(handle))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -613,7 +613,7 @@ func FindClose(handle Handle) (err error) {
 }
 
 func findFirstFile1(name *uint16, data *win32finddata1) (handle Handle, err error) {
-	r0, _, e1 := Syscall(procFindFirstFileW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(data)), 0)
+	r0, _, e1 := SyscallN(procFindFirstFileW.Addr(), uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(data)))
 	handle = Handle(r0)
 	if handle == InvalidHandle {
 		err = errnoErr(e1)
@@ -622,7 +622,7 @@ func findFirstFile1(name *uint16, data *win32finddata1) (handle Handle, err erro
 }
 
 func findNextFile1(handle Handle, data *win32finddata1) (err error) {
-	r1, _, e1 := Syscall(procFindNextFileW.Addr(), 2, uintptr(handle), uintptr(unsafe.Pointer(data)), 0)
+	r1, _, e1 := SyscallN(procFindNextFileW.Addr(), uintptr(handle), uintptr(unsafe.Pointer(data)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -630,7 +630,7 @@ func findNextFile1(handle Handle, data *win32finddata1) (err error) {
 }
 
 func FlushFileBuffers(handle Handle) (err error) {
-	r1, _, e1 := Syscall(procFlushFileBuffers.Addr(), 1, uintptr(handle), 0, 0)
+	r1, _, e1 := SyscallN(procFlushFileBuffers.Addr(), uintptr(handle))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -638,7 +638,7 @@ func FlushFileBuffers(handle Handle) (err error) {
 }
 
 func FlushViewOfFile(addr uintptr, length uintptr) (err error) {
-	r1, _, e1 := Syscall(procFlushViewOfFile.Addr(), 2, uintptr(addr), uintptr(length), 0)
+	r1, _, e1 := SyscallN(procFlushViewOfFile.Addr(), uintptr(addr), uintptr(length))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -650,7 +650,7 @@ func formatMessage(flags uint32, msgsrc uintptr, msgid uint32, langid uint32, bu
 	if len(buf) > 0 {
 		_p0 = &buf[0]
 	}
-	r0, _, e1 := Syscall9(procFormatMessageW.Addr(), 7, uintptr(flags), uintptr(msgsrc), uintptr(msgid), uintptr(langid), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(unsafe.Pointer(args)), 0, 0)
+	r0, _, e1 := SyscallN(procFormatMessageW.Addr(), uintptr(flags), uintptr(msgsrc), uintptr(msgid), uintptr(langid), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(unsafe.Pointer(args)))
 	n = uint32(r0)
 	if n == 0 {
 		err = errnoErr(e1)
@@ -659,7 +659,7 @@ func formatMessage(flags uint32, msgsrc uintptr, msgid uint32, langid uint32, bu
 }
 
 func FreeEnvironmentStrings(envs *uint16) (err error) {
-	r1, _, e1 := Syscall(procFreeEnvironmentStringsW.Addr(), 1, uintptr(unsafe.Pointer(envs)), 0, 0)
+	r1, _, e1 := SyscallN(procFreeEnvironmentStringsW.Addr(), uintptr(unsafe.Pointer(envs)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -667,7 +667,7 @@ func FreeEnvironmentStrings(envs *uint16) (err error) {
 }
 
 func FreeLibrary(handle Handle) (err error) {
-	r1, _, e1 := Syscall(procFreeLibrary.Addr(), 1, uintptr(handle), 0, 0)
+	r1, _, e1 := SyscallN(procFreeLibrary.Addr(), uintptr(handle))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -675,13 +675,13 @@ func FreeLibrary(handle Handle) (err error) {
 }
 
 func GetCommandLine() (cmd *uint16) {
-	r0, _, _ := Syscall(procGetCommandLineW.Addr(), 0, 0, 0, 0)
+	r0, _, _ := SyscallN(procGetCommandLineW.Addr(), 0)
 	cmd = (*uint16)(unsafe.Pointer(r0))
 	return
 }
 
 func GetComputerName(buf *uint16, n *uint32) (err error) {
-	r1, _, e1 := Syscall(procGetComputerNameW.Addr(), 2, uintptr(unsafe.Pointer(buf)), uintptr(unsafe.Pointer(n)), 0)
+	r1, _, e1 := SyscallN(procGetComputerNameW.Addr(), uintptr(unsafe.Pointer(buf)), uintptr(unsafe.Pointer(n)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -689,7 +689,7 @@ func GetComputerName(buf *uint16, n *uint32) (err error) {
 }
 
 func GetConsoleMode(console Handle, mode *uint32) (err error) {
-	r1, _, e1 := Syscall(procGetConsoleMode.Addr(), 2, uintptr(console), uintptr(unsafe.Pointer(mode)), 0)
+	r1, _, e1 := SyscallN(procGetConsoleMode.Addr(), uintptr(console), uintptr(unsafe.Pointer(mode)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -697,7 +697,7 @@ func GetConsoleMode(console Handle, mode *uint32) (err error) {
 }
 
 func GetCurrentDirectory(buflen uint32, buf *uint16) (n uint32, err error) {
-	r0, _, e1 := Syscall(procGetCurrentDirectoryW.Addr(), 2, uintptr(buflen), uintptr(unsafe.Pointer(buf)), 0)
+	r0, _, e1 := SyscallN(procGetCurrentDirectoryW.Addr(), uintptr(buflen), uintptr(unsafe.Pointer(buf)))
 	n = uint32(r0)
 	if n == 0 {
 		err = errnoErr(e1)
@@ -706,7 +706,7 @@ func GetCurrentDirectory(buflen uint32, buf *uint16) (n uint32, err error) {
 }
 
 func GetCurrentProcess() (pseudoHandle Handle, err error) {
-	r0, _, e1 := Syscall(procGetCurrentProcess.Addr(), 0, 0, 0, 0)
+	r0, _, e1 := SyscallN(procGetCurrentProcess.Addr(), 0)
 	pseudoHandle = Handle(r0)
 	if pseudoHandle == 0 {
 		err = errnoErr(e1)
@@ -715,13 +715,13 @@ func GetCurrentProcess() (pseudoHandle Handle, err error) {
 }
 
 func getCurrentProcessId() (pid uint32) {
-	r0, _, _ := Syscall(procGetCurrentProcessId.Addr(), 0, 0, 0, 0)
+	r0, _, _ := SyscallN(procGetCurrentProcessId.Addr(), 0)
 	pid = uint32(r0)
 	return
 }
 
 func GetEnvironmentStrings() (envs *uint16, err error) {
-	r0, _, e1 := Syscall(procGetEnvironmentStringsW.Addr(), 0, 0, 0, 0)
+	r0, _, e1 := SyscallN(procGetEnvironmentStringsW.Addr(), 0)
 	envs = (*uint16)(unsafe.Pointer(r0))
 	if envs == nil {
 		err = errnoErr(e1)
@@ -730,7 +730,7 @@ func GetEnvironmentStrings() (envs *uint16, err error) {
 }
 
 func GetEnvironmentVariable(name *uint16, buffer *uint16, size uint32) (n uint32, err error) {
-	r0, _, e1 := Syscall(procGetEnvironmentVariableW.Addr(), 3, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(buffer)), uintptr(size))
+	r0, _, e1 := SyscallN(procGetEnvironmentVariableW.Addr(), uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(buffer)), uintptr(size))
 	n = uint32(r0)
 	if n == 0 {
 		err = errnoErr(e1)
@@ -739,7 +739,7 @@ func GetEnvironmentVariable(name *uint16, buffer *uint16, size uint32) (n uint32
 }
 
 func GetExitCodeProcess(handle Handle, exitcode *uint32) (err error) {
-	r1, _, e1 := Syscall(procGetExitCodeProcess.Addr(), 2, uintptr(handle), uintptr(unsafe.Pointer(exitcode)), 0)
+	r1, _, e1 := SyscallN(procGetExitCodeProcess.Addr(), uintptr(handle), uintptr(unsafe.Pointer(exitcode)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -747,7 +747,7 @@ func GetExitCodeProcess(handle Handle, exitcode *uint32) (err error) {
 }
 
 func GetFileAttributesEx(name *uint16, level uint32, info *byte) (err error) {
-	r1, _, e1 := Syscall(procGetFileAttributesExW.Addr(), 3, uintptr(unsafe.Pointer(name)), uintptr(level), uintptr(unsafe.Pointer(info)))
+	r1, _, e1 := SyscallN(procGetFileAttributesExW.Addr(), uintptr(unsafe.Pointer(name)), uintptr(level), uintptr(unsafe.Pointer(info)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -755,7 +755,7 @@ func GetFileAttributesEx(name *uint16, level uint32, info *byte) (err error) {
 }
 
 func GetFileAttributes(name *uint16) (attrs uint32, err error) {
-	r0, _, e1 := Syscall(procGetFileAttributesW.Addr(), 1, uintptr(unsafe.Pointer(name)), 0, 0)
+	r0, _, e1 := SyscallN(procGetFileAttributesW.Addr(), uintptr(unsafe.Pointer(name)))
 	attrs = uint32(r0)
 	if attrs == INVALID_FILE_ATTRIBUTES {
 		err = errnoErr(e1)
@@ -764,7 +764,7 @@ func GetFileAttributes(name *uint16) (attrs uint32, err error) {
 }
 
 func GetFileInformationByHandle(handle Handle, data *ByHandleFileInformation) (err error) {
-	r1, _, e1 := Syscall(procGetFileInformationByHandle.Addr(), 2, uintptr(handle), uintptr(unsafe.Pointer(data)), 0)
+	r1, _, e1 := SyscallN(procGetFileInformationByHandle.Addr(), uintptr(handle), uintptr(unsafe.Pointer(data)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -772,7 +772,7 @@ func GetFileInformationByHandle(handle Handle, data *ByHandleFileInformation) (e
 }
 
 func GetFileType(filehandle Handle) (n uint32, err error) {
-	r0, _, e1 := Syscall(procGetFileType.Addr(), 1, uintptr(filehandle), 0, 0)
+	r0, _, e1 := SyscallN(procGetFileType.Addr(), uintptr(filehandle))
 	n = uint32(r0)
 	if n == 0 {
 		err = errnoErr(e1)
@@ -781,7 +781,7 @@ func GetFileType(filehandle Handle) (n uint32, err error) {
 }
 
 func getFinalPathNameByHandle(file Handle, filePath *uint16, filePathSize uint32, flags uint32) (n uint32, err error) {
-	r0, _, e1 := Syscall6(procGetFinalPathNameByHandleW.Addr(), 4, uintptr(file), uintptr(unsafe.Pointer(filePath)), uintptr(filePathSize), uintptr(flags), 0, 0)
+	r0, _, e1 := SyscallN(procGetFinalPathNameByHandleW.Addr(), uintptr(file), uintptr(unsafe.Pointer(filePath)), uintptr(filePathSize), uintptr(flags))
 	n = uint32(r0)
 	if n == 0 || n >= filePathSize {
 		err = errnoErr(e1)
@@ -790,7 +790,7 @@ func getFinalPathNameByHandle(file Handle, filePath *uint16, filePathSize uint32
 }
 
 func GetFullPathName(path *uint16, buflen uint32, buf *uint16, fname **uint16) (n uint32, err error) {
-	r0, _, e1 := Syscall6(procGetFullPathNameW.Addr(), 4, uintptr(unsafe.Pointer(path)), uintptr(buflen), uintptr(unsafe.Pointer(buf)), uintptr(unsafe.Pointer(fname)), 0, 0)
+	r0, _, e1 := SyscallN(procGetFullPathNameW.Addr(), uintptr(unsafe.Pointer(path)), uintptr(buflen), uintptr(unsafe.Pointer(buf)), uintptr(unsafe.Pointer(fname)))
 	n = uint32(r0)
 	if n == 0 {
 		err = errnoErr(e1)
@@ -799,7 +799,7 @@ func GetFullPathName(path *uint16, buflen uint32, buf *uint16, fname **uint16) (
 }
 
 func GetLastError() (lasterr error) {
-	r0, _, _ := Syscall(procGetLastError.Addr(), 0, 0, 0, 0)
+	r0, _, _ := SyscallN(procGetLastError.Addr(), 0)
 	if r0 != 0 {
 		lasterr = Errno(r0)
 	}
@@ -807,7 +807,7 @@ func GetLastError() (lasterr error) {
 }
 
 func GetLongPathName(path *uint16, buf *uint16, buflen uint32) (n uint32, err error) {
-	r0, _, e1 := Syscall(procGetLongPathNameW.Addr(), 3, uintptr(unsafe.Pointer(path)), uintptr(unsafe.Pointer(buf)), uintptr(buflen))
+	r0, _, e1 := SyscallN(procGetLongPathNameW.Addr(), uintptr(unsafe.Pointer(path)), uintptr(unsafe.Pointer(buf)), uintptr(buflen))
 	n = uint32(r0)
 	if n == 0 {
 		err = errnoErr(e1)
@@ -825,7 +825,7 @@ func GetProcAddress(module Handle, procname string) (proc uintptr, err error) {
 }
 
 func _GetProcAddress(module Handle, procname *byte) (proc uintptr, err error) {
-	r0, _, e1 := Syscall(procGetProcAddress.Addr(), 2, uintptr(module), uintptr(unsafe.Pointer(procname)), 0)
+	r0, _, e1 := SyscallN(procGetProcAddress.Addr(), uintptr(module), uintptr(unsafe.Pointer(procname)))
 	proc = uintptr(r0)
 	if proc == 0 {
 		err = errnoErr(e1)
@@ -834,7 +834,7 @@ func _GetProcAddress(module Handle, procname *byte) (proc uintptr, err error) {
 }
 
 func GetProcessTimes(handle Handle, creationTime *Filetime, exitTime *Filetime, kernelTime *Filetime, userTime *Filetime) (err error) {
-	r1, _, e1 := Syscall6(procGetProcessTimes.Addr(), 5, uintptr(handle), uintptr(unsafe.Pointer(creationTime)), uintptr(unsafe.Pointer(exitTime)), uintptr(unsafe.Pointer(kernelTime)), uintptr(unsafe.Pointer(userTime)), 0)
+	r1, _, e1 := SyscallN(procGetProcessTimes.Addr(), uintptr(handle), uintptr(unsafe.Pointer(creationTime)), uintptr(unsafe.Pointer(exitTime)), uintptr(unsafe.Pointer(kernelTime)), uintptr(unsafe.Pointer(userTime)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -842,7 +842,7 @@ func GetProcessTimes(handle Handle, creationTime *Filetime, exitTime *Filetime, 
 }
 
 func getQueuedCompletionStatus(cphandle Handle, qty *uint32, key *uintptr, overlapped **Overlapped, timeout uint32) (err error) {
-	r1, _, e1 := Syscall6(procGetQueuedCompletionStatus.Addr(), 5, uintptr(cphandle), uintptr(unsafe.Pointer(qty)), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(overlapped)), uintptr(timeout), 0)
+	r1, _, e1 := SyscallN(procGetQueuedCompletionStatus.Addr(), uintptr(cphandle), uintptr(unsafe.Pointer(qty)), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(overlapped)), uintptr(timeout))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -850,7 +850,7 @@ func getQueuedCompletionStatus(cphandle Handle, qty *uint32, key *uintptr, overl
 }
 
 func GetShortPathName(longpath *uint16, shortpath *uint16, buflen uint32) (n uint32, err error) {
-	r0, _, e1 := Syscall(procGetShortPathNameW.Addr(), 3, uintptr(unsafe.Pointer(longpath)), uintptr(unsafe.Pointer(shortpath)), uintptr(buflen))
+	r0, _, e1 := SyscallN(procGetShortPathNameW.Addr(), uintptr(unsafe.Pointer(longpath)), uintptr(unsafe.Pointer(shortpath)), uintptr(buflen))
 	n = uint32(r0)
 	if n == 0 {
 		err = errnoErr(e1)
@@ -859,7 +859,7 @@ func GetShortPathName(longpath *uint16, shortpath *uint16, buflen uint32) (n uin
 }
 
 func GetStartupInfo(startupInfo *StartupInfo) (err error) {
-	r1, _, e1 := Syscall(procGetStartupInfoW.Addr(), 1, uintptr(unsafe.Pointer(startupInfo)), 0, 0)
+	r1, _, e1 := SyscallN(procGetStartupInfoW.Addr(), uintptr(unsafe.Pointer(startupInfo)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -867,7 +867,7 @@ func GetStartupInfo(startupInfo *StartupInfo) (err error) {
 }
 
 func GetStdHandle(stdhandle int) (handle Handle, err error) {
-	r0, _, e1 := Syscall(procGetStdHandle.Addr(), 1, uintptr(stdhandle), 0, 0)
+	r0, _, e1 := SyscallN(procGetStdHandle.Addr(), uintptr(stdhandle))
 	handle = Handle(r0)
 	if handle == InvalidHandle {
 		err = errnoErr(e1)
@@ -876,12 +876,12 @@ func GetStdHandle(stdhandle int) (handle Handle, err error) {
 }
 
 func GetSystemTimeAsFileTime(time *Filetime) {
-	Syscall(procGetSystemTimeAsFileTime.Addr(), 1, uintptr(unsafe.Pointer(time)), 0, 0)
+	SyscallN(procGetSystemTimeAsFileTime.Addr(), uintptr(unsafe.Pointer(time)))
 	return
 }
 
 func GetTempPath(buflen uint32, buf *uint16) (n uint32, err error) {
-	r0, _, e1 := Syscall(procGetTempPathW.Addr(), 2, uintptr(buflen), uintptr(unsafe.Pointer(buf)), 0)
+	r0, _, e1 := SyscallN(procGetTempPathW.Addr(), uintptr(buflen), uintptr(unsafe.Pointer(buf)))
 	n = uint32(r0)
 	if n == 0 {
 		err = errnoErr(e1)
@@ -890,7 +890,7 @@ func GetTempPath(buflen uint32, buf *uint16) (n uint32, err error) {
 }
 
 func GetTimeZoneInformation(tzi *Timezoneinformation) (rc uint32, err error) {
-	r0, _, e1 := Syscall(procGetTimeZoneInformation.Addr(), 1, uintptr(unsafe.Pointer(tzi)), 0, 0)
+	r0, _, e1 := SyscallN(procGetTimeZoneInformation.Addr(), uintptr(unsafe.Pointer(tzi)))
 	rc = uint32(r0)
 	if rc == 0xffffffff {
 		err = errnoErr(e1)
@@ -899,7 +899,7 @@ func GetTimeZoneInformation(tzi *Timezoneinformation) (rc uint32, err error) {
 }
 
 func GetVersion() (ver uint32, err error) {
-	r0, _, e1 := Syscall(procGetVersion.Addr(), 0, 0, 0, 0)
+	r0, _, e1 := SyscallN(procGetVersion.Addr(), 0)
 	ver = uint32(r0)
 	if ver == 0 {
 		err = errnoErr(e1)
@@ -908,7 +908,7 @@ func GetVersion() (ver uint32, err error) {
 }
 
 func initializeProcThreadAttributeList(attrlist *_PROC_THREAD_ATTRIBUTE_LIST, attrcount uint32, flags uint32, size *uintptr) (err error) {
-	r1, _, e1 := Syscall6(procInitializeProcThreadAttributeList.Addr(), 4, uintptr(unsafe.Pointer(attrlist)), uintptr(attrcount), uintptr(flags), uintptr(unsafe.Pointer(size)), 0, 0)
+	r1, _, e1 := SyscallN(procInitializeProcThreadAttributeList.Addr(), uintptr(unsafe.Pointer(attrlist)), uintptr(attrcount), uintptr(flags), uintptr(unsafe.Pointer(size)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -925,7 +925,7 @@ func LoadLibrary(libname string) (handle Handle, err error) {
 }
 
 func _LoadLibrary(libname *uint16) (handle Handle, err error) {
-	r0, _, e1 := Syscall(procLoadLibraryW.Addr(), 1, uintptr(unsafe.Pointer(libname)), 0, 0)
+	r0, _, e1 := SyscallN(procLoadLibraryW.Addr(), uintptr(unsafe.Pointer(libname)))
 	handle = Handle(r0)
 	if handle == 0 {
 		err = errnoErr(e1)
@@ -934,7 +934,7 @@ func _LoadLibrary(libname *uint16) (handle Handle, err error) {
 }
 
 func LocalFree(hmem Handle) (handle Handle, err error) {
-	r0, _, e1 := Syscall(procLocalFree.Addr(), 1, uintptr(hmem), 0, 0)
+	r0, _, e1 := SyscallN(procLocalFree.Addr(), uintptr(hmem))
 	handle = Handle(r0)
 	if handle != 0 {
 		err = errnoErr(e1)
@@ -943,7 +943,7 @@ func LocalFree(hmem Handle) (handle Handle, err error) {
 }
 
 func MapViewOfFile(handle Handle, access uint32, offsetHigh uint32, offsetLow uint32, length uintptr) (addr uintptr, err error) {
-	r0, _, e1 := Syscall6(procMapViewOfFile.Addr(), 5, uintptr(handle), uintptr(access), uintptr(offsetHigh), uintptr(offsetLow), uintptr(length), 0)
+	r0, _, e1 := SyscallN(procMapViewOfFile.Addr(), uintptr(handle), uintptr(access), uintptr(offsetHigh), uintptr(offsetLow), uintptr(length))
 	addr = uintptr(r0)
 	if addr == 0 {
 		err = errnoErr(e1)
@@ -952,7 +952,7 @@ func MapViewOfFile(handle Handle, access uint32, offsetHigh uint32, offsetLow ui
 }
 
 func MoveFile(from *uint16, to *uint16) (err error) {
-	r1, _, e1 := Syscall(procMoveFileW.Addr(), 2, uintptr(unsafe.Pointer(from)), uintptr(unsafe.Pointer(to)), 0)
+	r1, _, e1 := SyscallN(procMoveFileW.Addr(), uintptr(unsafe.Pointer(from)), uintptr(unsafe.Pointer(to)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -964,7 +964,7 @@ func OpenProcess(da uint32, inheritHandle bool, pid uint32) (handle Handle, err 
 	if inheritHandle {
 		_p0 = 1
 	}
-	r0, _, e1 := Syscall(procOpenProcess.Addr(), 3, uintptr(da), uintptr(_p0), uintptr(pid))
+	r0, _, e1 := SyscallN(procOpenProcess.Addr(), uintptr(da), uintptr(_p0), uintptr(pid))
 	handle = Handle(r0)
 	if handle == 0 {
 		err = errnoErr(e1)
@@ -973,7 +973,7 @@ func OpenProcess(da uint32, inheritHandle bool, pid uint32) (handle Handle, err 
 }
 
 func postQueuedCompletionStatus(cphandle Handle, qty uint32, key uintptr, overlapped *Overlapped) (err error) {
-	r1, _, e1 := Syscall6(procPostQueuedCompletionStatus.Addr(), 4, uintptr(cphandle), uintptr(qty), uintptr(key), uintptr(unsafe.Pointer(overlapped)), 0, 0)
+	r1, _, e1 := SyscallN(procPostQueuedCompletionStatus.Addr(), uintptr(cphandle), uintptr(qty), uintptr(key), uintptr(unsafe.Pointer(overlapped)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -981,7 +981,7 @@ func postQueuedCompletionStatus(cphandle Handle, qty uint32, key uintptr, overla
 }
 
 func Process32First(snapshot Handle, procEntry *ProcessEntry32) (err error) {
-	r1, _, e1 := Syscall(procProcess32FirstW.Addr(), 2, uintptr(snapshot), uintptr(unsafe.Pointer(procEntry)), 0)
+	r1, _, e1 := SyscallN(procProcess32FirstW.Addr(), uintptr(snapshot), uintptr(unsafe.Pointer(procEntry)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -989,7 +989,7 @@ func Process32First(snapshot Handle, procEntry *ProcessEntry32) (err error) {
 }
 
 func Process32Next(snapshot Handle, procEntry *ProcessEntry32) (err error) {
-	r1, _, e1 := Syscall(procProcess32NextW.Addr(), 2, uintptr(snapshot), uintptr(unsafe.Pointer(procEntry)), 0)
+	r1, _, e1 := SyscallN(procProcess32NextW.Addr(), uintptr(snapshot), uintptr(unsafe.Pointer(procEntry)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -997,7 +997,7 @@ func Process32Next(snapshot Handle, procEntry *ProcessEntry32) (err error) {
 }
 
 func ReadConsole(console Handle, buf *uint16, toread uint32, read *uint32, inputControl *byte) (err error) {
-	r1, _, e1 := Syscall6(procReadConsoleW.Addr(), 5, uintptr(console), uintptr(unsafe.Pointer(buf)), uintptr(toread), uintptr(unsafe.Pointer(read)), uintptr(unsafe.Pointer(inputControl)), 0)
+	r1, _, e1 := SyscallN(procReadConsoleW.Addr(), uintptr(console), uintptr(unsafe.Pointer(buf)), uintptr(toread), uintptr(unsafe.Pointer(read)), uintptr(unsafe.Pointer(inputControl)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1009,7 +1009,7 @@ func ReadDirectoryChanges(handle Handle, buf *byte, buflen uint32, watchSubTree 
 	if watchSubTree {
 		_p0 = 1
 	}
-	r1, _, e1 := Syscall9(procReadDirectoryChangesW.Addr(), 8, uintptr(handle), uintptr(unsafe.Pointer(buf)), uintptr(buflen), uintptr(_p0), uintptr(mask), uintptr(unsafe.Pointer(retlen)), uintptr(unsafe.Pointer(overlapped)), uintptr(completionRoutine), 0)
+	r1, _, e1 := SyscallN(procReadDirectoryChangesW.Addr(), uintptr(handle), uintptr(unsafe.Pointer(buf)), uintptr(buflen), uintptr(_p0), uintptr(mask), uintptr(unsafe.Pointer(retlen)), uintptr(unsafe.Pointer(overlapped)), uintptr(completionRoutine))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1021,7 +1021,7 @@ func readFile(handle Handle, buf []byte, done *uint32, overlapped *Overlapped) (
 	if len(buf) > 0 {
 		_p0 = &buf[0]
 	}
-	r1, _, e1 := Syscall6(procReadFile.Addr(), 5, uintptr(handle), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(unsafe.Pointer(done)), uintptr(unsafe.Pointer(overlapped)), 0)
+	r1, _, e1 := SyscallN(procReadFile.Addr(), uintptr(handle), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(unsafe.Pointer(done)), uintptr(unsafe.Pointer(overlapped)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1029,7 +1029,7 @@ func readFile(handle Handle, buf []byte, done *uint32, overlapped *Overlapped) (
 }
 
 func RemoveDirectory(path *uint16) (err error) {
-	r1, _, e1 := Syscall(procRemoveDirectoryW.Addr(), 1, uintptr(unsafe.Pointer(path)), 0, 0)
+	r1, _, e1 := SyscallN(procRemoveDirectoryW.Addr(), uintptr(unsafe.Pointer(path)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1037,7 +1037,7 @@ func RemoveDirectory(path *uint16) (err error) {
 }
 
 func SetCurrentDirectory(path *uint16) (err error) {
-	r1, _, e1 := Syscall(procSetCurrentDirectoryW.Addr(), 1, uintptr(unsafe.Pointer(path)), 0, 0)
+	r1, _, e1 := SyscallN(procSetCurrentDirectoryW.Addr(), uintptr(unsafe.Pointer(path)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1045,7 +1045,7 @@ func SetCurrentDirectory(path *uint16) (err error) {
 }
 
 func SetEndOfFile(handle Handle) (err error) {
-	r1, _, e1 := Syscall(procSetEndOfFile.Addr(), 1, uintptr(handle), 0, 0)
+	r1, _, e1 := SyscallN(procSetEndOfFile.Addr(), uintptr(handle))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1053,7 +1053,7 @@ func SetEndOfFile(handle Handle) (err error) {
 }
 
 func SetEnvironmentVariable(name *uint16, value *uint16) (err error) {
-	r1, _, e1 := Syscall(procSetEnvironmentVariableW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)), 0)
+	r1, _, e1 := SyscallN(procSetEnvironmentVariableW.Addr(), uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1061,7 +1061,7 @@ func SetEnvironmentVariable(name *uint16, value *uint16) (err error) {
 }
 
 func SetFileAttributes(name *uint16, attrs uint32) (err error) {
-	r1, _, e1 := Syscall(procSetFileAttributesW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(attrs), 0)
+	r1, _, e1 := SyscallN(procSetFileAttributesW.Addr(), uintptr(unsafe.Pointer(name)), uintptr(attrs))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1069,7 +1069,7 @@ func SetFileAttributes(name *uint16, attrs uint32) (err error) {
 }
 
 func SetFileCompletionNotificationModes(handle Handle, flags uint8) (err error) {
-	r1, _, e1 := Syscall(procSetFileCompletionNotificationModes.Addr(), 2, uintptr(handle), uintptr(flags), 0)
+	r1, _, e1 := SyscallN(procSetFileCompletionNotificationModes.Addr(), uintptr(handle), uintptr(flags))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1077,7 +1077,7 @@ func SetFileCompletionNotificationModes(handle Handle, flags uint8) (err error) 
 }
 
 func SetFilePointer(handle Handle, lowoffset int32, highoffsetptr *int32, whence uint32) (newlowoffset uint32, err error) {
-	r0, _, e1 := Syscall6(procSetFilePointer.Addr(), 4, uintptr(handle), uintptr(lowoffset), uintptr(unsafe.Pointer(highoffsetptr)), uintptr(whence), 0, 0)
+	r0, _, e1 := SyscallN(procSetFilePointer.Addr(), uintptr(handle), uintptr(lowoffset), uintptr(unsafe.Pointer(highoffsetptr)), uintptr(whence))
 	newlowoffset = uint32(r0)
 	if newlowoffset == 0xffffffff {
 		err = errnoErr(e1)
@@ -1086,7 +1086,7 @@ func SetFilePointer(handle Handle, lowoffset int32, highoffsetptr *int32, whence
 }
 
 func SetFileTime(handle Handle, ctime *Filetime, atime *Filetime, wtime *Filetime) (err error) {
-	r1, _, e1 := Syscall6(procSetFileTime.Addr(), 4, uintptr(handle), uintptr(unsafe.Pointer(ctime)), uintptr(unsafe.Pointer(atime)), uintptr(unsafe.Pointer(wtime)), 0, 0)
+	r1, _, e1 := SyscallN(procSetFileTime.Addr(), uintptr(handle), uintptr(unsafe.Pointer(ctime)), uintptr(unsafe.Pointer(atime)), uintptr(unsafe.Pointer(wtime)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1094,7 +1094,7 @@ func SetFileTime(handle Handle, ctime *Filetime, atime *Filetime, wtime *Filetim
 }
 
 func SetHandleInformation(handle Handle, mask uint32, flags uint32) (err error) {
-	r1, _, e1 := Syscall(procSetHandleInformation.Addr(), 3, uintptr(handle), uintptr(mask), uintptr(flags))
+	r1, _, e1 := SyscallN(procSetHandleInformation.Addr(), uintptr(handle), uintptr(mask), uintptr(flags))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1102,7 +1102,7 @@ func SetHandleInformation(handle Handle, mask uint32, flags uint32) (err error) 
 }
 
 func TerminateProcess(handle Handle, exitcode uint32) (err error) {
-	r1, _, e1 := Syscall(procTerminateProcess.Addr(), 2, uintptr(handle), uintptr(exitcode), 0)
+	r1, _, e1 := SyscallN(procTerminateProcess.Addr(), uintptr(handle), uintptr(exitcode))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1110,7 +1110,7 @@ func TerminateProcess(handle Handle, exitcode uint32) (err error) {
 }
 
 func UnmapViewOfFile(addr uintptr) (err error) {
-	r1, _, e1 := Syscall(procUnmapViewOfFile.Addr(), 1, uintptr(addr), 0, 0)
+	r1, _, e1 := SyscallN(procUnmapViewOfFile.Addr(), uintptr(addr))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1118,7 +1118,7 @@ func UnmapViewOfFile(addr uintptr) (err error) {
 }
 
 func updateProcThreadAttribute(attrlist *_PROC_THREAD_ATTRIBUTE_LIST, flags uint32, attr uintptr, value unsafe.Pointer, size uintptr, prevvalue unsafe.Pointer, returnedsize *uintptr) (err error) {
-	r1, _, e1 := Syscall9(procUpdateProcThreadAttribute.Addr(), 7, uintptr(unsafe.Pointer(attrlist)), uintptr(flags), uintptr(attr), uintptr(value), uintptr(size), uintptr(prevvalue), uintptr(unsafe.Pointer(returnedsize)), 0, 0)
+	r1, _, e1 := SyscallN(procUpdateProcThreadAttribute.Addr(), uintptr(unsafe.Pointer(attrlist)), uintptr(flags), uintptr(attr), uintptr(value), uintptr(size), uintptr(prevvalue), uintptr(unsafe.Pointer(returnedsize)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1126,7 +1126,7 @@ func updateProcThreadAttribute(attrlist *_PROC_THREAD_ATTRIBUTE_LIST, flags uint
 }
 
 func VirtualLock(addr uintptr, length uintptr) (err error) {
-	r1, _, e1 := Syscall(procVirtualLock.Addr(), 2, uintptr(addr), uintptr(length), 0)
+	r1, _, e1 := SyscallN(procVirtualLock.Addr(), uintptr(addr), uintptr(length))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1134,7 +1134,7 @@ func VirtualLock(addr uintptr, length uintptr) (err error) {
 }
 
 func VirtualUnlock(addr uintptr, length uintptr) (err error) {
-	r1, _, e1 := Syscall(procVirtualUnlock.Addr(), 2, uintptr(addr), uintptr(length), 0)
+	r1, _, e1 := SyscallN(procVirtualUnlock.Addr(), uintptr(addr), uintptr(length))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1142,7 +1142,7 @@ func VirtualUnlock(addr uintptr, length uintptr) (err error) {
 }
 
 func WaitForSingleObject(handle Handle, waitMilliseconds uint32) (event uint32, err error) {
-	r0, _, e1 := Syscall(procWaitForSingleObject.Addr(), 2, uintptr(handle), uintptr(waitMilliseconds), 0)
+	r0, _, e1 := SyscallN(procWaitForSingleObject.Addr(), uintptr(handle), uintptr(waitMilliseconds))
 	event = uint32(r0)
 	if event == 0xffffffff {
 		err = errnoErr(e1)
@@ -1151,7 +1151,7 @@ func WaitForSingleObject(handle Handle, waitMilliseconds uint32) (event uint32, 
 }
 
 func WriteConsole(console Handle, buf *uint16, towrite uint32, written *uint32, reserved *byte) (err error) {
-	r1, _, e1 := Syscall6(procWriteConsoleW.Addr(), 5, uintptr(console), uintptr(unsafe.Pointer(buf)), uintptr(towrite), uintptr(unsafe.Pointer(written)), uintptr(unsafe.Pointer(reserved)), 0)
+	r1, _, e1 := SyscallN(procWriteConsoleW.Addr(), uintptr(console), uintptr(unsafe.Pointer(buf)), uintptr(towrite), uintptr(unsafe.Pointer(written)), uintptr(unsafe.Pointer(reserved)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1163,7 +1163,7 @@ func writeFile(handle Handle, buf []byte, done *uint32, overlapped *Overlapped) 
 	if len(buf) > 0 {
 		_p0 = &buf[0]
 	}
-	r1, _, e1 := Syscall6(procWriteFile.Addr(), 5, uintptr(handle), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(unsafe.Pointer(done)), uintptr(unsafe.Pointer(overlapped)), 0)
+	r1, _, e1 := SyscallN(procWriteFile.Addr(), uintptr(handle), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(unsafe.Pointer(done)), uintptr(unsafe.Pointer(overlapped)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1171,7 +1171,7 @@ func writeFile(handle Handle, buf []byte, done *uint32, overlapped *Overlapped) 
 }
 
 func AcceptEx(ls Handle, as Handle, buf *byte, rxdatalen uint32, laddrlen uint32, raddrlen uint32, recvd *uint32, overlapped *Overlapped) (err error) {
-	r1, _, e1 := Syscall9(procAcceptEx.Addr(), 8, uintptr(ls), uintptr(as), uintptr(unsafe.Pointer(buf)), uintptr(rxdatalen), uintptr(laddrlen), uintptr(raddrlen), uintptr(unsafe.Pointer(recvd)), uintptr(unsafe.Pointer(overlapped)), 0)
+	r1, _, e1 := SyscallN(procAcceptEx.Addr(), uintptr(ls), uintptr(as), uintptr(unsafe.Pointer(buf)), uintptr(rxdatalen), uintptr(laddrlen), uintptr(raddrlen), uintptr(unsafe.Pointer(recvd)), uintptr(unsafe.Pointer(overlapped)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1179,12 +1179,12 @@ func AcceptEx(ls Handle, as Handle, buf *byte, rxdatalen uint32, laddrlen uint32
 }
 
 func GetAcceptExSockaddrs(buf *byte, rxdatalen uint32, laddrlen uint32, raddrlen uint32, lrsa **RawSockaddrAny, lrsalen *int32, rrsa **RawSockaddrAny, rrsalen *int32) {
-	Syscall9(procGetAcceptExSockaddrs.Addr(), 8, uintptr(unsafe.Pointer(buf)), uintptr(rxdatalen), uintptr(laddrlen), uintptr(raddrlen), uintptr(unsafe.Pointer(lrsa)), uintptr(unsafe.Pointer(lrsalen)), uintptr(unsafe.Pointer(rrsa)), uintptr(unsafe.Pointer(rrsalen)), 0)
+	SyscallN(procGetAcceptExSockaddrs.Addr(), uintptr(unsafe.Pointer(buf)), uintptr(rxdatalen), uintptr(laddrlen), uintptr(raddrlen), uintptr(unsafe.Pointer(lrsa)), uintptr(unsafe.Pointer(lrsalen)), uintptr(unsafe.Pointer(rrsa)), uintptr(unsafe.Pointer(rrsalen)))
 	return
 }
 
 func TransmitFile(s Handle, handle Handle, bytesToWrite uint32, bytsPerSend uint32, overlapped *Overlapped, transmitFileBuf *TransmitFileBuffers, flags uint32) (err error) {
-	r1, _, e1 := Syscall9(procTransmitFile.Addr(), 7, uintptr(s), uintptr(handle), uintptr(bytesToWrite), uintptr(bytsPerSend), uintptr(unsafe.Pointer(overlapped)), uintptr(unsafe.Pointer(transmitFileBuf)), uintptr(flags), 0, 0)
+	r1, _, e1 := SyscallN(procTransmitFile.Addr(), uintptr(s), uintptr(handle), uintptr(bytesToWrite), uintptr(bytsPerSend), uintptr(unsafe.Pointer(overlapped)), uintptr(unsafe.Pointer(transmitFileBuf)), uintptr(flags))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1192,7 +1192,7 @@ func TransmitFile(s Handle, handle Handle, bytesToWrite uint32, bytsPerSend uint
 }
 
 func NetApiBufferFree(buf *byte) (neterr error) {
-	r0, _, _ := Syscall(procNetApiBufferFree.Addr(), 1, uintptr(unsafe.Pointer(buf)), 0, 0)
+	r0, _, _ := SyscallN(procNetApiBufferFree.Addr(), uintptr(unsafe.Pointer(buf)))
 	if r0 != 0 {
 		neterr = Errno(r0)
 	}
@@ -1200,7 +1200,7 @@ func NetApiBufferFree(buf *byte) (neterr error) {
 }
 
 func NetGetJoinInformation(server *uint16, name **uint16, bufType *uint32) (neterr error) {
-	r0, _, _ := Syscall(procNetGetJoinInformation.Addr(), 3, uintptr(unsafe.Pointer(server)), uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(bufType)))
+	r0, _, _ := SyscallN(procNetGetJoinInformation.Addr(), uintptr(unsafe.Pointer(server)), uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(bufType)))
 	if r0 != 0 {
 		neterr = Errno(r0)
 	}
@@ -1208,7 +1208,7 @@ func NetGetJoinInformation(server *uint16, name **uint16, bufType *uint32) (nete
 }
 
 func NetUserGetInfo(serverName *uint16, userName *uint16, level uint32, buf **byte) (neterr error) {
-	r0, _, _ := Syscall6(procNetUserGetInfo.Addr(), 4, uintptr(unsafe.Pointer(serverName)), uintptr(unsafe.Pointer(userName)), uintptr(level), uintptr(unsafe.Pointer(buf)), 0, 0)
+	r0, _, _ := SyscallN(procNetUserGetInfo.Addr(), uintptr(unsafe.Pointer(serverName)), uintptr(unsafe.Pointer(userName)), uintptr(level), uintptr(unsafe.Pointer(buf)))
 	if r0 != 0 {
 		neterr = Errno(r0)
 	}
@@ -1216,12 +1216,12 @@ func NetUserGetInfo(serverName *uint16, userName *uint16, level uint32, buf **by
 }
 
 func rtlGetNtVersionNumbers(majorVersion *uint32, minorVersion *uint32, buildNumber *uint32) {
-	Syscall(procRtlGetNtVersionNumbers.Addr(), 3, uintptr(unsafe.Pointer(majorVersion)), uintptr(unsafe.Pointer(minorVersion)), uintptr(unsafe.Pointer(buildNumber)))
+	SyscallN(procRtlGetNtVersionNumbers.Addr(), uintptr(unsafe.Pointer(majorVersion)), uintptr(unsafe.Pointer(minorVersion)), uintptr(unsafe.Pointer(buildNumber)))
 	return
 }
 
 func GetUserNameEx(nameFormat uint32, nameBuffre *uint16, nSize *uint32) (err error) {
-	r1, _, e1 := Syscall(procGetUserNameExW.Addr(), 3, uintptr(nameFormat), uintptr(unsafe.Pointer(nameBuffre)), uintptr(unsafe.Pointer(nSize)))
+	r1, _, e1 := SyscallN(procGetUserNameExW.Addr(), uintptr(nameFormat), uintptr(unsafe.Pointer(nameBuffre)), uintptr(unsafe.Pointer(nSize)))
 	if r1&0xff == 0 {
 		err = errnoErr(e1)
 	}
@@ -1229,7 +1229,7 @@ func GetUserNameEx(nameFormat uint32, nameBuffre *uint16, nSize *uint32) (err er
 }
 
 func TranslateName(accName *uint16, accNameFormat uint32, desiredNameFormat uint32, translatedName *uint16, nSize *uint32) (err error) {
-	r1, _, e1 := Syscall6(procTranslateNameW.Addr(), 5, uintptr(unsafe.Pointer(accName)), uintptr(accNameFormat), uintptr(desiredNameFormat), uintptr(unsafe.Pointer(translatedName)), uintptr(unsafe.Pointer(nSize)), 0)
+	r1, _, e1 := SyscallN(procTranslateNameW.Addr(), uintptr(unsafe.Pointer(accName)), uintptr(accNameFormat), uintptr(desiredNameFormat), uintptr(unsafe.Pointer(translatedName)), uintptr(unsafe.Pointer(nSize)))
 	if r1&0xff == 0 {
 		err = errnoErr(e1)
 	}
@@ -1237,7 +1237,7 @@ func TranslateName(accName *uint16, accNameFormat uint32, desiredNameFormat uint
 }
 
 func CommandLineToArgv(cmd *uint16, argc *int32) (argv *[8192]*[8192]uint16, err error) {
-	r0, _, e1 := Syscall(procCommandLineToArgvW.Addr(), 2, uintptr(unsafe.Pointer(cmd)), uintptr(unsafe.Pointer(argc)), 0)
+	r0, _, e1 := SyscallN(procCommandLineToArgvW.Addr(), uintptr(unsafe.Pointer(cmd)), uintptr(unsafe.Pointer(argc)))
 	argv = (*[8192]*[8192]uint16)(unsafe.Pointer(r0))
 	if argv == nil {
 		err = errnoErr(e1)
@@ -1246,7 +1246,7 @@ func CommandLineToArgv(cmd *uint16, argc *int32) (argv *[8192]*[8192]uint16, err
 }
 
 func GetUserProfileDirectory(t Token, dir *uint16, dirLen *uint32) (err error) {
-	r1, _, e1 := Syscall(procGetUserProfileDirectoryW.Addr(), 3, uintptr(t), uintptr(unsafe.Pointer(dir)), uintptr(unsafe.Pointer(dirLen)))
+	r1, _, e1 := SyscallN(procGetUserProfileDirectoryW.Addr(), uintptr(t), uintptr(unsafe.Pointer(dir)), uintptr(unsafe.Pointer(dirLen)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -1254,12 +1254,12 @@ func GetUserProfileDirectory(t Token, dir *uint16, dirLen *uint32) (err error) {
 }
 
 func FreeAddrInfoW(addrinfo *AddrinfoW) {
-	Syscall(procFreeAddrInfoW.Addr(), 1, uintptr(unsafe.Pointer(addrinfo)), 0, 0)
+	SyscallN(procFreeAddrInfoW.Addr(), uintptr(unsafe.Pointer(addrinfo)))
 	return
 }
 
 func GetAddrInfoW(nodename *uint16, servicename *uint16, hints *AddrinfoW, result **AddrinfoW) (sockerr error) {
-	r0, _, _ := Syscall6(procGetAddrInfoW.Addr(), 4, uintptr(unsafe.Pointer(nodename)), uintptr(unsafe.Pointer(servicename)), uintptr(unsafe.Pointer(hints)), uintptr(unsafe.Pointer(result)), 0, 0)
+	r0, _, _ := SyscallN(procGetAddrInfoW.Addr(), uintptr(unsafe.Pointer(nodename)), uintptr(unsafe.Pointer(servicename)), uintptr(unsafe.Pointer(hints)), uintptr(unsafe.Pointer(result)))
 	if r0 != 0 {
 		sockerr = Errno(r0)
 	}
@@ -1267,7 +1267,7 @@ func GetAddrInfoW(nodename *uint16, servicename *uint16, hints *AddrinfoW, resul
 }
 
 func WSACleanup() (err error) {
-	r1, _, e1 := Syscall(procWSACleanup.Addr(), 0, 0, 0, 0)
+	r1, _, e1 := SyscallN(procWSACleanup.Addr(), 0)
 	if r1 == socket_error {
 		err = errnoErr(e1)
 	}
@@ -1275,7 +1275,7 @@ func WSACleanup() (err error) {
 }
 
 func WSAEnumProtocols(protocols *int32, protocolBuffer *WSAProtocolInfo, bufferLength *uint32) (n int32, err error) {
-	r0, _, e1 := Syscall(procWSAEnumProtocolsW.Addr(), 3, uintptr(unsafe.Pointer(protocols)), uintptr(unsafe.Pointer(protocolBuffer)), uintptr(unsafe.Pointer(bufferLength)))
+	r0, _, e1 := SyscallN(procWSAEnumProtocolsW.Addr(), uintptr(unsafe.Pointer(protocols)), uintptr(unsafe.Pointer(protocolBuffer)), uintptr(unsafe.Pointer(bufferLength)))
 	n = int32(r0)
 	if n == -1 {
 		err = errnoErr(e1)
@@ -1284,7 +1284,7 @@ func WSAEnumProtocols(protocols *int32, protocolBuffer *WSAProtocolInfo, bufferL
 }
 
 func WSAIoctl(s Handle, iocc uint32, inbuf *byte, cbif uint32, outbuf *byte, cbob uint32, cbbr *uint32, overlapped *Overlapped, completionRoutine uintptr) (err error) {
-	r1, _, e1 := Syscall9(procWSAIoctl.Addr(), 9, uintptr(s), uintptr(iocc), uintptr(unsafe.Pointer(inbuf)), uintptr(cbif), uintptr(unsafe.Pointer(outbuf)), uintptr(cbob), uintptr(unsafe.Pointer(cbbr)), uintptr(unsafe.Pointer(overlapped)), uintptr(completionRoutine))
+	r1, _, e1 := SyscallN(procWSAIoctl.Addr(), uintptr(s), uintptr(iocc), uintptr(unsafe.Pointer(inbuf)), uintptr(cbif), uintptr(unsafe.Pointer(outbuf)), uintptr(cbob), uintptr(unsafe.Pointer(cbbr)), uintptr(unsafe.Pointer(overlapped)), uintptr(completionRoutine))
 	if r1 == socket_error {
 		err = errnoErr(e1)
 	}
@@ -1292,7 +1292,7 @@ func WSAIoctl(s Handle, iocc uint32, inbuf *byte, cbif uint32, outbuf *byte, cbo
 }
 
 func WSARecv(s Handle, bufs *WSABuf, bufcnt uint32, recvd *uint32, flags *uint32, overlapped *Overlapped, croutine *byte) (err error) {
-	r1, _, e1 := Syscall9(procWSARecv.Addr(), 7, uintptr(s), uintptr(unsafe.Pointer(bufs)), uintptr(bufcnt), uintptr(unsafe.Pointer(recvd)), uintptr(unsafe.Pointer(flags)), uintptr(unsafe.Pointer(overlapped)), uintptr(unsafe.Pointer(croutine)), 0, 0)
+	r1, _, e1 := SyscallN(procWSARecv.Addr(), uintptr(s), uintptr(unsafe.Pointer(bufs)), uintptr(bufcnt), uintptr(unsafe.Pointer(recvd)), uintptr(unsafe.Pointer(flags)), uintptr(unsafe.Pointer(overlapped)), uintptr(unsafe.Pointer(croutine)))
 	if r1 == socket_error {
 		err = errnoErr(e1)
 	}
@@ -1300,7 +1300,7 @@ func WSARecv(s Handle, bufs *WSABuf, bufcnt uint32, recvd *uint32, flags *uint32
 }
 
 func WSARecvFrom(s Handle, bufs *WSABuf, bufcnt uint32, recvd *uint32, flags *uint32, from *RawSockaddrAny, fromlen *int32, overlapped *Overlapped, croutine *byte) (err error) {
-	r1, _, e1 := Syscall9(procWSARecvFrom.Addr(), 9, uintptr(s), uintptr(unsafe.Pointer(bufs)), uintptr(bufcnt), uintptr(unsafe.Pointer(recvd)), uintptr(unsafe.Pointer(flags)), uintptr(unsafe.Pointer(from)), uintptr(unsafe.Pointer(fromlen)), uintptr(unsafe.Pointer(overlapped)), uintptr(unsafe.Pointer(croutine)))
+	r1, _, e1 := SyscallN(procWSARecvFrom.Addr(), uintptr(s), uintptr(unsafe.Pointer(bufs)), uintptr(bufcnt), uintptr(unsafe.Pointer(recvd)), uintptr(unsafe.Pointer(flags)), uintptr(unsafe.Pointer(from)), uintptr(unsafe.Pointer(fromlen)), uintptr(unsafe.Pointer(overlapped)), uintptr(unsafe.Pointer(croutine)))
 	if r1 == socket_error {
 		err = errnoErr(e1)
 	}
@@ -1308,7 +1308,7 @@ func WSARecvFrom(s Handle, bufs *WSABuf, bufcnt uint32, recvd *uint32, flags *ui
 }
 
 func WSASend(s Handle, bufs *WSABuf, bufcnt uint32, sent *uint32, flags uint32, overlapped *Overlapped, croutine *byte) (err error) {
-	r1, _, e1 := Syscall9(procWSASend.Addr(), 7, uintptr(s), uintptr(unsafe.Pointer(bufs)), uintptr(bufcnt), uintptr(unsafe.Pointer(sent)), uintptr(flags), uintptr(unsafe.Pointer(overlapped)), uintptr(unsafe.Pointer(croutine)), 0, 0)
+	r1, _, e1 := SyscallN(procWSASend.Addr(), uintptr(s), uintptr(unsafe.Pointer(bufs)), uintptr(bufcnt), uintptr(unsafe.Pointer(sent)), uintptr(flags), uintptr(unsafe.Pointer(overlapped)), uintptr(unsafe.Pointer(croutine)))
 	if r1 == socket_error {
 		err = errnoErr(e1)
 	}
@@ -1316,7 +1316,7 @@ func WSASend(s Handle, bufs *WSABuf, bufcnt uint32, sent *uint32, flags uint32, 
 }
 
 func WSASendTo(s Handle, bufs *WSABuf, bufcnt uint32, sent *uint32, flags uint32, to *RawSockaddrAny, tolen int32, overlapped *Overlapped, croutine *byte) (err error) {
-	r1, _, e1 := Syscall9(procWSASendTo.Addr(), 9, uintptr(s), uintptr(unsafe.Pointer(bufs)), uintptr(bufcnt), uintptr(unsafe.Pointer(sent)), uintptr(flags), uintptr(unsafe.Pointer(to)), uintptr(tolen), uintptr(unsafe.Pointer(overlapped)), uintptr(unsafe.Pointer(croutine)))
+	r1, _, e1 := SyscallN(procWSASendTo.Addr(), uintptr(s), uintptr(unsafe.Pointer(bufs)), uintptr(bufcnt), uintptr(unsafe.Pointer(sent)), uintptr(flags), uintptr(unsafe.Pointer(to)), uintptr(tolen), uintptr(unsafe.Pointer(overlapped)), uintptr(unsafe.Pointer(croutine)))
 	if r1 == socket_error {
 		err = errnoErr(e1)
 	}
@@ -1324,7 +1324,7 @@ func WSASendTo(s Handle, bufs *WSABuf, bufcnt uint32, sent *uint32, flags uint32
 }
 
 func WSAStartup(verreq uint32, data *WSAData) (sockerr error) {
-	r0, _, _ := Syscall(procWSAStartup.Addr(), 2, uintptr(verreq), uintptr(unsafe.Pointer(data)), 0)
+	r0, _, _ := SyscallN(procWSAStartup.Addr(), uintptr(verreq), uintptr(unsafe.Pointer(data)))
 	if r0 != 0 {
 		sockerr = Errno(r0)
 	}
@@ -1332,7 +1332,7 @@ func WSAStartup(verreq uint32, data *WSAData) (sockerr error) {
 }
 
 func bind(s Handle, name unsafe.Pointer, namelen int32) (err error) {
-	r1, _, e1 := Syscall(procbind.Addr(), 3, uintptr(s), uintptr(name), uintptr(namelen))
+	r1, _, e1 := SyscallN(procbind.Addr(), uintptr(s), uintptr(name), uintptr(namelen))
 	if r1 == socket_error {
 		err = errnoErr(e1)
 	}
@@ -1340,7 +1340,7 @@ func bind(s Handle, name unsafe.Pointer, namelen int32) (err error) {
 }
 
 func Closesocket(s Handle) (err error) {
-	r1, _, e1 := Syscall(procclosesocket.Addr(), 1, uintptr(s), 0, 0)
+	r1, _, e1 := SyscallN(procclosesocket.Addr(), uintptr(s))
 	if r1 == socket_error {
 		err = errnoErr(e1)
 	}
@@ -1348,7 +1348,7 @@ func Closesocket(s Handle) (err error) {
 }
 
 func connect(s Handle, name unsafe.Pointer, namelen int32) (err error) {
-	r1, _, e1 := Syscall(procconnect.Addr(), 3, uintptr(s), uintptr(name), uintptr(namelen))
+	r1, _, e1 := SyscallN(procconnect.Addr(), uintptr(s), uintptr(name), uintptr(namelen))
 	if r1 == socket_error {
 		err = errnoErr(e1)
 	}
@@ -1365,7 +1365,7 @@ func GetHostByName(name string) (h *Hostent, err error) {
 }
 
 func _GetHostByName(name *byte) (h *Hostent, err error) {
-	r0, _, e1 := Syscall(procgethostbyname.Addr(), 1, uintptr(unsafe.Pointer(name)), 0, 0)
+	r0, _, e1 := SyscallN(procgethostbyname.Addr(), uintptr(unsafe.Pointer(name)))
 	h = (*Hostent)(unsafe.Pointer(r0))
 	if h == nil {
 		err = errnoErr(e1)
@@ -1374,7 +1374,7 @@ func _GetHostByName(name *byte) (h *Hostent, err error) {
 }
 
 func getpeername(s Handle, rsa *RawSockaddrAny, addrlen *int32) (err error) {
-	r1, _, e1 := Syscall(procgetpeername.Addr(), 3, uintptr(s), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)))
+	r1, _, e1 := SyscallN(procgetpeername.Addr(), uintptr(s), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)))
 	if r1 == socket_error {
 		err = errnoErr(e1)
 	}
@@ -1391,7 +1391,7 @@ func GetProtoByName(name string) (p *Protoent, err error) {
 }
 
 func _GetProtoByName(name *byte) (p *Protoent, err error) {
-	r0, _, e1 := Syscall(procgetprotobyname.Addr(), 1, uintptr(unsafe.Pointer(name)), 0, 0)
+	r0, _, e1 := SyscallN(procgetprotobyname.Addr(), uintptr(unsafe.Pointer(name)))
 	p = (*Protoent)(unsafe.Pointer(r0))
 	if p == nil {
 		err = errnoErr(e1)
@@ -1414,7 +1414,7 @@ func GetServByName(name string, proto string) (s *Servent, err error) {
 }
 
 func _GetServByName(name *byte, proto *byte) (s *Servent, err error) {
-	r0, _, e1 := Syscall(procgetservbyname.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(proto)), 0)
+	r0, _, e1 := SyscallN(procgetservbyname.Addr(), uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(proto)))
 	s = (*Servent)(unsafe.Pointer(r0))
 	if s == nil {
 		err = errnoErr(e1)
@@ -1423,7 +1423,7 @@ func _GetServByName(name *byte, proto *byte) (s *Servent, err error) {
 }
 
 func getsockname(s Handle, rsa *RawSockaddrAny, addrlen *int32) (err error) {
-	r1, _, e1 := Syscall(procgetsockname.Addr(), 3, uintptr(s), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)))
+	r1, _, e1 := SyscallN(procgetsockname.Addr(), uintptr(s), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)))
 	if r1 == socket_error {
 		err = errnoErr(e1)
 	}
@@ -1431,7 +1431,7 @@ func getsockname(s Handle, rsa *RawSockaddrAny, addrlen *int32) (err error) {
 }
 
 func Getsockopt(s Handle, level int32, optname int32, optval *byte, optlen *int32) (err error) {
-	r1, _, e1 := Syscall6(procgetsockopt.Addr(), 5, uintptr(s), uintptr(level), uintptr(optname), uintptr(unsafe.Pointer(optval)), uintptr(unsafe.Pointer(optlen)), 0)
+	r1, _, e1 := SyscallN(procgetsockopt.Addr(), uintptr(s), uintptr(level), uintptr(optname), uintptr(unsafe.Pointer(optval)), uintptr(unsafe.Pointer(optlen)))
 	if r1 == socket_error {
 		err = errnoErr(e1)
 	}
@@ -1439,7 +1439,7 @@ func Getsockopt(s Handle, level int32, optname int32, optval *byte, optlen *int3
 }
 
 func listen(s Handle, backlog int32) (err error) {
-	r1, _, e1 := Syscall(proclisten.Addr(), 2, uintptr(s), uintptr(backlog), 0)
+	r1, _, e1 := SyscallN(proclisten.Addr(), uintptr(s), uintptr(backlog))
 	if r1 == socket_error {
 		err = errnoErr(e1)
 	}
@@ -1447,13 +1447,13 @@ func listen(s Handle, backlog int32) (err error) {
 }
 
 func Ntohs(netshort uint16) (u uint16) {
-	r0, _, _ := Syscall(procntohs.Addr(), 1, uintptr(netshort), 0, 0)
+	r0, _, _ := SyscallN(procntohs.Addr(), uintptr(netshort))
 	u = uint16(r0)
 	return
 }
 
 func Setsockopt(s Handle, level int32, optname int32, optval *byte, optlen int32) (err error) {
-	r1, _, e1 := Syscall6(procsetsockopt.Addr(), 5, uintptr(s), uintptr(level), uintptr(optname), uintptr(unsafe.Pointer(optval)), uintptr(optlen), 0)
+	r1, _, e1 := SyscallN(procsetsockopt.Addr(), uintptr(s), uintptr(level), uintptr(optname), uintptr(unsafe.Pointer(optval)), uintptr(optlen))
 	if r1 == socket_error {
 		err = errnoErr(e1)
 	}
@@ -1461,7 +1461,7 @@ func Setsockopt(s Handle, level int32, optname int32, optval *byte, optlen int32
 }
 
 func shutdown(s Handle, how int32) (err error) {
-	r1, _, e1 := Syscall(procshutdown.Addr(), 2, uintptr(s), uintptr(how), 0)
+	r1, _, e1 := SyscallN(procshutdown.Addr(), uintptr(s), uintptr(how))
 	if r1 == socket_error {
 		err = errnoErr(e1)
 	}
@@ -1469,7 +1469,7 @@ func shutdown(s Handle, how int32) (err error) {
 }
 
 func socket(af int32, typ int32, protocol int32) (handle Handle, err error) {
-	r0, _, e1 := Syscall(procsocket.Addr(), 3, uintptr(af), uintptr(typ), uintptr(protocol))
+	r0, _, e1 := SyscallN(procsocket.Addr(), uintptr(af), uintptr(typ), uintptr(protocol))
 	handle = Handle(r0)
 	if handle == InvalidHandle {
 		err = errnoErr(e1)


### PR DESCRIPTION
This is a follow up for CL 518995 that regenerates the
windows zsyscalls to use SyscallN instead of the various
SyscallX functions.

Fixes #57914
