### PR TITLE
crypto/tls: pretty-print SignatureScheme in tests

### DIFF
--- a/src/crypto/tls/boring_test.go
+++ b/src/crypto/tls/boring_test.go
@@ -200,7 +200,7 @@ func TestBoringServerSignatureAndHash(t *testing.T) {
 	}()
 
 	for _, sigHash := range defaultSupportedSignatureAlgorithms {
-		t.Run(fmt.Sprintf("%#x", sigHash), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%v", sigHash), func(t *testing.T) {
 			serverConfig := testConfig.Clone()
 			serverConfig.Certificates = make([]Certificate, 1)
 


### PR DESCRIPTION
When running crypto/tls tests with GOEXPERIMENT=boringcrypto, some
tests are embedded with unreadable hexadecimal values:

  === RUN   TestBoringServerSignatureAndHash/5053...3536

This corresponds to a string representation of SignatureScheme as it
implements fmt.Stringer.  With this change, the above will be printed
as:

  === RUN   TestBoringServerSignatureAndHash/PSSWithSHA256