### PR TITLE
[release-branch.go1.21] regexp: improved compile performance with a cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ _cgo_*
 _obj
 _test
 _testmain.go
+.history
 
 /VERSION.cache
 /bin/

--- a/src/regexp/syntax/cache.go
+++ b/src/regexp/syntax/cache.go
@@ -2,86 +2,143 @@ package syntax
 
 import (
 	"math"
+	"sync"
+	"syscall"
 	"time"
-
-	"github.com/alphadose/haxmap"
-	"github.com/pbnjay/memory"
 )
 
-type cacheRegexpItem struct {
-	regexp *Regexp
-	err error
-	lastUse time.Time
+type cacheMap[T any] struct {
+	value map[string]T
+	err map[string]error
+	lastUse map[string]time.Time
+	mu sync.Mutex
+	null T
 }
 
-type cacheProgItem struct {
-	prog *Prog
-	err error
-	lastUse time.Time
+func newCache[T any]() cacheMap[T] {
+	return cacheMap[T]{
+		value: map[string]T{},
+		err: map[string]error{},
+		lastUse: map[string]time.Time{},
+	}
 }
 
-var regexpCache *haxmap.Map[string, cacheRegexpItem] = haxmap.New[string, cacheRegexpItem]()
-var progCache *haxmap.Map[string, cacheProgItem] = haxmap.New[string, cacheProgItem]()
+// get returns a value or an error if it exists
+//
+// if the object key does not exist, it will return both a nil/zero value (of the relevant type) and nil error
+func (cache *cacheMap[T]) get(key string) (T, error) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	if val, ok := cache.value[key]; ok {
+		cache.lastUse[key] = time.Now()
+		return val, nil
+	}else if err, ok := cache.err[key]; ok {
+		cache.lastUse[key] = time.Now()
+		return cache.null, err
+	}
+
+	return cache.null, nil
+}
+
+// set sets or adds a new key with either a value, or an error
+func (cache *cacheMap[T]) set(key string, value T, err error) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	if err != nil {
+		cache.err[key] = err
+		delete(cache.value, key)
+		cache.lastUse[key] = time.Now()
+	}else{
+		cache.value[key] = value
+		delete(cache.err, key)
+		cache.lastUse[key] = time.Now()
+	}
+}
+
+// delOld removes old cache items
+func (cache *cacheMap[T]) delOld(cacheTime time.Duration){
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	if cacheTime == 0 {
+		for key := range cache.lastUse {
+			delete(cache.value, key)
+			delete(cache.err, key)
+			delete(cache.lastUse, key)
+		}
+		return
+	}
+
+	now := time.Now().UnixNano()
+
+	for key, lastUse := range cache.lastUse {
+		if now - lastUse.UnixNano() > int64(cacheTime) {
+			delete(cache.value, key)
+			delete(cache.err, key)
+			delete(cache.lastUse, key)
+		}
+	}
+}
+
+var regexpCache cacheMap[*Regexp] = newCache[*Regexp]()
+var progCache cacheMap[*Prog] = newCache[*Prog]()
 
 func init(){
 	go func(){
 		for {
 			time.Sleep(10 * time.Minute)
 
-			now := time.Now().UnixNano()
-
 			// default: remove cache items have not been accessed in over 2 hours
-			cacheTime := int64(2 * time.Hour)
+			cacheTime := 2 * time.Hour
 
-			// memory.FreeMemory() returns the total free system memory in bytes
-			// the math below, converts bytes to megabytes
-			mb := math.Round(float64(memory.FreeMemory()) / 1024 / 1024 * 100) / 100
+			// sysFreeMemory returns the total free system memory in megabytes
+			mb := sysFreeMemory()
 			if mb < 200 && mb != 0 {
 				// low memory: remove cache items have not been accessed in over 10 minutes
-				cacheTime = int64(10 * time.Minute)
+				cacheTime = 10 * time.Minute
 			}else if mb < 500 && mb != 0 {
 				// low memory: remove cache items have not been accessed in over 30 minutes
-				cacheTime = int64(30 * time.Minute)
+				cacheTime = 30 * time.Minute
 			}else if mb < 2000 && mb != 0 {
 				// low memory: remove cache items have not been accessed in over 1 hour
-				cacheTime = int64(1 * time.Hour)
+				cacheTime = 1 * time.Hour
 			}else if mb > 64000 {
 				// high memory: remove cache items have not been accessed in over 12 hour
-				cacheTime = int64(12 * time.Hour)
+				cacheTime = 12 * time.Hour
 			}else if mb > 32000 {
 				// high memory: remove cache items have not been accessed in over 6 hour
-				cacheTime = int64(6 * time.Hour)
+				cacheTime = 6 * time.Hour
 			}else if mb > 16000 {
 				// high memory: remove cache items have not been accessed in over 3 hour
-				cacheTime = int64(3 * time.Hour)
+				cacheTime = 3 * time.Hour
 			}
 
-			regexpCache.ForEach(func(key string, val cacheRegexpItem) bool {
-				if now - val.lastUse.UnixNano() > cacheTime {
-					regexpCache.Del(key)
-				}
-				return true
-			})
-
-			progCache.ForEach(func(key string, val cacheProgItem) bool {
-				if now - val.lastUse.UnixNano() > cacheTime {
-					progCache.Del(key)
-				}
-				return true
-			})
+			regexpCache.delOld(cacheTime)
+			progCache.delOld(cacheTime)
 
 			time.Sleep(10 * time.Second)
 
 			// clear cache if were still critically low on available memory
-			if mb := math.Round(float64(memory.FreeMemory()) / 1024 / 1024 * 100) / 100; mb < 10 && mb != 0 {
-				regexpCache.ForEach(func(key string, val cacheRegexpItem) bool {
-					return true
-				})
-	
-				progCache.ForEach(func(key string, val cacheProgItem) bool {
-					return true
-				})
+			if mb := sysFreeMemory(); mb < 10 && mb != 0 {
+				regexpCache.delOld(0)
+				progCache.delOld(0)
 			}
 		}
 	}()
+}
+
+// sysFreeMemory returns the amount of memory available in megabytes
+func sysFreeMemory() float64 {
+	in := &syscall.Sysinfo_t{}
+	err := syscall.Sysinfo(in)
+	if err != nil {
+		return 0
+	}
+
+	// If this is a 32-bit system, then these fields are
+	// uint32 instead of uint64.
+	// So we always convert to uint64 to match signature.
+	return math.Round(float64(uint64(in.Freeram) * uint64(in.Unit)) / 1024 / 1024 * 100) / 100
 }

--- a/src/regexp/syntax/cache.go
+++ b/src/regexp/syntax/cache.go
@@ -1,0 +1,87 @@
+package syntax
+
+import (
+	"math"
+	"time"
+
+	"github.com/alphadose/haxmap"
+	"github.com/pbnjay/memory"
+)
+
+type cacheRegexpItem struct {
+	regexp *Regexp
+	err error
+	lastUse time.Time
+}
+
+type cacheProgItem struct {
+	prog *Prog
+	err error
+	lastUse time.Time
+}
+
+var regexpCache *haxmap.Map[string, cacheRegexpItem] = haxmap.New[string, cacheRegexpItem]()
+var progCache *haxmap.Map[string, cacheProgItem] = haxmap.New[string, cacheProgItem]()
+
+func init(){
+	go func(){
+		for {
+			time.Sleep(10 * time.Minute)
+
+			now := time.Now().UnixNano()
+
+			// default: remove cache items have not been accessed in over 2 hours
+			cacheTime := int64(2 * time.Hour)
+
+			// memory.FreeMemory() returns the total free system memory in bytes
+			// the math below, converts bytes to megabytes
+			mb := math.Round(float64(memory.FreeMemory()) / 1024 / 1024 * 100) / 100
+			if mb < 200 && mb != 0 {
+				// low memory: remove cache items have not been accessed in over 10 minutes
+				cacheTime = int64(10 * time.Minute)
+			}else if mb < 500 && mb != 0 {
+				// low memory: remove cache items have not been accessed in over 30 minutes
+				cacheTime = int64(30 * time.Minute)
+			}else if mb < 2000 && mb != 0 {
+				// low memory: remove cache items have not been accessed in over 1 hour
+				cacheTime = int64(1 * time.Hour)
+			}else if mb > 64000 {
+				// high memory: remove cache items have not been accessed in over 12 hour
+				cacheTime = int64(12 * time.Hour)
+			}else if mb > 32000 {
+				// high memory: remove cache items have not been accessed in over 6 hour
+				cacheTime = int64(6 * time.Hour)
+			}else if mb > 16000 {
+				// high memory: remove cache items have not been accessed in over 3 hour
+				cacheTime = int64(3 * time.Hour)
+			}
+
+			regexpCache.ForEach(func(key string, val cacheRegexpItem) bool {
+				if now - val.lastUse.UnixNano() > cacheTime {
+					regexpCache.Del(key)
+				}
+				return true
+			})
+
+			progCache.ForEach(func(key string, val cacheProgItem) bool {
+				if now - val.lastUse.UnixNano() > cacheTime {
+					progCache.Del(key)
+				}
+				return true
+			})
+
+			time.Sleep(10 * time.Second)
+
+			// clear cache if were still critically low on available memory
+			if mb := math.Round(float64(memory.FreeMemory()) / 1024 / 1024 * 100) / 100; mb < 10 && mb != 0 {
+				regexpCache.ForEach(func(key string, val cacheRegexpItem) bool {
+					return true
+				})
+	
+				progCache.ForEach(func(key string, val cacheProgItem) bool {
+					return true
+				})
+			}
+		}
+	}()
+}


### PR DESCRIPTION
Adding a cache to compiled expressions can increase performance when the same expression is used multiple times.

This commit is inspired by how JavaScript handles regexp with a cache.

This commit also includes an interval to periodically clear old cache items that have not been accessed in a while.

The loop runs every 10 minutes, and tracks the memory usage to determine if the cache needs to be cleared early.