### PR TITLE
runtime/metrics: update "whether" usages in documentation

### DIFF
--- a/src/runtime/metrics/description.go
+++ b/src/runtime/metrics/description.go
@@ -42,11 +42,11 @@ type Description struct {
 	// types which their application may not understand.
 	Kind ValueKind
 
-	// Cumulative is whether or not the metric is cumulative. If a cumulative metric is just
+	// Cumulative indicates whether the metric is cumulative. If a cumulative metric is just
 	// a single number, then it increases monotonically. If the metric is a distribution,
 	// then each bucket count increases monotonically.
 	//
-	// This flag thus indicates whether or not it's useful to compute a rate from this value.
+	// This flag thus indicates whether it's useful to compute a rate from this value.
 	Cumulative bool
 }
 
@@ -340,7 +340,7 @@ var allDesc = []Description{
 	},
 	{
 		Name: "/memory/classes/heap/stacks:bytes",
-		Description: "Memory allocated from the heap that is reserved for stack space, whether or not it is currently in-use. " +
+		Description: "Memory allocated from the heap that is reserved for stack space, whether it is currently in-use or not. " +
 			"Currently, this represents all stack memory for goroutines. It also includes all OS thread stacks in non-cgo programs. " +
 			"Note that stacks may be allocated differently in the future, and this may change.",
 		Kind: KindUint64,

--- a/src/runtime/metrics/doc.go
+++ b/src/runtime/metrics/doc.go
@@ -331,7 +331,7 @@ Below is the full list of supported metrics, ordered lexicographically.
 
 	/memory/classes/heap/stacks:bytes
 		Memory allocated from the heap that is reserved for stack space,
-		whether or not it is currently in-use. Currently, this
+		whether it is currently in-use or not. Currently, this
 		represents all stack memory for goroutines. It also includes all
 		OS thread stacks in non-cgo programs. Note that stacks may be
 		allocated differently in the future, and this may change.


### PR DESCRIPTION
% go doc runtime/metrics.Description | grep 'whether or not'
% go doc runtime/metrics | grep 'whether or not'

Update these doc comments to use more idiomatic and common phrases
instead of "whether or not".
