### PR TITLE
slices: improve Insert panic message for index out of range

### DIFF
--- a/src/slices/slices.go
+++ b/src/slices/slices.go
@@ -136,7 +136,6 @@ func Insert[S ~[]E, E any](s S, i int, v ...E) S {
 	if m == 0 {
 		return s
 	}
-
 	n := len(s)
 	if i == n {
 		return append(s, v...)

--- a/src/slices/slices.go
+++ b/src/slices/slices.go
@@ -130,14 +130,14 @@ func ContainsFunc[S ~[]E, E any](s S, f func(E) bool) bool {
 // Insert panics if i is out of range.
 // This function is O(len(s) + len(v)).
 func Insert[S ~[]E, E any](s S, i int, v ...E) S {
-	n := len(s)
+	_ = s[i:]
+
 	m := len(v)
 	if m == 0 {
-		// Panic if i is not in the range [0:n] inclusive.
-		// See issue 63913.
-		_ = s[:n:n][i:]
 		return s
 	}
+
+	n := len(s)
 	if i == n {
 		return append(s, v...)
 	}

--- a/src/slices/slices.go
+++ b/src/slices/slices.go
@@ -130,7 +130,7 @@ func ContainsFunc[S ~[]E, E any](s S, f func(E) bool) bool {
 // Insert panics if i is out of range.
 // This function is O(len(s) + len(v)).
 func Insert[S ~[]E, E any](s S, i int, v ...E) S {
-	_ = s[i:]
+	_ = s[i:] // bounds check
 
 	m := len(v)
 	if m == 0 {


### PR DESCRIPTION
The panic message of the current implementation for index out of range is not ideal.
This PR tries to improve it.

Fixes #63913 and #64152