### PR TITLE
fmt: fix receiver names are different

### DIFF
--- a/src/fmt/print.go
+++ b/src/fmt/print.go
@@ -112,8 +112,8 @@ func (b *buffer) writeByte(c byte) {
 	*b = append(*b, c)
 }
 
-func (bp *buffer) writeRune(r rune) {
-	*bp = utf8.AppendRune(*bp, r)
+func (b *buffer) writeRune(r rune) {
+	*b = utf8.AppendRune(*b, r)
 }
 
 // pp is used to store a printer's state and is reused with sync.Pool to avoid allocations.


### PR DESCRIPTION
"buffer" call the receiver "b" in other method, don't call it "bp" in
another. Keep the same receiver names, as prescribed in Go Code Review
Comments (https://go.dev/s/style#receiver-names).