### PR TITLE
cmd/go/internal/work: use slices.Contains

### DIFF
--- a/src/cmd/go/internal/str/str.go
+++ b/src/cmd/go/internal/str/str.go
@@ -88,16 +88,6 @@ func FoldDup(list []string) (string, string) {
 	return "", ""
 }
 
-// Contains reports whether x contains s.
-func Contains(x []string, s string) bool {
-	for _, t := range x {
-		if t == s {
-			return true
-		}
-	}
-	return false
-}
-
 // Uniq removes consecutive duplicate strings from ss.
 func Uniq(ss *[]string) {
 	if len(*ss) <= 1 {

--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -3066,12 +3066,12 @@ func (b *Builder) dynimport(a *Action, objdir, importGo, cgoExe string, cflags, 
 
 	ldflags := cgoLDFLAGS
 	if (cfg.Goarch == "arm" && cfg.Goos == "linux") || cfg.Goos == "android" {
-		if !str.Contains(ldflags, "-no-pie") {
+		if !slices.Contains(ldflags, "-no-pie") {
 			// we need to use -pie for Linux/ARM to get accurate imported sym (added in https://golang.org/cl/5989058)
 			// this seems to be outdated, but we don't want to break existing builds depending on this (Issue 45940)
 			ldflags = append(ldflags, "-pie")
 		}
-		if str.Contains(ldflags, "-pie") && str.Contains(ldflags, "-static") {
+		if slices.Contains(ldflags, "-pie") && slices.Contains(ldflags, "-static") {
 			// -static -pie doesn't make sense, and causes link errors.
 			// Issue 26197.
 			n := make([]string, 0, len(ldflags)-1)


### PR DESCRIPTION
"cmd/go/internal/str.Contains" does the same thing as "slices.Contains".

Given that the slices package is already used in the work package,
replace "str.Contains" with "slices.Contains".

"str.Contains" is no longer used so just remove it.