### PR TITLE
cmd/fix: support go versions with patch release

### DIFF
--- a/src/cmd/fix/buildtag.go
+++ b/src/cmd/fix/buildtag.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"go/ast"
+	"go/version"
 	"strings"
 )
 
@@ -13,7 +14,7 @@ func init() {
 	register(buildtagFix)
 }
 
-const buildtagGoVersionCutoff = 1_18
+const buildtagGoVersionCutoff = "go1.18"
 
 var buildtagFix = fix{
 	name: "buildtag",
@@ -23,7 +24,7 @@ var buildtagFix = fix{
 }
 
 func buildtag(f *ast.File) bool {
-	if goVersion < buildtagGoVersionCutoff {
+	if version.Compare(*goVersion, buildtagGoVersionCutoff) == -1 {
 		return false
 	}
 

--- a/src/cmd/fix/buildtag.go
+++ b/src/cmd/fix/buildtag.go
@@ -24,7 +24,7 @@ var buildtagFix = fix{
 }
 
 func buildtag(f *ast.File) bool {
-	if version.Compare(*goVersion, buildtagGoVersionCutoff) == -1 {
+	if version.Compare(*goVersion, buildtagGoVersionCutoff) < 0 {
 		return false
 	}
 

--- a/src/cmd/fix/buildtag_test.go
+++ b/src/cmd/fix/buildtag_test.go
@@ -11,7 +11,7 @@ func init() {
 var buildtagTests = []testCase{
 	{
 		Name:    "buildtag.oldGo",
-		Version: "go1_10",
+		Version: "go1.10",
 		In: `//go:build yes
 // +build yes
 
@@ -20,7 +20,7 @@ package main
 	},
 	{
 		Name:    "buildtag.new",
-		Version: "go1_99",
+		Version: "go1.99",
 		In: `//go:build yes
 // +build yes
 

--- a/src/cmd/fix/buildtag_test.go
+++ b/src/cmd/fix/buildtag_test.go
@@ -11,7 +11,7 @@ func init() {
 var buildtagTests = []testCase{
 	{
 		Name:    "buildtag.oldGo",
-		Version: 1_10,
+		Version: "go1_10",
 		In: `//go:build yes
 // +build yes
 
@@ -20,7 +20,7 @@ package main
 	},
 	{
 		Name:    "buildtag.new",
-		Version: 1_99,
+		Version: "go1_99",
 		In: `//go:build yes
 // +build yes
 

--- a/src/cmd/fix/main.go
+++ b/src/cmd/fix/main.go
@@ -13,7 +13,7 @@ import (
 	"go/parser"
 	"go/scanner"
 	"go/token"
-	"internal/diff"
+	"go/version"
 	"io"
 	"io/fs"
 	"os"
@@ -21,6 +21,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"internal/diff"
 )
 
 var (
@@ -73,12 +75,10 @@ func main() {
 			report(fmt.Errorf("invalid -go=%s", *goVersionStr))
 			os.Exit(exitCode)
 		}
-		version := (*goVersionStr)[len("go"):]
-		f := strings.SplitN(version, ".", 3)
-		majorStr := f[0]
+		majorStr := version.Lang(*goVersionStr)
 		minorStr := "0"
-		if len(f) >= 1 {
-			minorStr, _, _ = strings.Cut(f[1], "rc")
+		if before, after, found := strings.Cut(majorStr, "."); found {
+			majorStr, minorStr = before, after
 		}
 		major, err1 := strconv.Atoi(majorStr)
 		minor, err2 := strconv.Atoi(minorStr)

--- a/src/cmd/fix/main.go
+++ b/src/cmd/fix/main.go
@@ -74,13 +74,12 @@ func main() {
 			os.Exit(exitCode)
 		}
 		version := (*goVersionStr)[len("go"):]
-		versionParts := strings.SplitN(version, ".", 3);
-		if len(versionParts) < 2 {
-			report(fmt.Errorf("invalid -go=%s", *goVersionStr))
-			os.Exit(exitCode)
+		f := strings.SplitN(version, ".", 3)
+		majorStr := f[0]
+		minorStr := "0"
+		if len(f) >= 1 {
+			minorStr, _, _ = strings.Cut(f[1], "rc")
 		}
-		majorStr := versionParts[0]
-		minorStr, _, _ := strings.Cut(versionParts[1], "rc")
 		major, err1 := strconv.Atoi(majorStr)
 		minor, err2 := strconv.Atoi(minorStr)
 		if err1 != nil || err2 != nil || major < 0 || major >= 100 || minor < 0 || minor >= 100 {

--- a/src/cmd/fix/main.go
+++ b/src/cmd/fix/main.go
@@ -14,14 +14,13 @@ import (
 	"go/scanner"
 	"go/token"
 	"go/version"
+	"internal/diff"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
-
-	"internal/diff"
 )
 
 var (

--- a/src/cmd/fix/main.go
+++ b/src/cmd/fix/main.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 
 	"internal/diff"
@@ -39,10 +38,8 @@ var forceRewrites = flag.String("force", "",
 var allowed, force map[string]bool
 
 var (
-	doDiff       = flag.Bool("diff", false, "display diffs instead of rewriting files")
-	goVersionStr = flag.String("go", "", "go language version for files")
-
-	goVersion int // 115 for go1.15
+	doDiff    = flag.Bool("diff", false, "display diffs instead of rewriting files")
+	goVersion = flag.String("go", "", "go language version for files")
 )
 
 // enable for debugging fix failures
@@ -70,24 +67,9 @@ func main() {
 	flag.Usage = usage
 	flag.Parse()
 
-	if *goVersionStr != "" {
-		if !version.IsValid(*goVersionStr) {
-			report(fmt.Errorf("invalid -go=%s", *goVersionStr))
-			os.Exit(exitCode)
-		}
-		majorStr := version.Lang(*goVersionStr)[len("go"):]
-		minorStr := "0"
-		if before, after, found := strings.Cut(majorStr, "."); found {
-			majorStr, minorStr = before, after
-		}
-		major, err1 := strconv.Atoi(majorStr)
-		minor, err2 := strconv.Atoi(minorStr)
-		if err1 != nil || err2 != nil || major < 0 || major >= 100 || minor < 0 || minor >= 100 {
-			report(fmt.Errorf("invalid -go=%s", *goVersionStr))
-			os.Exit(exitCode)
-		}
-
-		goVersion = major*100 + minor
+	if !version.IsValid(*goVersion) {
+		report(fmt.Errorf("invalid -go=%s", *goVersion))
+		os.Exit(exitCode)
 	}
 
 	sort.Sort(byDate(fixes))

--- a/src/cmd/fix/main.go
+++ b/src/cmd/fix/main.go
@@ -73,11 +73,14 @@ func main() {
 			report(fmt.Errorf("invalid -go=%s", *goVersionStr))
 			os.Exit(exitCode)
 		}
-		majorStr := (*goVersionStr)[len("go"):]
-		minorStr := "0"
-		if before, after, found := strings.Cut(majorStr, "."); found {
-			majorStr, minorStr = before, after
+		version := (*goVersionStr)[len("go"):]
+		versionParts := strings.SplitN(version, ".", 3);
+		if len(versionParts) < 2 {
+			report(fmt.Errorf("invalid -go=%s", *goVersionStr))
+			os.Exit(exitCode)
 		}
+		majorStr := versionParts[0]
+		minorStr, _, _ := strings.Cut(versionParts[1], "rc")
 		major, err1 := strconv.Atoi(majorStr)
 		minor, err2 := strconv.Atoi(minorStr)
 		if err1 != nil || err2 != nil || major < 0 || major >= 100 || minor < 0 || minor >= 100 {

--- a/src/cmd/fix/main.go
+++ b/src/cmd/fix/main.go
@@ -71,11 +71,11 @@ func main() {
 	flag.Parse()
 
 	if *goVersionStr != "" {
-		if !strings.HasPrefix(*goVersionStr, "go") {
+		if !version.IsValid(*goVersionStr) {
 			report(fmt.Errorf("invalid -go=%s", *goVersionStr))
 			os.Exit(exitCode)
 		}
-		majorStr := version.Lang(*goVersionStr)
+		majorStr := version.Lang(*goVersionStr)[len("go"):]
 		minorStr := "0"
 		if before, after, found := strings.Cut(majorStr, "."); found {
 			majorStr, minorStr = before, after

--- a/src/cmd/fix/main_test.go
+++ b/src/cmd/fix/main_test.go
@@ -106,10 +106,10 @@ func TestRewrite(t *testing.T) {
 					t.Parallel()
 				}
 			} else {
-				old := goVersion
-				goVersion = tt.Version
+				old := *goVersion
+				*goVersion = tt.Version
 				defer func() {
-					goVersion = old
+					*goVersion = old
 				}()
 			}
 

--- a/src/cmd/fix/main_test.go
+++ b/src/cmd/fix/main_test.go
@@ -8,11 +8,10 @@ import (
 	"fmt"
 	"go/ast"
 	"go/parser"
-	"strings"
-	"testing"
-
 	"internal/diff"
 	"internal/testenv"
+	"strings"
+	"testing"
 )
 
 type testCase struct {

--- a/src/cmd/fix/main_test.go
+++ b/src/cmd/fix/main_test.go
@@ -8,16 +8,17 @@ import (
 	"fmt"
 	"go/ast"
 	"go/parser"
-	"internal/diff"
-	"internal/testenv"
 	"strings"
 	"testing"
+
+	"internal/diff"
+	"internal/testenv"
 )
 
 type testCase struct {
 	Name    string
 	Fn      func(*ast.File) bool
-	Version int
+	Version string
 	In      string
 	Out     string
 }
@@ -96,7 +97,7 @@ func TestRewrite(t *testing.T) {
 	for _, tt := range testCases {
 		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
-			if tt.Version == 0 {
+			if tt.Version == "" {
 				if testing.Verbose() {
 					// Don't run in parallel: cmd/fix sometimes writes directly to stderr,
 					// and since -v prints which test is currently running we want that


### PR DESCRIPTION
Support go version with patch release(e.g. 1.21.0)
and release candidates(e.g. 1.21rc1)
when parsing the go version in the fix command
by using new "go/version" package.

Fixes #62584