### PR TITLE
encoding/xml: remove extra whitespace characters around "=" in actual XMLs if any

### DIFF
--- a/src/encoding/xml/xml.go
+++ b/src/encoding/xml/xml.go
@@ -2044,11 +2044,15 @@ func emitCDATA(w io.Writer, s []byte) error {
 func procInst(param, s string) string {
 	// TODO: this parsing is somewhat lame and not exact.
 	// It works for all actual cases, though.
-	param = param + "="
 	_, v, _ := strings.Cut(s, param)
 	if v == "" {
 		return ""
 	}
+	_, v, _ = strings.Cut(v, "=")
+	if v == "" {
+		return ""
+	}
+	v = strings.TrimSpace(v)
 	if v[0] != '\'' && v[0] != '"' {
 		return ""
 	}

--- a/src/encoding/xml/xml_test.go
+++ b/src/encoding/xml/xml_test.go
@@ -829,6 +829,7 @@ var procInstTests = []struct {
 	{`version="1.0" encoding='utf-8'`, [2]string{"1.0", "utf-8"}},
 	{`version="1.0" encoding='utf-8' `, [2]string{"1.0", "utf-8"}},
 	{`version="1.0" encoding=utf-8`, [2]string{"1.0", ""}},
+	{`version= "1.0" encoding = 'utf-8' `, [2]string{"1.0", "utf-8"}},
 	{`encoding="FOO" `, [2]string{"", "FOO"}},
 }
 


### PR DESCRIPTION
I got problem with XML title like this:
`version="1.0" encoding ="utf-8"`
Hopefully this will help somebody with xml parsing in Go.