### PR TITLE
go/doc, time: no need to wrap error with fmt.Errorf

### DIFF
--- a/src/go/doc/doc.go
+++ b/src/go/doc/doc.go
@@ -208,7 +208,7 @@ func (p *Package) collectFuncs(funcs []*Func) {
 func NewFromFiles(fset *token.FileSet, files []*ast.File, importPath string, opts ...any) (*Package, error) {
 	// Check for invalid API usage.
 	if fset == nil {
-		panic(fmt.Errorf("doc.NewFromFiles: no token.FileSet provided (fset == nil)"))
+		panic("doc.NewFromFiles: no token.FileSet provided (fset == nil)")
 	}
 	var mode Mode
 	switch len(opts) { // There can only be 0 or 1 options, so a simple switch works for now.
@@ -217,11 +217,11 @@ func NewFromFiles(fset *token.FileSet, files []*ast.File, importPath string, opt
 	case 1:
 		m, ok := opts[0].(Mode)
 		if !ok {
-			panic(fmt.Errorf("doc.NewFromFiles: option argument type must be doc.Mode"))
+			panic("doc.NewFromFiles: option argument type must be doc.Mode")
 		}
 		mode = m
 	default:
-		panic(fmt.Errorf("doc.NewFromFiles: there must not be more than 1 option argument"))
+		panic("doc.NewFromFiles: there must not be more than 1 option argument")
 	}
 
 	// Collect .go and _test.go files.

--- a/src/time/zoneinfo_test.go
+++ b/src/time/zoneinfo_test.go
@@ -6,7 +6,6 @@ package time_test
 
 import (
 	"errors"
-	"fmt"
 	"internal/testenv"
 	"os"
 	"reflect"
@@ -16,7 +15,7 @@ import (
 
 func init() {
 	if time.ZoneinfoForTesting() != nil {
-		panic(fmt.Errorf("zoneinfo initialized before first LoadLocation"))
+		panic("zoneinfo initialized before first LoadLocation")
 	}
 }
 


### PR DESCRIPTION
See CL 462046.