### PR TITLE
syscall: support O_SYNC flag for os.OpenFile on windows

### DIFF
--- a/src/syscall/syscall_windows.go
+++ b/src/syscall/syscall_windows.go
@@ -409,6 +409,12 @@ func Open(path string, mode int, perm uint32) (fd Handle, err error) {
 		// Necessary for opening directory handles.
 		attrs |= FILE_FLAG_BACKUP_SEMANTICS
 	}
+	if mode&O_SYNC != 0 {
+		// See https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea.
+		// See issue 35358 for details.
+		const _FILE_FLAG_WRITE_THROUGH = 0x80000000
+		attrs |= _FILE_FLAG_WRITE_THROUGH
+	}
 	return CreateFile(pathp, access, sharemode, sa, createmode, attrs, 0)
 }
 

--- a/src/syscall/syscall_windows.go
+++ b/src/syscall/syscall_windows.go
@@ -381,7 +381,6 @@ func Open(path string, mode int, perm uint32) (fd Handle, err error) {
 	default:
 		createmode = OPEN_EXISTING
 	}
-
 	var attrs uint32 = FILE_ATTRIBUTE_NORMAL
 	if perm&S_IWRITE == 0 {
 		attrs = FILE_ATTRIBUTE_READONLY

--- a/src/syscall/syscall_windows.go
+++ b/src/syscall/syscall_windows.go
@@ -381,10 +381,20 @@ func Open(path string, mode int, perm uint32) (fd Handle, err error) {
 	default:
 		createmode = OPEN_EXISTING
 	}
+
+	// See https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea.
+	// See issue 35358 for details.
+	const _FILE_FLAG_WRITE_THROUGH = 0x80000000
+	setFlagWriteThrough := false
+
 	var attrs uint32 = FILE_ATTRIBUTE_NORMAL
 	if perm&S_IWRITE == 0 {
 		attrs = FILE_ATTRIBUTE_READONLY
 		if createmode == CREATE_ALWAYS {
+			if mode&O_SYNC != 0 {
+				attrs |= _FILE_FLAG_WRITE_THROUGH
+				setFlagWriteThrough = true
+			}
 			// We have been asked to create a read-only file.
 			// If the file already exists, the semantics of
 			// the Unix open system call is to preserve the
@@ -409,10 +419,7 @@ func Open(path string, mode int, perm uint32) (fd Handle, err error) {
 		// Necessary for opening directory handles.
 		attrs |= FILE_FLAG_BACKUP_SEMANTICS
 	}
-	if mode&O_SYNC != 0 {
-		// See https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea.
-		// See issue 35358 for details.
-		const _FILE_FLAG_WRITE_THROUGH = 0x80000000
+	if !setFlagWriteThrough && mode&O_SYNC != 0 {
 		attrs |= _FILE_FLAG_WRITE_THROUGH
 	}
 	return CreateFile(pathp, access, sharemode, sa, createmode, attrs, 0)


### PR DESCRIPTION
os.OpenFile on windows did not use the O_SYNC flag. This meant
that even if the user set O_SYNC, os.OpenFile would ignore it.

This change adds a new flag FILE_FLAG_WRITE_THROUGH, which is
the equivalent of O_SYNC flag on Linux and is documented in
https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea

Fixes #35358
