### PR TITLE
bytes: use bytealg.MakeNoZero in Buffer.growSlice

### DIFF
--- a/src/bytes/buffer.go
+++ b/src/bytes/buffer.go
@@ -8,6 +8,7 @@ package bytes
 
 import (
 	"errors"
+	"internal/bytealg"
 	"io"
 	"unicode/utf8"
 )
@@ -246,9 +247,9 @@ func growSlice(b []byte, n int) []byte {
 		// we could rely purely on append to determine the growth rate.
 		c = 2 * cap(b)
 	}
-	b2 := append([]byte(nil), make([]byte, c)...)
+	b2 := bytealg.MakeNoZero(c)[:len(b)+n]
 	copy(b2, b)
-	return b2[:len(b)]
+	return b2
 }
 
 // WriteTo writes data to w until the buffer is drained or an error occurs.


### PR DESCRIPTION
Optimize the growth strategy of bytes.Buffer by using
bytealg.MakeNoZero, which allocates a slice without zeroing its
memory. This change is applied to Buffer.growSlice method,
eliminating unnecessary initialization for increased efficiency.

```
benchstat old.out new.out
goos: darwin
goarch: amd64
pkg: bytes
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
                             │   old.out    │               new.out               │
                             │    sec/op    │   sec/op     vs base                │
BufferWriteBlock/N4096-12      1114.0n ± 2%   985.9n ± 1%  -11.50% (p=0.000 n=10)
BufferWriteBlock/N65536-12      14.94µ ± 3%   13.18µ ± 3%  -11.77% (p=0.000 n=10)
BufferWriteBlock/N1048576-12    273.1µ ± 7%   209.4µ ± 1%  -23.33% (p=0.000 n=10)
geomean                         16.56µ        13.96µ       -15.72%

                             │   old.out    │                new.out                │
                             │     B/op     │     B/op      vs base                 │
BufferWriteBlock/N4096-12      7.000Ki ± 0%   7.000Ki ± 0%       ~ (p=1.000 n=10) ¹
BufferWriteBlock/N65536-12     127.0Ki ± 0%   127.0Ki ± 0%       ~ (p=1.000 n=10) ¹
BufferWriteBlock/N1048576-12   1.999Mi ± 0%   1.999Mi ± 0%       ~ (p=0.350 n=10)
geomean                        122.1Ki        122.1Ki       +0.00%
¹ all samples are equal

                             │  old.out   │               new.out               │
                             │ allocs/op  │ allocs/op   vs base                 │
BufferWriteBlock/N4096-12      3.000 ± 0%   3.000 ± 0%       ~ (p=1.000 n=10) ¹
BufferWriteBlock/N65536-12     7.000 ± 0%   7.000 ± 0%       ~ (p=1.000 n=10) ¹
BufferWriteBlock/N1048576-12   11.00 ± 0%   11.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                        6.136        6.136       +0.00%
¹ all samples are equal
```