### PR TITLE
modcmd: do not copy test embed files when vendoring

### DIFF
--- a/src/cmd/go/internal/modcmd/vendor.go
+++ b/src/cmd/go/internal/modcmd/vendor.go
@@ -313,7 +313,7 @@ func vendorPkg(vdir, pkg string) {
 			base.Fatalf("internal error: failed to find embedded files of %s: %v\n", pkg, err)
 		}
 	}
-	embedPatterns := str.StringList(bp.EmbedPatterns, bp.TestEmbedPatterns, bp.XTestEmbedPatterns)
+	embedPatterns := str.StringList(bp.EmbedPatterns)
 	embeds, err := load.ResolveEmbed(bp.Dir, embedPatterns)
 	if err != nil {
 		base.Fatal(err)

--- a/src/cmd/go/testdata/script/mod_vendor_embed.txt
+++ b/src/cmd/go/testdata/script/mod_vendor_embed.txt
@@ -1,8 +1,6 @@
 go mod vendor
 cmp vendor/example.com/a/samedir_embed.txt a/samedir_embed.txt
 cmp vendor/example.com/a/subdir/embed.txt a/subdir/embed.txt
-cmp vendor/example.com/a/subdir/test/embed.txt a/subdir/test/embed.txt
-cmp vendor/example.com/a/subdir/test/xtest/embed.txt a/subdir/test/xtest/embed.txt
 
 cd broken_no_matching_files
 ! go mod vendor
@@ -59,20 +57,6 @@ var subDir string
 func Str() string {
 	return sameDir + subDir
 }
--- a/a_test.go --
-package a
-
-import _ "embed"
-
-//go:embed subdir/test/embed.txt
-var subderTest string
--- a/a_x_test.go --
-package a_test
-
-import _ "embed"
-
-//go:embed subdir/test/xtest/embed.txt
-var subdirXtest string
 -- a/samedir_embed.txt --
 embedded file in same directory as package
 -- a/subdir/embed.txt --


### PR DESCRIPTION
Currently, `go mod vendor` copy all files matched by //go:embed, even when it is in a _test.go file. According to the documentation, it should not include test code for vendored packages.

Fixes #63473