### PR TITLE
runtime: clarify error when returning unpinned pointers

### DIFF
--- a/src/runtime/cgocall.go
+++ b/src/runtime/cgocall.go
@@ -525,7 +525,7 @@ func cgoCheckPointer(ptr any, arg any) {
 }
 
 const cgoCheckPointerFail = "cgo argument has Go pointer to unpinned Go pointer"
-const cgoResultFail = "cgo result has Go pointer"
+const cgoResultFail = "cgo result is unpinned Go pointer or points to unpinned Go pointer"
 
 // cgoCheckArg is the real work of cgoCheckPointer. The argument p
 // is either a pointer to the value (of type t), or the value itself,
@@ -718,8 +718,8 @@ func cgoInRange(p unsafe.Pointer, start, end uintptr) bool {
 }
 
 // cgoCheckResult is called to check the result parameter of an
-// exported Go function. It panics if the result is or contains a Go
-// pointer.
+// exported Go function. It panics if the result is or contains any
+// other pointer into unpinned Go memory.
 func cgoCheckResult(val any) {
 	if !goexperiment.CgoCheck2 && debug.cgocheck == 0 {
 		return

--- a/src/runtime/cgocall.go
+++ b/src/runtime/cgocall.go
@@ -530,9 +530,8 @@ const cgoResultFail = "cgo result is unpinned Go pointer or points to unpinned G
 // cgoCheckArg is the real work of cgoCheckPointer. The argument p
 // is either a pointer to the value (of type t), or the value itself,
 // depending on indir. The top parameter is whether we are at the top
-// level, where Go pointers are allowed. Go pointers to pinned objects that
-// don't reference other unpinned pointers (enforced by cgoCheckUnknownPointer)
-// are always allowed.
+// level, where Go pointers are allowed. Go pointers to pinned objects are
+// allowed as long as they don't reference other unpinned pointers.
 func cgoCheckArg(t *_type, p unsafe.Pointer, indir, top bool, msg string) {
 	if t.PtrBytes == 0 || p == nil {
 		// If the type has no pointers there is nothing to do.

--- a/src/runtime/cgocall.go
+++ b/src/runtime/cgocall.go
@@ -530,8 +530,9 @@ const cgoResultFail = "cgo result is unpinned Go pointer or points to unpinned G
 // cgoCheckArg is the real work of cgoCheckPointer. The argument p
 // is either a pointer to the value (of type t), or the value itself,
 // depending on indir. The top parameter is whether we are at the top
-// level, where Go pointers are allowed. Go pointers to pinned objects are
-// always allowed.
+// level, where Go pointers are allowed. Go pointers to pinned objects that
+// don't reference other unpinned pointers (enforced by cgoCheckUnknownPointer)
+// are always allowed.
 func cgoCheckArg(t *_type, p unsafe.Pointer, indir, top bool, msg string) {
 	if t.PtrBytes == 0 || p == nil {
 		// If the type has no pointers there is nothing to do.


### PR DESCRIPTION
With the introduction of runtime.Pinner, returning a pointer to a pinned
struct that then points to an unpinned Go pointer is correctly caught.

However, the error message remained as "cgo result has Go pointer",
which should be updated to acknowledge that Go pointers to pinned
memory are allowed.

This also updates the comments for cgoCheckArg and cgoCheckResult
to similarly clarify.

Updates #46787