### PR TITLE
crypto/rsa: PublicKey.Equal() documentation specifies that it requires a pointer

### DIFF
--- a/src/crypto/rsa/rsa.go
+++ b/src/crypto/rsa/rsa.go
@@ -59,7 +59,7 @@ func (pub *PublicKey) Size() int {
 
 // Equal reports whether pub and x have the same value.
 //
-// x must be a pointer to [PublicKey]
+// applie only to [*PublicKey], returns false in other cases.
 func (pub *PublicKey) Equal(x crypto.PublicKey) bool {
 	xx, ok := x.(*PublicKey)
 	if !ok {

--- a/src/crypto/rsa/rsa.go
+++ b/src/crypto/rsa/rsa.go
@@ -58,6 +58,8 @@ func (pub *PublicKey) Size() int {
 }
 
 // Equal reports whether pub and x have the same value.
+//
+// x must be a pointer to PublicKey
 func (pub *PublicKey) Equal(x crypto.PublicKey) bool {
 	xx, ok := x.(*PublicKey)
 	if !ok {

--- a/src/crypto/rsa/rsa.go
+++ b/src/crypto/rsa/rsa.go
@@ -59,7 +59,7 @@ func (pub *PublicKey) Size() int {
 
 // Equal reports whether pub and x have the same value.
 //
-// x must be a pointer to PublicKey
+// x must be a pointer to [PublicKey]
 func (pub *PublicKey) Equal(x crypto.PublicKey) bool {
 	xx, ok := x.(*PublicKey)
 	if !ok {


### PR DESCRIPTION
Fixes #49136
For #57752