### PR TITLE
log/slog: fix documentation on Handler.WithGroup

### DIFF
--- a/src/log/slog/handler.go
+++ b/src/log/slog/handler.go
@@ -76,11 +76,11 @@ type Handler interface {
 	// A Handler should treat WithGroup as starting a Group of Attrs that ends
 	// at the end of the log event. That is,
 	//
-	//     logger.WithGroup("s").LogAttrs(level, msg, slog.Int("a", 1), slog.Int("b", 2))
+	//     logger.WithGroup("s").LogAttrs(ctx, level, msg, slog.Int("a", 1), slog.Int("b", 2))
 	//
 	// should behave like
 	//
-	//     logger.LogAttrs(level, msg, slog.Group("s", slog.Int("a", 1), slog.Int("b", 2)))
+	//     logger.LogAttrs(ctx, level, msg, slog.Group("s", slog.Int("a", 1), slog.Int("b", 2)))
 	//
 	// If the name is empty, WithGroup returns the receiver.
 	WithGroup(name string) Handler


### PR DESCRIPTION
This PR contains a small fix in the documentation of Handler.WithGroup
(missing context in example).