### PR TITLE
cmp: optimize Compare

### DIFF
--- a/src/cmp/bench_test.go
+++ b/src/cmp/bench_test.go
@@ -1,0 +1,44 @@
+package cmp_test
+
+import (
+	"cmp"
+	"slices"
+	"strconv"
+	"testing"
+)
+
+func BenchmarkCompare_int(b *testing.B) {
+	var lst [1_000_000]int
+	for i := range lst {
+		lst[i] = i
+	}
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		slices.SortFunc(lst[:], cmp.Compare)
+	}
+}
+
+func BenchmarkCompare_float64(b *testing.B) {
+	var lst [1_000_000]float64
+	for i := range lst {
+		lst[i] = float64(i)
+	}
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		slices.SortFunc(lst[:], cmp.Compare)
+	}
+}
+
+func BenchmarkCompare_string(b *testing.B) {
+	var lst [1_000_000]string
+	for i := range lst {
+		lst[i] = strconv.Itoa(i)
+	}
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		slices.SortFunc(lst[:], cmp.Compare)
+	}
+}

--- a/src/cmp/bench_test.go
+++ b/src/cmp/bench_test.go
@@ -2,43 +2,56 @@ package cmp_test
 
 import (
 	"cmp"
-	"slices"
-	"strconv"
+	"math"
 	"testing"
 )
 
-func BenchmarkCompare_int(b *testing.B) {
-	var lst [1_000_000]int
-	for i := range lst {
-		lst[i] = i
-	}
-	b.ResetTimer()
+var sum int
 
+func BenchmarkCompare_int(b *testing.B) {
+	lst := [...]int{
+		0xfa3, 0x7fe, 0x03c, 0xcb9,
+		0x4ce, 0x4fb, 0x7d5, 0x38f,
+		0x73b, 0x322, 0x85c, 0xf4d,
+		0xbbc, 0x032, 0x059, 0xb93,
+	}
 	for n := 0; n < b.N; n++ {
-		slices.SortFunc(lst[:], cmp.Compare)
+		sum += cmp.Compare(lst[n%len(lst)], lst[(2*n)%len(lst)])
 	}
 }
 
 func BenchmarkCompare_float64(b *testing.B) {
-	var lst [1_000_000]float64
-	for i := range lst {
-		lst[i] = float64(i)
+	lst := [...]float64{
+		0.35573281, 0.77552566, 0.19006500, 0.66436280,
+		0.02769279, 0.97572397, 0.40945068, 0.26422857,
+		0.10985792, 0.35659522, 0.82752613, 0.18875522,
+		0.16410543, 0.03578153, 0.51636871, math.NaN(),
 	}
-	b.ResetTimer()
-
 	for n := 0; n < b.N; n++ {
-		slices.SortFunc(lst[:], cmp.Compare)
+		sum += cmp.Compare(lst[n%len(lst)], lst[(2*n)%len(lst)])
 	}
 }
 
-func BenchmarkCompare_string(b *testing.B) {
-	var lst [1_000_000]string
-	for i := range lst {
-		lst[i] = strconv.Itoa(i)
+func BenchmarkCompare_strings(b *testing.B) {
+	lst := [...]string{
+		"time",
+		"person",
+		"year",
+		"way",
+		"day",
+		"thing",
+		"man",
+		"world",
+		"life",
+		"hand",
+		"part",
+		"child",
+		"eye",
+		"woman",
+		"place",
+		"work",
 	}
-	b.ResetTimer()
-
 	for n := 0; n < b.N; n++ {
-		slices.SortFunc(lst[:], cmp.Compare)
+		sum += cmp.Compare(lst[n%len(lst)], lst[(2*n)%len(lst)])
 	}
 }

--- a/src/cmp/cmp.go
+++ b/src/cmp/cmp.go
@@ -38,18 +38,19 @@ func Less[T Ordered](x, y T) bool {
 // For floating-point types, a NaN is considered less than any non-NaN,
 // a NaN is considered equal to a NaN, and -0.0 is equal to 0.0.
 func Compare[T Ordered](x, y T) int {
-	xNaN := isNaN(x)
-	yNaN := isNaN(y)
-	if xNaN && yNaN {
+	if x == y {
 		return 0
 	}
-	if xNaN || x < y {
+	if x < y {
 		return -1
 	}
-	if yNaN || x > y {
-		return +1
+	if isNaN(x) {
+		if isNaN(y) {
+			return 0
+		}
+		return -1
 	}
-	return 0
+	return +1
 }
 
 // isNaN reports whether x is a NaN without requiring the math package.

--- a/src/cmp/cmp.go
+++ b/src/cmp/cmp.go
@@ -38,19 +38,19 @@ func Less[T Ordered](x, y T) bool {
 // For floating-point types, a NaN is considered less than any non-NaN,
 // a NaN is considered equal to a NaN, and -0.0 is equal to 0.0.
 func Compare[T Ordered](x, y T) int {
-	if x == y {
-		return 0
-	}
-	if x < y {
-		return -1
-	}
-	if isNaN(x) {
-		if isNaN(y) {
-			return 0
+	if x != y {
+		if isNaN(x) {
+			if isNaN(y) {
+				return 0
+			}
+			return -1
 		}
-		return -1
+		if x < y {
+			return -1
+		}
+		return +1
 	}
-	return +1
+	return 0
 }
 
 // isNaN reports whether x is a NaN without requiring the math package.

--- a/src/cmp/cmp.go
+++ b/src/cmp/cmp.go
@@ -45,6 +45,7 @@ func Compare[T Ordered](x, y T) int {
 			}
 			return -1
 		}
+		// If isNaN(y), x < y is false.
 		if x < y {
 			return -1
 		}


### PR DESCRIPTION
Compare provides three-way comparison for Ordered types, which certain
algorithms benefit from.

Float comparisons require NaN handling that should be optimized away for
all other types.
String comparisons benefit from using != which short-circuits on
different length strings.
Ideally the compiler would recognize the pattern and specialize on
strings, but this tries to improve the status quo.

goos: darwin
goarch: amd64
pkg: cmp
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
                   │  base.txt   │              patch.txt              │
                   │   sec/op    │   sec/op     vs base                │
Compare_int-12       1.638n ± 1%   1.635n ± 2%        ~ (p=0.698 n=10)
Compare_float64-12   2.397n ± 1%   2.206n ± 0%   -7.99% (p=0.000 n=10)
Compare_strings-12   8.054n ± 1%   6.705n ± 2%  -16.75% (p=0.000 n=10)
geomean              3.162n        2.892n        -8.56%

Updates #31187
Updates #61725