### PR TITLE
cmd/asm: add more flags to the documentation

### DIFF
--- a/src/cmd/asm/doc.go
+++ b/src/cmd/asm/doc.go
@@ -33,6 +33,8 @@ Flags:
 		Dump instructions as they are parsed.
 	-dynlink
 		Support references to Go symbols defined in other shared libraries.
+	-e
+		No limit on number of errors reported.
 	-gensymabis
 		Write symbol ABI information to output file. Don't assemble.
 	-o file
@@ -45,6 +47,8 @@ Flags:
 		Enable spectre mitigations in list (all, ret).
 	-trimpath prefix
 		Remove prefix from recorded source file paths.
+	-v
+		Print debug output.
 
 Input language:
 


### PR DESCRIPTION
Add the flags -e and -v.