### PR TITLE
log/slog: make hex a const

### DIFF
--- a/src/log/slog/json_handler.go
+++ b/src/log/slog/json_handler.go
@@ -226,7 +226,7 @@ func appendEscapedJSONString(buf []byte, s string) []byte {
 	return buf
 }
 
-var hex = "0123456789abcdef"
+const hex = "0123456789abcdef"
 
 // Copied from encoding/json/tables.go.
 //


### PR DESCRIPTION
hex is in fact immutable, declare it as a const to avoid accidental
modification, also for consistency with other packages.