### PR TITLE
reflect: compute the median h uniformly

### DIFF
--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -1539,7 +1539,7 @@ func typesByString(s string) []*abi.Type {
 		// This is a copy of sort.Search, with f(h) replaced by (*typ[h].String() >= s).
 		i, j := 0, len(offs)
 		for i < j {
-			h := i + (j-i)>>1 // avoid overflow when computing h
+			h := int(uint(i+j) >> 1) // avoid overflow when computing h
 			// i ≤ h < j
 			if !(stringFor(rtypeOff(section, offs[h])) >= s) {
 				i = h + 1 // preserves f(i-1) == false


### PR DESCRIPTION
Like sort.Search, use "h := int(uint(i+j) >> 1)" to compute the median h.