### PR TITLE
embed: fix typo in mux variable name

### DIFF
--- a/src/embed/example_test.go
+++ b/src/embed/example_test.go
@@ -14,9 +14,9 @@ import (
 var content embed.FS
 
 func Example() {
-	mutex := http.NewServeMux()
-	mutex.Handle("/", http.FileServer(http.FS(content)))
-	err := http.ListenAndServe(":8080", mutex)
+	mux := http.NewServeMux()
+	mux.Handle("/", http.FileServer(http.FS(content)))
+	err := http.ListenAndServe(":8080", mux)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
the conventional variable name for http.ServeMux is mux, not mutex.