### PR TITLE
syscall: Use the service account to get user information

### DIFF
--- a/src/syscall/security_windows.go
+++ b/src/syscall/security_windows.go
@@ -368,6 +368,9 @@ func (t Token) GetUserProfileDirectory() (string, error) {
 		if e == nil {
 			return UTF16ToString(b), nil
 		}
+		if e == ERROR_FILE_NOT_FOUND {
+			return "", nil
+		}
 		if e != ERROR_INSUFFICIENT_BUFFER {
 			return "", e
 		}


### PR DESCRIPTION
When calling user.Current() to get Username normally, everything is fine, but if the caller is a service user, err will be returned and Username cannot be obtained

After checking the code, I found an error when calling GetUserProfileDirectory() in current() to obtain information. The service account does not have a profile directory, so there will be an error of The system cannot find the file specified., but it does not affect others The acquisition of information should not directly return err to cause all information to be invalid

If you'd like to reproduce what I said, please run user.Current()  in is

func main() {
	username, err := user.Current()
	if err != nil {
		fmt.Println(err.Error())
	} else {
		fmt.Println(username.Username)
	}
}

go build -o current.exe

Correct
C:\>current.exe
TEST\Administrator

Incorrect
C:/inetpub/wwwroot/test/ >C:\current.exe
The system cannot find the file specified.


But in fact, we have already obtained other information at this time, such as the username

func lookupUsernameAndDomain(usid *syscall.SID) (username, domain string, e error) {
	username, domain, t, e := usid.LookupAccount("")
	if e != nil {
		return "", "", e
	}
	if t != syscall.SidTypeUser {
		return "", "", fmt.Errorf("user: should be user account type, not %d", t)
	}
	return username, domain, nil
}
func main() {
	t, e := syscall.OpenCurrentProcessToken()
	if e != nil {
		return
	}
	defer t.Close()
	u, e := t.GetTokenUser()
	if e != nil {
		return
	}

	username, domain, e := lookupUsernameAndDomain(u.User.Sid)
	fmt.Println(domain + `\` + username)
}

go build -o current.exe

C:\>current.exe
TEST\Administrator

C:/inetpub/wwwroot/test/ >C:\current.exe
IIS APPPOOL\test
