### PR TITLE
testing: note FailNow does not prevent Cleanup functions

### DIFF
--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -970,7 +970,7 @@ func (c *common) Failed() bool {
 
 // FailNow marks the function as having failed and stops its execution
 // by calling runtime.Goexit (which then runs all deferred calls in the
-// current goroutine).
+// current goroutine, as well as ones registered with Cleanup for the current test or benchmark).
 // Execution will continue at the next test or benchmark.
 // FailNow must be called from the goroutine running the
 // test or benchmark function, not from other goroutines


### PR DESCRIPTION
FailNow's documentation is fairly detailed about the way it causes
execution to stop, and what runs after it has been called.
However, from the Cleanup documentation it is not clear if functions
registered with it would meet this criteria.

Add an explicit note to clarify.