### PR TITLE
runtime/coverage: fix snapshot total calculation

### DIFF
--- a/src/internal/coverage/defs.go
+++ b/src/internal/coverage/defs.go
@@ -371,7 +371,7 @@ func Round4(x int) int {
 //     numCtrs uint32
 //     pkgid uint32
 //     funcid uint32
-//     counterArray [numBlocks]uint32
+//     counterArray [numCtrs]uint32
 // }
 //
 // where "numCtrs" is the number of blocks / coverable units within the

--- a/src/runtime/coverage/testsupport.go
+++ b/src/runtime/coverage/testsupport.go
@@ -294,19 +294,22 @@ func snapshot() float64 {
 	totExec := uint64(0)
 	for _, c := range cl {
 		sd := unsafe.Slice((*atomic.Uint32)(unsafe.Pointer(c.Counters)), c.Len)
-		tot += uint64(len(sd))
 		for i := 0; i < len(sd); i++ {
+			nCtrs := sd[i+coverage.NumCtrsOffset].Load()
+
 			// Skip ahead until the next non-zero value.
-			if sd[i].Load() == 0 {
+			if nCtrs == 0 {
 				continue
 			}
+
 			// We found a function that was executed.
-			nCtrs := sd[i+coverage.NumCtrsOffset].Load()
 			cst := i + coverage.FirstCtrOffset
 
 			if cst+int(nCtrs) > len(sd) {
 				break
 			}
+
+			tot += uint64(nCtrs)
 			counters := sd[cst : cst+int(nCtrs)]
 			for i := range counters {
 				if counters[i].Load() != 0 {


### PR DESCRIPTION
Sum number of counters to obtain total number of coverable units
instead of using length of the section data.

Updates https://github.com/golang/go/issues/62212