### PR TITLE
net: document IsNotFound field

### DIFF
--- a/src/net/net.go
+++ b/src/net/net.go
@@ -624,7 +624,11 @@ type DNSError struct {
 	Server      string // server used
 	IsTimeout   bool   // if true, timed out; not all timeouts set this
 	IsTemporary bool   // if true, error is temporary; not all errors set this
-	IsNotFound  bool   // if true, host could not be found
+
+	// IsNotFound is set to true when the requested name does not
+	// contain any records of the requested type (data not found),
+	// or the name itself was not found (NXDOMAIN).
+	IsNotFound bool
 }
 
 func (e *DNSError) Error() string {


### PR DESCRIPTION
After CL 534937, the IsNotFound field is set to true on
nodata and NXDOMAIN conditions consistently across systems
and all lookup methods.