### PR TITLE
cmd/link/internal/ld: add nil-check for def in *dwctxt.dotypedef

### DIFF
--- a/src/cmd/link/internal/ld/dwarf.go
+++ b/src/cmd/link/internal/ld/dwarf.go
@@ -488,7 +488,9 @@ func (d *dwctxt) dotypedef(parent *dwarf.DWDie, name string, def *dwarf.DWDie) *
 	tds := d.ldr.CreateExtSym("", 0)
 	tdsu := d.ldr.MakeSymbolUpdater(tds)
 	tdsu.SetType(sym.SDWARFTYPE)
-	def.Sym = dwSym(tds)
+	if def != nil {
+		def.Sym = dwSym(tds)
+	}
 	d.ldr.SetAttrNotInSymbolTable(tds, true)
 	d.ldr.SetAttrReachable(tds, true)
 


### PR DESCRIPTION
When assigning to def.Sym, it will panic if def is nil. Add nil-check
for def to avoid panic.