### PR TITLE
syscall: make origRlimitNofile atomic.Pointer[Rlimit]

### DIFF
--- a/src/syscall/exec_bsd.go
+++ b/src/syscall/exec_bsd.go
@@ -64,7 +64,7 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
 		ngroups, groups uintptr
 	)
 
-	rlim, rlimOK := origRlimitNofile.Load().(Rlimit)
+	rlim := origRlimitNofile.Load()
 
 	// guard against side effects of shuffling fds below.
 	// Make sure that nextfd is beyond any currently open files so
@@ -276,8 +276,8 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
 	}
 
 	// Restore original rlimit.
-	if rlimOK && rlim.Cur != 0 {
-		RawSyscall(SYS_SETRLIMIT, uintptr(RLIMIT_NOFILE), uintptr(unsafe.Pointer(&rlim)), 0)
+	if rlim.Cur != 0 {
+		RawSyscall(SYS_SETRLIMIT, uintptr(RLIMIT_NOFILE), uintptr(unsafe.Pointer(rlim)), 0)
 	}
 
 	// Time to exec.

--- a/src/syscall/exec_bsd.go
+++ b/src/syscall/exec_bsd.go
@@ -276,7 +276,7 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
 	}
 
 	// Restore original rlimit.
-	if rlim != nil && rlim.Cur != 0 {
+	if rlim != nil {
 		RawSyscall(SYS_SETRLIMIT, uintptr(RLIMIT_NOFILE), uintptr(unsafe.Pointer(rlim)), 0)
 	}
 

--- a/src/syscall/exec_bsd.go
+++ b/src/syscall/exec_bsd.go
@@ -276,7 +276,7 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
 	}
 
 	// Restore original rlimit.
-	if rlim.Cur != 0 {
+	if rlim != nil && rlim.Cur != 0 {
 		RawSyscall(SYS_SETRLIMIT, uintptr(RLIMIT_NOFILE), uintptr(unsafe.Pointer(rlim)), 0)
 	}
 

--- a/src/syscall/exec_freebsd.go
+++ b/src/syscall/exec_freebsd.go
@@ -71,7 +71,7 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
 		upid            uintptr
 	)
 
-	rlim, rlimOK := origRlimitNofile.Load().(Rlimit)
+	rlim := origRlimitNofile.Load()
 
 	// Record parent PID so child can test if it has died.
 	ppid, _, _ := RawSyscall(SYS_GETPID, 0, 0, 0)
@@ -300,8 +300,8 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
 	}
 
 	// Restore original rlimit.
-	if rlimOK && rlim.Cur != 0 {
-		RawSyscall(SYS_SETRLIMIT, uintptr(RLIMIT_NOFILE), uintptr(unsafe.Pointer(&rlim)), 0)
+	if rlim.Cur != 0 {
+		RawSyscall(SYS_SETRLIMIT, uintptr(RLIMIT_NOFILE), uintptr(unsafe.Pointer(rlim)), 0)
 	}
 
 	// Time to exec.

--- a/src/syscall/exec_freebsd.go
+++ b/src/syscall/exec_freebsd.go
@@ -300,7 +300,7 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
 	}
 
 	// Restore original rlimit.
-	if rlim != nil && rlim.Cur != 0 {
+	if rlim != nil {
 		RawSyscall(SYS_SETRLIMIT, uintptr(RLIMIT_NOFILE), uintptr(unsafe.Pointer(rlim)), 0)
 	}
 

--- a/src/syscall/exec_freebsd.go
+++ b/src/syscall/exec_freebsd.go
@@ -300,7 +300,7 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
 	}
 
 	// Restore original rlimit.
-	if rlim.Cur != 0 {
+	if rlim != nil && rlim.Cur != 0 {
 		RawSyscall(SYS_SETRLIMIT, uintptr(RLIMIT_NOFILE), uintptr(unsafe.Pointer(rlim)), 0)
 	}
 

--- a/src/syscall/exec_libc.go
+++ b/src/syscall/exec_libc.go
@@ -91,7 +91,7 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
 		ngroups, groups uintptr
 	)
 
-	rlim, rlimOK := origRlimitNofile.Load().(Rlimit)
+	rlim := origRlimitNofile.Load()
 
 	// guard against side effects of shuffling fds below.
 	// Make sure that nextfd is beyond any currently open files so
@@ -296,8 +296,8 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
 	}
 
 	// Restore original rlimit.
-	if rlimOK && rlim.Cur != 0 {
-		setrlimit1(RLIMIT_NOFILE, unsafe.Pointer(&rlim))
+	if rlim.Cur != 0 {
+		setrlimit1(RLIMIT_NOFILE, unsafe.Pointer(rlim))
 	}
 
 	// Time to exec.

--- a/src/syscall/exec_libc.go
+++ b/src/syscall/exec_libc.go
@@ -296,7 +296,7 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
 	}
 
 	// Restore original rlimit.
-	if rlim != nil && rlim.Cur != 0 {
+	if rlim != nil {
 		setrlimit1(RLIMIT_NOFILE, unsafe.Pointer(rlim))
 	}
 

--- a/src/syscall/exec_libc.go
+++ b/src/syscall/exec_libc.go
@@ -296,7 +296,7 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
 	}
 
 	// Restore original rlimit.
-	if rlim.Cur != 0 {
+	if rlim != nil && rlim.Cur != 0 {
 		setrlimit1(RLIMIT_NOFILE, unsafe.Pointer(rlim))
 	}
 

--- a/src/syscall/exec_libc2.go
+++ b/src/syscall/exec_libc2.go
@@ -65,7 +65,7 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
 		ngroups, groups uintptr
 	)
 
-	rlim, rlimOK := origRlimitNofile.Load().(Rlimit)
+	rlim := origRlimitNofile.Load()
 
 	// guard against side effects of shuffling fds below.
 	// Make sure that nextfd is beyond any currently open files so
@@ -272,8 +272,8 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
 	}
 
 	// Restore original rlimit.
-	if rlimOK && rlim.Cur != 0 {
-		rawSyscall(abi.FuncPCABI0(libc_setrlimit_trampoline), uintptr(RLIMIT_NOFILE), uintptr(unsafe.Pointer(&rlim)), 0)
+	if rlim.Cur != 0 {
+		rawSyscall(abi.FuncPCABI0(libc_setrlimit_trampoline), uintptr(RLIMIT_NOFILE), uintptr(unsafe.Pointer(rlim)), 0)
 	}
 
 	// Time to exec.

--- a/src/syscall/exec_libc2.go
+++ b/src/syscall/exec_libc2.go
@@ -272,7 +272,7 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
 	}
 
 	// Restore original rlimit.
-	if rlim.Cur != 0 {
+	if rlim != nil && rlim.Cur != 0 {
 		rawSyscall(abi.FuncPCABI0(libc_setrlimit_trampoline), uintptr(RLIMIT_NOFILE), uintptr(unsafe.Pointer(rlim)), 0)
 	}
 

--- a/src/syscall/exec_libc2.go
+++ b/src/syscall/exec_libc2.go
@@ -272,7 +272,7 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
 	}
 
 	// Restore original rlimit.
-	if rlim != nil && rlim.Cur != 0 {
+	if rlim != nil {
 		rawSyscall(abi.FuncPCABI0(libc_setrlimit_trampoline), uintptr(RLIMIT_NOFILE), uintptr(unsafe.Pointer(rlim)), 0)
 	}
 

--- a/src/syscall/exec_linux.go
+++ b/src/syscall/exec_linux.go
@@ -248,7 +248,7 @@ func forkAndExecInChild1(argv0 *byte, argv, envv []*byte, chroot, dir *byte, att
 		c                         uintptr
 	)
 
-	rlim, rlimOK := origRlimitNofile.Load().(Rlimit)
+	rlim := origRlimitNofile.Load()
 
 	if sys.UidMappings != nil {
 		puid = []byte("/proc/self/uid_map\000")
@@ -628,8 +628,8 @@ func forkAndExecInChild1(argv0 *byte, argv, envv []*byte, chroot, dir *byte, att
 	}
 
 	// Restore original rlimit.
-	if rlimOK && rlim.Cur != 0 {
-		rawSetrlimit(RLIMIT_NOFILE, &rlim)
+	if rlim.Cur != 0 {
+		rawSetrlimit(RLIMIT_NOFILE, rlim)
 	}
 
 	// Enable tracing if requested.

--- a/src/syscall/exec_linux.go
+++ b/src/syscall/exec_linux.go
@@ -628,7 +628,7 @@ func forkAndExecInChild1(argv0 *byte, argv, envv []*byte, chroot, dir *byte, att
 	}
 
 	// Restore original rlimit.
-	if rlim != nil && rlim.Cur != 0 {
+	if rlim != nil {
 		rawSetrlimit(RLIMIT_NOFILE, rlim)
 	}
 

--- a/src/syscall/exec_linux.go
+++ b/src/syscall/exec_linux.go
@@ -628,7 +628,7 @@ func forkAndExecInChild1(argv0 *byte, argv, envv []*byte, chroot, dir *byte, att
 	}
 
 	// Restore original rlimit.
-	if rlim.Cur != 0 {
+	if rlim != nil && rlim.Cur != 0 {
 		rawSetrlimit(RLIMIT_NOFILE, rlim)
 	}
 

--- a/src/syscall/exec_unix.go
+++ b/src/syscall/exec_unix.go
@@ -281,9 +281,9 @@ func Exec(argv0 string, argv []string, envv []string) (err error) {
 	}
 	runtime_BeforeExec()
 
-	rlim, rlimOK := origRlimitNofile.Load().(Rlimit)
-	if rlimOK && rlim.Cur != 0 {
-		Setrlimit(RLIMIT_NOFILE, &rlim)
+	rlim := origRlimitNofile.Load()
+	if rlim.Cur != 0 {
+		Setrlimit(RLIMIT_NOFILE, rlim)
 	}
 
 	var err1 error

--- a/src/syscall/exec_unix.go
+++ b/src/syscall/exec_unix.go
@@ -282,7 +282,7 @@ func Exec(argv0 string, argv []string, envv []string) (err error) {
 	runtime_BeforeExec()
 
 	rlim := origRlimitNofile.Load()
-	if rlim.Cur != 0 {
+	if rlim != nil && rlim.Cur != 0 {
 		Setrlimit(RLIMIT_NOFILE, rlim)
 	}
 

--- a/src/syscall/exec_unix.go
+++ b/src/syscall/exec_unix.go
@@ -282,7 +282,7 @@ func Exec(argv0 string, argv []string, envv []string) (err error) {
 	runtime_BeforeExec()
 
 	rlim := origRlimitNofile.Load()
-	if rlim != nil && rlim.Cur != 0 {
+	if rlim != nil {
 		Setrlimit(RLIMIT_NOFILE, rlim)
 	}
 

--- a/src/syscall/export_rlimit_test.go
+++ b/src/syscall/export_rlimit_test.go
@@ -7,8 +7,5 @@
 package syscall
 
 func OrigRlimitNofile() Rlimit {
-	if rlim, ok := origRlimitNofile.Load().(Rlimit); ok {
-		return rlim
-	}
-	return Rlimit{0, 0}
+	return *origRlimitNofile.Load()
 }

--- a/src/syscall/export_rlimit_test.go
+++ b/src/syscall/export_rlimit_test.go
@@ -7,8 +7,7 @@
 package syscall
 
 func OrigRlimitNofile() Rlimit {
-	rlim := origRlimitNofile.Load()
-	if rlim != nil {
+	if rlim := origRlimitNofile.Load(); rlim != nil {
 		return *rlim
 	}
 	return Rlimit{0, 0}

--- a/src/syscall/export_rlimit_test.go
+++ b/src/syscall/export_rlimit_test.go
@@ -7,5 +7,9 @@
 package syscall
 
 func OrigRlimitNofile() Rlimit {
-	return *origRlimitNofile.Load()
+	rlim := origRlimitNofile.Load()
+	if rlim != nil {
+		return *rlim
+	}
+	return Rlimit{0, 0}
 }

--- a/src/syscall/rlimit.go
+++ b/src/syscall/rlimit.go
@@ -40,9 +40,9 @@ func init() {
 func Setrlimit(resource int, rlim *Rlimit) error {
 	err := setrlimit(resource, rlim)
 	if err == nil && resource == RLIMIT_NOFILE {
-		// Store zeroes in origRlimitNofile to tell StartProcess
+		// Store nil in origRlimitNofile to tell StartProcess
 		// to not adjust the rlimit in the child process.
-		origRlimitNofile.Store(&Rlimit{0, 0})
+		origRlimitNofile.Store(nil)
 	}
 	return err
 }

--- a/src/syscall/rlimit.go
+++ b/src/syscall/rlimit.go
@@ -10,7 +10,8 @@ import (
 	"sync/atomic"
 )
 
-// origRlimitNofile, if not {0, 0}, is the original soft RLIMIT_NOFILE.
+// origRlimitNofile, if non-nil and not dereferenced to {0, 0},
+// is the original soft RLIMIT_NOFILE.
 var origRlimitNofile atomic.Pointer[Rlimit]
 
 // Some systems set an artificially low soft limit on open file count, for compatibility

--- a/src/syscall/rlimit.go
+++ b/src/syscall/rlimit.go
@@ -10,8 +10,7 @@ import (
 	"sync/atomic"
 )
 
-// origRlimitNofile, if non-nil and not dereferenced to {0, 0},
-// is the original soft RLIMIT_NOFILE.
+// origRlimitNofile, if non-nil, is the original soft RLIMIT_NOFILE.
 var origRlimitNofile atomic.Pointer[Rlimit]
 
 // Some systems set an artificially low soft limit on open file count, for compatibility

--- a/src/syscall/syscall_linux.go
+++ b/src/syscall/syscall_linux.go
@@ -1277,7 +1277,7 @@ func Munmap(b []byte) (err error) {
 func prlimit(pid int, resource int, newlimit *Rlimit, old *Rlimit) (err error) {
 	err = prlimit1(pid, resource, newlimit, old)
 	if err == nil && newlimit != nil && resource == RLIMIT_NOFILE {
-		origRlimitNofile.Store(Rlimit{0, 0})
+		origRlimitNofile.Store(&Rlimit{0, 0})
 	}
 	return err
 }

--- a/src/syscall/syscall_linux.go
+++ b/src/syscall/syscall_linux.go
@@ -1277,7 +1277,7 @@ func Munmap(b []byte) (err error) {
 func prlimit(pid int, resource int, newlimit *Rlimit, old *Rlimit) (err error) {
 	err = prlimit1(pid, resource, newlimit, old)
 	if err == nil && newlimit != nil && resource == RLIMIT_NOFILE {
-		origRlimitNofile.Store(&Rlimit{0, 0})
+		origRlimitNofile.Store(nil)
 	}
 	return err
 }


### PR DESCRIPTION
Currently we are bootstrapping with Go 1.20, origRlimitNofile can
be changed to atomic.Pointer[Rlimit].