### PR TITLE
Add proof of concept for T.Slog()

### DIFF
--- a/src/testing/slog_test.go
+++ b/src/testing/slog_test.go
@@ -1,0 +1,34 @@
+package testing_test
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func TestSlog(t *testing.T) {
+	// Slog log lines as they are currently printed out in tests.
+	logger1 := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{AddSource: true}))
+	logger1.Info("slog logging in parent test")
+
+	/*
+		t.Slog() allows:
+		- the indentation of slog output to match t.Log() output
+		- printing of the output under the correct test header
+	*/
+	logger2 := t.Slog()
+	logger2.Info("t.Slog log in parent test")
+	t.Error("t.Log in parent test")
+
+	// Additionally, t.Slog() indents slog output depending on the nesting level of the test.
+	t.Run("Subtest", func(t *testing.T) {
+		logger3 := t.Slog()
+		logger3.Info("t.Slog log in subtest")
+		t.Error("t.Log in subtest")
+
+		// Without t.Slog(), the slog log does not take into account the nesting level.
+		// This is in addition to the log being printed in the wrong section.
+		logger4 := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{AddSource: true}))
+		logger4.Info("slog logging in subtest")
+	})
+}

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -376,6 +376,7 @@ import (
 	"internal/goexperiment"
 	"internal/race"
 	"io"
+	"log/slog"
 	"math/rand"
 	"os"
 	"reflect"
@@ -1976,6 +1977,17 @@ func (t *T) report() {
 			t.flushToParent(t.name, format, "PASS", t.name, dstr)
 		}
 	}
+}
+
+// Slog returns a structured logger that writes to the test case output, like t.Log does.
+//
+// TODO: Figure out if we want Slog() behaviour to include the following:
+//
+//	When used with go test -json, any log messages are printed in JSON form.
+//	A TestEvent corresponding to a log message has OutputType "slog", and the Output field contains the JSON text.
+func (t *T) Slog() *slog.Logger {
+	// TODO: Add implementation
+	return nil
 }
 
 func listTests(matchString func(pat, str string) (bool, error), tests []InternalTest, benchmarks []InternalBenchmark, fuzzTargets []InternalFuzzTarget, examples []InternalExample) {


### PR DESCRIPTION
Addresses https://go.dev/issue/59928

<!---
This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
--->