### PR TITLE
debug/elf: return error in DynValue for invalid dynamic section size

### DIFF
--- a/src/debug/elf/file.go
+++ b/src/debug/elf/file.go
@@ -1659,6 +1659,14 @@ func (f *File) DynValue(tag DynTag) ([]uint64, error) {
 	// Parse the .dynamic section as a string of bytes.
 	var vals []uint64
 	for len(d) > 0 {
+		dynSize := 8
+		if f.Class == ELFCLASS64 {
+			dynSize = 16
+		}
+		if len(d)%dynSize != 0 {
+			return nil, errors.New("length of dynamic section is not a multiple of dynamic entry size")
+		}
+
 		var t DynTag
 		var v uint64
 		switch f.Class {

--- a/src/debug/elf/file.go
+++ b/src/debug/elf/file.go
@@ -1656,17 +1656,17 @@ func (f *File) DynValue(tag DynTag) ([]uint64, error) {
 		return nil, err
 	}
 
+	dynSize := 8
+	if f.Class == ELFCLASS64 {
+		dynSize = 16
+	}
+	if len(d)%dynSize != 0 {
+		return nil, errors.New("length of dynamic section is not a multiple of dynamic entry size")
+	}
+
 	// Parse the .dynamic section as a string of bytes.
 	var vals []uint64
 	for len(d) > 0 {
-		dynSize := 8
-		if f.Class == ELFCLASS64 {
-			dynSize = 16
-		}
-		if len(d)%dynSize != 0 {
-			return nil, errors.New("length of dynamic section is not a multiple of dynamic entry size")
-		}
-
 		var t DynTag
 		var v uint64
 		switch f.Class {


### PR DESCRIPTION
This is a follow-up to CL 536400.

Fixes #64446
