### PR TITLE
io/fs, os: unify PathError.Path for dirFS.{ReadFile, ReadDir}

### DIFF
--- a/src/io/fs/readdir_test.go
+++ b/src/io/fs/readdir_test.go
@@ -5,6 +5,7 @@
 package fs_test
 
 import (
+	"errors"
 	. "io/fs"
 	"os"
 	"testing"
@@ -89,5 +90,21 @@ func TestFileInfoToDirEntry(t *testing.T) {
 				t.Errorf("IsDir mismatch: got=%v, want=%v", g, w)
 			}
 		})
+	}
+}
+
+func TestReadDirPath(t *testing.T) {
+	errorPath := func(err error) string {
+		var perr *PathError
+		if !errors.As(err, &perr) {
+			return ""
+		}
+		return perr.Path
+	}
+	fsys := os.DirFS(t.TempDir())
+	_, err1 := ReadDir(fsys, "non-existent")
+	_, err2 := ReadDir(struct{ FS }{fsys}, "non-existent")
+	if s1, s2 := errorPath(err1), errorPath(err2); s1 != s2 {
+		t.Fatalf("s1: %s != s2: %s", s1, s2)
 	}
 }

--- a/src/io/fs/readdir_test.go
+++ b/src/io/fs/readdir_test.go
@@ -93,14 +93,15 @@ func TestFileInfoToDirEntry(t *testing.T) {
 	}
 }
 
-func TestReadDirPath(t *testing.T) {
-	errorPath := func(err error) string {
-		var perr *PathError
-		if !errors.As(err, &perr) {
-			return ""
-		}
-		return perr.Path
+func errorPath(err error) string {
+	var perr *PathError
+	if !errors.As(err, &perr) {
+		return ""
 	}
+	return perr.Path
+}
+
+func TestReadDirPath(t *testing.T) {
 	fsys := os.DirFS(t.TempDir())
 	_, err1 := ReadDir(fsys, "non-existent")
 	_, err2 := ReadDir(struct{ FS }{fsys}, "non-existent")

--- a/src/io/fs/readfile_test.go
+++ b/src/io/fs/readfile_test.go
@@ -5,7 +5,9 @@
 package fs_test
 
 import (
+	"errors"
 	. "io/fs"
+	"os"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -55,5 +57,21 @@ func TestReadFile(t *testing.T) {
 	data, err = ReadFile(sub, "hello.txt")
 	if string(data) != "hello, world" || err != nil {
 		t.Fatalf(`ReadFile(sub(.), "hello.txt") = %q, %v, want %q, nil`, data, err, "hello, world")
+	}
+}
+
+func TestReadFilePath(t *testing.T) {
+	errorPath := func(err error) string {
+		var perr *PathError
+		if !errors.As(err, &perr) {
+			return ""
+		}
+		return perr.Path
+	}
+	fsys := os.DirFS(t.TempDir())
+	_, err1 := ReadFile(fsys, "non-existent")
+	_, err2 := ReadFile(struct{ FS }{fsys}, "non-existent")
+	if s1, s2 := errorPath(err1), errorPath(err2); s1 != s2 {
+		t.Fatalf("s1: %s != s2: %s", s1, s2)
 	}
 }

--- a/src/io/fs/readfile_test.go
+++ b/src/io/fs/readfile_test.go
@@ -5,7 +5,6 @@
 package fs_test
 
 import (
-	"errors"
 	. "io/fs"
 	"os"
 	"testing"
@@ -61,13 +60,6 @@ func TestReadFile(t *testing.T) {
 }
 
 func TestReadFilePath(t *testing.T) {
-	errorPath := func(err error) string {
-		var perr *PathError
-		if !errors.As(err, &perr) {
-			return ""
-		}
-		return perr.Path
-	}
 	fsys := os.DirFS(t.TempDir())
 	_, err1 := ReadFile(fsys, "non-existent")
 	_, err2 := ReadFile(struct{ FS }{fsys}, "non-existent")

--- a/src/os/file.go
+++ b/src/os/file.go
@@ -690,7 +690,13 @@ func (dir dirFS) ReadFile(name string) ([]byte, error) {
 	if err != nil {
 		return nil, &PathError{Op: "readfile", Path: name, Err: err}
 	}
-	return ReadFile(fullname)
+	b, err := ReadFile(fullname)
+	if err != nil {
+		// See comment in dirFS.Open.
+		err.(*PathError).Path = name
+		return nil, err
+	}
+	return b, nil
 }
 
 // ReadDir reads the named directory, returning all its directory entries sorted
@@ -700,7 +706,13 @@ func (dir dirFS) ReadDir(name string) ([]DirEntry, error) {
 	if err != nil {
 		return nil, &PathError{Op: "readdir", Path: name, Err: err}
 	}
-	return ReadDir(fullname)
+	entries, err := ReadDir(fullname)
+	if err != nil {
+		// See comment in dirFS.Open.
+		err.(*PathError).Path = name
+		return nil, err
+	}
+	return entries, nil
 }
 
 func (dir dirFS) Stat(name string) (fs.FileInfo, error) {

--- a/src/os/file.go
+++ b/src/os/file.go
@@ -692,8 +692,10 @@ func (dir dirFS) ReadFile(name string) ([]byte, error) {
 	}
 	b, err := ReadFile(fullname)
 	if err != nil {
-		// See comment in dirFS.Open.
-		err.(*PathError).Path = name
+		if e, ok := err.(*PathError); ok {
+			// See comment in dirFS.Open.
+			e.Path = name
+		}
 		return nil, err
 	}
 	return b, nil
@@ -708,8 +710,10 @@ func (dir dirFS) ReadDir(name string) ([]DirEntry, error) {
 	}
 	entries, err := ReadDir(fullname)
 	if err != nil {
-		// See comment in dirFS.Open.
-		err.(*PathError).Path = name
+		if e, ok := err.(*PathError); ok {
+			// See comment in dirFS.Open.
+			e.Path = name
+		}
 		return nil, err
 	}
 	return entries, nil


### PR DESCRIPTION
Fixes #64366