### PR TITLE
SECURITY.md: update the Reporting a Vulnerability link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,4 +10,4 @@ part of that page.
 
 ## Reporting a Vulnerability
 
-See https://go.dev/security for how to report a vulnerability.
+See https://go.dev/security/policy for how to report a vulnerability.


### PR DESCRIPTION
The https://go.dev/security is about: "This page provides 
resources for Go developers to improve security for their 
projects.", https://go.dev/security/policy is about Go Security Policy.

go.dev/security links to go.dev/security/policy, 
but I think it is better to link directly to go.dev/security/policy 
in this case.