### PR TITLE
cmd/go: fix the accuracy of Mercurial vcs.* stamped data

### DIFF
--- a/src/cmd/go/internal/vcs/vcs.go
+++ b/src/cmd/go/internal/vcs/vcs.go
@@ -213,7 +213,7 @@ func hgStatus(vcsHg *Cmd, rootDir string) (Status, error) {
 	}
 
 	// Also look for untracked files.
-	out, err = vcsHg.runOutputVerboseOnly(rootDir, "status")
+	out, err = vcsHg.runOutputVerboseOnly(rootDir, "status -S")
 	if err != nil {
 		return Status{}, err
 	}

--- a/src/cmd/go/internal/vcs/vcs.go
+++ b/src/cmd/go/internal/vcs/vcs.go
@@ -189,12 +189,11 @@ func hgRemoteRepo(vcsHg *Cmd, rootDir string) (remoteRepo string, err error) {
 
 func hgStatus(vcsHg *Cmd, rootDir string) (Status, error) {
 	// Output changeset ID and seconds since epoch.
-	out, err := vcsHg.runOutputVerboseOnly(rootDir, `log -l1 -T {node}:{date|hgdate}`)
+	out, err := vcsHg.runOutputVerboseOnly(rootDir, `log -r. -T {node}:{date|hgdate}`)
 	if err != nil {
 		return Status{}, err
 	}
 
-	// Successful execution without output indicates an empty repo (no commits).
 	var rev string
 	var commitTime time.Time
 	if len(out) > 0 {

--- a/src/cmd/go/internal/vcs/vcs.go
+++ b/src/cmd/go/internal/vcs/vcs.go
@@ -37,6 +37,7 @@ import (
 type Cmd struct {
 	Name      string
 	Cmd       string     // name of binary to invoke command
+	Env       []string   // any environment values to set/override
 	RootNames []rootName // filename and mode indicating the root of a checkout directory
 
 	CreateCmd   []string // commands to download a fresh copy of a repository
@@ -154,6 +155,10 @@ func vcsByCmd(cmd string) *Cmd {
 var vcsHg = &Cmd{
 	Name: "Mercurial",
 	Cmd:  "hg",
+
+	// HGPLAIN=1 turns off additional output that a user may have enabled via
+	// config options or certain extensions.
+	Env: []string{"HGPLAIN=1"},
 	RootNames: []rootName{
 		{filename: ".hg", isDir: true},
 	},
@@ -688,6 +693,9 @@ func (v *Cmd) run1(dir string, cmdline string, keyval []string, verbose bool) ([
 
 	cmd := exec.Command(v.Cmd, args...)
 	cmd.Dir = dir
+	if v.Env != nil {
+		cmd.Env = append(cmd.Environ(), v.Env...)
+	}
 	if cfg.BuildX {
 		fmt.Fprintf(os.Stderr, "cd %s\n", dir)
 		fmt.Fprintf(os.Stderr, "%s %s\n", v.Cmd, strings.Join(args, " "))

--- a/src/cmd/go/testdata/script/version_buildvcs_hg.txt
+++ b/src/cmd/go/testdata/script/version_buildvcs_hg.txt
@@ -6,6 +6,8 @@
 [short] skip
 env GOBIN=$WORK/gopath/bin
 env oldpath=$PATH
+env TZ=GMT
+env HGRCPATH=$WORK/hgrc
 cd repo/a
 
 # If there's no local repository, there's no VCS info.
@@ -41,13 +43,31 @@ cd ..
 
 # Revision and commit time are tagged for repositories with commits.
 exec hg add a README
-exec hg commit -m 'initial commit'
+exec hg commit -m 'initial commit' --user test-user --date '2024-07-31T01:21:27+00:00'
 cd a
 go install
 go version -m $GOBIN/a$GOEXE
-stdout '^\tbuild\tvcs.revision='
-stdout '^\tbuild\tvcs.time='
+stdout '^\tbuild\tvcs.revision=71eaed52daeaafea83cb604f75b0a0336ef2c345$'
+stdout '^\tbuild\tvcs.time=2024-07-31T01:21:27Z$'
 stdout '^\tbuild\tvcs.modified=false$'
+rm $GOBIN/a$GOEXE
+
+# Add an extra commit and then back off of it to show that the hash is
+# from the checked out revision, not the tip revision.
+cp ../../outside/empty.txt .
+exec hg ci -Am 'another commit' --user test-user --date '2024-08-01T19:24:38+00:00'
+exec hg update --clean -r '.^'
+
+# Modified state is not thrown off by extra status output
+exec hg bisect -v -g .
+exec hg bisect -v -b '.^^'
+exec hg status
+stdout '^.+'
+go install
+go version -m $GOBIN/a$GOEXE
+stdout '^\tbuild\tvcs.revision=958ddd78a073f5f52b4b40838f677a2afc2a0f56$'
+stdout '^\tbuild\tvcs.time=2024-08-01T19:24:38Z$'
+stdout '^\tbuild\tvcs.modified=true$'
 rm $GOBIN/a$GOEXE
 
 # Building with -buildvcs=false suppresses the info.
@@ -88,4 +108,10 @@ go 1.18
 package main
 
 func main() {}
+-- $WORK/hgrc --
+[ui]
+# tweakdefaults is an opt-in that may print extra output in commands like
+# status.  That can be disabled by setting HGPLAIN=1.
+tweakdefaults = 1
+
 -- outside/empty.txt --

--- a/src/cmd/go/testdata/script/version_buildvcs_hg.txt
+++ b/src/cmd/go/testdata/script/version_buildvcs_hg.txt
@@ -31,13 +31,14 @@ cd ..
 env PATH=$oldpath
 rm .hg
 
-# If there is an empty repository in a parent directory, only "uncommitted" is tagged.
+# An empty repository or one explicitly updated to null uses the null cset ID,
+# and the time is hard set to 1/1/70, regardless of the current time.
 exec hg init
 cd a
 go install
 go version -m $GOBIN/a$GOEXE
-! stdout vcs.revision
-! stdout vcs.time
+stdout '^\tbuild\tvcs.revision=0000000000000000000000000000000000000000$'
+stdout '^\tbuild\tvcs.time=1970-01-01T00:00:00Z$'
 stdout '^\tbuild\tvcs.modified=true$'
 cd ..
 
@@ -65,8 +66,8 @@ exec hg status
 stdout '^.+'
 go install
 go version -m $GOBIN/a$GOEXE
-stdout '^\tbuild\tvcs.revision=958ddd78a073f5f52b4b40838f677a2afc2a0f56$'
-stdout '^\tbuild\tvcs.time=2024-08-01T19:24:38Z$'
+stdout '^\tbuild\tvcs.revision=71eaed52daeaafea83cb604f75b0a0336ef2c345$'
+stdout '^\tbuild\tvcs.time=2024-07-31T01:21:27Z$'
 stdout '^\tbuild\tvcs.modified=true$'
 rm $GOBIN/a$GOEXE
 

--- a/src/cmd/go/testdata/script/version_buildvcs_hg.txt
+++ b/src/cmd/go/testdata/script/version_buildvcs_hg.txt
@@ -68,7 +68,7 @@ go install
 go version -m $GOBIN/a$GOEXE
 stdout '^\tbuild\tvcs.revision=71eaed52daeaafea83cb604f75b0a0336ef2c345$'
 stdout '^\tbuild\tvcs.time=2024-07-31T01:21:27Z$'
-stdout '^\tbuild\tvcs.modified=true$'
+stdout '^\tbuild\tvcs.modified=false$'
 rm $GOBIN/a$GOEXE
 
 # Building with -buildvcs=false suppresses the info.


### PR DESCRIPTION
There were a few Mercurial command line uses that could cause the wrong
data to be used:

* The log command needs '-r.' to specify the currently checked out commit
* HGPLAIN is needed to disable optional output on commands
* '-S' is needed to for the 'status' command to recurse into any subrepos

The most likely issue to be seen here was the use of '-l1' instead of
'-r.', which prints the most recent commit instead of the current checkout.
Since tagging in Mercurial creates a new commit, this basically means the
data was wrong for every tagged build. 

This also adds an hgrc config file to the test, with config options to
keep the time and author values fixed.  It's what's used in the Mercurial
test harness to keep the commit hashes stable, and allows the tests here to
also match the time and the revision ID, to prevent regressing.

Fixes #63532