### PR TITLE
archive/zip: fix typo in FileHeader struct docs

### DIFF
--- a/src/archive/zip/struct.go
+++ b/src/archive/zip/struct.go
@@ -143,7 +143,7 @@ type FileHeader struct {
 	// Deprecated: Use CompressedSize64 instead.
 	CompressedSize uint32
 
-	// UncompressedSize is the compressed size of the file in bytes.
+	// UncompressedSize is the uncompressed size of the file in bytes.
 	// If either the uncompressed or compressed size of the file
 	// does not fit in 32 bits, CompressedSize is set to ^uint32(0).
 	//

--- a/src/archive/zip/struct.go
+++ b/src/archive/zip/struct.go
@@ -145,7 +145,7 @@ type FileHeader struct {
 
 	// UncompressedSize is the uncompressed size of the file in bytes.
 	// If either the uncompressed or compressed size of the file
-	// does not fit in 32 bits, CompressedSize is set to ^uint32(0).
+	// does not fit in 32 bits, UncompressedSize is set to ^uint32(0).
 	//
 	// Deprecated: Use UncompressedSize64 instead.
 	UncompressedSize uint32


### PR DESCRIPTION
Likely just a copy-paste error.