### PR TITLE
strings: explicitly set start to -1 in FieldsFunc

### DIFF
--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -398,10 +398,7 @@ func FieldsFunc(s string, f func(rune) bool) []string {
 		if f(rune) {
 			if start >= 0 {
 				spans = append(spans, span{start, end})
-				// Set start to a negative value.
-				// Note: using -1 here consistently and reproducibly
-				// slows down this code by a several percent on amd64.
-				start = ^start
+				start = -1
 			}
 		} else {
 			if start < 0 {


### PR DESCRIPTION
Comparing to bytes.FieldsFunc, there is a difference in setting start
to negative. Explicitly using -1 makes the code more clear and readable.