### PR TITLE
runtime/internal/atomic: add ppc64x operators for And/Or

### DIFF
--- a/src/runtime/internal/atomic/atomic_andor_test.go
+++ b/src/runtime/internal/atomic/atomic_andor_test.go
@@ -1,4 +1,6 @@
-// +build wasm
+//go:build wasm || ppc64 || ppc64le
+// +build wasm ppc64 ppc64le
+
 //
 // Copyright 2023 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
@@ -9,8 +11,8 @@
 package atomic_test
 
 import (
-	"testing"
 	"runtime/internal/atomic"
+	"testing"
 )
 
 func TestAnd32(t *testing.T) {
@@ -166,4 +168,3 @@ func TestOr64(t *testing.T) {
 		}
 	}
 }
-

--- a/src/runtime/internal/atomic/atomic_ppc64x.go
+++ b/src/runtime/internal/atomic/atomic_ppc64x.go
@@ -62,6 +62,24 @@ func And(ptr *uint32, val uint32)
 func Or(ptr *uint32, val uint32)
 
 //go:noescape
+func And32(ptr *uint32, val uint32) uint32
+
+//go:noescape
+func Or32(ptr *uint32, val uint32) uint32
+
+//go:noescape
+func And64(ptr *uint64, val uint64) uint64
+
+//go:noescape
+func Or64(ptr *uint64, val uint64) uint64
+
+//go:noescape
+func Anduintptr(ptr *uintptr, val uintptr) uintptr
+
+//go:noescape
+func Oruintptr(ptr *uintptr, val uintptr) uintptr
+
+//go:noescape
 func Cas64(ptr *uint64, old, new uint64) bool
 
 //go:noescape

--- a/src/runtime/internal/atomic/atomic_ppc64x.s
+++ b/src/runtime/internal/atomic/atomic_ppc64x.s
@@ -360,3 +360,67 @@ again:
 	STWCCC	R6, (R3)
 	BNE	again
 	RET
+
+// func Or32(addr *uint32, v uint32) old uint32
+TEXT ·Or32(SB), NOSPLIT, $0-20
+	MOVD	ptr+0(FP), R3
+	MOVW	val+8(FP), R4
+	LWSYNC
+again:
+	LWAR	(R3), R6
+	MOVW	R6, R7
+	OR	R4, R6
+	STWCCC	R6, (R3)
+	BNE	again
+	MOVW	R7, ret+16(FP)
+	RET
+
+// func And32(addr *uint32, v uint32) old uint32
+TEXT ·And32(SB), NOSPLIT, $0-20
+	MOVD	ptr+0(FP), R3
+	MOVW	val+8(FP), R4
+	LWSYNC
+again:
+	LWAR	(R3),R6
+	MOVW	R6, R7
+	AND	R4, R6
+	STWCCC	R6, (R3)
+	BNE	again
+	MOVW	R7, ret+16(FP)
+	RET
+
+// func Or64(addr *uint64, v uint64) old uint64
+TEXT ·Or64(SB), NOSPLIT, $0-24
+	MOVD	ptr+0(FP), R3
+	MOVD	val+8(FP), R4
+	LWSYNC
+again:
+	LDAR	(R3), R6
+	MOVD	R6, R7
+	OR	R4, R6
+	STDCCC	R6, (R3)
+	BNE	again
+	MOVD	R7, ret+16(FP)
+	RET
+
+// func And64(addr *uint64, v uint64) old uint64
+TEXT ·And64(SB), NOSPLIT, $0-24
+	MOVD	ptr+0(FP), R3
+	MOVD	val+8(FP), R4
+	LWSYNC
+again:
+	LDAR	(R3),R6
+	MOVD	R6, R7
+	AND	R4, R6
+	STDCCC	R6, (R3)
+	BNE	again
+	MOVD	R7, ret+16(FP)
+	RET
+
+// func Anduintptr(addr *uintptr, v uintptr) old uintptr
+TEXT ·Anduintptr(SB), NOSPLIT, $0-24
+	JMP	·And64(SB)
+
+// func Oruintptr(addr *uintptr, v uintptr) old uintptr
+TEXT ·Oruintptr(SB), NOSPLIT, $0-24
+	JMP	·Or64(SB)

--- a/src/runtime/internal/atomic/atomic_ppc64x.s
+++ b/src/runtime/internal/atomic/atomic_ppc64x.s
@@ -368,11 +368,10 @@ TEXT ·Or32(SB), NOSPLIT, $0-20
 	LWSYNC
 again:
 	LWAR	(R3), R6
-	MOVW	R6, R7
-	OR	R4, R6
-	STWCCC	R6, (R3)
+	OR	R4, R6, R7
+	STWCCC	R7, (R3)
 	BNE	again
-	MOVW	R7, ret+16(FP)
+	MOVW	R6, ret+16(FP)
 	RET
 
 // func And32(addr *uint32, v uint32) old uint32
@@ -382,11 +381,10 @@ TEXT ·And32(SB), NOSPLIT, $0-20
 	LWSYNC
 again:
 	LWAR	(R3),R6
-	MOVW	R6, R7
-	AND	R4, R6
-	STWCCC	R6, (R3)
+	AND	R4, R6, R7
+	STWCCC	R7, (R3)
 	BNE	again
-	MOVW	R7, ret+16(FP)
+	MOVW	R6, ret+16(FP)
 	RET
 
 // func Or64(addr *uint64, v uint64) old uint64
@@ -396,11 +394,10 @@ TEXT ·Or64(SB), NOSPLIT, $0-24
 	LWSYNC
 again:
 	LDAR	(R3), R6
-	MOVD	R6, R7
-	OR	R4, R6
-	STDCCC	R6, (R3)
+	OR	R4, R6, R7
+	STDCCC	R7, (R3)
 	BNE	again
-	MOVD	R7, ret+16(FP)
+	MOVD	R6, ret+16(FP)
 	RET
 
 // func And64(addr *uint64, v uint64) old uint64
@@ -410,11 +407,10 @@ TEXT ·And64(SB), NOSPLIT, $0-24
 	LWSYNC
 again:
 	LDAR	(R3),R6
-	MOVD	R6, R7
-	AND	R4, R6
-	STDCCC	R6, (R3)
+	AND	R4, R6, R7
+	STDCCC	R7, (R3)
 	BNE	again
-	MOVD	R7, ret+16(FP)
+	MOVD	R6, ret+16(FP)
 	RET
 
 // func Anduintptr(addr *uintptr, v uintptr) old uintptr


### PR DESCRIPTION
These primitives will be used by the new And/Or sync/atomic apis.

For #61395
