### PR TITLE
net/netip: optimize parseIPv4 and refactor IPv6 embedded IPv4 parsing

### DIFF
--- a/src/net/netip/netip_test.go
+++ b/src/net/netip/netip_test.go
@@ -60,7 +60,12 @@ func TestParseAddr(t *testing.T) {
 		// 4-in-6 with octet with leading zero
 		{
 			in:      "::ffff:1.2.03.4",
-			wantErr: `ParseAddr("::ffff:1.2.03.4"): ParseAddr("1.2.03.4"): IPv4 field has octet with leading zero (at "1.2.03.4")`,
+			wantErr: `ParseAddr("::ffff:1.2.03.4"): IPv4 field has octet with leading zero`,
+		},
+		// 4-in-6 with octet with unexpected character
+		{
+			in:      "::ffff:1.2.3.z",
+			wantErr: `ParseAddr("::ffff:1.2.3.z"): unexpected character (at "z")`,
 		},
 		// Basic zero IPv6 address.
 		{


### PR DESCRIPTION
This change refactors the parseIPv4 function to extract a new helper
function, parseIPv4Fields, which is now used by both parseIPv4 and
parseIPv6 functions. The extraction of this logic into a separate
helper function removes code duplication and improves the performance
of parsing IPv6 addresses that contain an embedded IPv4 address.

Additionally, the error handling within the IP address parsing logic
has been streamlined to provide clearer messages when encountering
incorrect formats or values in IPv4 fields.

Benchmark:

```
benchstat old.out new.out
goos: darwin
goarch: amd64
pkg: net/netip
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
                             │    old.out    │               new.out               │
                             │    sec/op     │   sec/op     vs base                │
ParseAddr/v4-12                 22.23n ±  2%   21.86n ± 2%        ~ (p=0.127 n=10)
ParseAddr/v6-12                 69.67n ±  7%   70.31n ± 1%        ~ (p=0.128 n=10)
ParseAddr/v6_ellipsis-12        48.22n ± 17%   48.58n ± 1%        ~ (p=0.739 n=10)
ParseAddr/v6_v4-12              60.73n ± 36%   51.54n ± 1%  -15.14% (p=0.000 n=10)
ParseAddr/v6_zone-12           102.50n ± 22%   93.50n ± 0%   -8.79% (p=0.000 n=10)
ParseAddrPort/v4-12             38.07n ±  1%   36.84n ± 2%   -3.22% (p=0.000 n=10)
ParseAddrPort/v6-12             84.61n ±  1%   87.21n ± 1%   +3.07% (p=0.000 n=10)
ParseAddrPort/v6_ellipsis-12    69.65n ±  8%   64.56n ± 2%   -7.31% (p=0.023 n=10)
ParseAddrPort/v6_v4-12          71.88n ±  1%   70.61n ± 1%   -1.76% (p=0.000 n=10)
ParseAddrPort/v6_zone-12        119.0n ±  2%   118.0n ± 2%        ~ (p=0.108 n=10)
geomean                         62.38n         60.17n        -3.54%

                             │   old.out    │               new.out               │
                             │     B/op     │    B/op     vs base                 │
ParseAddr/v4-12                0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ParseAddr/v6-12                0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ParseAddr/v6_ellipsis-12       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ParseAddr/v6_v4-12             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ParseAddr/v6_zone-12           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ParseAddrPort/v4-12            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ParseAddrPort/v6-12            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ParseAddrPort/v6_ellipsis-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ParseAddrPort/v6_v4-12         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ParseAddrPort/v6_zone-12       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                   ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                             │   old.out    │               new.out               │
                             │  allocs/op   │ allocs/op   vs base                 │
ParseAddr/v4-12                0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ParseAddr/v6-12                0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ParseAddr/v6_ellipsis-12       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ParseAddr/v6_v4-12             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ParseAddr/v6_zone-12           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ParseAddrPort/v4-12            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ParseAddrPort/v6-12            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ParseAddrPort/v6_ellipsis-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ParseAddrPort/v6_v4-12         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ParseAddrPort/v6_zone-12       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                   ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```