### PR TITLE
strings: added function to get string pointer from a string constant

### DIFF
--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -1299,7 +1299,7 @@ func CutSuffix(s, suffix string) (before string, found bool) {
 	return s[:len(s)-len(suffix)], true
 }
 
-// StringPointerFrom returns a string pointer for the given string.
+// StringPointerFrom returns a string pointer for the given string constant.
 // This is specifically useful when we are writing test cases such as passing a string pointer to a struct field.
 func StringPointerFrom(s string) *string {
 	newString := Join([]string{s}, "")

--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -1298,3 +1298,10 @@ func CutSuffix(s, suffix string) (before string, found bool) {
 	}
 	return s[:len(s)-len(suffix)], true
 }
+
+// StringPointerFrom returns a string pointer for the given string.
+// This is specifically useful when we are writing test cases such as passing a string pointer to a struct field.
+func StringPointerFrom(s string) *string {
+	newString := Join([]string{s}, "")
+	return &newString
+}

--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -1300,7 +1300,8 @@ func CutSuffix(s, suffix string) (before string, found bool) {
 }
 
 // StringPointerFrom returns a string pointer for the given string constant.
-// This is specifically useful when we are writing test cases such as passing a string pointer to a struct field.
+// This is specifically useful when we are writing test cases,
+// such as passing a string pointer to a struct field from a string constant.
 func StringPointerFrom(s string) *string {
 	newString := Join([]string{s}, "")
 	return &newString

--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -1303,6 +1303,5 @@ func CutSuffix(s, suffix string) (before string, found bool) {
 // This is specifically useful when we are writing test cases,
 // such as passing a string pointer to a struct field from a string constant.
 func StringPointerFrom(s string) *string {
-	newString := Join([]string{s}, "")
-	return &newString
+	return &s
 }

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -2051,3 +2051,27 @@ func BenchmarkReplaceAll(b *testing.B) {
 		stringSink = ReplaceAll("banana", "a", "<>")
 	}
 }
+
+func TestStringPointerFrom(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		args args
+		want string
+	}{
+		{
+			args: args{
+				s: "test",
+			},
+			want: "test",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StringPointerFrom(tt.args.s); *got != tt.want {
+				t.Errorf("StringPointerFrom() = %v, want %v", *got, tt.want)
+			}
+		})
+	}
+}

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -1698,6 +1698,39 @@ func TestCutSuffix(t *testing.T) {
 	}
 }
 
+func TestStringPointerFrom(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "valid string",
+			args: args{
+				s: "test",
+			},
+			want: "test",
+		},
+		{
+			name: "empty string",
+			args: args{
+				s: "",
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StringPointerFrom(tt.args.s); *got != tt.want {
+				t.Errorf("StringPointerFrom() = %v, want %v", *got, tt.want)
+			}
+		})
+	}
+}
+
 func makeBenchInputHard() string {
 	tokens := [...]string{
 		"<a>", "<p>", "<b>", "<strong>",
@@ -2049,38 +2082,5 @@ func BenchmarkReplaceAll(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		stringSink = ReplaceAll("banana", "a", "<>")
-	}
-}
-
-func TestStringPointerFrom(t *testing.T) {
-	type args struct {
-		s string
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "valid string",
-			args: args{
-				s: "test",
-			},
-			want: "test",
-		},
-		{
-			name: "empty string",
-			args: args{
-				s: "",
-			},
-			want: "",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := StringPointerFrom(tt.args.s); *got != tt.want {
-				t.Errorf("StringPointerFrom() = %v, want %v", *got, tt.want)
-			}
-		})
 	}
 }

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -2057,14 +2057,23 @@ func TestStringPointerFrom(t *testing.T) {
 		s string
 	}
 	tests := []struct {
+		name string
 		args args
 		want string
 	}{
 		{
+			name: "valid string",
 			args: args{
 				s: "test",
 			},
 			want: "test",
+		},
+		{
+			name: "empty string",
+			args: args{
+				s: "",
+			},
+			want: "",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This function will be useful mostly during testing. When we want to pass a string pointer to a struct member each time we have to create a separate variable and pass the address of that to the member variable, Which is a pain. This wrapper function will ease all those efforts.
Eg: 
type Employee struct{
Name *string
}

To pass a variable in testing , we have to
testName  := "hello"

emp := Employee{
  Name: &testName,
}

With this function it is

emp: = Employee{
  Name: strings.StringPointerFrom("hello")
}

It is really helpful when we are using table tests.
