### PR TITLE
net/http: bundled http2 uses the new round-robin scheduler

### DIFF
--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -3519,10 +3519,7 @@ func (srv *Server) onceSetNextProtoDefaults() {
 	// Enable HTTP/2 by default if the user hasn't otherwise
 	// configured their TLSNextProto map.
 	if srv.TLSNextProto == nil {
-		conf := &http2Server{
-			NewWriteScheduler: func() http2WriteScheduler { return http2NewPriorityWriteScheduler(nil) },
-		}
-		srv.nextProtoErr = http2ConfigureServer(srv, conf)
+		srv.nextProtoErr = http2ConfigureServer(srv, nil)
 	}
 }
 


### PR DESCRIPTION
Fix #64216 