### PR TITLE
bytes: use "start = ^start" to set start to a negative value

### DIFF
--- a/src/bytes/bytes.go
+++ b/src/bytes/bytes.go
@@ -494,7 +494,9 @@ func FieldsFunc(s []byte, f func(rune) bool) [][]byte {
 		if f(r) {
 			if start >= 0 {
 				spans = append(spans, span{start, i})
-				start = -1
+				// Set start to a negative value.
+				// Be consistent with strings.FieldsFunc.
+				start = ^start
 			}
 		} else {
 			if start < 0 {


### PR DESCRIPTION
While reading the source code, I noticed that bytes.FieldsFunc is
little different from strings.FieldsFunc in assigning 'start'.
    
However I don't have an amd64 machine to verify this:
"Note: using -1 here consistently and reproducibly
slows down this code by a several percent on amd64."
    
So I think this CL is at least for consistency with strings.FieldsFunc.