### PR TITLE
internal/zstd: optimize window reset using make for buffer allocation

### DIFF
--- a/src/internal/zstd/window.go
+++ b/src/internal/zstd/window.go
@@ -19,7 +19,11 @@ type window struct {
 
 // reset clears stored data and configures window size.
 func (w *window) reset(size int) {
-	w.data = w.data[:0]
+	b := w.data[:0]
+	if cap(b) < size {
+		b = make([]byte, 0, size)
+	}
+	w.data = b
 	w.off = 0
 	w.size = size
 }


### PR DESCRIPTION
Optimize the zstd window's reset function to use `make` for buffer
allocation when needed. This ensures efficient memory usage by
conditionally reallocating the buffer based on its capacity, improving
performance in scenarios where the existing buffer is insufficient.

```
goos: darwin
goarch: amd64
pkg: internal/zstd
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
         │   old.out   │            new.out            │
         │   sec/op    │   sec/op     vs base          │
Large-12   7.299m ± 5%   7.235m ± 1%  ~ (p=0.353 n=10)

         │   old.out    │            new.out             │
         │     B/s      │     B/s       vs base          │
Large-12   35.56Mi ± 4%   35.87Mi ± 1%  ~ (p=0.353 n=10)

         │   old.out    │               new.out                │
         │     B/op     │     B/op      vs base                │
Large-12   68.86Ki ± 4%   15.87Ki ± 1%  -76.95% (p=0.000 n=10)

         │  old.out   │            new.out             │
         │ allocs/op  │ allocs/op   vs base            │
Large-12   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```