### PR TITLE
internal/zstd: make val inlineable

### DIFF
--- a/src/internal/zstd/block.go
+++ b/src/internal/zstd/block.go
@@ -255,19 +255,19 @@ func (r *Reader) execSeqs(data block, off int, litbuf []byte, seqCount int) erro
 		return err
 	}
 
-	literalState, err := rbr.val(r.seqTableBits[seqLiteral])
-	if err != nil {
-		return err
+	literalState, ok := rbr.val(r.seqTableBits[seqLiteral])
+	if !ok {
+		return rbr.makeEOFError()
 	}
 
-	offsetState, err := rbr.val(r.seqTableBits[seqOffset])
-	if err != nil {
-		return err
+	offsetState, ok := rbr.val(r.seqTableBits[seqOffset])
+	if !ok {
+		return rbr.makeEOFError()
 	}
 
-	matchState, err := rbr.val(r.seqTableBits[seqMatch])
-	if err != nil {
-		return err
+	matchState, ok := rbr.val(r.seqTableBits[seqMatch])
+	if !ok {
+		return rbr.makeEOFError()
 	}
 
 	// Read and perform all the sequences. RFC 3.1.1.4.
@@ -282,21 +282,21 @@ func (r *Reader) execSeqs(data block, off int, litbuf []byte, seqCount int) erro
 		ptmatch := &r.seqTables[seqMatch][matchState]
 		ptliteral := &r.seqTables[seqLiteral][literalState]
 
-		add, err := rbr.val(ptoffset.basebits)
-		if err != nil {
-			return err
+		add, ok := rbr.val(ptoffset.basebits)
+		if !ok {
+			return rbr.makeEOFError()
 		}
 		offset := ptoffset.baseline + add
 
-		add, err = rbr.val(ptmatch.basebits)
-		if err != nil {
-			return err
+		add, ok = rbr.val(ptmatch.basebits)
+		if !ok {
+			return rbr.makeEOFError()
 		}
 		match := ptmatch.baseline + add
 
-		add, err = rbr.val(ptliteral.basebits)
-		if err != nil {
-			return err
+		add, ok = rbr.val(ptliteral.basebits)
+		if !ok {
+			return rbr.makeEOFError()
 		}
 		literal := ptliteral.baseline + add
 
@@ -333,21 +333,21 @@ func (r *Reader) execSeqs(data block, off int, litbuf []byte, seqCount int) erro
 		seq++
 		if seq < seqCount {
 			// Update the states.
-			add, err = rbr.val(ptliteral.bits)
-			if err != nil {
-				return err
+			add, ok = rbr.val(ptliteral.bits)
+			if !ok {
+				return rbr.makeEOFError()
 			}
 			literalState = uint32(ptliteral.base) + add
 
-			add, err = rbr.val(ptmatch.bits)
-			if err != nil {
-				return err
+			add, ok = rbr.val(ptmatch.bits)
+			if !ok {
+				return rbr.makeEOFError()
 			}
 			matchState = uint32(ptmatch.base) + add
 
-			add, err = rbr.val(ptoffset.bits)
-			if err != nil {
-				return err
+			add, ok = rbr.val(ptoffset.bits)
+			if !ok {
+				return rbr.makeEOFError()
 			}
 			offsetState = uint32(ptoffset.base) + add
 		}

--- a/src/internal/zstd/huff.go
+++ b/src/internal/zstd/huff.go
@@ -50,14 +50,14 @@ func (r *Reader) readHuff(data block, off int, table []uint16) (tableBits, roff 
 			return 0, 0, err
 		}
 
-		state1, err := rbr.val(uint8(fseBits))
-		if err != nil {
-			return 0, 0, err
+		state1, ok := rbr.val(uint8(fseBits))
+		if !ok {
+			return 0, 0, rbr.makeEOFError()
 		}
 
-		state2, err := rbr.val(uint8(fseBits))
-		if err != nil {
-			return 0, 0, err
+		state2, ok := rbr.val(uint8(fseBits))
+		if !ok {
+			return 0, 0, rbr.makeEOFError()
 		}
 
 		// There are two independent FSE streams, tracked by
@@ -75,9 +75,9 @@ func (r *Reader) readHuff(data block, off int, table []uint16) (tableBits, roff 
 				break
 			}
 
-			v, err := rbr.val(pt.bits)
-			if err != nil {
-				return 0, 0, err
+			v, ok := rbr.val(pt.bits)
+			if !ok {
+				return 0, 0, rbr.makeEOFError()
 			}
 			state1 = uint32(pt.base) + v
 
@@ -100,9 +100,9 @@ func (r *Reader) readHuff(data block, off int, table []uint16) (tableBits, roff 
 				break
 			}
 
-			v, err = rbr.val(pt.bits)
-			if err != nil {
-				return 0, 0, err
+			v, ok = rbr.val(pt.bits)
+			if !ok {
+				return 0, 0, rbr.makeEOFError()
 			}
 			state2 = uint32(pt.base) + v
 


### PR DESCRIPTION
Change reverseBitReader.val return type to make it inlineable.

goos: linux
goarch: amd64
pkg: internal/zstd
        │ /tmp/BenchmarkLarge.old │       /tmp/BenchmarkLarge.new       │
        │         sec/op          │   sec/op     vs base                │
Large-8               7.201m ± 2%   6.008m ± 4%  -16.58% (p=0.000 n=10)

        │ /tmp/BenchmarkLarge.old │       /tmp/BenchmarkLarge.new        │
        │           B/s           │     B/s       vs base                │
Large-8              23.64Mi ± 2%   28.33Mi ± 3%  +19.87% (p=0.000 n=10)

        │ /tmp/BenchmarkLarge.old │       /tmp/BenchmarkLarge.new        │
        │          B/op           │     B/op      vs base                │
Large-8              31.99Ki ± 3%   26.57Ki ± 1%  -16.92% (p=0.000 n=10)

        │ /tmp/BenchmarkLarge.old │    /tmp/BenchmarkLarge.new     │
        │        allocs/op        │ allocs/op   vs base            │
Large-8                0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10)
