### PR TITLE
encoding/binary: add missing test helper calls

### DIFF
--- a/src/encoding/binary/binary_test.go
+++ b/src/encoding/binary/binary_test.go
@@ -115,6 +115,7 @@ var res = []int32{0x01020304, 0x05060708}
 var putbuf = []byte{0, 0, 0, 0, 0, 0, 0, 0}
 
 func checkResult(t *testing.T, dir string, order ByteOrder, err error, have, want any) {
+	t.Helper()
 	if err != nil {
 		t.Errorf("%v %v: %v", dir, order, err)
 		return
@@ -183,6 +184,7 @@ var decoders = []struct {
 }
 
 func testRead(t *testing.T, order ByteOrder, b []byte, s1 any) {
+	t.Helper()
 	for _, dec := range decoders {
 		t.Run(dec.name, func(t *testing.T) {
 			var s2 Struct
@@ -193,6 +195,7 @@ func testRead(t *testing.T, order ByteOrder, b []byte, s1 any) {
 }
 
 func testWrite(t *testing.T, order ByteOrder, b []byte, s1 any) {
+	t.Helper()
 	for _, enc := range encoders {
 		t.Run(enc.name, func(t *testing.T) {
 			buf, err := enc.fn(order, s1)


### PR DESCRIPTION
Various functions in binary_test.go were missing some t.Helper() calls,
so this adds them in.

