### PR TITLE
runtime/internal/atomic: deduplicate And/Or code on arm

### DIFF
--- a/src/runtime/internal/atomic/atomic_andor_generic.go
+++ b/src/runtime/internal/atomic/atomic_andor_generic.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build s390x || loong64 || mips || mipsle || mips64 || mips64le
+//go:build arm || s390x || loong64 || mips || mipsle || mips64 || mips64le
 
 package atomic
 

--- a/src/runtime/internal/atomic/atomic_arm.go
+++ b/src/runtime/internal/atomic/atomic_arm.go
@@ -209,66 +209,6 @@ func And(addr *uint32, v uint32) {
 }
 
 //go:nosplit
-func Or32(addr *uint32, v uint32) uint32 {
-	for {
-		old := *addr
-		if Cas(addr, old, old|v) {
-			return old
-		}
-	}
-}
-
-//go:nosplit
-func And32(addr *uint32, v uint32) uint32 {
-	for {
-		old := *addr
-		if Cas(addr, old, old&v) {
-			return old
-		}
-	}
-}
-
-//go:nosplit
-func Or64(addr *uint64, v uint64) uint64 {
-	for {
-		old := *addr
-		if Cas64(addr, old, old|v) {
-			return old
-		}
-	}
-}
-
-//go:nosplit
-func And64(addr *uint64, v uint64) uint64 {
-	for {
-		old := *addr
-		if Cas64(addr, old, old&v) {
-			return old
-		}
-	}
-}
-
-//go:nosplit
-func Oruintptr(addr *uintptr, v uintptr) uintptr {
-	for {
-		old := *addr
-		if Casuintptr(addr, old, old|v) {
-			return old
-		}
-	}
-}
-
-//go:nosplit
-func Anduintptr(addr *uintptr, v uintptr) uintptr {
-	for {
-		old := *addr
-		if Casuintptr(addr, old, old&v) {
-			return old
-		}
-	}
-}
-
-//go:nosplit
 func armcas(ptr *uint32, old, new uint32) bool
 
 //go:noescape


### PR DESCRIPTION
Turns out after adding the generic implementation for And/Or we ended up
with duplicated ops that are exactly the same for arm.

Apologies for the oversight, this CL removes the redundant arm code and
adds arm to the generic build flags.

For #61395