### PR TITLE
internal/zstd: replace hardcoded block size with constant

### DIFF
--- a/src/internal/zstd/block.go
+++ b/src/internal/zstd/block.go
@@ -273,7 +273,7 @@ func (r *Reader) execSeqs(data block, off int, litbuf []byte, seqCount int) erro
 
 	seq := 0
 	for seq < seqCount {
-		if len(r.buffer)+len(litbuf) > 128<<10 {
+		if len(r.buffer)+len(litbuf) > blockMaximumSize {
 			return rbr.makeError("uncompressed size too big")
 		}
 

--- a/src/internal/zstd/literals.go
+++ b/src/internal/zstd/literals.go
@@ -53,7 +53,7 @@ func (r *Reader) readRawRLELiterals(data block, off int, hdr byte, outbuf []byte
 	// We are going to use the entire literal block in the output.
 	// The maximum size of one decompressed block is 128K,
 	// so we can't have more literals than that.
-	if regeneratedSize > 128<<10 {
+	if regeneratedSize > blockMaximumSize {
 		return 0, nil, r.makeError(off, "literal size too large")
 	}
 
@@ -121,7 +121,7 @@ func (r *Reader) readHuffLiterals(data block, off int, hdr byte, outbuf []byte) 
 	// We are going to use the entire literal block in the output.
 	// The maximum size of one decompressed block is 128K,
 	// so we can't have more literals than that.
-	if regeneratedSize > 128<<10 {
+	if regeneratedSize > blockMaximumSize {
 		return 0, nil, r.makeError(off, "literal size too large")
 	}
 

--- a/src/internal/zstd/zstd.go
+++ b/src/internal/zstd/zstd.go
@@ -17,6 +17,18 @@ import (
 // This is used to reject cases where we don't match zstd.
 var fuzzing = false
 
+const (
+	// magicNumber is the magic number used to identify a zstd stream.
+	// It is the first 4 bytes of a zstd stream.
+	magicNumber = 0xFD2FB528
+	// all 16 values, from 0x184D2A50 to 0x184D2A5F, signal the beginning of a skippable frame
+	magicSkippableStart = 0x184D2A50
+	magicSkippableMask  = 0xFFFFFFF0
+
+	// Maximum block size is smaller of window size and 128K
+	blockMaximumSize = 128 << 10
+)
+
 // Reader implements [io.Reader] to read a zstd compressed stream.
 type Reader struct {
 	// The underlying Reader.
@@ -176,8 +188,8 @@ retry:
 		return r.wrapError(relativeOffset, err)
 	}
 
-	if magic := binary.LittleEndian.Uint32(r.scratch[:4]); magic != 0xfd2fb528 {
-		if magic >= 0x184d2a50 && magic <= 0x184d2a5f {
+	if magic := binary.LittleEndian.Uint32(r.scratch[:4]); magic != magicNumber {
+		if magic&magicSkippableMask == magicSkippableStart {
 			// This is a skippable frame.
 			r.blockOffset += int64(relativeOffset) + 4
 			if err := r.skipFrame(); err != nil {
@@ -292,8 +304,9 @@ retry:
 	}
 
 	// RFC 8878 3.1.1.1.1.2. permits us to set an 8M max on window size.
-	if windowSize > 8<<20 {
-		windowSize = 8 << 20
+	const maxWindowSize = 8 << 20
+	if windowSize > maxWindowSize {
+		windowSize = maxWindowSize
 	}
 
 	relativeOffset += headerSize
@@ -382,7 +395,7 @@ func (r *Reader) readBlock() error {
 	// Maximum block size is smaller of window size and 128K.
 	// We don't record the window size for a single segment frame,
 	// so just use 128K. RFC 3.1.1.2.3, 3.1.1.2.4.
-	if blockSize > 128<<10 || (r.window.size > 0 && blockSize > r.window.size) {
+	if blockSize > blockMaximumSize || (r.window.size > 0 && blockSize > r.window.size) {
 		return r.makeError(relativeOffset, "block size too large")
 	}
 


### PR DESCRIPTION
Replace the hardcoded maximum block size (128<<10) with a named
constant (blockMaximumSize). This improves code readability and
maintainability by using a single source of truth for the maximum
block size value.

Also, introduce constants for magic numbers related to zstd stream
identification and skippable frames, enhancing code clarity.
