### PR TITLE
sync: prevent (*Map).Range from always escaping

### DIFF
--- a/src/sync/map.go
+++ b/src/sync/map.go
@@ -461,7 +461,8 @@ func (m *Map) Range(f func(key, value any) bool) {
 		read = m.loadReadOnly()
 		if read.amended {
 			read = readOnly{m: m.dirty}
-			m.read.Store(&read)
+			copyRead := read
+			m.read.Store(&copyRead)
 			m.dirty = nil
 			m.misses = 0
 		}

--- a/src/sync/map_test.go
+++ b/src/sync/map_test.go
@@ -5,6 +5,7 @@
 package sync_test
 
 import (
+	"internal/testenv"
 	"math/rand"
 	"reflect"
 	"runtime"
@@ -278,5 +279,18 @@ func TestCompareAndSwap_NonExistingKey(t *testing.T) {
 	if m.CompareAndSwap(m, nil, 42) {
 		// See https://go.dev/issue/51972#issuecomment-1126408637.
 		t.Fatalf("CompareAndSwap on an non-existing key succeeded")
+	}
+}
+
+func TestMapRangeNoAllocations(t *testing.T) { // Issue 62404
+	testenv.SkipIfOptimizationOff(t)
+	var m sync.Map
+	allocs := testing.AllocsPerRun(10, func() {
+		m.Range(func(key, value any) bool {
+			return true
+		})
+	})
+	if allocs > 0 {
+		t.Errorf("AllocsPerRun of m.Range = %v; want 0", allocs)
 	}
 }


### PR DESCRIPTION
After the change from CL 426074 the Range method on Map always 
escape the read variable, leading to an allocation.

Since the compiler doesn't do live-range splitting for local variables we 
need to use some hints to only escape in that particular branch.

Fixes #62404