### PR TITLE
cmd/compile: streamline pragma checks for TypeDecl

### DIFF
--- a/src/cmd/compile/internal/noder/writer.go
+++ b/src/cmd/compile/internal/noder/writer.go
@@ -2503,19 +2503,15 @@ func (c *declCollector) Visit(n syntax.Node) syntax.Visitor {
 		return c.withTParams(obj)
 
 	case *syntax.TypeDecl:
+		pw.checkPragmas(n.Pragma, 0, false)
+
 		obj := pw.info.Defs[n.Name].(*types2.TypeName)
 		d := typeDeclGen{TypeDecl: n, implicits: c.implicits}
 
-		if n.Alias {
-			pw.checkPragmas(n.Pragma, 0, false)
-		} else {
-			pw.checkPragmas(n.Pragma, 0, false)
-
-			// Assign a unique ID to function-scoped defined types.
-			if c.withinFunc {
-				*c.typegen++
-				d.gen = *c.typegen
-			}
+		// Assign a unique ID to function-scoped defined types.
+		if !n.Alias && c.withinFunc {
+			*c.typegen++
+			d.gen = *c.typegen
 		}
 
 		pw.typDecls[obj] = d


### PR DESCRIPTION
Simplify the handling of pragmas in type declarations within
noder/writer.go. Remove redundant checks by calling checkPragmas once at
the beginning of case *syntax.TypeDecl and eliminate unnecessary else block.
Also, ensure unique ID assignment for function-scoped defined types is only
performed when n.Alias is false.

Fixes a redundancy issue where pragma checks were performed inside both
branches of an if-else statement unnecessarily.

For #46731