### PR TITLE
runtime: unify the method signature for *sigctxt.fault

### DIFF
--- a/src/runtime/signal_freebsd_arm64.go
+++ b/src/runtime/signal_freebsd_arm64.go
@@ -52,7 +52,7 @@ func (c *sigctxt) sp() uint64  { return c.regs().mc_gpregs.gp_sp }
 //go:nowritebarrierrec
 func (c *sigctxt) pc() uint64 { return c.regs().mc_gpregs.gp_elr }
 
-func (c *sigctxt) fault() uint64 { return c.info.si_addr }
+func (c *sigctxt) fault() uintptr { return uintptr(c.info.si_addr) }
 
 func (c *sigctxt) sigcode() uint64 { return uint64(c.info.si_code) }
 func (c *sigctxt) sigaddr() uint64 { return c.info.si_addr }

--- a/src/runtime/signal_openbsd_arm64.go
+++ b/src/runtime/signal_openbsd_arm64.go
@@ -54,7 +54,7 @@ func (c *sigctxt) sp() uint64  { return (uint64)(c.regs().sc_sp) }
 //go:nowritebarrierrec
 func (c *sigctxt) rip() uint64 { return (uint64)(c.regs().sc_lr) } /* XXX */
 
-func (c *sigctxt) fault() uint64   { return c.sigaddr() }
+func (c *sigctxt) fault() uintptr  { return uintptr(c.sigaddr()) }
 func (c *sigctxt) sigcode() uint64 { return uint64(c.info.si_code) }
 func (c *sigctxt) sigaddr() uint64 {
 	return *(*uint64)(add(unsafe.Pointer(c.info), 16))


### PR DESCRIPTION
Currently, *sigctxt.fault of freebsd-arm64 and openbsd-arm64 return
uint64 which is different from other arches (return uintptr). Change
the method signature for consistency.