### PR TITLE
syscall: deathSignalParent use user uid and uid

### DIFF
--- a/src/syscall/exec_pdeathsig_test.go
+++ b/src/syscall/exec_pdeathsig_test.go
@@ -110,7 +110,7 @@ func deathSignalParent() {
 		Pdeathsig: syscall.SIGUSR1,
 		// UID/GID 99 is the user/group "nobody" on RHEL/Fedora and is
 		// unused on Ubuntu
-		Credential: &syscall.Credential{Uid: 99, Gid: 99},
+		Credential: &syscall.Credential{Uid: uint32(os.Getuid()), Gid: uint32(os.Getegid())},
 	}
 	cmd.SysProcAttr = &attrs
 


### PR DESCRIPTION
Fixes #62719.