### PR TITLE
internal/zstd: fix window resizing

### DIFF
--- a/src/internal/zstd/xxhash_test.go
+++ b/src/internal/zstd/xxhash_test.go
@@ -42,7 +42,11 @@ func TestLargeXXHash(t *testing.T) {
 		t.Skip("skipping expensive test in short mode")
 	}
 
-	data := bigData(t)
+	data, err := os.ReadFile("../../testdata/Isaac.Newton-Opticks.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	var xh xxhash64
 	xh.reset()
 	i := 0

--- a/src/internal/zstd/zstd.go
+++ b/src/internal/zstd/zstd.go
@@ -466,6 +466,7 @@ func (r *Reader) saveWindow(buf []byte) {
 	if keep < len(r.window) {
 		remove := len(r.window) - keep
 		copy(r.window[:], r.window[remove:])
+		r.window = r.window[:keep]
 	}
 
 	r.window = append(r.window, buf...)

--- a/src/internal/zstd/zstd_test.go
+++ b/src/internal/zstd/zstd_test.go
@@ -115,10 +115,13 @@ var (
 	bigDataErr   error
 )
 
-// bigData returns the contents of our large test file.
+// bigData returns the contents of our large test file repeated multiple times.
 func bigData(t testing.TB) []byte {
 	bigDataOnce.Do(func() {
 		bigDataBytes, bigDataErr = os.ReadFile("../../testdata/Isaac.Newton-Opticks.txt")
+		if bigDataErr == nil {
+			bigDataBytes = bytes.Repeat(bigDataBytes, 3)
+		}
 	})
 	if bigDataErr != nil {
 		t.Fatal(bigDataErr)


### PR DESCRIPTION
Incorrect window resizing led to checksum error and invalid result.
To demonstrate the problem bigData must be a bit bigger, 3x is enough.

This change fixes window resizing, increases bigData size and decouples
TestLargeXXHash from bigData because it uses hardcoded hash value.
