### PR TITLE
cmd/compile/internal/typecheck,runtime: replace *int32 of runtime.gorecover with unsafe.Pointer

### DIFF
--- a/src/cmd/compile/internal/typecheck/_builtin/runtime.go
+++ b/src/cmd/compile/internal/typecheck/_builtin/runtime.go
@@ -24,7 +24,7 @@ func throwinit()
 func panicwrap()
 
 func gopanic(interface{})
-func gorecover(*int32) interface{}
+func gorecover(unsafe.Pointer) interface{}
 func goschedguarded()
 
 // Note: these declarations are just for wasm port.

--- a/src/cmd/compile/internal/typecheck/builtin.go
+++ b/src/cmd/compile/internal/typecheck/builtin.go
@@ -36,206 +36,206 @@ var runtimeDecls = [...]struct {
 	{"throwinit", funcTag, 9},
 	{"panicwrap", funcTag, 9},
 	{"gopanic", funcTag, 11},
-	{"gorecover", funcTag, 14},
+	{"gorecover", funcTag, 12},
 	{"goschedguarded", funcTag, 9},
-	{"goPanicIndex", funcTag, 16},
-	{"goPanicIndexU", funcTag, 18},
-	{"goPanicSliceAlen", funcTag, 16},
-	{"goPanicSliceAlenU", funcTag, 18},
-	{"goPanicSliceAcap", funcTag, 16},
-	{"goPanicSliceAcapU", funcTag, 18},
-	{"goPanicSliceB", funcTag, 16},
-	{"goPanicSliceBU", funcTag, 18},
-	{"goPanicSlice3Alen", funcTag, 16},
-	{"goPanicSlice3AlenU", funcTag, 18},
-	{"goPanicSlice3Acap", funcTag, 16},
-	{"goPanicSlice3AcapU", funcTag, 18},
-	{"goPanicSlice3B", funcTag, 16},
-	{"goPanicSlice3BU", funcTag, 18},
-	{"goPanicSlice3C", funcTag, 16},
-	{"goPanicSlice3CU", funcTag, 18},
-	{"goPanicSliceConvert", funcTag, 16},
-	{"printbool", funcTag, 19},
-	{"printfloat", funcTag, 21},
-	{"printint", funcTag, 23},
-	{"printhex", funcTag, 25},
-	{"printuint", funcTag, 25},
-	{"printcomplex", funcTag, 27},
-	{"printstring", funcTag, 29},
-	{"printpointer", funcTag, 30},
-	{"printuintptr", funcTag, 31},
-	{"printiface", funcTag, 30},
-	{"printeface", funcTag, 30},
-	{"printslice", funcTag, 30},
+	{"goPanicIndex", funcTag, 14},
+	{"goPanicIndexU", funcTag, 16},
+	{"goPanicSliceAlen", funcTag, 14},
+	{"goPanicSliceAlenU", funcTag, 16},
+	{"goPanicSliceAcap", funcTag, 14},
+	{"goPanicSliceAcapU", funcTag, 16},
+	{"goPanicSliceB", funcTag, 14},
+	{"goPanicSliceBU", funcTag, 16},
+	{"goPanicSlice3Alen", funcTag, 14},
+	{"goPanicSlice3AlenU", funcTag, 16},
+	{"goPanicSlice3Acap", funcTag, 14},
+	{"goPanicSlice3AcapU", funcTag, 16},
+	{"goPanicSlice3B", funcTag, 14},
+	{"goPanicSlice3BU", funcTag, 16},
+	{"goPanicSlice3C", funcTag, 14},
+	{"goPanicSlice3CU", funcTag, 16},
+	{"goPanicSliceConvert", funcTag, 14},
+	{"printbool", funcTag, 17},
+	{"printfloat", funcTag, 19},
+	{"printint", funcTag, 21},
+	{"printhex", funcTag, 23},
+	{"printuint", funcTag, 23},
+	{"printcomplex", funcTag, 25},
+	{"printstring", funcTag, 27},
+	{"printpointer", funcTag, 28},
+	{"printuintptr", funcTag, 29},
+	{"printiface", funcTag, 28},
+	{"printeface", funcTag, 28},
+	{"printslice", funcTag, 28},
 	{"printnl", funcTag, 9},
 	{"printsp", funcTag, 9},
 	{"printlock", funcTag, 9},
 	{"printunlock", funcTag, 9},
-	{"concatstring2", funcTag, 34},
-	{"concatstring3", funcTag, 35},
-	{"concatstring4", funcTag, 36},
-	{"concatstring5", funcTag, 37},
-	{"concatstrings", funcTag, 39},
-	{"cmpstring", funcTag, 40},
-	{"intstring", funcTag, 43},
-	{"slicebytetostring", funcTag, 44},
-	{"slicebytetostringtmp", funcTag, 45},
-	{"slicerunetostring", funcTag, 48},
-	{"stringtoslicebyte", funcTag, 50},
-	{"stringtoslicerune", funcTag, 53},
-	{"slicecopy", funcTag, 54},
-	{"decoderune", funcTag, 55},
-	{"countrunes", funcTag, 56},
-	{"convT", funcTag, 57},
-	{"convTnoptr", funcTag, 57},
-	{"convT16", funcTag, 59},
-	{"convT32", funcTag, 61},
-	{"convT64", funcTag, 62},
-	{"convTstring", funcTag, 63},
-	{"convTslice", funcTag, 66},
-	{"assertE2I", funcTag, 67},
-	{"assertE2I2", funcTag, 67},
-	{"panicdottypeE", funcTag, 68},
-	{"panicdottypeI", funcTag, 68},
-	{"panicnildottype", funcTag, 69},
-	{"typeAssert", funcTag, 67},
-	{"interfaceSwitch", funcTag, 70},
-	{"ifaceeq", funcTag, 72},
-	{"efaceeq", funcTag, 72},
+	{"concatstring2", funcTag, 32},
+	{"concatstring3", funcTag, 33},
+	{"concatstring4", funcTag, 34},
+	{"concatstring5", funcTag, 35},
+	{"concatstrings", funcTag, 37},
+	{"cmpstring", funcTag, 38},
+	{"intstring", funcTag, 41},
+	{"slicebytetostring", funcTag, 42},
+	{"slicebytetostringtmp", funcTag, 43},
+	{"slicerunetostring", funcTag, 46},
+	{"stringtoslicebyte", funcTag, 48},
+	{"stringtoslicerune", funcTag, 51},
+	{"slicecopy", funcTag, 52},
+	{"decoderune", funcTag, 53},
+	{"countrunes", funcTag, 54},
+	{"convT", funcTag, 55},
+	{"convTnoptr", funcTag, 55},
+	{"convT16", funcTag, 57},
+	{"convT32", funcTag, 59},
+	{"convT64", funcTag, 60},
+	{"convTstring", funcTag, 61},
+	{"convTslice", funcTag, 64},
+	{"assertE2I", funcTag, 65},
+	{"assertE2I2", funcTag, 65},
+	{"panicdottypeE", funcTag, 66},
+	{"panicdottypeI", funcTag, 66},
+	{"panicnildottype", funcTag, 67},
+	{"typeAssert", funcTag, 65},
+	{"interfaceSwitch", funcTag, 68},
+	{"ifaceeq", funcTag, 70},
+	{"efaceeq", funcTag, 70},
 	{"panicrangeexit", funcTag, 9},
-	{"deferrangefunc", funcTag, 73},
-	{"rand32", funcTag, 74},
-	{"makemap64", funcTag, 76},
-	{"makemap", funcTag, 77},
-	{"makemap_small", funcTag, 78},
-	{"mapaccess1", funcTag, 79},
-	{"mapaccess1_fast32", funcTag, 80},
-	{"mapaccess1_fast64", funcTag, 81},
-	{"mapaccess1_faststr", funcTag, 82},
-	{"mapaccess1_fat", funcTag, 83},
-	{"mapaccess2", funcTag, 84},
-	{"mapaccess2_fast32", funcTag, 85},
-	{"mapaccess2_fast64", funcTag, 86},
-	{"mapaccess2_faststr", funcTag, 87},
-	{"mapaccess2_fat", funcTag, 88},
-	{"mapassign", funcTag, 79},
-	{"mapassign_fast32", funcTag, 80},
-	{"mapassign_fast32ptr", funcTag, 89},
-	{"mapassign_fast64", funcTag, 81},
-	{"mapassign_fast64ptr", funcTag, 89},
-	{"mapassign_faststr", funcTag, 82},
-	{"mapiterinit", funcTag, 90},
-	{"mapdelete", funcTag, 90},
-	{"mapdelete_fast32", funcTag, 91},
-	{"mapdelete_fast64", funcTag, 92},
-	{"mapdelete_faststr", funcTag, 93},
-	{"mapiternext", funcTag, 94},
-	{"mapclear", funcTag, 95},
-	{"makechan64", funcTag, 97},
-	{"makechan", funcTag, 98},
-	{"chanrecv1", funcTag, 100},
-	{"chanrecv2", funcTag, 101},
-	{"chansend1", funcTag, 103},
-	{"closechan", funcTag, 30},
-	{"writeBarrier", varTag, 105},
-	{"typedmemmove", funcTag, 106},
-	{"typedmemclr", funcTag, 107},
-	{"typedslicecopy", funcTag, 108},
-	{"selectnbsend", funcTag, 109},
-	{"selectnbrecv", funcTag, 110},
-	{"selectsetpc", funcTag, 111},
-	{"selectgo", funcTag, 112},
+	{"deferrangefunc", funcTag, 71},
+	{"rand32", funcTag, 72},
+	{"makemap64", funcTag, 74},
+	{"makemap", funcTag, 75},
+	{"makemap_small", funcTag, 76},
+	{"mapaccess1", funcTag, 77},
+	{"mapaccess1_fast32", funcTag, 78},
+	{"mapaccess1_fast64", funcTag, 79},
+	{"mapaccess1_faststr", funcTag, 80},
+	{"mapaccess1_fat", funcTag, 81},
+	{"mapaccess2", funcTag, 82},
+	{"mapaccess2_fast32", funcTag, 83},
+	{"mapaccess2_fast64", funcTag, 84},
+	{"mapaccess2_faststr", funcTag, 85},
+	{"mapaccess2_fat", funcTag, 86},
+	{"mapassign", funcTag, 77},
+	{"mapassign_fast32", funcTag, 78},
+	{"mapassign_fast32ptr", funcTag, 87},
+	{"mapassign_fast64", funcTag, 79},
+	{"mapassign_fast64ptr", funcTag, 87},
+	{"mapassign_faststr", funcTag, 80},
+	{"mapiterinit", funcTag, 88},
+	{"mapdelete", funcTag, 88},
+	{"mapdelete_fast32", funcTag, 89},
+	{"mapdelete_fast64", funcTag, 90},
+	{"mapdelete_faststr", funcTag, 91},
+	{"mapiternext", funcTag, 92},
+	{"mapclear", funcTag, 93},
+	{"makechan64", funcTag, 95},
+	{"makechan", funcTag, 96},
+	{"chanrecv1", funcTag, 98},
+	{"chanrecv2", funcTag, 99},
+	{"chansend1", funcTag, 101},
+	{"closechan", funcTag, 28},
+	{"writeBarrier", varTag, 103},
+	{"typedmemmove", funcTag, 104},
+	{"typedmemclr", funcTag, 105},
+	{"typedslicecopy", funcTag, 106},
+	{"selectnbsend", funcTag, 107},
+	{"selectnbrecv", funcTag, 108},
+	{"selectsetpc", funcTag, 109},
+	{"selectgo", funcTag, 110},
 	{"block", funcTag, 9},
-	{"makeslice", funcTag, 113},
-	{"makeslice64", funcTag, 114},
-	{"makeslicecopy", funcTag, 115},
-	{"growslice", funcTag, 117},
-	{"unsafeslicecheckptr", funcTag, 118},
+	{"makeslice", funcTag, 111},
+	{"makeslice64", funcTag, 112},
+	{"makeslicecopy", funcTag, 113},
+	{"growslice", funcTag, 115},
+	{"unsafeslicecheckptr", funcTag, 116},
 	{"panicunsafeslicelen", funcTag, 9},
 	{"panicunsafeslicenilptr", funcTag, 9},
-	{"unsafestringcheckptr", funcTag, 119},
+	{"unsafestringcheckptr", funcTag, 117},
 	{"panicunsafestringlen", funcTag, 9},
 	{"panicunsafestringnilptr", funcTag, 9},
-	{"memmove", funcTag, 120},
-	{"memclrNoHeapPointers", funcTag, 121},
-	{"memclrHasPointers", funcTag, 121},
-	{"memequal", funcTag, 122},
-	{"memequal0", funcTag, 123},
-	{"memequal8", funcTag, 123},
-	{"memequal16", funcTag, 123},
-	{"memequal32", funcTag, 123},
-	{"memequal64", funcTag, 123},
-	{"memequal128", funcTag, 123},
-	{"f32equal", funcTag, 124},
-	{"f64equal", funcTag, 124},
-	{"c64equal", funcTag, 124},
-	{"c128equal", funcTag, 124},
-	{"strequal", funcTag, 124},
-	{"interequal", funcTag, 124},
-	{"nilinterequal", funcTag, 124},
-	{"memhash", funcTag, 125},
-	{"memhash0", funcTag, 126},
-	{"memhash8", funcTag, 126},
-	{"memhash16", funcTag, 126},
-	{"memhash32", funcTag, 126},
-	{"memhash64", funcTag, 126},
-	{"memhash128", funcTag, 126},
-	{"f32hash", funcTag, 127},
-	{"f64hash", funcTag, 127},
-	{"c64hash", funcTag, 127},
-	{"c128hash", funcTag, 127},
-	{"strhash", funcTag, 127},
-	{"interhash", funcTag, 127},
-	{"nilinterhash", funcTag, 127},
-	{"int64div", funcTag, 128},
-	{"uint64div", funcTag, 129},
-	{"int64mod", funcTag, 128},
-	{"uint64mod", funcTag, 129},
-	{"float64toint64", funcTag, 130},
-	{"float64touint64", funcTag, 131},
-	{"float64touint32", funcTag, 132},
-	{"int64tofloat64", funcTag, 133},
-	{"int64tofloat32", funcTag, 135},
-	{"uint64tofloat64", funcTag, 136},
-	{"uint64tofloat32", funcTag, 137},
-	{"uint32tofloat64", funcTag, 138},
-	{"complex128div", funcTag, 139},
-	{"getcallerpc", funcTag, 140},
-	{"getcallersp", funcTag, 140},
-	{"racefuncenter", funcTag, 31},
+	{"memmove", funcTag, 118},
+	{"memclrNoHeapPointers", funcTag, 119},
+	{"memclrHasPointers", funcTag, 119},
+	{"memequal", funcTag, 120},
+	{"memequal0", funcTag, 121},
+	{"memequal8", funcTag, 121},
+	{"memequal16", funcTag, 121},
+	{"memequal32", funcTag, 121},
+	{"memequal64", funcTag, 121},
+	{"memequal128", funcTag, 121},
+	{"f32equal", funcTag, 122},
+	{"f64equal", funcTag, 122},
+	{"c64equal", funcTag, 122},
+	{"c128equal", funcTag, 122},
+	{"strequal", funcTag, 122},
+	{"interequal", funcTag, 122},
+	{"nilinterequal", funcTag, 122},
+	{"memhash", funcTag, 123},
+	{"memhash0", funcTag, 124},
+	{"memhash8", funcTag, 124},
+	{"memhash16", funcTag, 124},
+	{"memhash32", funcTag, 124},
+	{"memhash64", funcTag, 124},
+	{"memhash128", funcTag, 124},
+	{"f32hash", funcTag, 125},
+	{"f64hash", funcTag, 125},
+	{"c64hash", funcTag, 125},
+	{"c128hash", funcTag, 125},
+	{"strhash", funcTag, 125},
+	{"interhash", funcTag, 125},
+	{"nilinterhash", funcTag, 125},
+	{"int64div", funcTag, 126},
+	{"uint64div", funcTag, 127},
+	{"int64mod", funcTag, 126},
+	{"uint64mod", funcTag, 127},
+	{"float64toint64", funcTag, 128},
+	{"float64touint64", funcTag, 129},
+	{"float64touint32", funcTag, 130},
+	{"int64tofloat64", funcTag, 131},
+	{"int64tofloat32", funcTag, 133},
+	{"uint64tofloat64", funcTag, 134},
+	{"uint64tofloat32", funcTag, 135},
+	{"uint32tofloat64", funcTag, 136},
+	{"complex128div", funcTag, 137},
+	{"getcallerpc", funcTag, 138},
+	{"getcallersp", funcTag, 138},
+	{"racefuncenter", funcTag, 29},
 	{"racefuncexit", funcTag, 9},
-	{"raceread", funcTag, 31},
-	{"racewrite", funcTag, 31},
-	{"racereadrange", funcTag, 141},
-	{"racewriterange", funcTag, 141},
-	{"msanread", funcTag, 141},
-	{"msanwrite", funcTag, 141},
-	{"msanmove", funcTag, 142},
-	{"asanread", funcTag, 141},
-	{"asanwrite", funcTag, 141},
-	{"checkptrAlignment", funcTag, 143},
-	{"checkptrArithmetic", funcTag, 145},
-	{"libfuzzerTraceCmp1", funcTag, 146},
-	{"libfuzzerTraceCmp2", funcTag, 147},
-	{"libfuzzerTraceCmp4", funcTag, 148},
-	{"libfuzzerTraceCmp8", funcTag, 149},
-	{"libfuzzerTraceConstCmp1", funcTag, 146},
-	{"libfuzzerTraceConstCmp2", funcTag, 147},
-	{"libfuzzerTraceConstCmp4", funcTag, 148},
-	{"libfuzzerTraceConstCmp8", funcTag, 149},
-	{"libfuzzerHookStrCmp", funcTag, 150},
-	{"libfuzzerHookEqualFold", funcTag, 150},
-	{"addCovMeta", funcTag, 152},
+	{"raceread", funcTag, 29},
+	{"racewrite", funcTag, 29},
+	{"racereadrange", funcTag, 139},
+	{"racewriterange", funcTag, 139},
+	{"msanread", funcTag, 139},
+	{"msanwrite", funcTag, 139},
+	{"msanmove", funcTag, 140},
+	{"asanread", funcTag, 139},
+	{"asanwrite", funcTag, 139},
+	{"checkptrAlignment", funcTag, 141},
+	{"checkptrArithmetic", funcTag, 143},
+	{"libfuzzerTraceCmp1", funcTag, 144},
+	{"libfuzzerTraceCmp2", funcTag, 145},
+	{"libfuzzerTraceCmp4", funcTag, 146},
+	{"libfuzzerTraceCmp8", funcTag, 147},
+	{"libfuzzerTraceConstCmp1", funcTag, 144},
+	{"libfuzzerTraceConstCmp2", funcTag, 145},
+	{"libfuzzerTraceConstCmp4", funcTag, 146},
+	{"libfuzzerTraceConstCmp8", funcTag, 147},
+	{"libfuzzerHookStrCmp", funcTag, 148},
+	{"libfuzzerHookEqualFold", funcTag, 148},
+	{"addCovMeta", funcTag, 150},
 	{"x86HasPOPCNT", varTag, 6},
 	{"x86HasSSE41", varTag, 6},
 	{"x86HasFMA", varTag, 6},
 	{"armHasVFPv4", varTag, 6},
 	{"arm64HasATOMICS", varTag, 6},
-	{"asanregisterglobals", funcTag, 121},
+	{"asanregisterglobals", funcTag, 119},
 }
 
 func runtimeTypes() []*types.Type {
-	var typs [153]*types.Type
+	var typs [151]*types.Type
 	typs[0] = types.ByteType
 	typs[1] = types.NewPtr(typs[0])
 	typs[2] = types.Types[types.TANY]
@@ -248,147 +248,145 @@ func runtimeTypes() []*types.Type {
 	typs[9] = newSig(nil, nil)
 	typs[10] = types.Types[types.TINTER]
 	typs[11] = newSig(params(typs[10]), nil)
-	typs[12] = types.Types[types.TINT32]
-	typs[13] = types.NewPtr(typs[12])
-	typs[14] = newSig(params(typs[13]), params(typs[10]))
-	typs[15] = types.Types[types.TINT]
-	typs[16] = newSig(params(typs[15], typs[15]), nil)
-	typs[17] = types.Types[types.TUINT]
-	typs[18] = newSig(params(typs[17], typs[15]), nil)
-	typs[19] = newSig(params(typs[6]), nil)
-	typs[20] = types.Types[types.TFLOAT64]
+	typs[12] = newSig(params(typs[7]), params(typs[10]))
+	typs[13] = types.Types[types.TINT]
+	typs[14] = newSig(params(typs[13], typs[13]), nil)
+	typs[15] = types.Types[types.TUINT]
+	typs[16] = newSig(params(typs[15], typs[13]), nil)
+	typs[17] = newSig(params(typs[6]), nil)
+	typs[18] = types.Types[types.TFLOAT64]
+	typs[19] = newSig(params(typs[18]), nil)
+	typs[20] = types.Types[types.TINT64]
 	typs[21] = newSig(params(typs[20]), nil)
-	typs[22] = types.Types[types.TINT64]
+	typs[22] = types.Types[types.TUINT64]
 	typs[23] = newSig(params(typs[22]), nil)
-	typs[24] = types.Types[types.TUINT64]
+	typs[24] = types.Types[types.TCOMPLEX128]
 	typs[25] = newSig(params(typs[24]), nil)
-	typs[26] = types.Types[types.TCOMPLEX128]
+	typs[26] = types.Types[types.TSTRING]
 	typs[27] = newSig(params(typs[26]), nil)
-	typs[28] = types.Types[types.TSTRING]
-	typs[29] = newSig(params(typs[28]), nil)
-	typs[30] = newSig(params(typs[2]), nil)
-	typs[31] = newSig(params(typs[5]), nil)
-	typs[32] = types.NewArray(typs[0], 32)
-	typs[33] = types.NewPtr(typs[32])
-	typs[34] = newSig(params(typs[33], typs[28], typs[28]), params(typs[28]))
-	typs[35] = newSig(params(typs[33], typs[28], typs[28], typs[28]), params(typs[28]))
-	typs[36] = newSig(params(typs[33], typs[28], typs[28], typs[28], typs[28]), params(typs[28]))
-	typs[37] = newSig(params(typs[33], typs[28], typs[28], typs[28], typs[28], typs[28]), params(typs[28]))
-	typs[38] = types.NewSlice(typs[28])
-	typs[39] = newSig(params(typs[33], typs[38]), params(typs[28]))
-	typs[40] = newSig(params(typs[28], typs[28]), params(typs[15]))
-	typs[41] = types.NewArray(typs[0], 4)
-	typs[42] = types.NewPtr(typs[41])
-	typs[43] = newSig(params(typs[42], typs[22]), params(typs[28]))
-	typs[44] = newSig(params(typs[33], typs[1], typs[15]), params(typs[28]))
-	typs[45] = newSig(params(typs[1], typs[15]), params(typs[28]))
-	typs[46] = types.RuneType
-	typs[47] = types.NewSlice(typs[46])
-	typs[48] = newSig(params(typs[33], typs[47]), params(typs[28]))
-	typs[49] = types.NewSlice(typs[0])
-	typs[50] = newSig(params(typs[33], typs[28]), params(typs[49]))
-	typs[51] = types.NewArray(typs[46], 32)
-	typs[52] = types.NewPtr(typs[51])
-	typs[53] = newSig(params(typs[52], typs[28]), params(typs[47]))
-	typs[54] = newSig(params(typs[3], typs[15], typs[3], typs[15], typs[5]), params(typs[15]))
-	typs[55] = newSig(params(typs[28], typs[15]), params(typs[46], typs[15]))
-	typs[56] = newSig(params(typs[28]), params(typs[15]))
-	typs[57] = newSig(params(typs[1], typs[3]), params(typs[7]))
-	typs[58] = types.Types[types.TUINT16]
+	typs[28] = newSig(params(typs[2]), nil)
+	typs[29] = newSig(params(typs[5]), nil)
+	typs[30] = types.NewArray(typs[0], 32)
+	typs[31] = types.NewPtr(typs[30])
+	typs[32] = newSig(params(typs[31], typs[26], typs[26]), params(typs[26]))
+	typs[33] = newSig(params(typs[31], typs[26], typs[26], typs[26]), params(typs[26]))
+	typs[34] = newSig(params(typs[31], typs[26], typs[26], typs[26], typs[26]), params(typs[26]))
+	typs[35] = newSig(params(typs[31], typs[26], typs[26], typs[26], typs[26], typs[26]), params(typs[26]))
+	typs[36] = types.NewSlice(typs[26])
+	typs[37] = newSig(params(typs[31], typs[36]), params(typs[26]))
+	typs[38] = newSig(params(typs[26], typs[26]), params(typs[13]))
+	typs[39] = types.NewArray(typs[0], 4)
+	typs[40] = types.NewPtr(typs[39])
+	typs[41] = newSig(params(typs[40], typs[20]), params(typs[26]))
+	typs[42] = newSig(params(typs[31], typs[1], typs[13]), params(typs[26]))
+	typs[43] = newSig(params(typs[1], typs[13]), params(typs[26]))
+	typs[44] = types.RuneType
+	typs[45] = types.NewSlice(typs[44])
+	typs[46] = newSig(params(typs[31], typs[45]), params(typs[26]))
+	typs[47] = types.NewSlice(typs[0])
+	typs[48] = newSig(params(typs[31], typs[26]), params(typs[47]))
+	typs[49] = types.NewArray(typs[44], 32)
+	typs[50] = types.NewPtr(typs[49])
+	typs[51] = newSig(params(typs[50], typs[26]), params(typs[45]))
+	typs[52] = newSig(params(typs[3], typs[13], typs[3], typs[13], typs[5]), params(typs[13]))
+	typs[53] = newSig(params(typs[26], typs[13]), params(typs[44], typs[13]))
+	typs[54] = newSig(params(typs[26]), params(typs[13]))
+	typs[55] = newSig(params(typs[1], typs[3]), params(typs[7]))
+	typs[56] = types.Types[types.TUINT16]
+	typs[57] = newSig(params(typs[56]), params(typs[7]))
+	typs[58] = types.Types[types.TUINT32]
 	typs[59] = newSig(params(typs[58]), params(typs[7]))
-	typs[60] = types.Types[types.TUINT32]
-	typs[61] = newSig(params(typs[60]), params(typs[7]))
-	typs[62] = newSig(params(typs[24]), params(typs[7]))
-	typs[63] = newSig(params(typs[28]), params(typs[7]))
-	typs[64] = types.Types[types.TUINT8]
-	typs[65] = types.NewSlice(typs[64])
-	typs[66] = newSig(params(typs[65]), params(typs[7]))
-	typs[67] = newSig(params(typs[1], typs[1]), params(typs[1]))
-	typs[68] = newSig(params(typs[1], typs[1], typs[1]), nil)
-	typs[69] = newSig(params(typs[1]), nil)
-	typs[70] = newSig(params(typs[1], typs[1]), params(typs[15], typs[1]))
-	typs[71] = types.NewPtr(typs[5])
-	typs[72] = newSig(params(typs[71], typs[7], typs[7]), params(typs[6]))
-	typs[73] = newSig(nil, params(typs[10]))
-	typs[74] = newSig(nil, params(typs[60]))
-	typs[75] = types.NewMap(typs[2], typs[2])
-	typs[76] = newSig(params(typs[1], typs[22], typs[3]), params(typs[75]))
-	typs[77] = newSig(params(typs[1], typs[15], typs[3]), params(typs[75]))
-	typs[78] = newSig(nil, params(typs[75]))
-	typs[79] = newSig(params(typs[1], typs[75], typs[3]), params(typs[3]))
-	typs[80] = newSig(params(typs[1], typs[75], typs[60]), params(typs[3]))
-	typs[81] = newSig(params(typs[1], typs[75], typs[24]), params(typs[3]))
-	typs[82] = newSig(params(typs[1], typs[75], typs[28]), params(typs[3]))
-	typs[83] = newSig(params(typs[1], typs[75], typs[3], typs[1]), params(typs[3]))
-	typs[84] = newSig(params(typs[1], typs[75], typs[3]), params(typs[3], typs[6]))
-	typs[85] = newSig(params(typs[1], typs[75], typs[60]), params(typs[3], typs[6]))
-	typs[86] = newSig(params(typs[1], typs[75], typs[24]), params(typs[3], typs[6]))
-	typs[87] = newSig(params(typs[1], typs[75], typs[28]), params(typs[3], typs[6]))
-	typs[88] = newSig(params(typs[1], typs[75], typs[3], typs[1]), params(typs[3], typs[6]))
-	typs[89] = newSig(params(typs[1], typs[75], typs[7]), params(typs[3]))
-	typs[90] = newSig(params(typs[1], typs[75], typs[3]), nil)
-	typs[91] = newSig(params(typs[1], typs[75], typs[60]), nil)
-	typs[92] = newSig(params(typs[1], typs[75], typs[24]), nil)
-	typs[93] = newSig(params(typs[1], typs[75], typs[28]), nil)
-	typs[94] = newSig(params(typs[3]), nil)
-	typs[95] = newSig(params(typs[1], typs[75]), nil)
-	typs[96] = types.NewChan(typs[2], types.Cboth)
-	typs[97] = newSig(params(typs[1], typs[22]), params(typs[96]))
-	typs[98] = newSig(params(typs[1], typs[15]), params(typs[96]))
-	typs[99] = types.NewChan(typs[2], types.Crecv)
-	typs[100] = newSig(params(typs[99], typs[3]), nil)
-	typs[101] = newSig(params(typs[99], typs[3]), params(typs[6]))
-	typs[102] = types.NewChan(typs[2], types.Csend)
-	typs[103] = newSig(params(typs[102], typs[3]), nil)
-	typs[104] = types.NewArray(typs[0], 3)
-	typs[105] = types.NewStruct([]*types.Field{types.NewField(src.NoXPos, Lookup("enabled"), typs[6]), types.NewField(src.NoXPos, Lookup("pad"), typs[104]), types.NewField(src.NoXPos, Lookup("cgo"), typs[6]), types.NewField(src.NoXPos, Lookup("alignme"), typs[24])})
-	typs[106] = newSig(params(typs[1], typs[3], typs[3]), nil)
-	typs[107] = newSig(params(typs[1], typs[3]), nil)
-	typs[108] = newSig(params(typs[1], typs[3], typs[15], typs[3], typs[15]), params(typs[15]))
-	typs[109] = newSig(params(typs[102], typs[3]), params(typs[6]))
-	typs[110] = newSig(params(typs[3], typs[99]), params(typs[6], typs[6]))
-	typs[111] = newSig(params(typs[71]), nil)
-	typs[112] = newSig(params(typs[1], typs[1], typs[71], typs[15], typs[15], typs[6]), params(typs[15], typs[6]))
-	typs[113] = newSig(params(typs[1], typs[15], typs[15]), params(typs[7]))
-	typs[114] = newSig(params(typs[1], typs[22], typs[22]), params(typs[7]))
-	typs[115] = newSig(params(typs[1], typs[15], typs[15], typs[7]), params(typs[7]))
-	typs[116] = types.NewSlice(typs[2])
-	typs[117] = newSig(params(typs[3], typs[15], typs[15], typs[15], typs[1]), params(typs[116]))
-	typs[118] = newSig(params(typs[1], typs[7], typs[22]), nil)
-	typs[119] = newSig(params(typs[7], typs[22]), nil)
-	typs[120] = newSig(params(typs[3], typs[3], typs[5]), nil)
-	typs[121] = newSig(params(typs[7], typs[5]), nil)
-	typs[122] = newSig(params(typs[3], typs[3], typs[5]), params(typs[6]))
-	typs[123] = newSig(params(typs[3], typs[3]), params(typs[6]))
-	typs[124] = newSig(params(typs[7], typs[7]), params(typs[6]))
-	typs[125] = newSig(params(typs[3], typs[5], typs[5]), params(typs[5]))
-	typs[126] = newSig(params(typs[7], typs[5]), params(typs[5]))
-	typs[127] = newSig(params(typs[3], typs[5]), params(typs[5]))
-	typs[128] = newSig(params(typs[22], typs[22]), params(typs[22]))
-	typs[129] = newSig(params(typs[24], typs[24]), params(typs[24]))
-	typs[130] = newSig(params(typs[20]), params(typs[22]))
-	typs[131] = newSig(params(typs[20]), params(typs[24]))
-	typs[132] = newSig(params(typs[20]), params(typs[60]))
-	typs[133] = newSig(params(typs[22]), params(typs[20]))
-	typs[134] = types.Types[types.TFLOAT32]
-	typs[135] = newSig(params(typs[22]), params(typs[134]))
-	typs[136] = newSig(params(typs[24]), params(typs[20]))
-	typs[137] = newSig(params(typs[24]), params(typs[134]))
-	typs[138] = newSig(params(typs[60]), params(typs[20]))
-	typs[139] = newSig(params(typs[26], typs[26]), params(typs[26]))
-	typs[140] = newSig(nil, params(typs[5]))
-	typs[141] = newSig(params(typs[5], typs[5]), nil)
-	typs[142] = newSig(params(typs[5], typs[5], typs[5]), nil)
-	typs[143] = newSig(params(typs[7], typs[1], typs[5]), nil)
-	typs[144] = types.NewSlice(typs[7])
-	typs[145] = newSig(params(typs[7], typs[144]), nil)
-	typs[146] = newSig(params(typs[64], typs[64], typs[17]), nil)
-	typs[147] = newSig(params(typs[58], typs[58], typs[17]), nil)
-	typs[148] = newSig(params(typs[60], typs[60], typs[17]), nil)
-	typs[149] = newSig(params(typs[24], typs[24], typs[17]), nil)
-	typs[150] = newSig(params(typs[28], typs[28], typs[17]), nil)
-	typs[151] = types.NewArray(typs[0], 16)
-	typs[152] = newSig(params(typs[7], typs[60], typs[151], typs[28], typs[15], typs[64], typs[64]), params(typs[60]))
+	typs[60] = newSig(params(typs[22]), params(typs[7]))
+	typs[61] = newSig(params(typs[26]), params(typs[7]))
+	typs[62] = types.Types[types.TUINT8]
+	typs[63] = types.NewSlice(typs[62])
+	typs[64] = newSig(params(typs[63]), params(typs[7]))
+	typs[65] = newSig(params(typs[1], typs[1]), params(typs[1]))
+	typs[66] = newSig(params(typs[1], typs[1], typs[1]), nil)
+	typs[67] = newSig(params(typs[1]), nil)
+	typs[68] = newSig(params(typs[1], typs[1]), params(typs[13], typs[1]))
+	typs[69] = types.NewPtr(typs[5])
+	typs[70] = newSig(params(typs[69], typs[7], typs[7]), params(typs[6]))
+	typs[71] = newSig(nil, params(typs[10]))
+	typs[72] = newSig(nil, params(typs[58]))
+	typs[73] = types.NewMap(typs[2], typs[2])
+	typs[74] = newSig(params(typs[1], typs[20], typs[3]), params(typs[73]))
+	typs[75] = newSig(params(typs[1], typs[13], typs[3]), params(typs[73]))
+	typs[76] = newSig(nil, params(typs[73]))
+	typs[77] = newSig(params(typs[1], typs[73], typs[3]), params(typs[3]))
+	typs[78] = newSig(params(typs[1], typs[73], typs[58]), params(typs[3]))
+	typs[79] = newSig(params(typs[1], typs[73], typs[22]), params(typs[3]))
+	typs[80] = newSig(params(typs[1], typs[73], typs[26]), params(typs[3]))
+	typs[81] = newSig(params(typs[1], typs[73], typs[3], typs[1]), params(typs[3]))
+	typs[82] = newSig(params(typs[1], typs[73], typs[3]), params(typs[3], typs[6]))
+	typs[83] = newSig(params(typs[1], typs[73], typs[58]), params(typs[3], typs[6]))
+	typs[84] = newSig(params(typs[1], typs[73], typs[22]), params(typs[3], typs[6]))
+	typs[85] = newSig(params(typs[1], typs[73], typs[26]), params(typs[3], typs[6]))
+	typs[86] = newSig(params(typs[1], typs[73], typs[3], typs[1]), params(typs[3], typs[6]))
+	typs[87] = newSig(params(typs[1], typs[73], typs[7]), params(typs[3]))
+	typs[88] = newSig(params(typs[1], typs[73], typs[3]), nil)
+	typs[89] = newSig(params(typs[1], typs[73], typs[58]), nil)
+	typs[90] = newSig(params(typs[1], typs[73], typs[22]), nil)
+	typs[91] = newSig(params(typs[1], typs[73], typs[26]), nil)
+	typs[92] = newSig(params(typs[3]), nil)
+	typs[93] = newSig(params(typs[1], typs[73]), nil)
+	typs[94] = types.NewChan(typs[2], types.Cboth)
+	typs[95] = newSig(params(typs[1], typs[20]), params(typs[94]))
+	typs[96] = newSig(params(typs[1], typs[13]), params(typs[94]))
+	typs[97] = types.NewChan(typs[2], types.Crecv)
+	typs[98] = newSig(params(typs[97], typs[3]), nil)
+	typs[99] = newSig(params(typs[97], typs[3]), params(typs[6]))
+	typs[100] = types.NewChan(typs[2], types.Csend)
+	typs[101] = newSig(params(typs[100], typs[3]), nil)
+	typs[102] = types.NewArray(typs[0], 3)
+	typs[103] = types.NewStruct([]*types.Field{types.NewField(src.NoXPos, Lookup("enabled"), typs[6]), types.NewField(src.NoXPos, Lookup("pad"), typs[102]), types.NewField(src.NoXPos, Lookup("cgo"), typs[6]), types.NewField(src.NoXPos, Lookup("alignme"), typs[22])})
+	typs[104] = newSig(params(typs[1], typs[3], typs[3]), nil)
+	typs[105] = newSig(params(typs[1], typs[3]), nil)
+	typs[106] = newSig(params(typs[1], typs[3], typs[13], typs[3], typs[13]), params(typs[13]))
+	typs[107] = newSig(params(typs[100], typs[3]), params(typs[6]))
+	typs[108] = newSig(params(typs[3], typs[97]), params(typs[6], typs[6]))
+	typs[109] = newSig(params(typs[69]), nil)
+	typs[110] = newSig(params(typs[1], typs[1], typs[69], typs[13], typs[13], typs[6]), params(typs[13], typs[6]))
+	typs[111] = newSig(params(typs[1], typs[13], typs[13]), params(typs[7]))
+	typs[112] = newSig(params(typs[1], typs[20], typs[20]), params(typs[7]))
+	typs[113] = newSig(params(typs[1], typs[13], typs[13], typs[7]), params(typs[7]))
+	typs[114] = types.NewSlice(typs[2])
+	typs[115] = newSig(params(typs[3], typs[13], typs[13], typs[13], typs[1]), params(typs[114]))
+	typs[116] = newSig(params(typs[1], typs[7], typs[20]), nil)
+	typs[117] = newSig(params(typs[7], typs[20]), nil)
+	typs[118] = newSig(params(typs[3], typs[3], typs[5]), nil)
+	typs[119] = newSig(params(typs[7], typs[5]), nil)
+	typs[120] = newSig(params(typs[3], typs[3], typs[5]), params(typs[6]))
+	typs[121] = newSig(params(typs[3], typs[3]), params(typs[6]))
+	typs[122] = newSig(params(typs[7], typs[7]), params(typs[6]))
+	typs[123] = newSig(params(typs[3], typs[5], typs[5]), params(typs[5]))
+	typs[124] = newSig(params(typs[7], typs[5]), params(typs[5]))
+	typs[125] = newSig(params(typs[3], typs[5]), params(typs[5]))
+	typs[126] = newSig(params(typs[20], typs[20]), params(typs[20]))
+	typs[127] = newSig(params(typs[22], typs[22]), params(typs[22]))
+	typs[128] = newSig(params(typs[18]), params(typs[20]))
+	typs[129] = newSig(params(typs[18]), params(typs[22]))
+	typs[130] = newSig(params(typs[18]), params(typs[58]))
+	typs[131] = newSig(params(typs[20]), params(typs[18]))
+	typs[132] = types.Types[types.TFLOAT32]
+	typs[133] = newSig(params(typs[20]), params(typs[132]))
+	typs[134] = newSig(params(typs[22]), params(typs[18]))
+	typs[135] = newSig(params(typs[22]), params(typs[132]))
+	typs[136] = newSig(params(typs[58]), params(typs[18]))
+	typs[137] = newSig(params(typs[24], typs[24]), params(typs[24]))
+	typs[138] = newSig(nil, params(typs[5]))
+	typs[139] = newSig(params(typs[5], typs[5]), nil)
+	typs[140] = newSig(params(typs[5], typs[5], typs[5]), nil)
+	typs[141] = newSig(params(typs[7], typs[1], typs[5]), nil)
+	typs[142] = types.NewSlice(typs[7])
+	typs[143] = newSig(params(typs[7], typs[142]), nil)
+	typs[144] = newSig(params(typs[62], typs[62], typs[15]), nil)
+	typs[145] = newSig(params(typs[56], typs[56], typs[15]), nil)
+	typs[146] = newSig(params(typs[58], typs[58], typs[15]), nil)
+	typs[147] = newSig(params(typs[22], typs[22], typs[15]), nil)
+	typs[148] = newSig(params(typs[26], typs[26], typs[15]), nil)
+	typs[149] = types.NewArray(typs[0], 16)
+	typs[150] = newSig(params(typs[7], typs[58], typs[149], typs[26], typs[13], typs[62], typs[62]), params(typs[58]))
 	return typs[:]
 }
 

--- a/src/cmd/compile/internal/typecheck/func.go
+++ b/src/cmd/compile/internal/typecheck/func.go
@@ -758,10 +758,9 @@ func tcRecover(n *ir.CallExpr) ir.Node {
 	// FP is equal to caller's SP plus FixedFrameSize.
 	var fp ir.Node = ir.NewCallExpr(n.Pos(), ir.OGETCALLERSP, nil, nil)
 	if off := base.Ctxt.Arch.FixedFrameSize; off != 0 {
-		fp = ir.NewBinaryExpr(n.Pos(), ir.OADD, fp, ir.NewInt(base.Pos, off))
+		fp = ir.NewBinaryExpr(n.Pos(), ir.OUNSAFEADD, fp, ir.NewInt(base.Pos, off))
 	}
-	// TODO(mdempsky): Replace *int32 with unsafe.Pointer, without upsetting checkptr.
-	fp = ir.NewConvExpr(n.Pos(), ir.OCONVNOP, types.NewPtr(types.Types[types.TINT32]), fp)
+	fp = ir.NewConvExpr(n.Pos(), ir.OCONVNOP, types.Types[types.TUNSAFEPTR], fp)
 
 	n.SetOp(ir.ORECOVERFP)
 	n.SetType(types.Types[types.TINTER])

--- a/src/cmd/compile/internal/typecheck/typecheck.go
+++ b/src/cmd/compile/internal/typecheck/typecheck.go
@@ -496,7 +496,7 @@ func typecheck1(n ir.Node, top int) ir.Node {
 		if len(n.Args) != 0 {
 			base.FatalfAt(n.Pos(), "unexpected arguments: %v", n)
 		}
-		n.SetType(types.Types[types.TUINTPTR])
+		n.SetType(types.Types[types.TUNSAFEPTR])
 		return n
 
 	case ir.OCONVNOP:

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -981,7 +981,7 @@ func (p *_panic) initOpenCodedDefers(fn funcInfo, varp unsafe.Pointer) bool {
 // this doesn't need to be nosplit.
 //
 //go:nosplit
-func gorecover(argp uintptr) any {
+func gorecover(argp unsafe.Pointer) any {
 	// Must be in a function running as part of a deferred call during the panic.
 	// Must be called from the topmost function of the call
 	// (the function used in the defer statement).
@@ -990,7 +990,7 @@ func gorecover(argp uintptr) any {
 	// If they match, the caller is the one who can recover.
 	gp := getg()
 	p := gp._panic
-	if p != nil && !p.goexit && !p.recovered && argp == uintptr(p.argp) {
+	if p != nil && !p.goexit && !p.recovered && argp == p.argp {
 		p.recovered = true
 		return p.arg
 	}


### PR DESCRIPTION
Complete a TODO.