### PR TITLE
runtime/internal/atomic: add memory barrier for mips Cas on failure

### DIFF
--- a/src/runtime/internal/atomic/atomic_mipsx.go
+++ b/src/runtime/internal/atomic/atomic_mipsx.go
@@ -49,11 +49,6 @@ func unlock() {
 }
 
 //go:nosplit
-func unlockNoFence() {
-	lock.state = 0
-}
-
-//go:nosplit
 func Xadd64(addr *uint64, delta int64) (new uint64) {
 	lockAndCheck(addr)
 
@@ -85,7 +80,7 @@ func Cas64(addr *uint64, old, new uint64) (swapped bool) {
 		return true
 	}
 
-	unlockNoFence()
+	unlock()
 	return false
 }
 

--- a/src/runtime/internal/atomic/atomic_mipsx.s
+++ b/src/runtime/internal/atomic/atomic_mipsx.s
@@ -28,6 +28,7 @@ try_cas:
 	MOVB	R3, ret+12(FP)
 	RET
 cas_fail:
+	SYNC
 	MOVB	R0, ret+12(FP)
 	RET
 


### PR DESCRIPTION
Add a memory barrier on the failure case of the
compare-and-swap for mips, this avoids potential
race conditions.

For #63506