### PR TITLE
log/syslog: Fix Dial cannot work properly when the syslog service is unavailable

### DIFF
--- a/src/log/syslog/syslog.go
+++ b/src/log/syslog/syslog.go
@@ -125,22 +125,13 @@ func Dial(network, raddr string, priority Priority, tag string) (*Writer, error)
 	}
 	hostname, _ := os.Hostname()
 
-	w := &Writer{
+	return &Writer{
 		priority: priority,
 		tag:      tag,
 		hostname: hostname,
 		network:  network,
 		raddr:    raddr,
-	}
-
-	w.mu.Lock()
-	defer w.mu.Unlock()
-
-	err := w.connect()
-	if err != nil {
-		return nil, err
-	}
-	return w, err
+	}, nil
 }
 
 // connect makes a connection to the syslog server.

--- a/src/log/syslog/syslog_test.go
+++ b/src/log/syslog/syslog_test.go
@@ -464,7 +464,5 @@ func TestDialWhenConnectionIsBad(t *testing.T) {
 		t.Errorf("Info() failed: %v", err)
 	}
 
-	// fmt.Println(<-done)
-
 	check(t, msg, <-done, tr)
 }

--- a/src/log/syslog/syslog_test.go
+++ b/src/log/syslog/syslog_test.go
@@ -430,3 +430,41 @@ func TestConcurrentReconnect(t *testing.T) {
 		t.Error("timeout in concurrent reconnect")
 	}
 }
+
+func TestDialWhenConnectionIsBad(t *testing.T) {
+	var (
+		tr   = "unix"
+		addr = "127.0.0.1:12345"
+	)
+
+	if !testableNetwork(tr) {
+		t.Skipf("skipping on %s/%s; 'unix' is not supported", runtime.GOOS, runtime.GOARCH)
+	}
+
+	// connection is bad, but we don't know it yet
+	w, err := Dial(tr, addr, LOG_USER|LOG_ERR, "syslog_test")
+	if err != nil {
+		t.Fatalf("syslog.Dial() failed: %v", err)
+	}
+	defer w.Close()
+
+	if err := w.Info("test"); err == nil {
+		t.Error("expected error")
+	}
+
+	// connection is recovered
+	done := make(chan string, 1)
+	addr, sock, srvWG := startServer(t, tr, addr, done)
+	defer srvWG.Wait()
+	defer sock.Close()
+	defer os.Remove(addr)
+
+	msg := "Test Connection"
+	if err := w.Info(msg); err != nil {
+		t.Errorf("Info() failed: %v", err)
+	}
+
+	// fmt.Println(<-done)
+
+	check(t, msg, <-done, tr)
+}


### PR DESCRIPTION
…ed, causing the overall connection to be unavailable

see https://github.com/golang/go/issues/64165
