### PR TITLE
cmd/go: scale go list with GOMAXPROCS

### DIFF
--- a/src/cmd/go/internal/modload/list.go
+++ b/src/cmd/go/internal/modload/list.go
@@ -21,6 +21,7 @@ import (
 	"cmd/go/internal/modfetch/codehost"
 	"cmd/go/internal/modinfo"
 	"cmd/go/internal/search"
+	"cmd/internal/par"
 	"cmd/internal/pkgpattern"
 
 	"golang.org/x/mod/module"
@@ -273,19 +274,29 @@ func listModules(ctx context.Context, rs *Requirements, args []string, mode List
 			continue
 		}
 
-		matched := false
+		var matches []module.Version
 		for _, m := range mg.BuildList() {
 			if match(m.Path) {
-				matched = true
 				if !matchedModule[m] {
 					matchedModule[m] = true
-					mods = append(mods, moduleInfo(ctx, rs, m, mode, reuse))
+					matches = append(matches, m)
 				}
 			}
 		}
-		if !matched {
+
+		if len(matches) == 0 {
 			fmt.Fprintf(os.Stderr, "warning: pattern %q matched no module dependencies\n", arg)
 		}
+
+		q := par.NewQueue(runtime.GOMAXPROCS(0))
+		fetchedMods := make([]*modinfo.ModulePublic, len(matches))
+		for i, m := range matches {
+			q.Add(func() {
+				fetchedMods[i] = moduleInfo(ctx, rs, m, mode, reuse)
+			})
+		}
+		<-q.Idle()
+		mods = append(mods, fetchedMods...)
 	}
 
 	return rs, mods, mgErr


### PR DESCRIPTION
Benchmark from the go-list-benchmark branch shows the following result:

goos: darwin
goarch: arm64
pkg: cmd/go
cpu: Apple M1 Max
                     │   old.txt   │               new.txt               │
                     │   sec/op    │   sec/op     vs base                │
ListModules/Empty-10   7.768m ± 5%   7.768m ± 6%        ~ (p=0.989 n=20)
ListModules/Cmd-10     272.3m ± 2%   137.8m ± 2%  -49.40% (p=0.000 n=20)
ListModules/K8S-10     10.741 ± 2%    2.525 ± 5%  -76.49% (p=0.000 n=20)
geomean                283.2m        139.3m       -50.82%

                     │   old.txt    │               new.txt               │
                     │  sys-sec/op  │  sys-sec/op   vs base               │
ListModules/Empty-10   2.380m ±  9%   2.443m ±  9%       ~ (p=0.314 n=20)
ListModules/Cmd-10     51.84m ± 13%   47.27m ± 14%       ~ (p=0.289 n=20)
ListModules/K8S-10      1.660 ±  8%    1.485 ± 28%       ~ (p=0.512 n=20)
geomean                58.95m         55.56m        -5.75%

                     │   old.txt    │               new.txt                │
                     │ user-sec/op  │ user-sec/op   vs base                │
ListModules/Empty-10   3.034m ±  4%   3.053m ±  3%        ~ (p=0.445 n=20)
ListModules/Cmd-10     18.01m ± 11%   15.39m ±  5%  -14.55% (p=0.000 n=20)
ListModules/K8S-10     407.6m ± 11%   209.2m ± 49%  -48.67% (p=0.000 n=20)
geomean                28.13m         21.42m        -23.86%

Fixes #63136