### PR TITLE
mime/multipart, net/textproto: introduce ErrMessageTooLarge for better error handling

### DIFF
--- a/src/mime/multipart/multipart.go
+++ b/src/mime/multipart/multipart.go
@@ -30,6 +30,7 @@ package multipart
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"internal/godebug"
 	"io"
@@ -172,8 +173,7 @@ func (p *Part) populateHeaders(maxMIMEHeaderSize, maxMIMEHeaders int64) error {
 	if err == nil {
 		p.Header = header
 	}
-	// TODO: Add a distinguishable error to net/textproto.
-	if err != nil && err.Error() == "message too large" {
+	if errors.Is(err, textproto.ErrMessageTooLarge) {
 		err = ErrMessageTooLarge
 	}
 	return err


### PR DESCRIPTION
This change modifies the handling of errors when a message is too large in
both mime/multipart and net/textproto packages.
Previously, these packages created a new error with the same string each
time a message was deemed too large.
With this change, they now use a common exported error variable.

The purpose of this modification is to allow proper error identification
by comparing it directly using errors.Is(),
instead of matching error strings which can be error-prone and less efficient.

In addition, related TODO comments that were suggesting this type of improvement
have been removed from the codebase as well.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.
