### PR TITLE
log/slog: use atomic.Pointer instead of atomic.Value

### DIFF
--- a/src/log/slog/logger.go
+++ b/src/log/slog/logger.go
@@ -14,14 +14,14 @@ import (
 	"time"
 )
 
-var defaultLogger atomic.Value
+var defaultLogger atomic.Pointer[Logger]
 
 func init() {
 	defaultLogger.Store(New(newDefaultHandler(loginternal.DefaultOutput)))
 }
 
 // Default returns the default Logger.
-func Default() *Logger { return defaultLogger.Load().(*Logger) }
+func Default() *Logger { return defaultLogger.Load() }
 
 // SetDefault makes l the default Logger.
 // After this call, output from the log package's default Logger


### PR DESCRIPTION
There is no need to use atomic.Value, atomic.Pointer should also
be more performant here.