### PR TITLE
runtime: no need to convert 'c.fault()' to uintptr in sighandler

### DIFF
--- a/src/runtime/signal_unix.go
+++ b/src/runtime/signal_unix.go
@@ -698,7 +698,7 @@ func sighandler(sig uint32, info *siginfo, ctxt unsafe.Pointer, gp *g) {
 		// the unwinding code.
 		gp.sig = sig
 		gp.sigcode0 = uintptr(c.sigcode())
-		gp.sigcode1 = uintptr(c.fault())
+		gp.sigcode1 = c.fault()
 		gp.sigpc = c.sigpc()
 
 		c.preparePanic(sig, gp)


### PR DESCRIPTION
After CL 528817, *sigctxt.fault of all arches return uintptr, so
there is no need to convert 'c.fault()' to uintptr anymore.