### PR TITLE
net/http/cgi: the PATH_INFO should be empty or start with a slash

### DIFF
--- a/src/net/http/cgi/host.go
+++ b/src/net/http/cgi/host.go
@@ -115,21 +115,14 @@ func removeLeadingDuplicates(env []string) (ret []string) {
 }
 
 func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	root := h.Root
-	if root == "" {
-		root = "/"
-	}
-
 	if len(req.TransferEncoding) > 0 && req.TransferEncoding[0] == "chunked" {
 		rw.WriteHeader(http.StatusBadRequest)
 		rw.Write([]byte("Chunked request bodies are not supported by CGI."))
 		return
 	}
 
-	pathInfo := req.URL.Path
-	if root != "/" && strings.HasPrefix(pathInfo, root) {
-		pathInfo = pathInfo[len(root):]
-	}
+	root := strings.TrimRight(h.Root, "/")
+	pathInfo := strings.TrimPrefix(req.URL.Path, root)
 
 	port := "80"
 	if req.TLS != nil {

--- a/src/net/http/cgi/host_test.go
+++ b/src/net/http/cgi/host_test.go
@@ -210,14 +210,14 @@ func TestPathInfoDirRoot(t *testing.T) {
 	check(t)
 	h := &Handler{
 		Path: "testdata/test.cgi",
-		Root: "/myscript/",
+		Root: "/myscript//",
 	}
 	expectedMap := map[string]string{
-		"env-PATH_INFO":       "bar",
+		"env-PATH_INFO":       "/bar",
 		"env-QUERY_STRING":    "a=b",
 		"env-REQUEST_URI":     "/myscript/bar?a=b",
 		"env-SCRIPT_FILENAME": "testdata/test.cgi",
-		"env-SCRIPT_NAME":     "/myscript/",
+		"env-SCRIPT_NAME":     "/myscript",
 	}
 	runCgiTest(t, h, "GET /myscript/bar?a=b HTTP/1.0\nHost: example.com\n\n", expectedMap)
 }
@@ -278,7 +278,7 @@ func TestPathInfoNoRoot(t *testing.T) {
 		"env-QUERY_STRING":    "a=b",
 		"env-REQUEST_URI":     "/bar?a=b",
 		"env-SCRIPT_FILENAME": "testdata/test.cgi",
-		"env-SCRIPT_NAME":     "/",
+		"env-SCRIPT_NAME":     "",
 	}
 	runCgiTest(t, h, "GET /bar?a=b HTTP/1.0\nHost: example.com\n\n", expectedMap)
 }


### PR DESCRIPTION
fixed PATH_INFO not starting with a slash as described in RFC 3875 
for PATH_INFO.

Fixes #63925