### PR TITLE
net/http: fix request canceler leak on connection close

### DIFF
--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -2277,6 +2277,7 @@ func (pc *persistConn) readLoop() {
 			pc.t.cancelRequest(rc.cancelKey, rc.req.Context().Err())
 		case <-pc.closech:
 			alive = false
+			pc.t.setReqCanceler(rc.cancelKey, nil)
 		}
 
 		testHookReadLoopBeforeNextRead()


### PR DESCRIPTION
writeLoop goroutine closes persistConn closech in case of request body
write error which in turn finishes readLoop without removing request canceler.

Fixes #61708
