### PR TITLE
x/sys: fix trimmed socket opt string in unix/syscall_linux

### DIFF
--- a/src/cmd/vendor/golang.org/x/sys/unix/syscall_linux.go
+++ b/src/cmd/vendor/golang.org/x/sys/unix/syscall_linux.go
@@ -1310,7 +1310,11 @@ func GetsockoptString(fd, level, opt int) (string, error) {
 			return "", err
 		}
 	}
-	return string(buf[:vallen-1]), nil
+	if buf[vallen-1] == 0 {
+		return string(buf[:vallen-1]), nil
+	} else {
+		return string(buf[:vallen]), nil
+	}
 }
 
 func GetsockoptTpacketStats(fd, level, opt int) (*TpacketStats, error) {


### PR DESCRIPTION
Take null-byte into account and trim only if needed. Fixes #63217
