### PR TITLE
cmd/compile/internal/types2: use ReplaceAll in *Context.instanceHash

### DIFF
--- a/src/cmd/compile/internal/types2/context.go
+++ b/src/cmd/compile/internal/types2/context.go
@@ -79,7 +79,7 @@ func (ctxt *Context) instanceHash(orig Type, targs []Type) string {
 		h.typeList(targs)
 	}
 
-	return strings.Replace(buf.String(), " ", "#", -1) // ReplaceAll is not available in Go1.4
+	return strings.ReplaceAll(buf.String(), " ", "#")
 }
 
 // lookup returns an existing instantiation of orig with targs, if it exists.

--- a/src/go/types/context.go
+++ b/src/go/types/context.go
@@ -81,7 +81,7 @@ func (ctxt *Context) instanceHash(orig Type, targs []Type) string {
 		h.typeList(targs)
 	}
 
-	return strings.Replace(buf.String(), " ", "#", -1) // ReplaceAll is not available in Go1.4
+	return strings.ReplaceAll(buf.String(), " ", "#")
 }
 
 // lookup returns an existing instantiation of orig with targs, if it exists.


### PR DESCRIPTION
strings.ReplaceAll is currently available.
