### PR TITLE
internal/zstd: allow stream consisting of skippable frames

### DIFF
--- a/src/internal/zstd/zstd.go
+++ b/src/internal/zstd/zstd.go
@@ -169,7 +169,7 @@ retry:
 
 	// Read magic number. RFC 3.1.1.
 	if _, err := io.ReadFull(r.r, r.scratch[:4]); err != nil {
-		// We require that the stream contain at least one frame.
+		// We require that the stream contains at least one frame.
 		if err == io.EOF && !r.readOneFrame {
 			err = io.ErrUnexpectedEOF
 		}
@@ -183,6 +183,7 @@ retry:
 			if err := r.skipFrame(); err != nil {
 				return err
 			}
+			r.readOneFrame = true
 			goto retry
 		}
 

--- a/src/internal/zstd/zstd_test.go
+++ b/src/internal/zstd/zstd_test.go
@@ -95,6 +95,17 @@ var tests = []struct {
 		"",
 		"\x28\xb5\x2f\xfd\x00\x00\x15\x00\x00\x00\x00",
 	},
+	{
+		"single skippable frame",
+		"",
+		"\x50\x2a\x4d\x18\x00\x00\x00\x00",
+	},
+	{
+		"two skippable frames",
+		"",
+		"\x50\x2a\x4d\x18\x00\x00\x00\x00" +
+			"\x50\x2a\x4d\x18\x00\x00\x00\x00",
+	},
 }
 
 func TestSamples(t *testing.T) {


### PR DESCRIPTION
For #62513
