### PR TITLE
crypto/subtle: use PCALIGN in xorBytes

### DIFF
--- a/src/crypto/subtle/xor_amd64.s
+++ b/src/crypto/subtle/xor_amd64.s
@@ -18,6 +18,7 @@ TEXT ·xorBytes(SB), NOSPLIT, $0
 aligned:
 	MOVQ $0, AX // position in slices
 
+	PCALIGN $16
 loop16b:
 	MOVOU (SI)(AX*1), X0   // XOR 16byte forwards.
 	MOVOU (CX)(AX*1), X1
@@ -28,6 +29,7 @@ loop16b:
 	JNE   loop16b
 	RET
 
+	PCALIGN $16
 loop_1b:
 	SUBQ  $1, DX           // XOR 1byte backwards.
 	MOVB  (SI)(DX*1), DI


### PR DESCRIPTION
goos: linux
goarch: amd64
pkg: crypto/subtle
cpu: Intel(R) Core(TM) i5-8350U CPU @ 1.70GHz
                      │   master    │                HEAD                 │
                      │   sec/op    │   sec/op     vs base                │
XORBytes/8Bytes-8       10.90n ± 1%   10.96n ± 5%        ~ (p=0.617 n=10)
XORBytes/128Bytes-8     14.85n ± 2%   12.05n ± 2%  -18.82% (p=0.000 n=10)
XORBytes/2048Bytes-8    88.30n ± 2%   72.64n ± 1%  -17.73% (p=0.000 n=10)
XORBytes/32768Bytes-8   1.489µ ± 2%   1.442µ ± 1%   -3.12% (p=0.000 n=10)
geomean                 67.91n        60.99n       -10.19%

                      │    master    │                 HEAD                 │
                      │     B/s      │     B/s       vs base                │
XORBytes/8Bytes-8       700.5Mi ± 1%   696.5Mi ± 5%        ~ (p=0.631 n=10)
XORBytes/128Bytes-8     8.026Gi ± 2%   9.890Gi ± 2%  +23.22% (p=0.000 n=10)
XORBytes/2048Bytes-8    21.60Gi ± 2%   26.26Gi ± 1%  +21.55% (p=0.000 n=10)
XORBytes/32768Bytes-8   20.50Gi ± 2%   21.16Gi ± 1%   +3.21% (p=0.000 n=10)
geomean                 7.022Gi        7.819Gi       +11.34%

For #63678
