### PR TITLE
cmd/go: make malformed go.sum a fatal error

### DIFF
--- a/src/cmd/go/testdata/script/malformed_gosum_issue62345.txt
+++ b/src/cmd/go/testdata/script/malformed_gosum_issue62345.txt
@@ -1,0 +1,51 @@
+! go mod download
+stderr '^malformed go.sum:\n.*go.sum:3: wrong number of fields 5\n$'
+
+go mod tidy
+cmp go.sum go.sum.after-tidy
+
+-- go.mod --
+module m
+
+go 1.20
+
+require rsc.io/quote v1.5.2
+
+require (
+	golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c // indirect
+	rsc.io/sampler v1.3.0 // indirect
+	rsc.io/testonly v1.0.0 // indirect
+)
+
+-- go.sum --
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c h1:pvCbr/wm8HzDD3fVywevekufpn6tCGPY3spdHeZJEsw=
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+rsc.io/quote v1.5.2 # invalid line
+rsc.io/quote v1.5.2/go.mod h1:LzX7hefJvL54yjefDEDHNONDjII0t9xZLPXsUe+TKr0=
+rsc.io/sampler v1.3.0 h1:HLGR/BgEtI3r0uymSP/nl2uPLsUnNJX8toRyhfpBTII=
+rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+rsc.io/testonly v1.0.0 h1:K/VWHdO+Jv7woUXG0GzVNx1czBXUt3Ib1deaMn+xk64=
+rsc.io/testonly v1.0.0/go.mod h1:OqmGbIFOcF+XrFReLOGZ6BhMM7uMBiQwZsyNmh74SzY=
+
+-- main.go --
+package main
+
+import (
+	"fmt"
+
+	"rsc.io/quote"
+)
+
+func main() {
+	fmt.Println(quote.Hello())
+}
+
+-- go.sum.after-tidy --
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c h1:pvCbr/wm8HzDD3fVywevekufpn6tCGPY3spdHeZJEsw=
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+rsc.io/quote v1.5.2 h1:3fEykkD9k7lYzXqCYrwGAf7iNhbk4yCjHmKBN9td4L0=
+rsc.io/quote v1.5.2/go.mod h1:LzX7hefJvL54yjefDEDHNONDjII0t9xZLPXsUe+TKr0=
+rsc.io/sampler v1.3.0 h1:HLGR/BgEtI3r0uymSP/nl2uPLsUnNJX8toRyhfpBTII=
+rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+rsc.io/testonly v1.0.0 h1:K/VWHdO+Jv7woUXG0GzVNx1czBXUt3Ib1deaMn+xk64=
+rsc.io/testonly v1.0.0/go.mod h1:OqmGbIFOcF+XrFReLOGZ6BhMM7uMBiQwZsyNmh74SzY=


### PR DESCRIPTION
In CL 197062, many errors related to go.sum were changed from base.Fatal
to error returns. The malformed go.sum error was lost in the process.
Currently, when go encounters a malformed go.sum file, go will read the
well-formed part of the file and then silently ignore the rest.

The motivation behind moving away from base.Fatal was to make the errors
show up in -json output. Simply propagating the malformed go.sum error
would not achieve this:

- For an argument-less 'go mod download -json' with a go>=1.17 module,
  a malformed go.sum causes an error during LoadModGraph already, before
  go ever starts downloading modules and printing their JSON.
- In other cases, a malformed go.sum would be reported as Error for one
  of the modules (presumably the one which gets downloaded first) but
  none of the others.
- In either case, 'go mod download' manages to download enough data to
  succeed on a re-run, making the error look intermittent.

Switch the error back to a Fatal one, but give 'go mod tidy' an
exception to let it fix broken go.sum files.

Fixes #62345
