### PR TITLE
internal/zstd: reset reader buffer

### DIFF
--- a/src/internal/zstd/zstd.go
+++ b/src/internal/zstd/zstd.go
@@ -104,7 +104,7 @@ func (r *Reader) Reset(input io.Reader) {
 	r.frameSizeUnknown = false
 	r.remainingFrameSize = 0
 	r.blockOffset = 0
-	// buffer
+	r.buffer = r.buffer[:0]
 	r.off = 0
 	// repeatedOffset1
 	// repeatedOffset2

--- a/src/internal/zstd/zstd_test.go
+++ b/src/internal/zstd/zstd_test.go
@@ -127,6 +127,26 @@ func TestSamples(t *testing.T) {
 	}
 }
 
+func TestReset(t *testing.T) {
+	input := strings.NewReader("")
+	r := NewReader(input)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			input.Reset(test.compressed)
+			r.Reset(input)
+			got, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotstr := string(got)
+			if gotstr != test.uncompressed {
+				t.Errorf("got %q want %q", gotstr, test.uncompressed)
+			}
+		})
+	}
+}
+
 var (
 	bigDataOnce  sync.Once
 	bigDataBytes []byte


### PR DESCRIPTION
Reset r.buffer on Reset to avoid subsequent Read calls
observing previously decoded data.

For #62513
