### PR TITLE
cmd/cgo/internal/test: benchmark for #cgo noescape directive

### DIFF
--- a/src/cmd/cgo/internal/test/test.go
+++ b/src/cmd/cgo/internal/test/test.go
@@ -115,6 +115,13 @@ int add(int x, int y) {
 	return x+y;
 };
 
+// escape vs noescape
+
+#cgo noescape handleGoStringPointerNoescape
+void handleGoStringPointerNoescape(void *s) {}
+
+void handleGoStringPointerEscape(void *s) {}
+
 // Following mimics vulkan complex definitions for benchmarking cgocheck overhead.
 
 typedef uint32_t VkFlags;
@@ -1104,6 +1111,18 @@ func benchCgoCall(b *testing.B) {
 		var a0 C.VkDeviceCreateInfo
 		for i := 0; i < b.N; i++ {
 			C.handleComplexPointer(&a0)
+		}
+	})
+	b.Run("string-pointer-escape", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var s string
+			C.handleGoStringPointerEscape(unsafe.Pointer(&s))
+		}
+	})
+	b.Run("string-pointer-noescape", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var s string
+			C.handleGoStringPointerNoescape(unsafe.Pointer(&s))
 		}
 	})
 	b.Run("eight-pointers", func(b *testing.B) {


### PR DESCRIPTION
case: passing a single Go string object to C function.
result: 87 ns vs 61 ns.

BenchmarkCgoCall/string-pointer-escape
BenchmarkCgoCall/string-pointer-escape-12        67731663   87.02 ns/op
BenchmarkCgoCall/string-pointer-noescape
BenchmarkCgoCall/string-pointer-noescape-12    99424776   61.30 ns/op

For #56378