### PR TITLE
src/time: add duration day as const

### DIFF
--- a/src/time/time.go
+++ b/src/time/time.go
@@ -634,6 +634,7 @@ const (
 //
 //	seconds := 10
 //	fmt.Print(time.Duration(seconds)*time.Second) // prints 10s
+
 const (
 	Nanosecond  Duration = 1
 	Microsecond          = 1000 * Nanosecond

--- a/src/time/time.go
+++ b/src/time/time.go
@@ -114,7 +114,6 @@ import (
 // these methods does not change the actual instant it represents, only the time
 // zone in which to interpret it.
 
-//
 // Representations of a Time value saved by the GobEncode, MarshalBinary,
 // MarshalJSON, and MarshalText methods store the Time.Location's offset, but not
 // the location name. They therefore lose information about Daylight Saving Time.
@@ -642,6 +641,7 @@ const (
 	Second               = 1000 * Millisecond
 	Minute               = 60 * Second
 	Hour                 = 60 * Minute
+	Day                  = 60 * Hour
 )
 
 // String returns a string representing the duration in the form "72h3m0.5s".

--- a/src/time/time.go
+++ b/src/time/time.go
@@ -641,7 +641,7 @@ const (
 	Second               = 1000 * Millisecond
 	Minute               = 60 * Second
 	Hour                 = 60 * Minute
-	Day                  = 60 * Hour
+	Day                  = 24 * Hour
 )
 
 // String returns a string representing the duration in the form "72h3m0.5s".


### PR DESCRIPTION
Everytime we want to represent a "Day" duration, we need to define a const as 24 * time.Hour directly in the code, and it's kinda boring 

Why don't define it directly in the time package? That's the point of this one line PR