### PR TITLE
os: avoid TestFileChdir fail when GOROOT is a symbolic link

### DIFF
--- a/src/os/os_test.go
+++ b/src/os/os_test.go
@@ -1620,8 +1620,17 @@ func TestFileChdir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Getwd: %s", err)
 	}
-	if !equal(wdNew, wd) {
-		t.Fatalf("fd.Chdir failed, got %s, want %s", wdNew, wd)
+
+	wdInfo, err := fd.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	newInfo, err := Stat(wdNew)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !SameFile(wdInfo, newInfo) {
+		t.Fatalf("fd.Chdir failed: got %s, want %s", wdNew, wd)
 	}
 }
 


### PR DESCRIPTION
If GOROOT is a symbolic link,
the paths obtained from the
first and second Getwd of TestFileChdir are different,
and this CL fixes the test failure in this situation.

Fixes #64281