### PR TITLE
database/sql/driver: fix incorrect link

### DIFF
--- a/src/database/sql/driver/driver.go
+++ b/src/database/sql/driver/driver.go
@@ -536,7 +536,7 @@ func (v RowsAffected) RowsAffected() (int64, error) {
 
 // ResultNoRows is a pre-defined [Result] for drivers to return when a DDL
 // command (such as a CREATE TABLE) succeeds. It returns an error for both
-// LastInsertId and [RowsAffected].
+// LastInsertId and RowsAffected.
 var ResultNoRows noRows
 
 type noRows struct{}


### PR DESCRIPTION
RowsAffected is currently linked to RowsAffected type,
but RowsAffected here means the RowsAffected method
of the Result interface.
