### PR TITLE
unicode: use *Range32 instead of Range32 in loop of is32

### DIFF
--- a/src/unicode/letter.go
+++ b/src/unicode/letter.go
@@ -140,7 +140,7 @@ func is32(ranges []Range32, r uint32) bool {
 	hi := len(ranges)
 	for lo < hi {
 		m := lo + (hi-lo)/2
-		range_ := ranges[m]
+		range_ := &ranges[m]
 		if range_.Lo <= r && r <= range_.Hi {
 			return range_.Stride == 1 || (r-range_.Lo)%range_.Stride == 0
 		}


### PR DESCRIPTION
As with code above, use *Range32 for consistency. Perhaps
could reduce some instructions at runtime.