### PR TITLE
testing: remove unnecessary TempDir implementation detail from its doc

### DIFF
--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -1173,7 +1173,7 @@ func (c *common) Cleanup(f func()) {
 }
 
 // TempDir returns a temporary directory for the test to use.
-// The directory is automatically removed by Cleanup when the test and
+// The directory is automatically removed when the test and
 // all its subtests complete.
 // Each subsequent call to t.TempDir returns a unique directory;
 // if the directory creation fails, TempDir terminates the test by calling Fatal.


### PR DESCRIPTION
The "by Cleanup" detail about the removal mechanism is not necessary for
users. The previous wording could even cause confusion whether they
should do something for Cleanup to occur.