### PR TITLE
math: added generic and variadic MaxMany and MinMany functions

### DIFF
--- a/src/math/all_test.go
+++ b/src/math/all_test.go
@@ -3282,6 +3282,138 @@ func TestFloat32Sqrt(t *testing.T) {
 	}
 }
 
+func TestMaxManyMultipleArgs(t *testing.T) {
+	maximum := MaxMany(3, 5, -2.5, 0)
+	if maximum != 5 {
+		t.Error("Maximum should be 5, not", maximum)
+	}
+}
+
+func TestMaxManyInf(t *testing.T) {
+	maximum := MaxMany(3, 5, -2.5, Inf(1), 0)
+	if !IsInf(maximum, 1) {
+		t.Error("Maximum should be +Inf, not", maximum)
+	}
+}
+
+func TestMaxManyNegativeInf(t *testing.T) {
+	maximum := MaxMany(3, 5, -2.5, Inf(-1), 0)
+	if maximum != 5 {
+		t.Error("Maximum should be 5, not", maximum)
+	}
+}
+
+func TestMaxManyInfOnlyArg(t *testing.T) {
+	maximum := MaxMany(Inf(1))
+	if !IsInf(maximum, 1) {
+		t.Error("Maximum should be inf, not", maximum)
+	}
+}
+
+func TestMaxManyNaN(t *testing.T) {
+	nan := NaN()
+	maximum := MaxMany(3, 5, -2.5, nan, 0)
+	if !IsNaN(maximum) {
+		t.Errorf("Maximum should be %v, not %v", nan, maximum)
+	}
+}
+
+func TestMaxManyNaNOnlyArg(t *testing.T) {
+	nan := NaN()
+	maximum := MaxMany(nan)
+	if !IsNaN(maximum) {
+		t.Errorf("Maximum should be %v, not %v", nan, maximum)
+	}
+}
+
+func TestMaxManyWithBothInfAndNaN(t *testing.T) {
+	nan := NaN()
+	maximum := MaxMany(nan, 3.3, Inf(1), Inf(-1), 0, 9, -5)
+	if !IsInf(maximum, 1) {
+		t.Errorf("Maximum should be +Inf, not %v", maximum)
+	}
+}
+
+func TestMaxManySingleArg(t *testing.T) {
+	maximum := MaxMany(3)
+	if maximum != 3 {
+		t.Error("Maximum should be 3, not", maximum)
+	}
+}
+
+func TestMaxManyEqualArgs(t *testing.T) {
+	maximum := MaxMany(3, 3, 3)
+	if maximum != 3 {
+		t.Error("Maximum should be 3, not", maximum)
+	}
+}
+
+func TestMinManyArgs(t *testing.T) {
+	minimum := MinMany(3, 5, -2.5, 0)
+	if minimum != -2.5 {
+		t.Error("Minimum should be -2.5, not", minimum)
+	}
+}
+
+func TestMinManyInf(t *testing.T) {
+	minimum := MinMany(3, 5, -2.5, Inf(-1), 0)
+	if minimum != Inf(-1) {
+		t.Error("Minimum should be -Inf, not", minimum)
+	}
+}
+
+func TestMinManyPositiveInf(t *testing.T) {
+	minimum := MinMany(3, 5, -2.5, Inf(1), 0)
+	if minimum != -2.5 {
+		t.Error("Minimum should be -2.5, not", minimum)
+	}
+}
+
+func TestMinManyInfOnlyArg(t *testing.T) {
+	minimum := MinMany(Inf(-1))
+	if minimum != Inf(-1) {
+		t.Error("Minimum should be -inf, not", minimum)
+	}
+}
+
+func TestMinManyNaN(t *testing.T) {
+	nan := NaN()
+	minimum := MinMany(3, 5, -2.5, nan, 0)
+	if !IsNaN(minimum) {
+		t.Errorf("Minimum should be %v, not %v", nan, minimum)
+	}
+}
+
+func TestMinManyNaNOnlyArg(t *testing.T) {
+	nan := NaN()
+	minimum := MinMany(nan)
+	if !IsNaN(minimum) {
+		t.Errorf("Minimum should be %v, not %v", nan, minimum)
+	}
+}
+
+func TestMinManyWithBothInfAndNaN(t *testing.T) {
+	nan := NaN()
+	minimum := MinMany(nan, 3.3, Inf(1), Inf(-1), 0, 9, -5)
+	if !IsInf(minimum, -1) {
+		t.Errorf("Minimum should be +Inf, not %v", minimum)
+	}
+}
+
+func TestMinManySingleArg(t *testing.T) {
+	minimum := MinMany(3)
+	if minimum != 3 {
+		t.Error("Minimum should be 3, not", minimum)
+	}
+}
+
+func TestMinManyEqualArgs(t *testing.T) {
+	minimum := MinMany(3, 3, 3)
+	if minimum != 3 {
+		t.Error("Minimum should be 3, not", minimum)
+	}
+}
+
 // Benchmarks
 
 // Global exported variables are used to store the

--- a/src/math/dim.go
+++ b/src/math/dim.go
@@ -98,3 +98,69 @@ func min(x, y float64) float64 {
 	}
 	return y
 }
+
+// rune and byte data types are added implicitly due to them being alias for
+// int32 and uint8 respectively.
+type Number interface {
+	int | int8 | int16 | int32 | int64 |
+		uint | uint8 | uint16 | uint32 | uint64 |
+		float32 | float64
+}
+
+// Returns the highest number among multiple arguments passed in
+//
+// Special cases are:
+//
+//	If +Inf is among the arguments, return +Inf
+//	If NaN is among the arguments, return NaN
+//	If both +Inf and NaN are among the arguments, return +Inf
+func MaxMany[T Number](numbers ...T) float64 {
+	var maximum T
+	var hasNaN bool
+	for index, number := range numbers {
+		numberFloat := float64(number)
+		switch {
+		case index == 0:
+			maximum = number
+		case IsInf(numberFloat, 1):
+			return Inf(1)
+		case IsNaN(numberFloat):
+			hasNaN = true
+		case number > maximum:
+			maximum = number
+		}
+	}
+	if hasNaN {
+		return NaN()
+	}
+	return float64(maximum)
+}
+
+// Returns the lowest number among multiple arguments passed in
+//
+// Special cases are:
+//
+//	If -Inf is among the arguments, return -Inf
+//	If NaN is among the arguments, return NaN
+//	If both -Inf and NaN are among the arguments, return -Inf
+func MinMany[T Number](numbers ...T) float64 {
+	var minimum T
+	var hasNaN bool
+	for index, number := range numbers {
+		numberFloat := float64(number)
+		switch {
+		case index == 0:
+			minimum = number
+		case IsInf(numberFloat, 1):
+			return Inf(-1)
+		case IsNaN(numberFloat):
+			hasNaN = true
+		case number < minimum:
+			minimum = number
+		}
+	}
+	if hasNaN {
+		return NaN()
+	}
+	return float64(minimum)
+}


### PR DESCRIPTION
Although the Min() and Max() functions in the math package are usable, they have 2 main drawbacks. First, the arguments must be float64 types, which makes the user cast their other numeric types to float64 like int before using the function. Second, the number of arguments is limited by two. If an user wants to find the maximum or minimum value among multiple arguments, he/she would have to implement in-house solutions.

A possible solution is to add a couple functions like these MaxMany() and MinMany(), which are generic and variadic -- you may pass in any number data type argument, and as many as you like. An interface named Number with type constraints to all ints, uints, and floats, was added to help making the function generic.

Max() and Min() cover specific cases like dealing with infinities and NaN, which were also implemented in MaxMany() and MinMany(). The Signbit() case is not covered because of unfamiliarity with the topic, but can be added if required.

The functions were thoroughly tested and the test cases were added to the all_test.go file. 