### PR TITLE
net/url: use quick path in URL.Encode() on empty map

### DIFF
--- a/src/net/url/url.go
+++ b/src/net/url/url.go
@@ -970,7 +970,7 @@ func parseQuery(m Values, query string) (err error) {
 // Encode encodes the values into “URL encoded” form
 // ("bar=baz&foo=quux") sorted by key.
 func (v Values) Encode() string {
-	if v == nil {
+	if len(v) == 0 {
 		return ""
 	}
 	var buf strings.Builder

--- a/src/net/url/url_test.go
+++ b/src/net/url/url_test.go
@@ -1072,6 +1072,7 @@ type EncodeQueryTest struct {
 
 var encodeQueryTests = []EncodeQueryTest{
 	{nil, ""},
+	{Values{}, ""},
 	{Values{"q": {"puppies"}, "oe": {"utf8"}}, "oe=utf8&q=puppies"},
 	{Values{"q": {"dogs", "&", "7"}}, "q=dogs&q=%26&q=7"},
 	{Values{


### PR DESCRIPTION
Make url.Values.Encode() slightly more efficient when url.Values
is an empty but non-nil map.