### PR TITLE
net: don't force cgo resolver for .local subdomain queries

### DIFF
--- a/src/net/conf.go
+++ b/src/net/conf.go
@@ -405,10 +405,6 @@ func (c *conf) lookupOrder(r *Resolver, hostname string) (ret hostLookupOrder, d
 					return hostLookupCgo, dnsConf
 				}
 
-				// e.g. "mdns4", "mdns4_minimal"
-				// We already returned true before if it was *.local.
-				// libc wouldn't have found a hit on this anyway.
-
 				// We don't parse mdns.allow files. They're rare. If one
 				// exists, it might list other TLDs (besides .local) or even
 				// '*', so just let libc deal with it.

--- a/src/net/conf_test.go
+++ b/src/net/conf_test.go
@@ -257,7 +257,7 @@ func TestConfHostLookupOrder(t *testing.T) {
 			hostTests: []nssHostTest{
 				{"x.com", "myhostname", hostLookupFilesDNS},
 				{"x", "myhostname", hostLookupFilesDNS},
-				{"x.local", "myhostname", hostLookupCgo},
+				{"x.local", "myhostname", hostLookupFilesDNS},
 			},
 		},
 		{
@@ -268,7 +268,7 @@ func TestConfHostLookupOrder(t *testing.T) {
 			hostTests: []nssHostTest{
 				{"x.com", "myhostname", hostLookupDNSFiles},
 				{"x", "myhostname", hostLookupDNSFiles},
-				{"x.local", "myhostname", hostLookupCgo},
+				{"x.local", "myhostname", hostLookupDNSFiles},
 			},
 		},
 		{

--- a/src/net/net.go
+++ b/src/net/net.go
@@ -54,8 +54,7 @@ when the LOCALDOMAIN environment variable is present (even if empty),
 when the RES_OPTIONS or HOSTALIASES environment variable is non-empty,
 when the ASR_CONFIG environment variable is non-empty (OpenBSD only),
 when /etc/resolv.conf or /etc/nsswitch.conf specify the use of features that the
-Go resolver does not implement, and when the name being looked up ends in .local
-or is an mDNS name.
+Go resolver does not implement.
 
 The resolver decision can be overridden by setting the netdns value of the
 GODEBUG environment variable (see package runtime) to go or cgo, as in:


### PR DESCRIPTION
The cgo resolver sends DNS queries for .local subdomain
lookups, just as we do in the go resolver.
We don't need to fallback to the cgo resolver for this
domains when nsswitch.conf uses only file and dns modules.

This has a benefit that we select a consistent resolver,
that is only based on the system configuration, regardless
of the queried domain.

Updates #63978