### PR TITLE
runtime: mark traceEnabled and traceShuttingDown as no:split

### DIFF
--- a/src/runtime/trace.go
+++ b/src/runtime/trace.go
@@ -257,11 +257,15 @@ func traceBufPtrOf(b *traceBuf) traceBufPtr {
 }
 
 // traceEnabled returns true if the trace is currently enabled.
+//
+//go:nosplit
 func traceEnabled() bool {
 	return trace.enabled
 }
 
 // traceShuttingDown returns true if the trace is currently shutting down.
+//
+//go:nosplit
 func traceShuttingDown() bool {
 	return trace.shutdown
 }


### PR DESCRIPTION
This fixes a regression from CL 494181. 
The traceEnabled function splits the stack and is being
called by reentersyscall that shouldn't call anything
that splits the stack. Same with traceShuttingDown.

Fixes #61975