### PR TITLE
runtime/debug: fix minor BuildSetting doc typos

### DIFF
--- a/src/runtime/debug/mod.go
+++ b/src/runtime/debug/mod.go
@@ -75,8 +75,8 @@ type Module struct {
 //   - CGO_ENABLED: the effective CGO_ENABLED environment variable
 //   - CGO_CFLAGS: the effective CGO_CFLAGS environment variable
 //   - CGO_CPPFLAGS: the effective CGO_CPPFLAGS environment variable
-//   - CGO_CXXFLAGS:  the effective CGO_CPPFLAGS environment variable
-//   - CGO_LDFLAGS: the effective CGO_CPPFLAGS environment variable
+//   - CGO_CXXFLAGS:  the effective CGO_CXXFLAGS environment variable
+//   - CGO_LDFLAGS: the effective CGO_LDFLAGS environment variable
 //   - GOARCH: the architecture target
 //   - GOAMD64/GOARM/GO386/etc: the architecture feature level for GOARCH
 //   - GOOS: the operating system target


### PR DESCRIPTION
Corrects a couple of defined key descriptions.
