### PR TITLE
cmd/go/internal/cache: use == to test for io.EOF

### DIFF
--- a/src/cmd/go/internal/cache/prog.go
+++ b/src/cmd/go/internal/cache/prog.go
@@ -229,7 +229,7 @@ func (c *ProgCache) readLoop(readLoopDone chan<- struct{}) {
 			if c.closing.Load() {
 				return // quietly
 			}
-			if errors.Is(err, io.EOF) {
+			if err == io.EOF {
 				c.mu.Lock()
 				inFlight := len(c.inFlight)
 				c.mu.Unlock()


### PR DESCRIPTION
The documentation of io.EOF: Read must return EOF itself, not an error
wrapping EOF, because callers will test for EOF using ==.

encoding/json package provides an example "ExampleDecoder" which uses
"err == io.EOF" as well, so I think it's more idiomatic to use == to test for io.EOF.