### PR TITLE
feat: adding errors interface in join method

### DIFF
--- a/src/errors/join.go
+++ b/src/errors/join.go
@@ -8,7 +8,7 @@ import (
 	"unsafe"
 )
 
-// Join returns an error that wraps the given errors.
+// Join returns an Errors interface that wraps the given errors.
 // Any nil error values are discarded.
 // Join returns nil if every value in errs is nil.
 // The error formats as the concatenation of the strings obtained
@@ -16,7 +16,7 @@ import (
 // between each string.
 //
 // A non-nil error returned by Join implements the Unwrap() []error method.
-func Join(errs ...error) error {
+func Join(errs ...error) Errors {
 	n := 0
 	for _, err := range errs {
 		if err != nil {
@@ -35,6 +35,13 @@ func Join(errs ...error) error {
 		}
 	}
 	return e
+}
+
+// Errors is the interface used in Join method 
+// to satisfy the Unwrap() method
+type Errors interface {
+	Error() string
+	Unwrap() []error
 }
 
 type joinError struct {

--- a/src/errors/join_test.go
+++ b/src/errors/join_test.go
@@ -6,8 +6,9 @@ package errors_test
 
 import (
 	"errors"
-	"reflect"
 	"testing"
+
+	"slices"
 )
 
 func TestJoinReturnsNil(t *testing.T) {
@@ -22,7 +23,7 @@ func TestJoinReturnsNil(t *testing.T) {
 	}
 }
 
-func TestJoin(t *testing.T) {
+func TestJoinUnwrapMethod(t *testing.T) {
 	err1 := errors.New("err1")
 	err2 := errors.New("err2")
 	for _, test := range []struct {
@@ -38,8 +39,8 @@ func TestJoin(t *testing.T) {
 		errs: []error{err1, nil, err2},
 		want: []error{err1, err2},
 	}} {
-		got := errors.Join(test.errs...).(interface{ Unwrap() []error }).Unwrap()
-		if !reflect.DeepEqual(got, test.want) {
+		got := errors.Join(test.errs...).Unwrap()
+		if !slices.Equal(got, test.want) {
 			t.Errorf("Join(%v) = %v; want %v", test.errs, got, test.want)
 		}
 		if len(got) != cap(got) {


### PR DESCRIPTION
I created an interface Errors 
```
type Errors interface {
	Error() string
	Unwrap() []error
}

```
with the purpose of utilizing the Unwrap() method without the need to declare an interface in the code.

```
errors.Join(test.errs...).(interface{ Unwrap() []error }).Unwrap()
``` 

In this case, we can use:

```
errors.Join(test.errs...).Unwrap()
```