### PR TITLE
slices: optimize Compact and CompactFunc

### DIFF
--- a/src/slices/slices.go
+++ b/src/slices/slices.go
@@ -347,12 +347,10 @@ func Clone[S ~[]E, E any](s S) S {
 // Compact zeroes the elements between the new length and the original length.
 func Compact[S ~[]E, E comparable](s S) S {
 	if len(s) > 1 {
-		k := 1
-		for ; k < len(s); k++ {
+		for k := 1; k < len(s); k++ {
 			if s[k] == s[k-1] {
 				s2 := s[k:]
-				k2 := 1
-				for ; k2 < len(s2); k2++ {
+				for k2 := 1; k2 < len(s2); k2++ {
 					if s2[k2] != s2[k2-1] {
 						s[k] = s2[k2]
 						k++
@@ -372,12 +370,10 @@ func Compact[S ~[]E, E comparable](s S) S {
 // CompactFunc zeroes the elements between the new length and the original length.
 func CompactFunc[S ~[]E, E any](s S, eq func(E, E) bool) S {
 	if len(s) > 1 {
-		k := 1
-		for ; k < len(s); k++ {
+		for k := 1; k < len(s); k++ {
 			if eq(s[k], s[k-1]) {
 				s2 := s[k:]
-				k2 := 1
-				for ; k2 < len(s2); k2++ {
+				for k2 := 1; k2 < len(s2); k2++ {
 					if !eq(s2[k2], s2[k2-1]) {
 						s[k] = s2[k2]
 						k++

--- a/src/slices/slices.go
+++ b/src/slices/slices.go
@@ -349,23 +349,17 @@ func Compact[S ~[]E, E comparable](s S) S {
 	if len(s) < 2 {
 		return s
 	}
-	k := 1
-	for ; k < len(s); k++ {
-		if s[k] == s[k-1] {
-			s2 := s[k-1:]
-			k2 := 1
-			for ; k2 < len(s2); k2++ {
-				if s2[k2] != s2[k2-1] {
-					s[k] = s2[k2]
-					k++
-				}
+	i := 1
+	for k := 1; k < len(s); k++ {
+		if s[k] != s[k-1] {
+			if i != k {
+				s[i] = s[k]
 			}
-
-			clear(s[k:]) // zero/nil out the obsolete elements, for GC
-			return s[:k]
+			i++
 		}
 	}
-	return s
+	clear(s[i:]) // zero/nil out the obsolete elements, for GC
+	return s[:i]
 }
 
 // CompactFunc is like [Compact] but uses an equality function to compare elements.
@@ -375,24 +369,17 @@ func CompactFunc[S ~[]E, E any](s S, eq func(E, E) bool) S {
 	if len(s) < 2 {
 		return s
 	}
-
-	k := 1
-	for ; k < len(s); k++ {
-		if eq(s[k], s[k-1]) {
-			s2 := s[k-1:]
-			k2 := 1
-			for ; k2 < len(s2); k2++ {
-				if !eq(s2[k2], s2[k2-1]) {
-					s[k] = s2[k2]
-					k++
-				}
+	i := 1
+	for k := 1; k < len(s); k++ {
+		if !eq(s[k], s[k-1]) {
+			if i != k {
+				s[i] = s[k]
 			}
-
-			clear(s[k:]) // zero/nil out the obsolete elements, for GC
-			return s[:k]
+			i++
 		}
 	}
-	return s
+	clear(s[i:]) // zero/nil out the obsolete elements, for GC
+	return s[:i]
 }
 
 // Grow increases the slice's capacity, if necessary, to guarantee space for

--- a/src/slices/slices.go
+++ b/src/slices/slices.go
@@ -350,7 +350,7 @@ func Compact[S ~[]E, E comparable](s S) S {
 		k := 1
 		for ; k < len(s); k++ {
 			if s[k] == s[k-1] {
-				s2 := s[k-1:]
+				s2 := s[k:]
 				k2 := 1
 				for ; k2 < len(s2); k2++ {
 					if s2[k2] != s2[k2-1] {
@@ -375,7 +375,7 @@ func CompactFunc[S ~[]E, E any](s S, eq func(E, E) bool) S {
 		k := 1
 		for ; k < len(s); k++ {
 			if eq(s[k], s[k-1]) {
-				s2 := s[k-1:]
+				s2 := s[k:]
 				k2 := 1
 				for ; k2 < len(s2); k2++ {
 					if !eq(s2[k2], s2[k2-1]) {

--- a/src/slices/slices.go
+++ b/src/slices/slices.go
@@ -349,17 +349,23 @@ func Compact[S ~[]E, E comparable](s S) S {
 	if len(s) < 2 {
 		return s
 	}
-	i := 1
-	for k := 1; k < len(s); k++ {
-		if s[k] != s[k-1] {
-			if i != k {
-				s[i] = s[k]
+	k := 1
+	for ; k < len(s); k++ {
+		if s[k] == s[k-1] {
+			s2 := s[k-1:]
+			k2 := 1
+			for ; k2 < len(s2); k2++ {
+				if s2[k2] != s2[k2-1] {
+					s[k] = s2[k2]
+					k++
+				}
 			}
-			i++
+
+			clear(s[k:]) // zero/nil out the obsolete elements, for GC
+			return s[:k]
 		}
 	}
-	clear(s[i:]) // zero/nil out the obsolete elements, for GC
-	return s[:i]
+	return s
 }
 
 // CompactFunc is like [Compact] but uses an equality function to compare elements.
@@ -369,17 +375,24 @@ func CompactFunc[S ~[]E, E any](s S, eq func(E, E) bool) S {
 	if len(s) < 2 {
 		return s
 	}
-	i := 1
-	for k := 1; k < len(s); k++ {
-		if !eq(s[k], s[k-1]) {
-			if i != k {
-				s[i] = s[k]
+
+	k := 1
+	for ; k < len(s); k++ {
+		if eq(s[k], s[k-1]) {
+			s2 := s[k-1:]
+			k2 := 1
+			for ; k2 < len(s2); k2++ {
+				if !eq(s2[k2], s2[k2-1]) {
+					s[k] = s2[k2]
+					k++
+				}
 			}
-			i++
+
+			clear(s[k:]) // zero/nil out the obsolete elements, for GC
+			return s[:k]
 		}
 	}
-	clear(s[i:]) // zero/nil out the obsolete elements, for GC
-	return s[:i]
+	return s
 }
 
 // Grow increases the slice's capacity, if necessary, to guarantee space for

--- a/src/slices/slices.go
+++ b/src/slices/slices.go
@@ -346,40 +346,50 @@ func Clone[S ~[]E, E any](s S) S {
 // which may have a smaller length.
 // Compact zeroes the elements between the new length and the original length.
 func Compact[S ~[]E, E comparable](s S) S {
-	if len(s) < 2 {
-		return s
-	}
-	i := 1
-	for k := 1; k < len(s); k++ {
-		if s[k] != s[k-1] {
-			if i != k {
-				s[i] = s[k]
+	if len(s) > 1 {
+		k := 1
+		for ; k < len(s); k++ {
+			if s[k] == s[k-1] {
+				s2 := s[k-1:]
+				k2 := 1
+				for ; k2 < len(s2); k2++ {
+					if s2[k2] != s2[k2-1] {
+						s[k] = s2[k2]
+						k++
+					}
+				}
+
+				clear(s[k:]) // zero/nil out the obsolete elements, for GC
+				return s[:k]
 			}
-			i++
 		}
 	}
-	clear(s[i:]) // zero/nil out the obsolete elements, for GC
-	return s[:i]
+	return s
 }
 
 // CompactFunc is like [Compact] but uses an equality function to compare elements.
 // For runs of elements that compare equal, CompactFunc keeps the first one.
 // CompactFunc zeroes the elements between the new length and the original length.
 func CompactFunc[S ~[]E, E any](s S, eq func(E, E) bool) S {
-	if len(s) < 2 {
-		return s
-	}
-	i := 1
-	for k := 1; k < len(s); k++ {
-		if !eq(s[k], s[k-1]) {
-			if i != k {
-				s[i] = s[k]
+	if len(s) > 1 {
+		k := 1
+		for ; k < len(s); k++ {
+			if eq(s[k], s[k-1]) {
+				s2 := s[k-1:]
+				k2 := 1
+				for ; k2 < len(s2); k2++ {
+					if !eq(s2[k2], s2[k2-1]) {
+						s[k] = s2[k2]
+						k++
+					}
+				}
+
+				clear(s[k:]) // zero/nil out the obsolete elements, for GC
+				return s[:k]
 			}
-			i++
 		}
 	}
-	clear(s[i:]) // zero/nil out the obsolete elements, for GC
-	return s[:i]
+	return s
 }
 
 // Grow increases the slice's capacity, if necessary, to guarantee space for

--- a/src/slices/slices_test.go
+++ b/src/slices/slices_test.go
@@ -824,8 +824,6 @@ func TestCompactFunc(t *testing.T) {
 		copy := Clone(test.s)
 		if got := CompactFunc(copy, equal[int]); !Equal(got, test.want) {
 			t.Errorf("CompactFunc(%v, equal[int]) = %v, want %v", test.s, got, test.want)
-		} else {
-			t.Logf("CompactFunc(%v, equal[int]) = %v, want %v", test.s, got, test.want)
 		}
 	}
 
@@ -834,8 +832,6 @@ func TestCompactFunc(t *testing.T) {
 	want := []string{"a", "B"}
 	if got := CompactFunc(copy, strings.EqualFold); !Equal(got, want) {
 		t.Errorf("CompactFunc(%v, strings.EqualFold) = %v, want %v", s1, got, want)
-	} else {
-		t.Logf("CompactFunc(%v, strings.EqualFold) = %v, want %v", s1, got, want)
 	}
 }
 

--- a/src/slices/slices_test.go
+++ b/src/slices/slices_test.go
@@ -775,11 +775,6 @@ var compactTests = []struct {
 		[]int{1, 2, 2, 3, 3, 4},
 		[]int{1, 2, 3, 4},
 	},
-	{
-		"dup start",
-		[]int{1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
-		[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
-	},
 }
 
 func TestCompact(t *testing.T) {
@@ -806,17 +801,25 @@ func BenchmarkCompact(b *testing.B) {
 
 func BenchmarkCompact_Large(b *testing.B) {
 	type Large [16]int
+	const N = 1024
 
-	ss1 := make([]Large, 1024)
-	ss2 := make([]Large, 1024)
-	for i := range ss2 {
-		ss2[i][0] = i
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = Compact(ss1)
-		_ = Compact(ss2)
-	}
+	b.Run("all_dup", func(b *testing.B) {
+		ss := make([]Large, N)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = Compact(ss)
+		}
+	})
+	b.Run("no_dup", func(b *testing.B) {
+		ss :=make([]Large, N)
+		for i := range ss {
+			ss[i][0] = i
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = Compact(ss)
+		}
+	})
 }
 
 func TestCompactFunc(t *testing.T) {
@@ -897,17 +900,25 @@ func BenchmarkCompactFunc(b *testing.B) {
 
 func BenchmarkCompactFunc_Large(b *testing.B) {
 	type Element = int
-
-	ss1 := make([]Element, 1024*1024)
-	ss2 := make([]Element, 1024*1024)
-	for i := range ss2 {
-		ss2[i] = i
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = CompactFunc(ss1, func(a, b Element) bool { return a == b })
-		_ = CompactFunc(ss2, func(a, b Element) bool { return a == b })
-	}
+	const N = 1024*1024
+	
+	b.Run("all_dup", func(b *testing.B) {
+		ss := make([]Element, N)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = CompactFunc(ss, func(a, b Element) bool { return a == b })
+		}
+	})
+	b.Run("no_dup", func(b *testing.B) {
+		ss := make([]Element, N)
+		for i := range ss {
+			ss[i] = i
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = CompactFunc(ss, func(a, b Element) bool { return a == b })
+		}
+	})
 }
 
 func TestGrow(t *testing.T) {

--- a/src/slices/slices_test.go
+++ b/src/slices/slices_test.go
@@ -811,7 +811,7 @@ func BenchmarkCompact_Large(b *testing.B) {
 		}
 	})
 	b.Run("no_dup", func(b *testing.B) {
-		ss :=make([]Large, N)
+		ss := make([]Large, N)
 		for i := range ss {
 			ss[i][0] = i
 		}
@@ -900,8 +900,8 @@ func BenchmarkCompactFunc(b *testing.B) {
 
 func BenchmarkCompactFunc_Large(b *testing.B) {
 	type Element = int
-	const N = 1024*1024
-	
+	const N = 1024 * 1024
+
 	b.Run("all_dup", func(b *testing.B) {
 		ss := make([]Element, N)
 		b.ResetTimer()


### PR DESCRIPTION
Try to save a comparison in the loop bodies of Compact and CompactFunc.

Note: due to #64272, some bound checks still fail to be removed.

                            │ old.txt  │             new.txt              │
                            │   sec/op    │   sec/op     vs base                │
Compact/nil-4                 4.191n ± 9%   3.402n ± 1%  -18.84% (p=0.000 n=10)
Compact/one-4                 5.289n ± 2%   4.553n ± 2%  -13.93% (p=0.000 n=10)
Compact/sorted-4              9.865n ± 0%   6.882n ± 1%  -30.24% (p=0.000 n=10)
Compact/2_items-4             11.10n ± 2%   12.11n ± 2%   +9.00% (p=0.000 n=10)
Compact/unsorted-4            9.831n ± 3%   6.918n ± 2%  -29.62% (p=0.000 n=10)
Compact/many-4                16.40n ± 4%   14.90n ± 1%   -9.20% (p=0.000 n=10)
Compact/dup_start-4           29.87n ± 0%   28.06n ± 3%   -6.04% (p=0.001 n=10)
Compact_Large/all_dup-4       13.11µ ± 0%   13.12µ ± 0%        ~ (p=0.971 n=10)
Compact_Large/no_dup-4        6.972µ ± 0%   5.806µ ± 0%  -16.73% (p=0.000 n=10)
CompactFunc/nil-4             5.300n ± 0%   5.309n ± 1%        ~ (p=0.289 n=10)
CompactFunc/one-4             6.051n ± 1%   6.442n ± 3%   +6.46% (p=0.000 n=10)
CompactFunc/sorted-4          16.24n ± 1%   12.79n ± 2%  -21.24% (p=0.000 n=10)
CompactFunc/2_items-4         17.89n ± 1%   17.75n ± 0%   -0.75% (p=0.000 n=10)
CompactFunc/unsorted-4        16.26n ± 0%   12.83n ± 1%  -21.07% (p=0.000 n=10)
CompactFunc/many-4            30.71n ± 1%   29.07n ± 0%   -5.32% (p=0.000 n=10)
CompactFunc/dup_start-4       78.94n ± 1%   67.19n ± 1%  -14.89% (p=0.000 n=10)
CompactFunc_Large/all_dup-4   3.277m ± 0%   3.692m ± 2%  +12.67% (p=0.000 n=10)
CompactFunc_Large/no_dup-4    4.019m ± 0%   2.826m ± 1%  -29.68% (p=0.000 n=10)
geomean                       109.6n        96.99n       -11.47%


