### PR TITLE
slices: avoid an unnecessary check in Replace

### DIFF
--- a/src/slices/slices.go
+++ b/src/slices/slices.go
@@ -268,9 +268,7 @@ func Replace[S ~[]E, E any](s S, i, j int, v ...E) S {
 	if i+len(v) <= j {
 		// Easy, as v fits in the deleted portion.
 		copy(r[i:], v)
-		if i+len(v) != j {
-			copy(r[i+len(v):], s[j:])
-		}
+		copy(r[i+len(v):], s[j:])
 		return r
 	}
 


### PR DESCRIPTION
The current implementation of the builtin copy function will return early
when it is found that the addresses of the first elements of the two
slice arguments are identical, so it is unnecessarily to do this in user code.

See #57759 for details.
