### PR TITLE
runtime: fix comments for itab

### DIFF
--- a/src/runtime/runtime2.go
+++ b/src/runtime/runtime2.go
@@ -960,7 +960,7 @@ type funcinl struct {
 // layout of Itab known to compilers
 // allocated in non-garbage-collected memory
 // Needs to be in sync with
-// ../cmd/compile/internal/reflectdata/reflect.go:/^func.WriteTabs.
+// ../cmd/compile/internal/reflectdata/reflect.go:/^func.WritePluginTable.
 type itab struct {
 	inter *interfacetype
 	_type *_type


### PR DESCRIPTION
The function WriteTabs has been renamed WritePluginTable.