### PR TITLE
crypto/hmac: allocate hmac struct on the stack

### DIFF
--- a/src/crypto/hmac/hmac.go
+++ b/src/crypto/hmac/hmac.go
@@ -134,7 +134,13 @@ func New(h func() hash.Hash, key []byte) hash.Hash {
 		}
 		// BoringCrypto did not recognize h, so fall through to standard Go code.
 	}
+
 	hm := new(hmac)
+	hm.init(h, key)
+	return hm
+}
+
+func (hm *hmac) init(h func() hash.Hash, key []byte) {
 	hm.outer = h()
 	hm.inner = h()
 	unique := true
@@ -167,8 +173,6 @@ func New(h func() hash.Hash, key []byte) hash.Hash {
 		hm.opad[i] ^= 0x5c
 	}
 	hm.inner.Write(hm.ipad)
-
-	return hm
 }
 
 // Equal compares two MACs for equality without leaking timing information.


### PR DESCRIPTION
goos: linux
goarch: amd64
pkg: crypto/hmac
cpu: Intel(R) Core(TM) i5-4460  CPU @ 3.20GHz
                │    before    │                after                 │
                │    sec/op    │    sec/op     vs base                │
HMACSHA256_1K-4   3.302µ ±  1%   3.296µ ±  1%        ~ (p=0.740 n=25)
HMACSHA256_32-4   611.9n ±  3%   613.5n ±  2%        ~ (p=0.450 n=25)
NewWriteSum-4     3.432µ ± 27%   2.513µ ± 18%  -26.78% (p=0.011 n=25)
geomean           1.907µ         1.719µ         -9.84%

                │    before     │                 after                  │
                │      B/s      │      B/s        vs base                │
HMACSHA256_1K-4   295.8Mi ±  1%    296.3Mi ±  1%        ~ (p=0.740 n=25)
HMACSHA256_32-4   49.87Mi ±  3%    49.74Mi ±  2%        ~ (p=0.461 n=25)
NewWriteSum-4     8.888Mi ± 38%   12.140Mi ± 15%  +36.59% (p=0.011 n=25)
geomean           50.80Mi          56.35Mi        +10.93%

                │   before   │                after                 │
                │    B/op    │    B/op     vs base                  │
HMACSHA256_1K-4   32.00 ± 0%   32.00 ± 0%        ~ (p=1.000 n=25) ¹
HMACSHA256_32-4   32.00 ± 0%   32.00 ± 0%        ~ (p=1.000 n=25) ¹
NewWriteSum-4     544.0 ± 0%   448.0 ± 0%  -17.65% (p=0.000 n=25)
geomean           82.28        77.12        -6.27%
¹ all samples are equal

                │   before   │                after                 │
                │ allocs/op  │ allocs/op   vs base                  │
HMACSHA256_1K-4   1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=25) ¹
HMACSHA256_32-4   1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=25) ¹
NewWriteSum-4     7.000 ± 0%   6.000 ± 0%  -14.29% (p=0.000 n=25)
geomean           1.913        1.817        -5.01%
¹ all samples are equal
