### PR TITLE
runtime/internal/atomic: add generic implementation for And/Or

### DIFF
--- a/src/runtime/internal/atomic/atomic_andor_generic.go
+++ b/src/runtime/internal/atomic/atomic_andor_generic.go
@@ -1,0 +1,73 @@
+//go:build s390x || loong64 || mips || mipsle || mips64 || mips64le
+
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package atomic
+
+//go:nosplit
+//go:noinline
+func And32(ptr *uint32, val uint32) uint32 {
+	for {
+		old := *ptr
+		if Cas(ptr, old, old&val) {
+			return old
+		}
+	}
+}
+
+//go:nosplit
+//go:noinline
+func Or32(ptr *uint32, val uint32) uint32 {
+	for {
+		old := *ptr
+		if Cas(ptr, old, old|val) {
+			return old
+		}
+	}
+}
+
+//go:nosplit
+//go:noinline
+func And64(ptr *uint64, val uint64) uint64 {
+	for {
+		old := *ptr
+		if Cas64(ptr, old, old&val) {
+			return old
+		}
+	}
+}
+
+//go:nosplit
+//go:noinline
+func Or64(ptr *uint64, val uint64) uint64 {
+	for {
+		old := *ptr
+		if Cas64(ptr, old, old|val) {
+			return old
+		}
+	}
+}
+
+//go:nosplit
+//go:noinline
+func Anduintptr(ptr *uintptr, val uintptr) uintptr {
+	for {
+		old := *ptr
+		if Casuintptr(ptr, old, old&val) {
+			return old
+		}
+	}
+}
+
+//go:nosplit
+//go:noinline
+func Oruintptr(ptr *uintptr, val uintptr) uintptr {
+	for {
+		old := *ptr
+		if Casuintptr(ptr, old, old|val) {
+			return old
+		}
+	}
+}

--- a/src/runtime/internal/atomic/atomic_andor_generic.go
+++ b/src/runtime/internal/atomic/atomic_andor_generic.go
@@ -1,13 +1,12 @@
-//go:build s390x || loong64 || mips || mipsle || mips64 || mips64le
-
 // Copyright 2023 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build s390x || loong64 || mips || mipsle || mips64 || mips64le
+
 package atomic
 
 //go:nosplit
-//go:noinline
 func And32(ptr *uint32, val uint32) uint32 {
 	for {
 		old := *ptr
@@ -18,7 +17,6 @@ func And32(ptr *uint32, val uint32) uint32 {
 }
 
 //go:nosplit
-//go:noinline
 func Or32(ptr *uint32, val uint32) uint32 {
 	for {
 		old := *ptr
@@ -29,7 +27,6 @@ func Or32(ptr *uint32, val uint32) uint32 {
 }
 
 //go:nosplit
-//go:noinline
 func And64(ptr *uint64, val uint64) uint64 {
 	for {
 		old := *ptr
@@ -40,7 +37,6 @@ func And64(ptr *uint64, val uint64) uint64 {
 }
 
 //go:nosplit
-//go:noinline
 func Or64(ptr *uint64, val uint64) uint64 {
 	for {
 		old := *ptr
@@ -51,7 +47,6 @@ func Or64(ptr *uint64, val uint64) uint64 {
 }
 
 //go:nosplit
-//go:noinline
 func Anduintptr(ptr *uintptr, val uintptr) uintptr {
 	for {
 		old := *ptr
@@ -62,7 +57,6 @@ func Anduintptr(ptr *uintptr, val uintptr) uintptr {
 }
 
 //go:nosplit
-//go:noinline
 func Oruintptr(ptr *uintptr, val uintptr) uintptr {
 	for {
 		old := *ptr

--- a/src/runtime/internal/atomic/atomic_andor_test.go
+++ b/src/runtime/internal/atomic/atomic_andor_test.go
@@ -1,6 +1,3 @@
-//go:build 386 || amd64 || arm || arm64 || ppc64 || ppc64le || riscv64 || wasm
-
-//
 // Copyright 2023 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
Without having all the architectures implementing the And/Or operators
merged I can't proceed with the public sync/atomic apis. This CL adds a
generic implementation that should work for all the remaining arches,
while waiting for the native assembly implementations in CL 531835, 
CL 531678, CL 531895.

I regret the oversight of not pushing this earlier.

For #61395