### PR TITLE
net: handle the network parameter properly in LookupPort

### DIFF
--- a/src/net/cgo_unix.go
+++ b/src/net/cgo_unix.go
@@ -80,7 +80,7 @@ func cgoLookupHost(ctx context.Context, name string) (hosts []string, err error)
 func cgoLookupPort(ctx context.Context, network, service string) (port int, err error) {
 	var hints _C_struct_addrinfo
 	switch network {
-	case "": // no hints
+	case "ip": // no hints
 	case "tcp", "tcp4", "tcp6":
 		*_C_ai_socktype(&hints) = _C_SOCK_STREAM
 		*_C_ai_protocol(&hints) = _C_IPPROTO_TCP

--- a/src/net/lookup_plan9.go
+++ b/src/net/lookup_plan9.go
@@ -203,26 +203,36 @@ func (r *Resolver) lookupIP(ctx context.Context, network, host string) (addrs []
 	return
 }
 
-func (*Resolver) lookupPort(ctx context.Context, network, service string) (port int, err error) {
+func (r *Resolver) lookupPort(ctx context.Context, network, service string) (port int, err error) {
 	switch network {
-	case "tcp4", "tcp6":
-		network = "tcp"
-	case "udp4", "udp6":
-		network = "udp"
+	case "ip": // no hints
+		if p, err := r.lookupPortWithNetwork(ctx, "tcp", "ip", service); err == nil {
+			return p, nil
+		}
+		return r.lookupPortWithNetwork(ctx, "udp", "ip", service)
+	case "tcp", "tcp4", "tcp6":
+		return r.lookupPortWithNetwork(ctx, "tcp", "tcp", service)
+	case "udp", "udp4", "udp6":
+		return r.lookupPortWithNetwork(ctx, "udp", "udp", service)
+	default:
+		return 0, &DNSError{Err: "unknown network", Name: network + "/" + service}
 	}
+}
+
+func (*Resolver) lookupPortWithNetwork(ctx context.Context, network, errNetwork, service string) (port int, err error) {
 	lines, err := queryCS(ctx, network, "127.0.0.1", toLower(service))
 	if err != nil {
 		if stringsHasSuffix(err.Error(), "can't translate service") {
-			return 0, &DNSError{Err: "unknown port", Name: network + "/" + service, IsNotFound: true}
+			return 0, &DNSError{Err: "unknown port", Name: errNetwork + "/" + service, IsNotFound: true}
 		}
 		return
 	}
 	if len(lines) == 0 {
-		return 0, &DNSError{Err: "unknown port", Name: network + "/" + service, IsNotFound: true}
+		return 0, &DNSError{Err: "unknown port", Name: errNetwork + "/" + service, IsNotFound: true}
 	}
 	f := getFields(lines[0])
 	if len(f) < 2 {
-		return 0, &DNSError{Err: "unknown port", Name: network + "/" + service, IsNotFound: true}
+		return 0, &DNSError{Err: "unknown port", Name: errNetwork + "/" + service, IsNotFound: true}
 	}
 	s := f[1]
 	if i := bytealg.IndexByteString(s, '!'); i >= 0 {
@@ -231,7 +241,7 @@ func (*Resolver) lookupPort(ctx context.Context, network, service string) (port 
 	if n, _, ok := dtoi(s); ok {
 		return n, nil
 	}
-	return 0, &DNSError{Err: "unknown port", Name: network + "/" + service, IsNotFound: true}
+	return 0, &DNSError{Err: "unknown port", Name: errNetwork + "/" + service, IsNotFound: true}
 }
 
 func (r *Resolver) lookupCNAME(ctx context.Context, name string) (cname string, err error) {

--- a/src/net/lookup_test.go
+++ b/src/net/lookup_test.go
@@ -1476,7 +1476,7 @@ func TestLookupPortNotFound(t *testing.T) {
 var tcpOnlyService = func() string {
 	// plan9 does not have submissions service defined in the service database.
 	if runtime.GOOS == "plan9" {
-		return "smtps"
+		return "https"
 	}
 	return "submissions"
 }()

--- a/src/net/lookup_test.go
+++ b/src/net/lookup_test.go
@@ -1470,7 +1470,7 @@ func TestLookupPortNotFound(t *testing.T) {
 }
 
 func TestLookupPortDifferentNetwork(t *testing.T) {
-	// imaps service is only avilable through a tcp network, see:
+	// imaps service is only available through a tcp network, see:
 	// https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=imaps
 	_, err := LookupPort("udp", "imaps")
 	var dnsErr *DNSError

--- a/src/net/lookup_test.go
+++ b/src/net/lookup_test.go
@@ -1506,11 +1506,15 @@ func TestLookupPortEmptyIPNetworkString(t *testing.T) {
 func allResolvers(t *testing.T, f func(t *testing.T)) {
 	t.Run("default resolver", f)
 	t.Run("forced go resolver", func(t *testing.T) {
-		defer forceGoDNS()()
-		f(t)
+		if fixup := forceGoDNS(); fixup != nil {
+			defer fixup()
+			f(t)
+		}
 	})
 	t.Run("forced cgo resolver", func(t *testing.T) {
-		defer forceCgoDNS()()
-		f(t)
+		if fixup := forceCgoDNS(); fixup != nil {
+			defer fixup()
+			f(t)
+		}
 	})
 }

--- a/src/net/lookup_test.go
+++ b/src/net/lookup_test.go
@@ -1468,3 +1468,12 @@ func TestLookupPortNotFound(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestLookupPortDifferentNetwork(t *testing.T) {
+	// imaps service is only avilable with a tcp network, see:
+	// https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=imaps
+	_, err := LookupPort("udp", "imaps")
+	if dnsErr, ok := err.(*DNSError); !ok || !dnsErr.IsNotFound {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/src/net/lookup_test.go
+++ b/src/net/lookup_test.go
@@ -1473,7 +1473,13 @@ func TestLookupPortNotFound(t *testing.T) {
 
 // submissions service is only available through a tcp network, see:
 // https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=submissions
-const tcpOnlyService = "submissions"
+var tcpOnlyService = func() string {
+	// plan9 does not have submissions service defined in the service database.
+	if runtime.GOOS == "plan9" {
+		return "smtps"
+	}
+	return "submissions"
+}()
 
 func TestLookupPortDifferentNetwork(t *testing.T) {
 	allResolvers(t, func(t *testing.T) {

--- a/src/net/lookup_test.go
+++ b/src/net/lookup_test.go
@@ -1494,7 +1494,7 @@ func TestLookupPortEmptyNetworkString(t *testing.T) {
 	})
 }
 
-func TestLookupPortEmptyIPNetworkString(t *testing.T) {
+func TestLookupPortIPNetworkString(t *testing.T) {
 	allResolvers(t, func(t *testing.T) {
 		_, err := LookupPort("ip", tcpOnlyService)
 		if err != nil {

--- a/src/net/lookup_test.go
+++ b/src/net/lookup_test.go
@@ -1471,16 +1471,15 @@ func TestLookupPortNotFound(t *testing.T) {
 	})
 }
 
+// submissions service is only available through a tcp network, see:
+// https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=submissions
+const tcpOnlyService = "submissions"
+
 func TestLookupPortDifferentNetwork(t *testing.T) {
 	allResolvers(t, func(t *testing.T) {
-		// imaps service is only available through a tcp network, see:
-		// https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=imaps
-		_, err := LookupPort("udp", "imaps")
+		_, err := LookupPort("udp", tcpOnlyService)
 		var dnsErr *DNSError
 		if !errors.As(err, &dnsErr) || !dnsErr.IsNotFound {
-			// TODO remove, for debugging:
-			goLookupPort("tcp", "imaps")
-			t.Logf("services: %#v", services)
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -1488,7 +1487,16 @@ func TestLookupPortDifferentNetwork(t *testing.T) {
 
 func TestLookupPortEmptyNetworkString(t *testing.T) {
 	allResolvers(t, func(t *testing.T) {
-		_, err := LookupPort("", "imaps")
+		_, err := LookupPort("", tcpOnlyService)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestLookupPortEmptyIPNetworkString(t *testing.T) {
+	allResolvers(t, func(t *testing.T) {
+		_, err := LookupPort("ip", tcpOnlyService)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/src/net/lookup_test.go
+++ b/src/net/lookup_test.go
@@ -1470,10 +1470,11 @@ func TestLookupPortNotFound(t *testing.T) {
 }
 
 func TestLookupPortDifferentNetwork(t *testing.T) {
-	// imaps service is only avilable with a tcp network, see:
+	// imaps service is only avilable through a tcp network, see:
 	// https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=imaps
 	_, err := LookupPort("udp", "imaps")
-	if dnsErr, ok := err.(*DNSError); !ok || !dnsErr.IsNotFound {
+	var dnsErr *DNSError
+	if !errors.As(err, &dnsErr) || !dnsErr.IsNotFound {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/src/net/lookup_windows.go
+++ b/src/net/lookup_windows.go
@@ -200,18 +200,27 @@ func (r *Resolver) lookupPort(ctx context.Context, network, service string) (int
 	// TODO(bradfitz): finish ctx plumbing. Nothing currently depends on this.
 	acquireThread()
 	defer releaseThread()
-	var stype int32
+
+	var hints syscall.AddrinfoW
+
 	switch network {
-	case "tcp4", "tcp6":
-		stype = syscall.SOCK_STREAM
-	case "udp4", "udp6":
-		stype = syscall.SOCK_DGRAM
+	case "tcp", "tcp4", "tcp6":
+		hints.Socktype = syscall.SOCK_STREAM
+		hints.Protocol = syscall.IPPROTO_TCP
+	case "udp", "udp4", "udp6":
+		hints.Socktype = syscall.SOCK_DGRAM
+		hints.Protocol = syscall.IPPROTO.UDP
+	default:
+		return 0, &DNSError{Err: "unknown network", Name: network + "/" + service}
 	}
-	hints := syscall.AddrinfoW{
-		Family:   syscall.AF_UNSPEC,
-		Socktype: stype,
-		Protocol: syscall.IPPROTO_IP,
+
+	switch ipVersion(network) {
+	case '4':
+		hints.Family = syscall.AF_INET
+	case '6':
+		hints.Family = syscall.AF_INET6
 	}
+
 	var result *syscall.AddrinfoW
 	e := syscall.GetAddrInfoW(nil, syscall.StringToUTF16Ptr(service), &hints, &result)
 	if e != nil {

--- a/src/net/lookup_windows.go
+++ b/src/net/lookup_windows.go
@@ -209,7 +209,7 @@ func (r *Resolver) lookupPort(ctx context.Context, network, service string) (int
 		hints.Protocol = syscall.IPPROTO_TCP
 	case "udp", "udp4", "udp6":
 		hints.Socktype = syscall.SOCK_DGRAM
-		hints.Protocol = syscall.IPPROTO.UDP
+		hints.Protocol = syscall.IPPROTO_UDP
 	default:
 		return 0, &DNSError{Err: "unknown network", Name: network + "/" + service}
 	}

--- a/src/net/lookup_windows.go
+++ b/src/net/lookup_windows.go
@@ -204,6 +204,7 @@ func (r *Resolver) lookupPort(ctx context.Context, network, service string) (int
 	var hints syscall.AddrinfoW
 
 	switch network {
+	case "ip": // no hints
 	case "tcp", "tcp4", "tcp6":
 		hints.Socktype = syscall.SOCK_STREAM
 		hints.Protocol = syscall.IPPROTO_TCP

--- a/src/net/port_unix.go
+++ b/src/net/port_unix.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build unix || js || wasip1
+//TODO uncomment
+////go:build unix || js || wasip1
 
 // Read system port mappings from /etc/services
 

--- a/src/net/port_unix.go
+++ b/src/net/port_unix.go
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//TODO uncomment
-////go:build unix || js || wasip1
+//go:build unix || js || wasip1
 
 // Read system port mappings from /etc/services
 


### PR DESCRIPTION
The cgo version (unix) is populating the GetAddrInfo hints
based on the network parameter, but windows not quite.

This change populates the hints the same way as the
cgo unix version does now.

This bug was spotted by Bryan in CL 530415.
https://go-review.googlesource.com/c/go/+/530415/comment/76640dc7_ed0409ca/