### PR TITLE
strconv: replace cloneString with bytealg.CloneString

### DIFF
--- a/src/bytes/bytes.go
+++ b/src/bytes/bytes.go
@@ -1358,10 +1358,7 @@ func Cut(s, sep []byte) (before, after []byte, found bool) {
 // The result may have additional unused capacity.
 // Clone(nil) returns nil.
 func Clone(b []byte) []byte {
-	if b == nil {
-		return nil
-	}
-	return append([]byte{}, b...)
+	return bytealg.Clone(b)
 }
 
 // CutPrefix returns s without the provided leading prefix byte slice

--- a/src/internal/bytealg/bytealg.go
+++ b/src/internal/bytealg/bytealg.go
@@ -153,3 +153,32 @@ func IndexRabinKarp(s, substr string) int {
 // It is the caller's responsibility to ensure uninitialized bytes
 // do not leak to the end user.
 func MakeNoZero(n int) []byte
+
+// Clone returns a copy of b[:len(b)].
+// The result may have additional unused capacity.
+// Clone(nil) returns nil.
+func Clone(b []byte) []byte {
+	if b == nil {
+		return nil
+	}
+	return append([]byte{}, b...)
+}
+
+// CloneString returns a fresh copy of s.
+// It guarantees to make a copy of s into a new allocation,
+// which can be important when retaining only a small substring
+// of a much larger string. Using Clone can help such programs
+// use less memory. Of course, since using Clone makes a copy,
+// overuse of Clone can make programs use more memory.
+// Clone should typically be used only rarely, and only when
+// profiling indicates that it is needed.
+// For strings of length zero the string "" will be returned
+// and no allocation is made.
+func CloneString(s string) string {
+	if len(s) == 0 {
+		return ""
+	}
+	b := MakeNoZero(len(s))
+	copy(b, s)
+	return unsafe.String(&b[0], len(b))
+}

--- a/src/strconv/atoc.go
+++ b/src/strconv/atoc.go
@@ -4,6 +4,10 @@
 
 package strconv
 
+import (
+	"internal/bytealg"
+)
+
 const fnParseComplex = "ParseComplex"
 
 // convErr splits an error returned by parseFloatPrefix
@@ -11,7 +15,7 @@ const fnParseComplex = "ParseComplex"
 func convErr(err error, s string) (syntax, range_ error) {
 	if x, ok := err.(*NumError); ok {
 		x.Func = fnParseComplex
-		x.Num = cloneString(s)
+		x.Num = bytealg.CloneString(s)
 		if x.Err == ErrRange {
 			return nil, x
 		}

--- a/src/strconv/atoi.go
+++ b/src/strconv/atoi.go
@@ -4,7 +4,10 @@
 
 package strconv
 
-import "errors"
+import (
+	"errors"
+	"internal/bytealg"
+)
 
 // lower(c) is a lower-case letter if and only if
 // c is either that lower-case letter or the equivalent upper-case letter.
@@ -33,36 +36,20 @@ func (e *NumError) Error() string {
 
 func (e *NumError) Unwrap() error { return e.Err }
 
-// cloneString returns a string copy of x.
-//
-// All ParseXXX functions allow the input string to escape to the error value.
-// This hurts strconv.ParseXXX(string(b)) calls where b is []byte since
-// the conversion from []byte must allocate a string on the heap.
-// If we assume errors are infrequent, then we can avoid escaping the input
-// back to the output by copying it first. This allows the compiler to call
-// strconv.ParseXXX without a heap allocation for most []byte to string
-// conversions, since it can now prove that the string cannot escape Parse.
-//
-// TODO: Use strings.Clone instead? However, we cannot depend on "strings"
-// since it incurs a transitive dependency on "unicode".
-// Either move strings.Clone to an internal/bytealg or make the
-// "strings" to "unicode" dependency lighter (see https://go.dev/issue/54098).
-func cloneString(x string) string { return string([]byte(x)) }
-
 func syntaxError(fn, str string) *NumError {
-	return &NumError{fn, cloneString(str), ErrSyntax}
+	return &NumError{fn, bytealg.CloneString(str), ErrSyntax}
 }
 
 func rangeError(fn, str string) *NumError {
-	return &NumError{fn, cloneString(str), ErrRange}
+	return &NumError{fn, bytealg.CloneString(str), ErrRange}
 }
 
 func baseError(fn, str string, base int) *NumError {
-	return &NumError{fn, cloneString(str), errors.New("invalid base " + Itoa(base))}
+	return &NumError{fn, bytealg.CloneString(str), errors.New("invalid base " + Itoa(base))}
 }
 
 func bitSizeError(fn, str string, bitSize int) *NumError {
-	return &NumError{fn, cloneString(str), errors.New("invalid bit size " + Itoa(bitSize))}
+	return &NumError{fn, bytealg.CloneString(str), errors.New("invalid bit size " + Itoa(bitSize))}
 }
 
 const intSize = 32 << (^uint(0) >> 63)
@@ -221,7 +208,7 @@ func ParseInt(s string, base int, bitSize int) (i int64, err error) {
 	un, err = ParseUint(s, base, bitSize)
 	if err != nil && err.(*NumError).Err != ErrRange {
 		err.(*NumError).Func = fnParseInt
-		err.(*NumError).Num = cloneString(s0)
+		err.(*NumError).Num = bytealg.CloneString(s0)
 		return 0, err
 	}
 

--- a/src/strings/clone.go
+++ b/src/strings/clone.go
@@ -5,7 +5,7 @@
 package strings
 
 import (
-	"unsafe"
+	"internal/bytealg"
 )
 
 // Clone returns a fresh copy of s.
@@ -19,10 +19,5 @@ import (
 // For strings of length zero the string "" will be returned
 // and no allocation is made.
 func Clone(s string) string {
-	if len(s) == 0 {
-		return ""
-	}
-	b := make([]byte, len(s))
-	copy(b, s)
-	return unsafe.String(&b[0], len(b))
+	return bytealg.CloneString(s)
 }


### PR DESCRIPTION
DO NOT REVIEW
DO NOT SUBMIT

The cloneString function behaves the same as strings.Clone, but it was implemented here in order to avoid transitive dependencies.

By moving it to bytealg.CloneString we are able to expose this utility internally without encountering transitive dependency problems.

While at it, also add bytealg.Clone that work on byte slices.

For #54098
