### PR TITLE
[release-branch.go1.21] path/filepath: consider \\?\c: as a volume on Windows

### DIFF
--- a/src/path/filepath/path_test.go
+++ b/src/path/filepath/path_test.go
@@ -109,6 +109,8 @@ var wincleantests = []PathTest{
 	{`//abc`, `\\abc`},
 	{`///abc`, `\\\abc`},
 	{`//abc//`, `\\abc\\`},
+	{`\\?\C:\`, `\\?\C:\`},
+	{`\\?\C:\a`, `\\?\C:\a`},
 
 	// Don't allow cleaning to move an element with a colon to the start of the path.
 	{`a/../c:`, `.\c:`},
@@ -1610,10 +1612,13 @@ var volumenametests = []VolumeNameTest{
 	{`//.`, `\\.`},
 	{`//./`, `\\.\`},
 	{`//./NUL`, `\\.\NUL`},
-	{`//?/`, `\\?`},
+	{`//?`, `\\?`},
+	{`//?/`, `\\?\`},
+	{`//?/NUL`, `\\?\NUL`},
+	{`/??`, `\??`},
+	{`/??/`, `\??\`},
+	{`/??/NUL`, `\??\NUL`},
 	{`//./a/b`, `\\.\a`},
-	{`//?/`, `\\?`},
-	{`//?/`, `\\?`},
 	{`//./C:`, `\\.\C:`},
 	{`//./C:/`, `\\.\C:`},
 	{`//./C:/a/b/c`, `\\.\C:`},
@@ -1622,8 +1627,8 @@ var volumenametests = []VolumeNameTest{
 	{`//./UNC/host\`, `\\.\UNC\host\`},
 	{`//./UNC`, `\\.\UNC`},
 	{`//./UNC/`, `\\.\UNC\`},
-	{`\\?\x`, `\\?`},
-	{`\??\x`, `\??`},
+	{`\\?\x`, `\\?\x`},
+	{`\??\x`, `\??\x`},
 }
 
 func TestVolumeName(t *testing.T) {


### PR DESCRIPTION
While fixing several bugs in path handling on Windows, beginning with \\?\.

Prior to #540277, VolumeName considered the first path component after the \\?\ prefix to be part of the volume name. After, it considered only the \\? prefix to be the volume name.

Restore the previous behavior.

Fixes #64041
Updates #64028

Change-Id: I6523789e61776342800bd607fb3f29d496257e68 Reviewed-on: https://go-review.googlesource.com/c/go/+/541175
LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
Reviewed-by: Roland Shoemaker <roland@golang.org>
(cherry picked from commit eda42f7c60adab26ed1a340414c726c4bf46b1f7)
