### PR TITLE
cmd/link/internal/sym: uncomment code for RelocName

### DIFF
--- a/src/cmd/link/internal/sym/reloc.go
+++ b/src/cmd/link/internal/sym/reloc.go
@@ -8,6 +8,7 @@ import (
 	"cmd/internal/objabi"
 	"cmd/internal/sys"
 	"debug/elf"
+	"debug/macho"
 )
 
 // RelocVariant is a linker-internal variation on a relocation.
@@ -30,24 +31,21 @@ const (
 )
 
 func RelocName(arch *sys.Arch, r objabi.RelocType) string {
-	// We didn't have some relocation types at Go1.4.
-	// Uncomment code when we include those in bootstrap code.
-
 	switch {
 	case r >= objabi.MachoRelocOffset: // Mach-O
-		// nr := (r - objabi.MachoRelocOffset)>>1
-		// switch ctxt.Arch.Family {
-		// case sys.AMD64:
-		// 	return macho.RelocTypeX86_64(nr).String()
-		// case sys.ARM:
-		// 	return macho.RelocTypeARM(nr).String()
-		// case sys.ARM64:
-		// 	return macho.RelocTypeARM64(nr).String()
-		// case sys.I386:
-		// 	return macho.RelocTypeGeneric(nr).String()
-		// default:
-		// 	panic("unreachable")
-		// }
+		nr := (r - objabi.MachoRelocOffset) >> 1
+		switch arch.Family {
+		case sys.AMD64:
+			return macho.RelocTypeX86_64(nr).String()
+		case sys.ARM:
+			return macho.RelocTypeARM(nr).String()
+		case sys.ARM64:
+			return macho.RelocTypeARM64(nr).String()
+		case sys.I386:
+			return macho.RelocTypeGeneric(nr).String()
+		default:
+			panic("unreachable")
+		}
 	case r >= objabi.ElfRelocOffset: // ELF
 		nr := r - objabi.ElfRelocOffset
 		switch arch.Family {

--- a/src/cmd/link/internal/sym/reloc.go
+++ b/src/cmd/link/internal/sym/reloc.go
@@ -37,12 +37,8 @@ func RelocName(arch *sys.Arch, r objabi.RelocType) string {
 		switch arch.Family {
 		case sys.AMD64:
 			return macho.RelocTypeX86_64(nr).String()
-		case sys.ARM:
-			return macho.RelocTypeARM(nr).String()
 		case sys.ARM64:
 			return macho.RelocTypeARM64(nr).String()
-		case sys.I386:
-			return macho.RelocTypeGeneric(nr).String()
 		default:
 			panic("unreachable")
 		}


### PR DESCRIPTION
Currently we include those relocation types in bootstrap code.