### PR TITLE
cmd/compile/internal/types2: use strings.ReplaceAll for goTypeName

### DIFF
--- a/src/cmd/compile/internal/types2/typexpr.go
+++ b/src/cmd/compile/internal/types2/typexpr.go
@@ -207,7 +207,7 @@ func (check *Checker) genericType(e syntax.Expr, cause *string) Type {
 // goTypeName returns the Go type name for typ and
 // removes any occurrences of "types2." from that name.
 func goTypeName(typ Type) string {
-	return strings.Replace(fmt.Sprintf("%T", typ), "types2.", "", -1) // strings.ReplaceAll is not available in Go 1.4
+	return strings.ReplaceAll(fmt.Sprintf("%T", typ), "types2.", "")
 }
 
 // typInternal drives type checking of types.


### PR DESCRIPTION
strings.ReplaceAll is currently available.