### PR TITLE
log/slog: fix Record.back slice always too small during Add()

### DIFF
--- a/src/log/slog/logger_test.go
+++ b/src/log/slog/logger_test.go
@@ -276,7 +276,7 @@ func TestAlloc(t *testing.T) {
 		s := "abc"
 		i := 2000
 		d := time.Second
-		wantAllocs(t, 11, func() {
+		wantAllocs(t, 10, func() {
 			dl.Info("hello",
 				"n", i, "s", s, "d", d,
 				"n", i, "s", s, "d", d,

--- a/src/log/slog/record.go
+++ b/src/log/slog/record.go
@@ -138,12 +138,11 @@ func (r *Record) Add(args ...any) {
 			r.nFront++
 		} else {
 			if r.back == nil {
-				r.back = make([]Attr, 0, countAttrs(args))
+				r.back = make([]Attr, 0, countAttrs(args)+1)
 			}
 			r.back = append(r.back, a)
 		}
 	}
-
 }
 
 // countAttrs returns the number of Attrs that would be created from args.

--- a/src/log/slog/record.go
+++ b/src/log/slog/record.go
@@ -139,6 +139,8 @@ func (r *Record) Add(args ...any) {
 		} else {
 			if r.back == nil {
 				r.back = make([]Attr, 0, countAttrs(args)+1)
+			} else {
+				r.back = slices.Grow(r.back, countAttrs(args)+1)
 			}
 			r.back = append(r.back, a)
 		}

--- a/src/log/slog/record.go
+++ b/src/log/slog/record.go
@@ -139,8 +139,6 @@ func (r *Record) Add(args ...any) {
 		} else {
 			if r.back == nil {
 				r.back = make([]Attr, 0, countAttrs(args)+1)
-			} else {
-				r.back = slices.Grow(r.back, countAttrs(args)+1)
 			}
 			r.back = append(r.back, a)
 		}


### PR DESCRIPTION
When slog.Record.Add(args) is called, with enough args to cause the
Record.back []Attr to be created, it is being created 1 too small, which
results in it immediately being grown again by append before the function
exits (needless allocation and copying).
This is because it is created with a capacity equal to countAttrs(args),
but forgets that there is an additional attribute to be appended: a
(args is just the remaining unconsumed attributes).
This PR fixes that by adding 1 to the capacity to account for the `a` attribute.

Additionally, when Record.back already exists, it will most likely be at
max capacity already. Rather than append to it and risk having it grown
multiple times, or grow too large, this adds a slices.Grow call to set it
to the right capacity, similar to what is already done in the
Record.AddAttrs(attrs) function.
