### PR TITLE
net/netip: allow only valid prefix digits in ParsePrefix

### DIFF
--- a/src/net/netip/netip.go
+++ b/src/net/netip/netip.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"math"
 	"strconv"
-	"unicode"
 
 	"internal/bytealg"
 	"internal/intern"
@@ -1311,16 +1310,9 @@ func ParsePrefix(s string) (Prefix, error) {
 
 	bitsStr := s[i+1:]
 
-	// non-digit characters are not valid in a prefix
-	for _, c := range bitsStr {
-		if !unicode.IsDigit(c) {
-			return Prefix{}, errors.New("netip.ParsePrefix(" + strconv.Quote(s) + "): only decimal digits are allowed in a prefix: " + strconv.Quote(bitsStr))
-		}
-	}
-
-	// leading zeroes are not valid in a prefix
-	if len(bitsStr) > 1 && bitsStr[0] == '0' {
-		return Prefix{}, errors.New("netip.ParsePrefix(" + strconv.Quote(s) + "): leading zeroes cannot be present in a prefix: " + strconv.Quote(bitsStr))
+	// strconv.Atoi accepts a leading sign and leading zeroes, but we don't want that.
+	if len(bitsStr) > 1 && (bitsStr[0] < '1' || bitsStr[0] > '9') {
+		return Prefix{}, errors.New("netip.ParsePrefix(" + strconv.Quote(s) + "): bad bits after slash: " + strconv.Quote(bitsStr))
 	}
 
 	bits, err := strconv.Atoi(bitsStr)

--- a/src/net/netip/netip.go
+++ b/src/net/netip/netip.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"math"
 	"strconv"
+	"unicode"
 
 	"internal/bytealg"
 	"internal/intern"
@@ -1309,6 +1310,19 @@ func ParsePrefix(s string) (Prefix, error) {
 	}
 
 	bitsStr := s[i+1:]
+
+	// leading zeroes are not valid in a prefix
+	if len(bitsStr) > 1 && bytealg.IndexByteString(bitsStr, '0') == 0 {
+		return Prefix{}, errors.New("netip.ParsePrefix(" + strconv.Quote(s) + "): leading zeroes cannot be present in a prefix: " + strconv.Quote(bitsStr))
+	}
+
+	// non-digit characters are not valid in a prefix
+	for _, c := range bitsStr {
+		if !unicode.IsDigit(c) {
+			return Prefix{}, errors.New("netip.ParsePrefix(" + strconv.Quote(s) + "): only decimal digits are allowed in a prefix: " + strconv.Quote(bitsStr))
+		}
+	}
+
 	bits, err := strconv.Atoi(bitsStr)
 	if err != nil {
 		return Prefix{}, errors.New("netip.ParsePrefix(" + strconv.Quote(s) + "): bad bits after slash: " + strconv.Quote(bitsStr))

--- a/src/net/netip/netip.go
+++ b/src/net/netip/netip.go
@@ -1311,16 +1311,16 @@ func ParsePrefix(s string) (Prefix, error) {
 
 	bitsStr := s[i+1:]
 
-	// leading zeroes are not valid in a prefix
-	if len(bitsStr) > 1 && bitsStr[0] == '0' {
-		return Prefix{}, errors.New("netip.ParsePrefix(" + strconv.Quote(s) + "): leading zeroes cannot be present in a prefix: " + strconv.Quote(bitsStr))
-	}
-
 	// non-digit characters are not valid in a prefix
 	for _, c := range bitsStr {
 		if !unicode.IsDigit(c) {
 			return Prefix{}, errors.New("netip.ParsePrefix(" + strconv.Quote(s) + "): only decimal digits are allowed in a prefix: " + strconv.Quote(bitsStr))
 		}
+	}
+
+	// leading zeroes are not valid in a prefix
+	if len(bitsStr) > 1 && bitsStr[0] == '0' {
+		return Prefix{}, errors.New("netip.ParsePrefix(" + strconv.Quote(s) + "): leading zeroes cannot be present in a prefix: " + strconv.Quote(bitsStr))
 	}
 
 	bits, err := strconv.Atoi(bitsStr)

--- a/src/net/netip/netip.go
+++ b/src/net/netip/netip.go
@@ -1312,7 +1312,7 @@ func ParsePrefix(s string) (Prefix, error) {
 	bitsStr := s[i+1:]
 
 	// leading zeroes are not valid in a prefix
-	if len(bitsStr) > 1 && bytealg.IndexByteString(bitsStr, '0') == 0 {
+	if len(bitsStr) > 1 && bitsStr[0] == '0' {
 		return Prefix{}, errors.New("netip.ParsePrefix(" + strconv.Quote(s) + "): leading zeroes cannot be present in a prefix: " + strconv.Quote(bitsStr))
 	}
 

--- a/src/net/netip/netip_test.go
+++ b/src/net/netip/netip_test.go
@@ -1452,11 +1452,11 @@ func TestParsePrefixError(t *testing.T) {
 		},
 		{
 			prefix: "1.1.1.0/q",
-			errstr: "bad bits",
+			errstr: "only decimal digits are allowed in a prefix",
 		},
 		{
 			prefix: "1.1.1.0/-1",
-			errstr: "out of range",
+			errstr: "only decimal digits are allowed in a prefix",
 		},
 		{
 			prefix: "1.1.1.0/33",
@@ -1474,6 +1474,22 @@ func TestParsePrefixError(t *testing.T) {
 		{
 			prefix: "2001:db8::%a/32",
 			errstr: "zones cannot be present",
+		},
+		{
+			prefix: "1.1.1.0/+32",
+			errstr: "only decimal digits are allowed in a prefix",
+		},
+		{
+			prefix: "1.1.1.0/-32",
+			errstr: "only decimal digits are allowed in a prefix",
+		},
+		{
+			prefix: "1.1.1.0/032",
+			errstr: "leading zeroes cannot be present in a prefix",
+		},
+		{
+			prefix: "1.1.1.0/0032",
+			errstr: "leading zeroes cannot be present in a prefix",
 		},
 	}
 	for _, test := range tests {

--- a/src/net/netip/netip_test.go
+++ b/src/net/netip/netip_test.go
@@ -1452,11 +1452,11 @@ func TestParsePrefixError(t *testing.T) {
 		},
 		{
 			prefix: "1.1.1.0/q",
-			errstr: "only decimal digits are allowed in a prefix",
+			errstr: "bad bits",
 		},
 		{
 			prefix: "1.1.1.0/-1",
-			errstr: "only decimal digits are allowed in a prefix",
+			errstr: "bad bits",
 		},
 		{
 			prefix: "1.1.1.0/33",
@@ -1477,19 +1477,19 @@ func TestParsePrefixError(t *testing.T) {
 		},
 		{
 			prefix: "1.1.1.0/+32",
-			errstr: "only decimal digits are allowed in a prefix",
+			errstr: "bad bits",
 		},
 		{
 			prefix: "1.1.1.0/-32",
-			errstr: "only decimal digits are allowed in a prefix",
+			errstr: "bad bits",
 		},
 		{
 			prefix: "1.1.1.0/032",
-			errstr: "leading zeroes cannot be present in a prefix",
+			errstr: "bad bits",
 		},
 		{
 			prefix: "1.1.1.0/0032",
-			errstr: "leading zeroes cannot be present in a prefix",
+			errstr: "bad bits",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
The prefix bits for a call to ParsePrefix are passed raw to
strconv.Atoi, this means that it can accept +- signs as well as leading
zeroes, which are not allowed prefix values following RFC 4632 Section
3.1 and RFC 4291 Section 2.3.

Validate non-digit characters as well as leading zeroes and return an
error accordingly.

Fixes #63850