### PR TITLE
encoding/json: declare hex as a const

### DIFF
--- a/src/encoding/json/encode.go
+++ b/src/encoding/json/encode.go
@@ -245,7 +245,7 @@ func (e *MarshalerError) Error() string {
 // Unwrap returns the underlying error.
 func (e *MarshalerError) Unwrap() error { return e.Err }
 
-var hex = "0123456789abcdef"
+const hex = "0123456789abcdef"
 
 // An encodeState encodes JSON into a bytes.Buffer.
 type encodeState struct {


### PR DESCRIPTION
hex is in fact immutable, declare it as a const to avoid accidental
modification, also for consistency with other packages.