### PR TITLE
runtime: docfix countAlloc

### DIFF
--- a/src/runtime/mbitmap.go
+++ b/src/runtime/mbitmap.go
@@ -441,7 +441,7 @@ func typeBitsBulkBarrier(typ *_type, dst, src, size uintptr) {
 }
 
 // countAlloc returns the number of objects allocated in span s by
-// scanning the allocation bitmap.
+// scanning the mark bitmap.
 func (s *mspan) countAlloc() int {
 	count := 0
 	bytes := divRoundUp(uintptr(s.nelems), 8)


### PR DESCRIPTION
fix typo in `countAlloc` doc