### PR TITLE
go/printer: fix invalid output for empty decls

### DIFF
--- a/src/go/printer/nodes.go
+++ b/src/go/printer/nodes.go
@@ -1739,16 +1739,7 @@ func (p *printer) genDecl(d *ast.GenDecl) {
 	p.setPos(d.Pos())
 	p.print(d.Tok, blank)
 
-	// Empty decls for "var ()", "const ()", "import ()"
-	if len(d.Specs) == 0 && d.Lparen == token.NoPos && d.Rparen == token.NoPos {
-		switch d.Tok {
-		case token.VAR, token.CONST, token.IMPORT:
-			p.print(token.LPAREN, token.RPAREN)
-			return
-		}
-	}
-
-	if d.Lparen.IsValid() || len(d.Specs) > 1 {
+	if d.Lparen.IsValid() || len(d.Specs) != 1 {
 		// group of parenthesized declarations
 		p.setPos(d.Lparen)
 		p.print(token.LPAREN)

--- a/src/go/printer/nodes.go
+++ b/src/go/printer/nodes.go
@@ -1739,6 +1739,15 @@ func (p *printer) genDecl(d *ast.GenDecl) {
 	p.setPos(d.Pos())
 	p.print(d.Tok, blank)
 
+	// Empty decls for "var ()", "const ()", "import ()"
+	if len(d.Specs) == 0 {
+		switch d.Tok {
+		case token.VAR, token.CONST, token.IMPORT:
+			p.print(token.LPAREN, token.RPAREN)
+			return
+		}
+	}
+
 	if d.Lparen.IsValid() || len(d.Specs) > 1 {
 		// group of parenthesized declarations
 		p.setPos(d.Lparen)

--- a/src/go/printer/nodes.go
+++ b/src/go/printer/nodes.go
@@ -1740,7 +1740,7 @@ func (p *printer) genDecl(d *ast.GenDecl) {
 	p.print(d.Tok, blank)
 
 	// Empty decls for "var ()", "const ()", "import ()"
-	if len(d.Specs) == 0 {
+	if len(d.Specs) == 0 && d.Lparen == token.NoPos && d.Rparen == token.NoPos {
 		switch d.Tok {
 		case token.VAR, token.CONST, token.IMPORT:
 			p.print(token.LPAREN, token.RPAREN)

--- a/src/go/printer/printer_test.go
+++ b/src/go/printer/printer_test.go
@@ -853,30 +853,13 @@ func TestSourcePosNewline(t *testing.T) {
 // valid syntax e.g "var ()" instead of just "var", which is invalid and cannot
 // be parsed.
 func TestEmptyDecl(t *testing.T) { // issue 63566
-	var tableTests = []struct {
-		tok      token.Token
-		expected string
-	}{
-		{
-			tok:      token.VAR,
-			expected: "var ()",
-		},
-		{
-			tok:      token.CONST,
-			expected: "const ()",
-		},
-		{
-			tok:      token.IMPORT,
-			expected: "import ()",
-		},
-	}
-
-	for _, tt := range tableTests {
+	for _, tok := range []token.Token{token.IMPORT, token.CONST, token.TYPE, token.VAR} {
 		var buf bytes.Buffer
-		Fprint(&buf, token.NewFileSet(), &ast.GenDecl{Tok: tt.tok})
+		Fprint(&buf, token.NewFileSet(), &ast.GenDecl{Tok: tok})
 		got := buf.String()
-		if got != tt.expected {
-			t.Errorf("got %q, expected %q\n", got, tt.expected)
+		want := tok.String() + " ()"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 }

--- a/src/go/printer/printer_test.go
+++ b/src/go/printer/printer_test.go
@@ -848,3 +848,35 @@ func TestSourcePosNewline(t *testing.T) {
 		t.Errorf("unexpected Fprint output:\n%s", buf.Bytes())
 	}
 }
+
+// TestEmptyDecl tests that empty decls for const, var, import are printed with
+// valid syntax e.g "var ()" instead of just "var", which is invalid and cannot
+// be parsed.
+func TestEmptyDecl(t *testing.T) { // issue 63566
+	var tableTests = []struct {
+		tok      token.Token
+		expected string
+	}{
+		{
+			tok:      token.VAR,
+			expected: "var ()",
+		},
+		{
+			tok:      token.CONST,
+			expected: "const ()",
+		},
+		{
+			tok:      token.IMPORT,
+			expected: "import ()",
+		},
+	}
+
+	for _, tt := range tableTests {
+		var buf bytes.Buffer
+		Fprint(&buf, token.NewFileSet(), &ast.GenDecl{Tok: tt.tok})
+		got := buf.String()
+		if got != tt.expected {
+			t.Errorf("got %q, expected %q\n", got, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
The current output for empty declarations such as var, const, import
results in "var", "const", "import" respectively. These are not valid
and the parser will promptly reject them as invalid syntax.

This CL updates this behavior by adding "()" to the output of empty
decls so the syntax becomes valid, e.g "var ()" instead of "var".

Fixes #63566