### PR TITLE
internal/cpu: add comments to copied functions

### DIFF
--- a/src/internal/cpu/cpu.go
+++ b/src/internal/cpu/cpu.go
@@ -212,6 +212,8 @@ field:
 
 // indexByte returns the index of the first instance of c in s,
 // or -1 if c is not present in s.
+// indexByte is semantically the same as [strings.IndexByte].
+// We copy this function because "internal/cpu" should not have external dependencies.
 func indexByte(s string, c byte) int {
 	for i := 0; i < len(s); i++ {
 		if s[i] == c {


### PR DESCRIPTION
Just as same as other copied functions,
like stringsTrimSuffix in "os/executable_procfs.go"