### PR TITLE
reflect: optimize VisibleFields a bit

### DIFF
--- a/src/reflect/benchmark_test.go
+++ b/src/reflect/benchmark_test.go
@@ -408,3 +408,40 @@ func BenchmarkMapIterNext(b *testing.B) {
 		it.Reset(m)
 	}
 }
+
+func BenchmarkVisibleFields(b *testing.B) {
+	type z struct{ int }
+	type y struct{ z }
+	type _x struct{ y }
+	type w struct{ _x }
+	type v struct{ w }
+	type u struct{ v }
+	type t struct{ u }
+	type s struct{ t }
+	type r struct{ s }
+	type q struct{ r }
+	type p struct{ q }
+	type o struct{ p }
+	type n struct{ o }
+	type m struct{ n }
+	type l struct{ m }
+	type k struct{ l }
+	type j struct{ k }
+	type i struct{ j }
+	type h struct{ i }
+	type g struct{ h }
+	type f struct{ g }
+	type e struct{ f }
+	type d struct{ e }
+	type c struct{ d }
+	type _b struct{ c }
+	type a struct{ _b }
+	type nested struct{ a }
+	var x nested
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		typ := TypeOf(x)
+		VisibleFields(typ)
+	}
+}

--- a/src/reflect/visiblefields.go
+++ b/src/reflect/visiblefields.go
@@ -22,7 +22,7 @@ func VisibleFields(t Type) []StructField {
 	}
 	w := &visibleFieldsWalker{
 		byName:   make(map[string]int),
-		visiting: make(map[Type]bool),
+		visiting: make(map[Type]struct{}),
 		fields:   make([]StructField, 0, t.NumField()),
 		index:    make([]int, 0, 2),
 	}
@@ -48,7 +48,7 @@ func VisibleFields(t Type) []StructField {
 
 type visibleFieldsWalker struct {
 	byName   map[string]int
-	visiting map[Type]bool
+	visiting map[Type]struct{}
 	fields   []StructField
 	index    []int
 }
@@ -59,10 +59,10 @@ type visibleFieldsWalker struct {
 // Fields that have been overridden have their
 // Name field cleared.
 func (w *visibleFieldsWalker) walk(t Type) {
-	if w.visiting[t] {
+	if _, found := w.visiting[t]; found {
 		return
 	}
-	w.visiting[t] = true
+	w.visiting[t] = struct{}{}
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
 		w.index = append(w.index, i)


### PR DESCRIPTION
The benchstat result:

% benchstat old.txt new.txt 
goos: darwin
goarch: arm64
pkg: reflect
                │   old.txt   │              new.txt               │
                │   sec/op    │   sec/op     vs base               │
VisibleFields-8   7.636µ ± 0%   7.561µ ± 0%  -0.98% (p=0.000 n=10)

                │   old.txt    │               new.txt               │
                │     B/op     │     B/op      vs base               │
VisibleFields-8   17.12Ki ± 0%   16.87Ki ± 0%  -1.46% (p=0.000 n=10)

                │  old.txt   │            new.txt             │
                │ allocs/op  │ allocs/op   vs base            │
VisibleFields-8   76.00 ± 0%   76.00 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal