### PR TITLE
runtime: fix badmorestackg0 never called on wasm

### DIFF
--- a/src/runtime/asm_wasm.s
+++ b/src/runtime/asm_wasm.s
@@ -223,7 +223,7 @@ TEXT runtime·morestack(SB), NOSPLIT, $0-0
 
 	// Cannot grow scheduler stack (m->g0).
 	Get g
-	Get R1
+	Get R2
 	I64Eq
 	If
 		CALLNORESUME runtime·badmorestackg0(SB)


### PR DESCRIPTION
Previously, badmorestackg0 was never called since it was behind a g ==
R1 check, R1 holding g.m. This is clearly wrong, since we want to check
if g == g0. Fixed by using R2 that holds the value of g0.

Fixes #63953