### PR TITLE
builtin: mention PanicNilError in comments of recover

### DIFF
--- a/src/builtin/builtin.go
+++ b/src/builtin/builtin.go
@@ -286,7 +286,7 @@ func panic(v any)
 // not stop a panicking sequence. In this case, or when the goroutine is not
 // panicking, recover returns nil.
 //
-// Prior to Go 1.21, recover could also return nil if panic is called with
+// Prior to Go 1.21, recover would also return nil if panic is called with
 // a nil argument. See [panic] for details.
 func recover() any
 

--- a/src/builtin/builtin.go
+++ b/src/builtin/builtin.go
@@ -284,7 +284,7 @@ func panic(v any)
 // by restoring normal execution and retrieves the error value passed to the
 // call of panic. If recover is called outside the deferred function it will
 // not stop a panicking sequence. In this case, or when the goroutine is not
-// panicking, recover returns nil. 
+// panicking, recover returns nil.
 //
 // Prior to Go 1.21, recover could also return nil if panic is called with
 // a nil argument. See [panic] for details.

--- a/src/builtin/builtin.go
+++ b/src/builtin/builtin.go
@@ -284,9 +284,11 @@ func panic(v any)
 // by restoring normal execution and retrieves the error value passed to the
 // call of panic. If recover is called outside the deferred function it will
 // not stop a panicking sequence. In this case, or when the goroutine is not
-// panicking, or if the argument supplied to panic was nil, recover returns
-// nil. Thus the return value from recover reports whether the goroutine is
-// panicking.
+// panicking, recover returns nil. Prior to Go 1.21, if the argument
+// supplied to panic was nil, recover would also return nil. Starting from
+// Go 1.21, if panic is called with a nil argument, recover resolves with a
+// PanicNilError. Thus the return value from recover reports whether the
+// goroutine is panicking.
 func recover() any
 
 // The print built-in function formats its arguments in an

--- a/src/builtin/builtin.go
+++ b/src/builtin/builtin.go
@@ -287,8 +287,8 @@ func panic(v any)
 // panicking, recover returns nil. Prior to Go 1.21, if the argument
 // supplied to panic was nil, recover would also return nil. Starting from
 // Go 1.21, if panic is called with a nil argument, recover resolves with a
-// PanicNilError. Thus the return value from recover reports whether the
-// goroutine is panicking.
+// [runtime.PanicNilError]. Thus the return value from recover reports
+// whether the goroutine is panicking.
 func recover() any
 
 // The print built-in function formats its arguments in an

--- a/src/builtin/builtin.go
+++ b/src/builtin/builtin.go
@@ -284,11 +284,10 @@ func panic(v any)
 // by restoring normal execution and retrieves the error value passed to the
 // call of panic. If recover is called outside the deferred function it will
 // not stop a panicking sequence. In this case, or when the goroutine is not
-// panicking, recover returns nil. Prior to Go 1.21, if the argument
-// supplied to panic was nil, recover would also return nil. Starting from
-// Go 1.21, if panic is called with a nil argument, recover resolves with a
-// [runtime.PanicNilError]. Thus the return value from recover reports
-// whether the goroutine is panicking.
+// panicking, recover returns nil. 
+//
+// Prior to Go 1.21, recover could also return nil if panic is called with
+// a nil argument. See [panic] for details.
 func recover() any
 
 // The print built-in function formats its arguments in an


### PR DESCRIPTION
As of CL 461956 `recover` will not return `nil` if `panic` is called with `nil`. I have updated  comments of `recover` to account for this change.