### PR TITLE
all: use range over integer in benchmarks

### DIFF
--- a/src/archive/tar/tar_test.go
+++ b/src/archive/tar/tar_test.go
@@ -798,7 +798,7 @@ func Benchmark(b *testing.B) {
 		for _, v := range vectors {
 			b.Run(v.label, func(b *testing.B) {
 				b.ReportAllocs()
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					// Writing to io.Discard because we want to
 					// test purely the writer code and not bring in disk performance into this.
 					tw := NewWriter(io.Discard)
@@ -833,7 +833,7 @@ func Benchmark(b *testing.B) {
 			b.Run(v.label, func(b *testing.B) {
 				b.ReportAllocs()
 				// Read from the byte buffer.
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					r.Reset(buf.Bytes())
 					tr := NewReader(&r)
 					if _, err := tr.Next(); err != nil {

--- a/src/archive/zip/zip_test.go
+++ b/src/archive/zip/zip_test.go
@@ -759,7 +759,7 @@ func TestZeroLengthHeader(t *testing.T) {
 // Just benchmarking how fast the Zip64 test above is. Not related to
 // our zip performance, since the test above disabled CRC32 and flate.
 func BenchmarkZip64Test(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		testZip64(b, 1<<26)
 	}
 }

--- a/src/bufio/bufio_test.go
+++ b/src/bufio/bufio_test.go
@@ -1839,7 +1839,7 @@ func BenchmarkReaderCopyOptimal(b *testing.B) {
 	src := NewReader(srcBuf)
 	dstBuf := new(bytes.Buffer)
 	dst := onlyWriter{dstBuf}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		srcBuf.Reset()
 		src.Reset(srcBuf)
 		dstBuf.Reset()
@@ -1853,7 +1853,7 @@ func BenchmarkReaderCopyUnoptimal(b *testing.B) {
 	src := NewReader(onlyReader{srcBuf})
 	dstBuf := new(bytes.Buffer)
 	dst := onlyWriter{dstBuf}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		srcBuf.Reset()
 		src.Reset(onlyReader{srcBuf})
 		dstBuf.Reset()
@@ -1867,7 +1867,7 @@ func BenchmarkReaderCopyNoWriteTo(b *testing.B) {
 	src := onlyReader{srcReader}
 	dstBuf := new(bytes.Buffer)
 	dst := onlyWriter{dstBuf}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		srcBuf.Reset()
 		srcReader.Reset(srcBuf)
 		dstBuf.Reset()
@@ -1883,7 +1883,7 @@ func BenchmarkReaderWriteToOptimal(b *testing.B) {
 	if _, ok := io.Discard.(io.ReaderFrom); !ok {
 		b.Fatal("io.Discard doesn't support ReaderFrom")
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		r.Seek(0, io.SeekStart)
 		srcReader.Reset(onlyReader{r})
 		n, err := srcReader.WriteTo(io.Discard)
@@ -1900,7 +1900,7 @@ func BenchmarkReaderReadString(b *testing.B) {
 	r := strings.NewReader("       foo       foo        42        42        42        42        42        42        42        42       4.2       4.2       4.2       4.2\n")
 	buf := NewReader(r)
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		r.Seek(0, io.SeekStart)
 		buf.Reset(r)
 
@@ -1917,7 +1917,7 @@ func BenchmarkWriterCopyOptimal(b *testing.B) {
 	src := onlyReader{srcBuf}
 	dstBuf := new(bytes.Buffer)
 	dst := NewWriter(dstBuf)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		srcBuf.Reset()
 		dstBuf.Reset()
 		dst.Reset(dstBuf)
@@ -1930,7 +1930,7 @@ func BenchmarkWriterCopyUnoptimal(b *testing.B) {
 	src := onlyReader{srcBuf}
 	dstBuf := new(bytes.Buffer)
 	dst := NewWriter(onlyWriter{dstBuf})
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		srcBuf.Reset()
 		dstBuf.Reset()
 		dst.Reset(onlyWriter{dstBuf})
@@ -1944,7 +1944,7 @@ func BenchmarkWriterCopyNoReadFrom(b *testing.B) {
 	dstBuf := new(bytes.Buffer)
 	dstWriter := NewWriter(dstBuf)
 	dst := onlyWriter{dstWriter}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		srcBuf.Reset()
 		dstBuf.Reset()
 		dstWriter.Reset(dstBuf)
@@ -1955,7 +1955,7 @@ func BenchmarkWriterCopyNoReadFrom(b *testing.B) {
 func BenchmarkReaderEmpty(b *testing.B) {
 	b.ReportAllocs()
 	str := strings.Repeat("x", 16<<10)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		br := NewReader(strings.NewReader(str))
 		n, err := io.Copy(io.Discard, br)
 		if err != nil {
@@ -1971,7 +1971,7 @@ func BenchmarkWriterEmpty(b *testing.B) {
 	b.ReportAllocs()
 	str := strings.Repeat("x", 1<<10)
 	bs := []byte(str)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		bw := NewWriter(io.Discard)
 		bw.Flush()
 		bw.WriteByte('a')
@@ -1989,7 +1989,7 @@ func BenchmarkWriterFlush(b *testing.B) {
 	b.ReportAllocs()
 	bw := NewWriter(io.Discard)
 	str := strings.Repeat("x", 50)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		bw.WriteString(str)
 		bw.Flush()
 	}

--- a/src/bytes/buffer_test.go
+++ b/src/bytes/buffer_test.go
@@ -520,7 +520,7 @@ func BenchmarkReadString(b *testing.B) {
 	data := make([]byte, n)
 	data[n-1] = 'x'
 	b.SetBytes(int64(n))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf := NewBuffer(data)
 		_, err := buf.ReadString('x')
 		if err != nil {
@@ -651,7 +651,7 @@ func BenchmarkWriteByte(b *testing.B) {
 	const n = 4 << 10
 	b.SetBytes(n)
 	buf := NewBuffer(make([]byte, n))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf.Reset()
 		for i := 0; i < n; i++ {
 			buf.WriteByte('x')
@@ -664,7 +664,7 @@ func BenchmarkWriteRune(b *testing.B) {
 	const r = '☺'
 	b.SetBytes(int64(n * utf8.RuneLen(r)))
 	buf := NewBuffer(make([]byte, n*utf8.UTFMax))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf.Reset()
 		for i := 0; i < n; i++ {
 			buf.WriteRune(r)
@@ -675,7 +675,7 @@ func BenchmarkWriteRune(b *testing.B) {
 // From Issue 5154.
 func BenchmarkBufferNotEmptyWriteRead(b *testing.B) {
 	buf := make([]byte, 1024)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		var b Buffer
 		b.Write(buf[0:1])
 		for i := 0; i < 5<<10; i++ {
@@ -688,7 +688,7 @@ func BenchmarkBufferNotEmptyWriteRead(b *testing.B) {
 // Check that we don't compact too often. From Issue 5154.
 func BenchmarkBufferFullSmallReads(b *testing.B) {
 	buf := make([]byte, 1024)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		var b Buffer
 		b.Write(buf)
 		for b.Len()+20 < b.Cap() {
@@ -706,7 +706,7 @@ func BenchmarkBufferWriteBlock(b *testing.B) {
 	for _, n := range []int{1 << 12, 1 << 16, 1 << 20} {
 		b.Run(fmt.Sprintf("N%d", n), func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				var bb Buffer
 				for bb.Len() < n {
 					bb.Write(block)
@@ -721,7 +721,7 @@ func BenchmarkBufferAppendNoCopy(b *testing.B) {
 	bb.Grow(16 << 20)
 	b.SetBytes(int64(bb.Available()))
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		bb.Reset()
 		b := bb.AvailableBuffer()
 		b = b[:cap(b)] // use max capacity to simulate a large append operation

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -567,7 +567,7 @@ func bmIndexByte(index func([]byte, byte) int) func(b *testing.B, n int) {
 	return func(b *testing.B, n int) {
 		buf := bmbuf[0:n]
 		buf[n-1] = 'x'
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			j := index(buf, 'x')
 			if j != n-1 {
 				b.Fatal("bad index", j)
@@ -589,7 +589,7 @@ func bmIndexRuneASCII(index func([]byte, rune) int) func(b *testing.B, n int) {
 	return func(b *testing.B, n int) {
 		buf := bmbuf[0:n]
 		buf[n-1] = 'x'
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			j := index(buf, 'x')
 			if j != n-1 {
 				b.Fatal("bad index", j)
@@ -603,7 +603,7 @@ func bmIndexRune(index func([]byte, rune) int) func(b *testing.B, n int) {
 	return func(b *testing.B, n int) {
 		buf := bmbuf[0:n]
 		utf8.EncodeRune(buf[n-3:], '世')
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			j := index(buf, '世')
 			if j != n-3 {
 				b.Fatal("bad index", j)
@@ -620,7 +620,7 @@ func BenchmarkEqual(b *testing.B) {
 		var buf [4]byte
 		buf1 := buf[0:0]
 		buf2 := buf[1:1]
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			eq := Equal(buf1, buf2)
 			if !eq {
 				b.Fatal("bad equal")
@@ -641,7 +641,7 @@ func bmEqual(equal func([]byte, []byte) bool) func(b *testing.B, n int) {
 		buf2 := bmbuf[n : 2*n]
 		buf1[n-1] = 'x'
 		buf2[n-1] = 'x'
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			eq := equal(buf1, buf2)
 			if !eq {
 				b.Fatal("bad equal")
@@ -671,7 +671,7 @@ func BenchmarkEqualBothUnaligned(b *testing.B) {
 			buf2[n-1] = 'x'
 			b.Run(fmt.Sprint(n, off), func(b *testing.B) {
 				b.SetBytes(int64(n))
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					eq := Equal(buf1, buf2)
 					if !eq {
 						b.Fatal("bad equal")
@@ -688,7 +688,7 @@ func BenchmarkIndex(b *testing.B) {
 	benchBytes(b, indexSizes, func(b *testing.B, n int) {
 		buf := bmbuf[0:n]
 		buf[n-1] = 'x'
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			j := Index(buf, buf[n-7:])
 			if j != n-7 {
 				b.Fatal("bad index", j)
@@ -703,7 +703,7 @@ func BenchmarkIndexEasy(b *testing.B) {
 		buf := bmbuf[0:n]
 		buf[n-1] = 'x'
 		buf[n-7] = 'x'
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			j := Index(buf, buf[n-7:])
 			if j != n-7 {
 				b.Fatal("bad index", j)
@@ -718,7 +718,7 @@ func BenchmarkCount(b *testing.B) {
 	benchBytes(b, indexSizes, func(b *testing.B, n int) {
 		buf := bmbuf[0:n]
 		buf[n-1] = 'x'
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			j := Count(buf, buf[n-7:])
 			if j != 1 {
 				b.Fatal("bad count", j)
@@ -733,7 +733,7 @@ func BenchmarkCountEasy(b *testing.B) {
 		buf := bmbuf[0:n]
 		buf[n-1] = 'x'
 		buf[n-7] = 'x'
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			j := Count(buf, buf[n-7:])
 			if j != 1 {
 				b.Fatal("bad count", j)
@@ -752,7 +752,7 @@ func BenchmarkCountSingle(b *testing.B) {
 			buf[i] = 1
 		}
 		expect := (len(buf) + (step - 1)) / step
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			j := Count(buf, []byte{1})
 			if j != expect {
 				b.Fatal("bad count", j, expect)
@@ -1130,7 +1130,7 @@ func BenchmarkToUpper(b *testing.B) {
 	for _, tc := range upperTests {
 		tin := []byte(tc.in)
 		b.Run(tc.in, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				actual := ToUpper(tin)
 				if !Equal(actual, tc.out) {
 					b.Errorf("ToUpper(%q) = %q; want %q", tc.in, actual, tc.out)
@@ -1144,7 +1144,7 @@ func BenchmarkToLower(b *testing.B) {
 	for _, tc := range lowerTests {
 		tin := []byte(tc.in)
 		b.Run(tc.in, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				actual := ToLower(tin)
 				if !Equal(actual, tc.out) {
 					b.Errorf("ToLower(%q) = %q; want %q", tc.in, actual, tc.out)
@@ -1939,7 +1939,7 @@ func BenchmarkFields(b *testing.B) {
 					b.ReportAllocs()
 					b.SetBytes(int64(j))
 					data := sd.data[:j]
-					for i := 0; i < b.N; i++ {
+					for range b.N {
 						Fields(data)
 					}
 				})
@@ -1956,7 +1956,7 @@ func BenchmarkFieldsFunc(b *testing.B) {
 					b.ReportAllocs()
 					b.SetBytes(int64(j))
 					data := sd.data[:j]
-					for i := 0; i < b.N; i++ {
+					for range b.N {
 						FieldsFunc(data, unicode.IsSpace)
 					}
 				})
@@ -1977,7 +1977,7 @@ func BenchmarkTrimSpace(b *testing.B) {
 	}
 	for _, test := range tests {
 		b.Run(test.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				TrimSpace(test.input)
 			}
 		})
@@ -1997,7 +1997,7 @@ func BenchmarkToValidUTF8(b *testing.B) {
 	b.ResetTimer()
 	for _, test := range tests {
 		b.Run(test.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				ToValidUTF8(test.input, replacement)
 			}
 		})
@@ -2024,19 +2024,19 @@ func makeBenchInputHard() []byte {
 var benchInputHard = makeBenchInputHard()
 
 func benchmarkIndexHard(b *testing.B, sep []byte) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Index(benchInputHard, sep)
 	}
 }
 
 func benchmarkLastIndexHard(b *testing.B, sep []byte) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		LastIndex(benchInputHard, sep)
 	}
 }
 
 func benchmarkCountHard(b *testing.B, sep []byte) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Count(benchInputHard, sep)
 	}
 }
@@ -2057,41 +2057,41 @@ func BenchmarkCountHard2(b *testing.B) { benchmarkCountHard(b, []byte("</pre>"))
 func BenchmarkCountHard3(b *testing.B) { benchmarkCountHard(b, []byte("<b>hello world</b>")) }
 
 func BenchmarkSplitEmptySeparator(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Split(benchInputHard, nil)
 	}
 }
 
 func BenchmarkSplitSingleByteSeparator(b *testing.B) {
 	sep := []byte("/")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Split(benchInputHard, sep)
 	}
 }
 
 func BenchmarkSplitMultiByteSeparator(b *testing.B) {
 	sep := []byte("hello")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Split(benchInputHard, sep)
 	}
 }
 
 func BenchmarkSplitNSingleByteSeparator(b *testing.B) {
 	sep := []byte("/")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		SplitN(benchInputHard, sep, 10)
 	}
 }
 
 func BenchmarkSplitNMultiByteSeparator(b *testing.B) {
 	sep := []byte("hello")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		SplitN(benchInputHard, sep, 10)
 	}
 }
 
 func BenchmarkRepeat(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Repeat([]byte("-"), 80)
 	}
 }
@@ -2106,7 +2106,7 @@ func BenchmarkRepeatLarge(b *testing.B) {
 				continue
 			}
 			b.Run(fmt.Sprintf("%d/%d", 1<<j, k), func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					Repeat(s, n)
 				}
 				b.SetBytes(int64(n * len(s)))
@@ -2130,7 +2130,7 @@ func BenchmarkBytesCompare(b *testing.B) {
 			}
 
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				Compare(x, y)
 			}
 		})
@@ -2143,7 +2143,7 @@ func BenchmarkIndexAnyASCII(b *testing.B) {
 	for k := 1; k <= 2048; k <<= 4 {
 		for j := 1; j <= 64; j <<= 1 {
 			b.Run(fmt.Sprintf("%d:%d", k, j), func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					IndexAny(x[:k], cs[:j])
 				}
 			})
@@ -2157,7 +2157,7 @@ func BenchmarkIndexAnyUTF8(b *testing.B) {
 	for k := 1; k <= 2048; k <<= 4 {
 		for j := 1; j <= 64; j <<= 1 {
 			b.Run(fmt.Sprintf("%d:%d", k, j), func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					IndexAny(x[:k], cs[:j])
 				}
 			})
@@ -2171,7 +2171,7 @@ func BenchmarkLastIndexAnyASCII(b *testing.B) {
 	for k := 1; k <= 2048; k <<= 4 {
 		for j := 1; j <= 64; j <<= 1 {
 			b.Run(fmt.Sprintf("%d:%d", k, j), func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					LastIndexAny(x[:k], cs[:j])
 				}
 			})
@@ -2185,7 +2185,7 @@ func BenchmarkLastIndexAnyUTF8(b *testing.B) {
 	for k := 1; k <= 2048; k <<= 4 {
 		for j := 1; j <= 64; j <<= 1 {
 			b.Run(fmt.Sprintf("%d:%d", k, j), func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					LastIndexAny(x[:k], cs[:j])
 				}
 			})
@@ -2199,7 +2199,7 @@ func BenchmarkTrimASCII(b *testing.B) {
 		for j := 1; j <= 16; j <<= 1 {
 			b.Run(fmt.Sprintf("%d:%d", k, j), func(b *testing.B) {
 				x := Repeat([]byte(cs[:j]), k) // Always matches set
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					Trim(x[:k], cs[:j])
 				}
 			})
@@ -2209,7 +2209,7 @@ func BenchmarkTrimASCII(b *testing.B) {
 
 func BenchmarkTrimByte(b *testing.B) {
 	x := []byte("  the quick brown fox   ")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Trim(x, " ")
 	}
 }
@@ -2222,7 +2222,7 @@ func BenchmarkIndexPeriodic(b *testing.B) {
 			for i := 0; i < len(buf); i += skip {
 				buf[i] = 1
 			}
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				Index(buf, key)
 			}
 		})

--- a/src/bytes/compare_test.go
+++ b/src/bytes/compare_test.go
@@ -156,7 +156,7 @@ func TestEndianBaseCompare(t *testing.T) {
 func BenchmarkCompareBytesEqual(b *testing.B) {
 	b1 := []byte("Hello Gophers!")
 	b2 := []byte("Hello Gophers!")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if Compare(b1, b2) != 0 {
 			b.Fatal("b1 != b2")
 		}
@@ -166,7 +166,7 @@ func BenchmarkCompareBytesEqual(b *testing.B) {
 func BenchmarkCompareBytesToNil(b *testing.B) {
 	b1 := []byte("Hello Gophers!")
 	var b2 []byte
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if Compare(b1, b2) != 1 {
 			b.Fatal("b1 > b2 failed")
 		}
@@ -176,7 +176,7 @@ func BenchmarkCompareBytesToNil(b *testing.B) {
 func BenchmarkCompareBytesEmpty(b *testing.B) {
 	b1 := []byte("")
 	b2 := b1
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if Compare(b1, b2) != 0 {
 			b.Fatal("b1 != b2")
 		}
@@ -186,7 +186,7 @@ func BenchmarkCompareBytesEmpty(b *testing.B) {
 func BenchmarkCompareBytesIdentical(b *testing.B) {
 	b1 := []byte("Hello Gophers!")
 	b2 := b1
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if Compare(b1, b2) != 0 {
 			b.Fatal("b1 != b2")
 		}
@@ -196,7 +196,7 @@ func BenchmarkCompareBytesIdentical(b *testing.B) {
 func BenchmarkCompareBytesSameLength(b *testing.B) {
 	b1 := []byte("Hello Gophers!")
 	b2 := []byte("Hello, Gophers")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if Compare(b1, b2) != -1 {
 			b.Fatal("b1 < b2 failed")
 		}
@@ -206,7 +206,7 @@ func BenchmarkCompareBytesSameLength(b *testing.B) {
 func BenchmarkCompareBytesDifferentLength(b *testing.B) {
 	b1 := []byte("Hello Gophers!")
 	b2 := []byte("Hello, Gophers!")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if Compare(b1, b2) != -1 {
 			b.Fatal("b1 < b2 failed")
 		}
@@ -271,7 +271,7 @@ func BenchmarkCompareBytesBig(b *testing.B) {
 	}
 	b2 := append([]byte{}, b1...)
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if Compare(b1, b2) != 0 {
 			b.Fatal("b1 != b2")
 		}
@@ -287,7 +287,7 @@ func BenchmarkCompareBytesBigIdentical(b *testing.B) {
 	}
 	b2 := b1
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if Compare(b1, b2) != 0 {
 			b.Fatal("b1 != b2")
 		}

--- a/src/cmd/api/api_test.go
+++ b/src/cmd/api/api_test.go
@@ -197,7 +197,7 @@ func TestSkipInternal(t *testing.T) {
 }
 
 func BenchmarkAll(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, context := range contexts {
 			w := NewWalker(context, filepath.Join(testenv.GOROOT(b), "src"))
 			for _, name := range w.stdPackages {

--- a/src/cmd/cgo/internal/test/test.go
+++ b/src/cmd/cgo/internal/test/test.go
@@ -1103,50 +1103,50 @@ func benchCgoCall(b *testing.B) {
 		const x = C.int(2)
 		const y = C.int(3)
 
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			C.add(x, y)
 		}
 	})
 
 	b.Run("one-pointer", func(b *testing.B) {
 		var a0 C.VkDeviceCreateInfo
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			C.handleComplexPointer(&a0)
 		}
 	})
 	b.Run("string-pointer-escape", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			var s string
 			C.handleGoStringPointerEscape(unsafe.Pointer(&s))
 		}
 	})
 	b.Run("string-pointer-noescape", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			var s string
 			C.handleGoStringPointerNoescape(unsafe.Pointer(&s))
 		}
 	})
 	b.Run("eight-pointers", func(b *testing.B) {
 		var a0, a1, a2, a3, a4, a5, a6, a7 C.VkDeviceCreateInfo
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			C.handleComplexPointer8(&a0, &a1, &a2, &a3, &a4, &a5, &a6, &a7)
 		}
 	})
 	b.Run("eight-pointers-nil", func(b *testing.B) {
 		var a0, a1, a2, a3, a4, a5, a6, a7 *C.VkDeviceCreateInfo
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			C.handleComplexPointer8(a0, a1, a2, a3, a4, a5, a6, a7)
 		}
 	})
 	b.Run("eight-pointers-array", func(b *testing.B) {
 		var a [8]C.VkDeviceCreateInfo
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			C.handleComplexPointer8(&a[0], &a[1], &a[2], &a[3], &a[4], &a[5], &a[6], &a[7])
 		}
 	})
 	b.Run("eight-pointers-slice", func(b *testing.B) {
 		a := make([]C.VkDeviceCreateInfo, 8)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			C.handleComplexPointer8(&a[0], &a[1], &a[2], &a[3], &a[4], &a[5], &a[6], &a[7])
 		}
 	})
@@ -1155,7 +1155,7 @@ func benchCgoCall(b *testing.B) {
 // Benchmark measuring overhead from Go to C and back to Go (via a callback)
 func benchCallback(b *testing.B) {
 	var x = false
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		nestedCall(func() { x = true })
 	}
 	if !x {
@@ -1166,7 +1166,7 @@ func benchCallback(b *testing.B) {
 var sinkString string
 
 func benchGoString(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sinkString = C.GoString(C.cstr)
 	}
 	const want = "abcefghijklmnopqrstuvwxyzABCEFGHIJKLMNOPQRSTUVWXYZ1234567890"

--- a/src/cmd/compile/internal/reflectdata/alg_test.go
+++ b/src/cmd/compile/internal/reflectdata/alg_test.go
@@ -54,7 +54,7 @@ func BenchmarkEqArrayOfFloats5(b *testing.B) {
 	var a [5]float32
 	var c [5]float32
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = a == c
 	}
 }
@@ -63,7 +63,7 @@ func BenchmarkEqArrayOfFloats64(b *testing.B) {
 	var a [64]float32
 	var c [64]float32
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = a == c
 	}
 }
@@ -72,7 +72,7 @@ func BenchmarkEqArrayOfFloats1024(b *testing.B) {
 	var a [1024]float32
 	var c [1024]float32
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = a == c
 	}
 }
@@ -138,7 +138,7 @@ func BenchmarkEqStruct(b *testing.B) {
 	x.a = [size]byte{1, 2, 3, 4, 5, 6, 7, 8}
 	y.a = [size]byte{2, 3, 4, 5, 6, 7, 8, 9}
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		f := x == y
 		if f {
 			println("hello")

--- a/src/cmd/compile/internal/ssa/bench_test.go
+++ b/src/cmd/compile/internal/ssa/bench_test.go
@@ -23,7 +23,7 @@ func fn(a, b int) bool {
 }
 
 func BenchmarkPhioptPass(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		a := rand.Perm(i/10 + 10)
 		for i := 1; i < len(a)/2; i++ {
 			fn(a[i]-a[i-1], a[i+len(a)/2-2]-a[i+len(a)/2-1])
@@ -44,7 +44,7 @@ func BenchmarkInvertLessThanNoov(b *testing.B) {
 	p1 := Point{1, 2}
 	p2 := Point{2, 3}
 	p3 := Point{3, 4}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sign(p1, p2, p3)
 	}
 }

--- a/src/cmd/compile/internal/ssa/copyelim_test.go
+++ b/src/cmd/compile/internal/ssa/copyelim_test.go
@@ -34,7 +34,7 @@ func benchmarkCopyElim(b *testing.B, n int) {
 		values[i], values[len(values)-1-i] = values[len(values)-1-i], values[i]
 	}
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		fun := c.Fun("entry", Bloc("entry", values...))
 		Copyelim(fun.f)
 	}

--- a/src/cmd/compile/internal/ssa/deadcode_test.go
+++ b/src/cmd/compile/internal/ssa/deadcode_test.go
@@ -152,7 +152,7 @@ func BenchmarkDeadCode(b *testing.B) {
 				blocks = append(blocks, Bloc(fmt.Sprintf("dead%d", i), Goto("exit")))
 			}
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				fun := c.Fun("entry", blocks...)
 				Deadcode(fun.f)
 			}

--- a/src/cmd/compile/internal/ssa/dom_test.go
+++ b/src/cmd/compile/internal/ssa/dom_test.go
@@ -169,7 +169,7 @@ func benchmarkDominators(b *testing.B, size int, bg blockGen) {
 	CheckFunc(fun.f)
 	b.SetBytes(int64(size))
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		domBenchRes = dominators(fun.f)
 	}
 }

--- a/src/cmd/compile/internal/ssa/fuse_test.go
+++ b/src/cmd/compile/internal/ssa/fuse_test.go
@@ -296,7 +296,7 @@ func BenchmarkFuse(b *testing.B) {
 					Exit("mem")))
 
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				fun := c.Fun("entry", blocks...)
 				fuseLate(fun.f)
 			}

--- a/src/cmd/compile/internal/ssa/nilcheck_test.go
+++ b/src/cmd/compile/internal/ssa/nilcheck_test.go
@@ -53,7 +53,7 @@ func benchmarkNilCheckDeep(b *testing.B, depth int) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		nilcheckelim(fun.f)
 	}
 }

--- a/src/cmd/compile/internal/ssa/passbm_test.go
+++ b/src/cmd/compile/internal/ssa/passbm_test.go
@@ -39,7 +39,7 @@ func benchFnPass(b *testing.B, fn passFunc, size int, bg blockGen) {
 	fun := c.Fun("entry", bg(size)...)
 	CheckFunc(fun.f)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		fn(fun.f)
 		b.StopTimer()
 		CheckFunc(fun.f)

--- a/src/cmd/compile/internal/ssa/rewriteCond_test.go
+++ b/src/cmd/compile/internal/ssa/rewriteCond_test.go
@@ -518,7 +518,7 @@ func benchSoloJump(b *testing.B) {
 	d := rnd.Int63n(10)
 
 	// 6 out 10 conditions evaluate to true
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if r1+r2 < 0 {
 			d *= 2
 			d /= 2
@@ -580,7 +580,7 @@ func benchCombJump(b *testing.B) {
 	d := rnd.Int63n(10)
 
 	// 6 out 10 conditions evaluate to true
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if r1+r2 <= 0 {
 			d *= 2
 			d /= 2

--- a/src/cmd/compile/internal/test/bench_test.go
+++ b/src/cmd/compile/internal/test/bench_test.go
@@ -12,7 +12,7 @@ var globl32 int32
 func BenchmarkLoadAdd(b *testing.B) {
 	x := make([]int64, 1024)
 	y := make([]int64, 1024)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		var s int64
 		for i := range x {
 			s ^= x[i] + y[i]
@@ -24,7 +24,7 @@ func BenchmarkLoadAdd(b *testing.B) {
 // Added for ppc64 extswsli on power9
 func BenchmarkExtShift(b *testing.B) {
 	x := make([]int32, 1024)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		var s int64
 		for i := range x {
 			s ^= int64(x[i]+32) * 8
@@ -36,7 +36,7 @@ func BenchmarkExtShift(b *testing.B) {
 func BenchmarkModify(b *testing.B) {
 	a := make([]int64, 1024)
 	v := globl
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for j := range a {
 			a[j] += v
 		}
@@ -45,7 +45,7 @@ func BenchmarkModify(b *testing.B) {
 
 func BenchmarkMullImm(b *testing.B) {
 	x := make([]int32, 1024)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		var s int32
 		for i := range x {
 			s += x[i] * 100
@@ -56,7 +56,7 @@ func BenchmarkMullImm(b *testing.B) {
 
 func BenchmarkConstModify(b *testing.B) {
 	a := make([]int64, 1024)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for j := range a {
 			a[j] += 3
 		}
@@ -66,7 +66,7 @@ func BenchmarkConstModify(b *testing.B) {
 func BenchmarkBitSet(b *testing.B) {
 	const N = 64 * 8
 	a := make([]uint64, N/64)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for j := uint64(0); j < N; j++ {
 			a[j/64] |= 1 << (j % 64)
 		}
@@ -76,7 +76,7 @@ func BenchmarkBitSet(b *testing.B) {
 func BenchmarkBitClear(b *testing.B) {
 	const N = 64 * 8
 	a := make([]uint64, N/64)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for j := uint64(0); j < N; j++ {
 			a[j/64] &^= 1 << (j % 64)
 		}
@@ -86,7 +86,7 @@ func BenchmarkBitClear(b *testing.B) {
 func BenchmarkBitToggle(b *testing.B) {
 	const N = 64 * 8
 	a := make([]uint64, N/64)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for j := uint64(0); j < N; j++ {
 			a[j/64] ^= 1 << (j % 64)
 		}
@@ -96,7 +96,7 @@ func BenchmarkBitToggle(b *testing.B) {
 func BenchmarkBitSetConst(b *testing.B) {
 	const N = 64
 	a := make([]uint64, N)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for j := range a {
 			a[j] |= 1 << 37
 		}
@@ -106,7 +106,7 @@ func BenchmarkBitSetConst(b *testing.B) {
 func BenchmarkBitClearConst(b *testing.B) {
 	const N = 64
 	a := make([]uint64, N)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for j := range a {
 			a[j] &^= 1 << 37
 		}
@@ -116,7 +116,7 @@ func BenchmarkBitClearConst(b *testing.B) {
 func BenchmarkBitToggleConst(b *testing.B) {
 	const N = 64
 	a := make([]uint64, N)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for j := range a {
 			a[j] ^= 1 << 37
 		}

--- a/src/cmd/compile/internal/test/divconst_test.go
+++ b/src/cmd/compile/internal/test/divconst_test.go
@@ -13,30 +13,30 @@ var boolres bool
 var i64res int64
 
 func BenchmarkDivconstI64(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		i64res = int64(i) / 7
 	}
 }
 
 func BenchmarkModconstI64(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		i64res = int64(i) % 7
 	}
 }
 
 func BenchmarkDivisiblePow2constI64(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		boolres = int64(i)%16 == 0
 	}
 }
 func BenchmarkDivisibleconstI64(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		boolres = int64(i)%7 == 0
 	}
 }
 
 func BenchmarkDivisibleWDivconstI64(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		i64res = int64(i) / 7
 		boolres = int64(i)%7 == 0
 	}
@@ -97,28 +97,28 @@ func TestDivmodConstU64(t *testing.T) {
 func BenchmarkDivconstU64(b *testing.B) {
 	b.Run("3", func(b *testing.B) {
 		x := uint64(123456789123456789)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x += x << 4
 			u64res = uint64(x) / 3
 		}
 	})
 	b.Run("5", func(b *testing.B) {
 		x := uint64(123456789123456789)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x += x << 4
 			u64res = uint64(x) / 5
 		}
 	})
 	b.Run("37", func(b *testing.B) {
 		x := uint64(123456789123456789)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x += x << 4
 			u64res = uint64(x) / 37
 		}
 	})
 	b.Run("1234567", func(b *testing.B) {
 		x := uint64(123456789123456789)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x += x << 4
 			u64res = uint64(x) / 1234567
 		}
@@ -126,19 +126,19 @@ func BenchmarkDivconstU64(b *testing.B) {
 }
 
 func BenchmarkModconstU64(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		u64res = uint64(i) % 7
 	}
 }
 
 func BenchmarkDivisibleconstU64(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		boolres = uint64(i)%7 == 0
 	}
 }
 
 func BenchmarkDivisibleWDivconstU64(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		u64res = uint64(i) / 7
 		boolres = uint64(i)%7 == 0
 	}
@@ -147,31 +147,31 @@ func BenchmarkDivisibleWDivconstU64(b *testing.B) {
 var i32res int32
 
 func BenchmarkDivconstI32(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		i32res = int32(i) / 7
 	}
 }
 
 func BenchmarkModconstI32(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		i32res = int32(i) % 7
 	}
 }
 
 func BenchmarkDivisiblePow2constI32(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		boolres = int32(i)%16 == 0
 	}
 }
 
 func BenchmarkDivisibleconstI32(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		boolres = int32(i)%7 == 0
 	}
 }
 
 func BenchmarkDivisibleWDivconstI32(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		i32res = int32(i) / 7
 		boolres = int32(i)%7 == 0
 	}
@@ -180,25 +180,25 @@ func BenchmarkDivisibleWDivconstI32(b *testing.B) {
 var u32res uint32
 
 func BenchmarkDivconstU32(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		u32res = uint32(i) / 7
 	}
 }
 
 func BenchmarkModconstU32(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		u32res = uint32(i) % 7
 	}
 }
 
 func BenchmarkDivisibleconstU32(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		boolres = uint32(i)%7 == 0
 	}
 }
 
 func BenchmarkDivisibleWDivconstU32(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		u32res = uint32(i) / 7
 		boolres = uint32(i)%7 == 0
 	}
@@ -207,31 +207,31 @@ func BenchmarkDivisibleWDivconstU32(b *testing.B) {
 var i16res int16
 
 func BenchmarkDivconstI16(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		i16res = int16(i) / 7
 	}
 }
 
 func BenchmarkModconstI16(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		i16res = int16(i) % 7
 	}
 }
 
 func BenchmarkDivisiblePow2constI16(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		boolres = int16(i)%16 == 0
 	}
 }
 
 func BenchmarkDivisibleconstI16(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		boolres = int16(i)%7 == 0
 	}
 }
 
 func BenchmarkDivisibleWDivconstI16(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		i16res = int16(i) / 7
 		boolres = int16(i)%7 == 0
 	}
@@ -240,25 +240,25 @@ func BenchmarkDivisibleWDivconstI16(b *testing.B) {
 var u16res uint16
 
 func BenchmarkDivconstU16(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		u16res = uint16(i) / 7
 	}
 }
 
 func BenchmarkModconstU16(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		u16res = uint16(i) % 7
 	}
 }
 
 func BenchmarkDivisibleconstU16(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		boolres = uint16(i)%7 == 0
 	}
 }
 
 func BenchmarkDivisibleWDivconstU16(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		u16res = uint16(i) / 7
 		boolres = uint16(i)%7 == 0
 	}
@@ -267,31 +267,31 @@ func BenchmarkDivisibleWDivconstU16(b *testing.B) {
 var i8res int8
 
 func BenchmarkDivconstI8(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		i8res = int8(i) / 7
 	}
 }
 
 func BenchmarkModconstI8(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		i8res = int8(i) % 7
 	}
 }
 
 func BenchmarkDivisiblePow2constI8(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		boolres = int8(i)%16 == 0
 	}
 }
 
 func BenchmarkDivisibleconstI8(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		boolres = int8(i)%7 == 0
 	}
 }
 
 func BenchmarkDivisibleWDivconstI8(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		i8res = int8(i) / 7
 		boolres = int8(i)%7 == 0
 	}
@@ -300,25 +300,25 @@ func BenchmarkDivisibleWDivconstI8(b *testing.B) {
 var u8res uint8
 
 func BenchmarkDivconstU8(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		u8res = uint8(i) / 7
 	}
 }
 
 func BenchmarkModconstU8(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		u8res = uint8(i) % 7
 	}
 }
 
 func BenchmarkDivisibleconstU8(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		boolres = uint8(i)%7 == 0
 	}
 }
 
 func BenchmarkDivisibleWDivconstU8(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		u8res = uint8(i) / 7
 		boolres = uint8(i)%7 == 0
 	}

--- a/src/cmd/compile/internal/test/float_test.go
+++ b/src/cmd/compile/internal/test/float_test.go
@@ -526,7 +526,7 @@ func TestFloatSignalingNaNConversionConst(t *testing.T) {
 var sinkFloat float64
 
 func BenchmarkMul2(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		var m float64 = 1
 		for j := 0; j < 500; j++ {
 			m *= 2
@@ -535,7 +535,7 @@ func BenchmarkMul2(b *testing.B) {
 	}
 }
 func BenchmarkMulNeg2(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		var m float64 = 1
 		for j := 0; j < 500; j++ {
 			m *= -2

--- a/src/cmd/compile/internal/test/iface_test.go
+++ b/src/cmd/compile/internal/test/iface_test.go
@@ -114,7 +114,7 @@ func i2Int4(i I, p *Int) Int {
 
 func BenchmarkEfaceInteger(b *testing.B) {
 	sum := 0
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		sum += i2int(i)
 	}
 	sink = sum
@@ -128,7 +128,7 @@ func i2int(i interface{}) int {
 func BenchmarkTypeAssert(b *testing.B) {
 	e := any(Int(0))
 	r := true
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, ok := e.(I)
 		if !ok {
 			r = false

--- a/src/cmd/compile/internal/test/mulconst_test.go
+++ b/src/cmd/compile/internal/test/mulconst_test.go
@@ -25,7 +25,7 @@ func BenchmarkMulconstI32(b *testing.B) {
 	// 3x = 2x + x
 	b.Run("3", func(b *testing.B) {
 		x := int32(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 3
 		}
 		mulSinkI32 = x
@@ -33,7 +33,7 @@ func BenchmarkMulconstI32(b *testing.B) {
 	// 5x = 4x + x
 	b.Run("5", func(b *testing.B) {
 		x := int32(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 5
 		}
 		mulSinkI32 = x
@@ -41,7 +41,7 @@ func BenchmarkMulconstI32(b *testing.B) {
 	// 12x = 8x + 4x
 	b.Run("12", func(b *testing.B) {
 		x := int32(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 12
 		}
 		mulSinkI32 = x
@@ -49,7 +49,7 @@ func BenchmarkMulconstI32(b *testing.B) {
 	// 120x = 128x - 8x
 	b.Run("120", func(b *testing.B) {
 		x := int32(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 120
 		}
 		mulSinkI32 = x
@@ -57,7 +57,7 @@ func BenchmarkMulconstI32(b *testing.B) {
 	// -120x = 8x - 120x
 	b.Run("-120", func(b *testing.B) {
 		x := int32(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= -120
 		}
 		mulSinkI32 = x
@@ -65,7 +65,7 @@ func BenchmarkMulconstI32(b *testing.B) {
 	// 65537x = 65536x + x
 	b.Run("65537", func(b *testing.B) {
 		x := int32(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 65537
 		}
 		mulSinkI32 = x
@@ -73,7 +73,7 @@ func BenchmarkMulconstI32(b *testing.B) {
 	// 65538x = 65536x + 2x
 	b.Run("65538", func(b *testing.B) {
 		x := int32(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 65538
 		}
 		mulSinkI32 = x
@@ -84,7 +84,7 @@ func BenchmarkMulconstI64(b *testing.B) {
 	// 3x = 2x + x
 	b.Run("3", func(b *testing.B) {
 		x := int64(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 3
 		}
 		mulSinkI64 = x
@@ -92,7 +92,7 @@ func BenchmarkMulconstI64(b *testing.B) {
 	// 5x = 4x + x
 	b.Run("5", func(b *testing.B) {
 		x := int64(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 5
 		}
 		mulSinkI64 = x
@@ -100,7 +100,7 @@ func BenchmarkMulconstI64(b *testing.B) {
 	// 12x = 8x + 4x
 	b.Run("12", func(b *testing.B) {
 		x := int64(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 12
 		}
 		mulSinkI64 = x
@@ -108,7 +108,7 @@ func BenchmarkMulconstI64(b *testing.B) {
 	// 120x = 128x - 8x
 	b.Run("120", func(b *testing.B) {
 		x := int64(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 120
 		}
 		mulSinkI64 = x
@@ -116,7 +116,7 @@ func BenchmarkMulconstI64(b *testing.B) {
 	// -120x = 8x - 120x
 	b.Run("-120", func(b *testing.B) {
 		x := int64(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= -120
 		}
 		mulSinkI64 = x
@@ -124,7 +124,7 @@ func BenchmarkMulconstI64(b *testing.B) {
 	// 65537x = 65536x + x
 	b.Run("65537", func(b *testing.B) {
 		x := int64(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 65537
 		}
 		mulSinkI64 = x
@@ -132,7 +132,7 @@ func BenchmarkMulconstI64(b *testing.B) {
 	// 65538x = 65536x + 2x
 	b.Run("65538", func(b *testing.B) {
 		x := int64(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 65538
 		}
 		mulSinkI64 = x
@@ -143,7 +143,7 @@ func BenchmarkMulconstU32(b *testing.B) {
 	// 3x = 2x + x
 	b.Run("3", func(b *testing.B) {
 		x := uint32(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 3
 		}
 		mulSinkU32 = x
@@ -151,7 +151,7 @@ func BenchmarkMulconstU32(b *testing.B) {
 	// 5x = 4x + x
 	b.Run("5", func(b *testing.B) {
 		x := uint32(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 5
 		}
 		mulSinkU32 = x
@@ -159,7 +159,7 @@ func BenchmarkMulconstU32(b *testing.B) {
 	// 12x = 8x + 4x
 	b.Run("12", func(b *testing.B) {
 		x := uint32(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 12
 		}
 		mulSinkU32 = x
@@ -167,7 +167,7 @@ func BenchmarkMulconstU32(b *testing.B) {
 	// 120x = 128x - 8x
 	b.Run("120", func(b *testing.B) {
 		x := uint32(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 120
 		}
 		mulSinkU32 = x
@@ -175,7 +175,7 @@ func BenchmarkMulconstU32(b *testing.B) {
 	// 65537x = 65536x + x
 	b.Run("65537", func(b *testing.B) {
 		x := uint32(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 65537
 		}
 		mulSinkU32 = x
@@ -183,7 +183,7 @@ func BenchmarkMulconstU32(b *testing.B) {
 	// 65538x = 65536x + 2x
 	b.Run("65538", func(b *testing.B) {
 		x := uint32(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 65538
 		}
 		mulSinkU32 = x
@@ -194,7 +194,7 @@ func BenchmarkMulconstU64(b *testing.B) {
 	// 3x = 2x + x
 	b.Run("3", func(b *testing.B) {
 		x := uint64(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 3
 		}
 		mulSinkU64 = x
@@ -202,7 +202,7 @@ func BenchmarkMulconstU64(b *testing.B) {
 	// 5x = 4x + x
 	b.Run("5", func(b *testing.B) {
 		x := uint64(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 5
 		}
 		mulSinkU64 = x
@@ -210,7 +210,7 @@ func BenchmarkMulconstU64(b *testing.B) {
 	// 12x = 8x + 4x
 	b.Run("12", func(b *testing.B) {
 		x := uint64(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 12
 		}
 		mulSinkU64 = x
@@ -218,7 +218,7 @@ func BenchmarkMulconstU64(b *testing.B) {
 	// 120x = 128x - 8x
 	b.Run("120", func(b *testing.B) {
 		x := uint64(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 120
 		}
 		mulSinkU64 = x
@@ -226,7 +226,7 @@ func BenchmarkMulconstU64(b *testing.B) {
 	// 65537x = 65536x + x
 	b.Run("65537", func(b *testing.B) {
 		x := uint64(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 65537
 		}
 		mulSinkU64 = x
@@ -234,7 +234,7 @@ func BenchmarkMulconstU64(b *testing.B) {
 	// 65538x = 65536x + 2x
 	b.Run("65538", func(b *testing.B) {
 		x := uint64(1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x *= 65538
 		}
 		mulSinkU64 = x

--- a/src/cmd/compile/internal/test/shift_test.go
+++ b/src/cmd/compile/internal/test/shift_test.go
@@ -1034,7 +1034,7 @@ var shiftSink64 int64
 
 func BenchmarkShiftArithmeticRight(b *testing.B) {
 	x := shiftSink64
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		x = x >> (i & 63)
 	}
 	shiftSink64 = x

--- a/src/cmd/compile/internal/test/switch_test.go
+++ b/src/cmd/compile/internal/test/switch_test.go
@@ -18,7 +18,7 @@ func BenchmarkSwitch8Unpredictable(b *testing.B) {
 func benchmarkSwitch8(b *testing.B, predictable bool) {
 	n := 0
 	rng := newRNG()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		rng = rng.next(predictable)
 		switch rng.value() & 7 {
 		case 0:
@@ -51,7 +51,7 @@ func BenchmarkSwitch32Unpredictable(b *testing.B) {
 func benchmarkSwitch32(b *testing.B, predictable bool) {
 	n := 0
 	rng := newRNG()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		rng = rng.next(predictable)
 		switch rng.value() & 31 {
 		case 0, 1, 2:
@@ -96,7 +96,7 @@ func benchmarkSwitchString(b *testing.B, predictable bool) {
 	}
 	n := 0
 	rng := newRNG()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		rng = rng.next(predictable)
 		switch a[rng.value()&7] {
 		case "foo":
@@ -139,7 +139,7 @@ func benchmarkSwitchType(b *testing.B, predictable bool) {
 	}
 	n := 0
 	rng := newRNG()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		rng = rng.next(predictable)
 		switch a[rng.value()&7].(type) {
 		case int8:
@@ -255,7 +255,7 @@ func benchmarkSwitchInterfaceType(b *testing.B, predictable bool) {
 	}
 	n := 0
 	rng := newRNG()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		rng = rng.next(predictable)
 		switch a[rng.value()&7].(type) {
 		case SI0:

--- a/src/cmd/compile/internal/types2/lookup_test.go
+++ b/src/cmd/compile/internal/types2/lookup_test.go
@@ -49,7 +49,7 @@ func BenchmarkLookupFieldOrMethod(b *testing.B) {
 	lookup()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		lookup()
 	}
 }

--- a/src/cmd/compile/internal/types2/named_test.go
+++ b/src/cmd/compile/internal/types2/named_test.go
@@ -56,7 +56,7 @@ type Inst = G[int]
 				// Access underlying once, to trigger any lazy calculation.
 				_ = test.typ.Underlying()
 				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					_ = test.typ.Underlying()
 				}
 			})

--- a/src/cmd/compile/internal/types2/self_test.go
+++ b/src/cmd/compile/internal/types2/self_test.go
@@ -75,7 +75,7 @@ func runbench(b *testing.B, path string, ignoreFuncBodies, writeInfo bool) {
 
 	b.ResetTimer()
 	start := time.Now()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		conf := Config{
 			IgnoreFuncBodies: ignoreFuncBodies,
 			Importer:         defaultImporter(),

--- a/src/cmd/go/internal/cfg/bench_test.go
+++ b/src/cmd/go/internal/cfg/bench_test.go
@@ -12,7 +12,7 @@ import (
 func BenchmarkLookPath(b *testing.B) {
 	testenv.MustHaveExecPath(b, "go")
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, err := LookPath("go")
 		if err != nil {
 			b.Fatal(err)

--- a/src/cmd/internal/notsha256/sha256_test.go
+++ b/src/cmd/internal/notsha256/sha256_test.go
@@ -147,7 +147,7 @@ func benchmarkSize(b *testing.B, size int) {
 	b.Run("New", func(b *testing.B) {
 		b.ReportAllocs()
 		b.SetBytes(int64(size))
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			bench.Reset()
 			bench.Write(buf[:size])
 			bench.Sum(sum[:0])
@@ -156,7 +156,7 @@ func benchmarkSize(b *testing.B, size int) {
 	b.Run("Sum256", func(b *testing.B) {
 		b.ReportAllocs()
 		b.SetBytes(int64(size))
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			Sum256(buf[:size])
 		}
 	})

--- a/src/compress/bzip2/bzip2_test.go
+++ b/src/compress/bzip2/bzip2_test.go
@@ -229,7 +229,7 @@ func benchmarkDecode(b *testing.B, compressed []byte) {
 	b.ReportAllocs()
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		r := bytes.NewReader(compressed)
 		io.Copy(io.Discard, NewReader(r))
 	}

--- a/src/compress/flate/reader_test.go
+++ b/src/compress/flate/reader_test.go
@@ -53,7 +53,7 @@ func BenchmarkDecode(b *testing.B) {
 		buf0, compressed, w = nil, nil, nil
 		runtime.GC()
 		b.StartTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			io.Copy(io.Discard, NewReader(bytes.NewReader(buf1)))
 		}
 	})

--- a/src/compress/flate/writer_test.go
+++ b/src/compress/flate/writer_test.go
@@ -32,7 +32,7 @@ func BenchmarkEncode(b *testing.B) {
 		}
 		runtime.GC()
 		b.StartTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			w.Reset(io.Discard)
 			w.Write(buf1)
 			w.Close()

--- a/src/compress/lzw/reader_test.go
+++ b/src/compress/lzw/reader_test.go
@@ -294,7 +294,7 @@ func BenchmarkDecoder(b *testing.B) {
 			buf1 := getInputBuf(buf, n)
 			runtime.GC()
 			b.StartTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				io.Copy(io.Discard, NewReader(bytes.NewReader(buf1), LSB, 8))
 			}
 		})
@@ -305,7 +305,7 @@ func BenchmarkDecoder(b *testing.B) {
 			runtime.GC()
 			b.StartTimer()
 			r := NewReader(bytes.NewReader(buf1), LSB, 8)
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				io.Copy(io.Discard, r)
 				r.Close()
 				r.(*Reader).Reset(bytes.NewReader(buf1), LSB, 8)

--- a/src/compress/lzw/writer_test.go
+++ b/src/compress/lzw/writer_test.go
@@ -219,7 +219,7 @@ func BenchmarkEncoder(b *testing.B) {
 		runtime.GC()
 		b.Run(fmt.Sprint("1e", e), func(b *testing.B) {
 			b.SetBytes(int64(n))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				w := NewWriter(io.Discard, LSB, 8)
 				w.Write(buf1)
 				w.Close()
@@ -228,7 +228,7 @@ func BenchmarkEncoder(b *testing.B) {
 		b.Run(fmt.Sprint("1e-Reuse", e), func(b *testing.B) {
 			b.SetBytes(int64(n))
 			w := NewWriter(io.Discard, LSB, 8)
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				w.Write(buf1)
 				w.Close()
 				w.(*Writer).Reset(io.Discard, LSB, 8)

--- a/src/container/heap/heap_test.go
+++ b/src/container/heap/heap_test.go
@@ -175,7 +175,7 @@ func TestRemove2(t *testing.T) {
 func BenchmarkDup(b *testing.B) {
 	const n = 10000
 	h := make(myHeap, 0, n)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for j := 0; j < n; j++ {
 			Push(&h, 0) // all elements are the same
 		}

--- a/src/context/benchmark_test.go
+++ b/src/context/benchmark_test.go
@@ -93,19 +93,19 @@ func BenchmarkCancelTree(b *testing.B) {
 	for _, d := range depths {
 		b.Run(fmt.Sprintf("depth=%d", d), func(b *testing.B) {
 			b.Run("Root=Background", func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					buildContextTree(Background(), d)
 				}
 			})
 			b.Run("Root=OpenCanceler", func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					ctx, cancel := WithCancel(Background())
 					buildContextTree(ctx, d)
 					cancel()
 				}
 			})
 			b.Run("Root=ClosedCanceler", func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					ctx, cancel := WithCancel(Background())
 					cancel()
 					buildContextTree(ctx, d)
@@ -125,12 +125,12 @@ func BenchmarkCheckCanceled(b *testing.B) {
 	ctx, cancel := WithCancel(Background())
 	cancel()
 	b.Run("Err", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			ctx.Err()
 		}
 	})
 	b.Run("Done", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			select {
 			case <-ctx.Done():
 			default:
@@ -161,7 +161,7 @@ func BenchmarkDeepValueNewGoRoutine(b *testing.B) {
 		}
 
 		b.Run(fmt.Sprintf("depth=%d", depth), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				var wg sync.WaitGroup
 				wg.Add(1)
 				go func() {
@@ -182,7 +182,7 @@ func BenchmarkDeepValueSameGoRoutine(b *testing.B) {
 		}
 
 		b.Run(fmt.Sprintf("depth=%d", depth), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				ctx.Value(-1)
 			}
 		})

--- a/src/crypto/aes/aes_test.go
+++ b/src/crypto/aes/aes_test.go
@@ -353,7 +353,7 @@ func BenchmarkEncrypt(b *testing.B) {
 	out := make([]byte, len(tt.in))
 	b.SetBytes(int64(len(out)))
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		c.Encrypt(out, tt.in)
 	}
 }
@@ -367,7 +367,7 @@ func BenchmarkDecrypt(b *testing.B) {
 	out := make([]byte, len(tt.out))
 	b.SetBytes(int64(len(out)))
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		c.Decrypt(out, tt.out)
 	}
 }
@@ -377,7 +377,7 @@ func BenchmarkExpand(b *testing.B) {
 	n := len(tt.key) + 28
 	c := &aesCipher{make([]uint32, n), make([]uint32, n)}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		expandKey(tt.key, c.enc, c.dec)
 	}
 }

--- a/src/crypto/cipher/benchmark_test.go
+++ b/src/crypto/cipher/benchmark_test.go
@@ -23,7 +23,7 @@ func benchmarkAESGCMSeal(b *testing.B, buf []byte, keySize int) {
 	var out []byte
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		out = aesgcm.Seal(out[:0], nonce[:], buf, ad[:])
 	}
 }
@@ -42,7 +42,7 @@ func benchmarkAESGCMOpen(b *testing.B, buf []byte, keySize int) {
 	ct := aesgcm.Seal(nil, nonce[:], buf[:], ad[:])
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		out, _ = aesgcm.Open(out[:0], nonce[:], ct, ad[:])
 	}
 }
@@ -74,7 +74,7 @@ func benchmarkAESStream(b *testing.B, mode func(cipher.Block, []byte) cipher.Str
 	stream := mode(aes, iv[:])
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		stream.XORKeyStream(buf, buf)
 	}
 }
@@ -118,7 +118,7 @@ func BenchmarkAESCBCEncrypt1K(b *testing.B) {
 	var iv [16]byte
 	aes, _ := aes.NewCipher(key[:])
 	cbc := cipher.NewCBCEncrypter(aes, iv[:])
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		cbc.CryptBlocks(buf, buf)
 	}
 }
@@ -131,7 +131,7 @@ func BenchmarkAESCBCDecrypt1K(b *testing.B) {
 	var iv [16]byte
 	aes, _ := aes.NewCipher(key[:])
 	cbc := cipher.NewCBCDecrypter(aes, iv[:])
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		cbc.CryptBlocks(buf, buf)
 	}
 }

--- a/src/crypto/des/des_test.go
+++ b/src/crypto/des/des_test.go
@@ -1515,7 +1515,7 @@ func BenchmarkEncrypt(b *testing.B) {
 	out := make([]byte, len(tt.in))
 	b.SetBytes(int64(len(out)))
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		c.Encrypt(out, tt.in)
 	}
 }
@@ -1529,7 +1529,7 @@ func BenchmarkDecrypt(b *testing.B) {
 	out := make([]byte, len(tt.out))
 	b.SetBytes(int64(len(out)))
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		c.Decrypt(out, tt.out)
 	}
 }
@@ -1543,7 +1543,7 @@ func BenchmarkTDESEncrypt(b *testing.B) {
 	out := make([]byte, len(tt.in))
 	b.SetBytes(int64(len(out)))
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		c.Encrypt(out, tt.in)
 	}
 }
@@ -1557,7 +1557,7 @@ func BenchmarkTDESDecrypt(b *testing.B) {
 	out := make([]byte, len(tt.out))
 	b.SetBytes(int64(len(out)))
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		c.Decrypt(out, tt.out)
 	}
 }

--- a/src/crypto/ecdh/ecdh_test.go
+++ b/src/crypto/ecdh/ecdh_test.go
@@ -382,7 +382,7 @@ func BenchmarkECDH(b *testing.B) {
 
 		var allocationsSink byte
 
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			key, err := curve.GenerateKey(rand)
 			if err != nil {
 				b.Fatal(err)

--- a/src/crypto/ecdsa/ecdsa_test.go
+++ b/src/crypto/ecdsa/ecdsa_test.go
@@ -541,7 +541,7 @@ func BenchmarkSign(b *testing.B) {
 
 		b.ReportAllocs()
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			sig, err := SignASN1(r, priv, hashed)
 			if err != nil {
 				b.Fatal(err)
@@ -567,7 +567,7 @@ func BenchmarkVerify(b *testing.B) {
 
 		b.ReportAllocs()
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			if !VerifyASN1(&priv.PublicKey, hashed, sig) {
 				b.Fatal("verify failed")
 			}
@@ -580,7 +580,7 @@ func BenchmarkGenerateKey(b *testing.B) {
 		r := bufio.NewReaderSize(rand.Reader, 1<<15)
 		b.ReportAllocs()
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			if _, err := GenerateKey(curve, r); err != nil {
 				b.Fatal(err)
 			}

--- a/src/crypto/ed25519/ed25519_test.go
+++ b/src/crypto/ed25519/ed25519_test.go
@@ -342,7 +342,7 @@ func TestAllocations(t *testing.T) {
 
 func BenchmarkKeyGeneration(b *testing.B) {
 	var zero zeroReader
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if _, _, err := GenerateKey(zero); err != nil {
 			b.Fatal(err)
 		}
@@ -351,7 +351,7 @@ func BenchmarkKeyGeneration(b *testing.B) {
 
 func BenchmarkNewKeyFromSeed(b *testing.B) {
 	seed := make([]byte, SeedSize)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = NewKeyFromSeed(seed)
 	}
 }
@@ -364,7 +364,7 @@ func BenchmarkSigning(b *testing.B) {
 	}
 	message := []byte("Hello, world!")
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Sign(priv, message)
 	}
 }
@@ -378,7 +378,7 @@ func BenchmarkVerification(b *testing.B) {
 	message := []byte("Hello, world!")
 	signature := Sign(priv, message)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Verify(pub, message, signature)
 	}
 }

--- a/src/crypto/elliptic/elliptic_test.go
+++ b/src/crypto/elliptic/elliptic_test.go
@@ -366,7 +366,7 @@ func BenchmarkScalarBaseMult(b *testing.B) {
 		priv, _, _, _ := GenerateKey(curve, rand.Reader)
 		b.ReportAllocs()
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x, _ := curve.ScalarBaseMult(priv)
 			// Prevent the compiler from optimizing out the operation.
 			priv[0] ^= byte(x.Bits()[0])
@@ -380,7 +380,7 @@ func BenchmarkScalarMult(b *testing.B) {
 		priv, _, _, _ := GenerateKey(curve, rand.Reader)
 		b.ReportAllocs()
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x, y = curve.ScalarMult(x, y, priv)
 		}
 	})
@@ -391,7 +391,7 @@ func BenchmarkMarshalUnmarshal(b *testing.B) {
 		_, x, y, _ := GenerateKey(curve, rand.Reader)
 		b.Run("Uncompressed", func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				buf := Marshal(curve, x, y)
 				xx, yy := Unmarshal(curve, buf)
 				if xx.Cmp(x) != 0 || yy.Cmp(y) != 0 {
@@ -401,7 +401,7 @@ func BenchmarkMarshalUnmarshal(b *testing.B) {
 		})
 		b.Run("Compressed", func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				buf := MarshalCompressed(curve, x, y)
 				xx, yy := UnmarshalCompressed(curve, buf)
 				if xx.Cmp(x) != 0 || yy.Cmp(y) != 0 {

--- a/src/crypto/hmac/hmac_test.go
+++ b/src/crypto/hmac/hmac_test.go
@@ -662,7 +662,7 @@ func BenchmarkHMACSHA256_1K(b *testing.B) {
 	buf := make([]byte, 1024)
 	h := New(sha256.New, key)
 	b.SetBytes(int64(len(buf)))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		h.Write(buf)
 		mac := h.Sum(nil)
 		h.Reset()
@@ -675,7 +675,7 @@ func BenchmarkHMACSHA256_32(b *testing.B) {
 	buf := make([]byte, 32)
 	h := New(sha256.New, key)
 	b.SetBytes(int64(len(buf)))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		h.Write(buf)
 		mac := h.Sum(nil)
 		h.Reset()
@@ -686,7 +686,7 @@ func BenchmarkHMACSHA256_32(b *testing.B) {
 func BenchmarkNewWriteSum(b *testing.B) {
 	buf := make([]byte, 32)
 	b.SetBytes(int64(len(buf)))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		h := New(sha256.New, make([]byte, 32))
 		h.Write(buf)
 		mac := h.Sum(nil)

--- a/src/crypto/internal/bigmod/nat_test.go
+++ b/src/crypto/internal/bigmod/nat_test.go
@@ -389,7 +389,7 @@ func BenchmarkModAdd(b *testing.B) {
 	m := makeBenchmarkModulus()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x.Add(y, m)
 	}
 }
@@ -400,7 +400,7 @@ func BenchmarkModSub(b *testing.B) {
 	m := makeBenchmarkModulus()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x.Sub(y, m)
 	}
 }
@@ -410,7 +410,7 @@ func BenchmarkMontgomeryRepr(b *testing.B) {
 	m := makeBenchmarkModulus()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x.montgomeryRepresentation(m)
 	}
 }
@@ -422,7 +422,7 @@ func BenchmarkMontgomeryMul(b *testing.B) {
 	m := makeBenchmarkModulus()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		out.montgomeryMul(x, y, m)
 	}
 }
@@ -433,7 +433,7 @@ func BenchmarkModMul(b *testing.B) {
 	m := makeBenchmarkModulus()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x.Mul(y, m)
 	}
 }
@@ -448,7 +448,7 @@ func BenchmarkExpBig(b *testing.B) {
 	n.Add(n, one)
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		out.Exp(x, e, n)
 	}
 }
@@ -460,7 +460,7 @@ func BenchmarkExp(b *testing.B) {
 	m := makeBenchmarkModulus()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		out.Exp(x, e, m)
 	}
 }

--- a/src/crypto/internal/edwards25519/edwards25519_test.go
+++ b/src/crypto/internal/edwards25519/edwards25519_test.go
@@ -303,7 +303,7 @@ func decodeHex(s string) []byte {
 
 func BenchmarkEncodingDecoding(b *testing.B) {
 	p := new(Point).Set(dalekScalarBasepoint)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf := p.Bytes()
 		_, err := p.SetBytes(buf)
 		if err != nil {

--- a/src/crypto/internal/edwards25519/field/fe_bench_test.go
+++ b/src/crypto/internal/edwards25519/field/fe_bench_test.go
@@ -10,7 +10,7 @@ func BenchmarkAdd(b *testing.B) {
 	x := new(Element).One()
 	y := new(Element).Add(x, x)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x.Add(x, y)
 	}
 }
@@ -19,7 +19,7 @@ func BenchmarkMultiply(b *testing.B) {
 	x := new(Element).One()
 	y := new(Element).Add(x, x)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x.Multiply(x, y)
 	}
 }
@@ -27,7 +27,7 @@ func BenchmarkMultiply(b *testing.B) {
 func BenchmarkSquare(b *testing.B) {
 	x := new(Element).Add(feOne, feOne)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x.Square(x)
 	}
 }
@@ -35,7 +35,7 @@ func BenchmarkSquare(b *testing.B) {
 func BenchmarkInvert(b *testing.B) {
 	x := new(Element).Add(feOne, feOne)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x.Invert(x)
 	}
 }
@@ -43,7 +43,7 @@ func BenchmarkInvert(b *testing.B) {
 func BenchmarkMult32(b *testing.B) {
 	x := new(Element).One()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x.Mult32(x, 0xaa42aa42)
 	}
 }

--- a/src/crypto/internal/edwards25519/scalarmult_test.go
+++ b/src/crypto/internal/edwards25519/scalarmult_test.go
@@ -183,7 +183,7 @@ func TestVarTimeDoubleBaseMultMatchesBaseMult(t *testing.T) {
 func BenchmarkScalarBaseMult(b *testing.B) {
 	var p Point
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		p.ScalarBaseMult(dalekScalar)
 	}
 }
@@ -191,7 +191,7 @@ func BenchmarkScalarBaseMult(b *testing.B) {
 func BenchmarkScalarMult(b *testing.B) {
 	var p Point
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		p.ScalarMult(dalekScalar, B)
 	}
 }
@@ -199,7 +199,7 @@ func BenchmarkScalarMult(b *testing.B) {
 func BenchmarkVarTimeDoubleScalarBaseMult(b *testing.B) {
 	var p Point
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		p.VarTimeDoubleScalarBaseMult(dalekScalar, B, dalekScalar)
 	}
 }

--- a/src/crypto/internal/nistec/fiat/fiat_test.go
+++ b/src/crypto/internal/nistec/fiat/fiat_test.go
@@ -14,7 +14,7 @@ func BenchmarkMul(b *testing.B) {
 		v := new(fiat.P224Element).One()
 		b.ReportAllocs()
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			v.Mul(v, v)
 		}
 	})
@@ -22,7 +22,7 @@ func BenchmarkMul(b *testing.B) {
 		v := new(fiat.P384Element).One()
 		b.ReportAllocs()
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			v.Mul(v, v)
 		}
 	})
@@ -30,7 +30,7 @@ func BenchmarkMul(b *testing.B) {
 		v := new(fiat.P521Element).One()
 		b.ReportAllocs()
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			v.Mul(v, v)
 		}
 	})
@@ -41,7 +41,7 @@ func BenchmarkSquare(b *testing.B) {
 		v := new(fiat.P224Element).One()
 		b.ReportAllocs()
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			v.Square(v)
 		}
 	})
@@ -49,7 +49,7 @@ func BenchmarkSquare(b *testing.B) {
 		v := new(fiat.P384Element).One()
 		b.ReportAllocs()
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			v.Square(v)
 		}
 	})
@@ -57,7 +57,7 @@ func BenchmarkSquare(b *testing.B) {
 		v := new(fiat.P521Element).One()
 		b.ReportAllocs()
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			v.Square(v)
 		}
 	})

--- a/src/crypto/internal/nistec/nistec_test.go
+++ b/src/crypto/internal/nistec/nistec_test.go
@@ -280,7 +280,7 @@ func benchmarkScalarMult[P nistPoint[P]](b *testing.B, p P, scalarSize int) {
 	rand.Read(scalar)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		p.ScalarMult(p, scalar)
 	}
 }
@@ -305,7 +305,7 @@ func benchmarkScalarBaseMult[P nistPoint[P]](b *testing.B, p P, scalarSize int) 
 	rand.Read(scalar)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		p.ScalarBaseMult(scalar)
 	}
 }

--- a/src/crypto/md5/md5_test.go
+++ b/src/crypto/md5/md5_test.go
@@ -238,7 +238,7 @@ func benchmarkSize(b *testing.B, size int, unaligned bool) {
 		}
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		bench.Reset()
 		bench.Write(buf[:size])
 		bench.Sum(sum[:0])

--- a/src/crypto/rand/util_test.go
+++ b/src/crypto/rand/util_test.go
@@ -143,7 +143,7 @@ func TestIntNegativeMaxPanics(t *testing.T) {
 
 func BenchmarkPrime(b *testing.B) {
 	r := mathrand.New(mathrand.NewSource(time.Now().UnixNano()))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		rand.Prime(r, 1024)
 	}
 }

--- a/src/crypto/rc4/rc4_test.go
+++ b/src/crypto/rc4/rc4_test.go
@@ -144,7 +144,7 @@ func benchmark(b *testing.B, size int64) {
 	}
 	b.SetBytes(size)
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		c.XORKeyStream(buf, buf)
 	}
 }

--- a/src/crypto/rsa/boring_test.go
+++ b/src/crypto/rsa/boring_test.go
@@ -70,7 +70,7 @@ func BenchmarkBoringVerify(b *testing.B) {
 
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		err := VerifyPKCS1v15(key, crypto.SHA1, hash, sig)
 		if err == nil {
 			b.Fatalf("sha1: expected verification error")

--- a/src/crypto/rsa/rsa_test.go
+++ b/src/crypto/rsa/rsa_test.go
@@ -474,7 +474,7 @@ func benchmarkDecryptPKCS1v15(b *testing.B, k *PrivateKey) {
 
 	b.ResetTimer()
 	var sink byte
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		p, err := DecryptPKCS1v15(r, k, c)
 		if err != nil {
 			b.Fatal(err)
@@ -492,7 +492,7 @@ func BenchmarkEncryptPKCS1v15(b *testing.B) {
 		m := []byte("Hello Gophers")
 
 		var sink byte
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			c, err := EncryptPKCS1v15(r, &test2048Key.PublicKey, m)
 			if err != nil {
 				b.Fatal(err)
@@ -514,7 +514,7 @@ func BenchmarkDecryptOAEP(b *testing.B) {
 
 		b.ResetTimer()
 		var sink byte
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			p, err := DecryptOAEP(sha256.New(), r, test2048Key, c, nil)
 			if err != nil {
 				b.Fatal(err)
@@ -533,7 +533,7 @@ func BenchmarkEncryptOAEP(b *testing.B) {
 		m := []byte("Hello Gophers")
 
 		var sink byte
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			c, err := EncryptOAEP(sha256.New(), r, &test2048Key.PublicKey, m, nil)
 			if err != nil {
 				b.Fatal(err)
@@ -549,7 +549,7 @@ func BenchmarkSignPKCS1v15(b *testing.B) {
 
 		var sink byte
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			s, err := SignPKCS1v15(rand.Reader, test2048Key, crypto.SHA256, hashed[:])
 			if err != nil {
 				b.Fatal(err)
@@ -568,7 +568,7 @@ func BenchmarkVerifyPKCS1v15(b *testing.B) {
 		}
 
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			err := VerifyPKCS1v15(&test2048Key.PublicKey, crypto.SHA256, hashed[:], s)
 			if err != nil {
 				b.Fatal(err)
@@ -583,7 +583,7 @@ func BenchmarkSignPSS(b *testing.B) {
 
 		var sink byte
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			s, err := SignPSS(rand.Reader, test2048Key, crypto.SHA256, hashed[:], nil)
 			if err != nil {
 				b.Fatal(err)
@@ -602,7 +602,7 @@ func BenchmarkVerifyPSS(b *testing.B) {
 		}
 
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			err := VerifyPSS(&test2048Key.PublicKey, crypto.SHA256, hashed[:], s, nil)
 			if err != nil {
 				b.Fatal(err)

--- a/src/crypto/sha1/sha1_test.go
+++ b/src/crypto/sha1/sha1_test.go
@@ -242,7 +242,7 @@ func benchmarkSize(b *testing.B, size int) {
 	b.Run("New", func(b *testing.B) {
 		b.ReportAllocs()
 		b.SetBytes(int64(size))
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			bench.Reset()
 			bench.Write(buf[:size])
 			bench.Sum(sum[:0])
@@ -251,7 +251,7 @@ func benchmarkSize(b *testing.B, size int) {
 	b.Run("Sum", func(b *testing.B) {
 		b.ReportAllocs()
 		b.SetBytes(int64(size))
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			Sum(buf[:size])
 		}
 	})

--- a/src/crypto/sha256/sha256_test.go
+++ b/src/crypto/sha256/sha256_test.go
@@ -333,7 +333,7 @@ func benchmarkSize(b *testing.B, size int) {
 	b.Run("New", func(b *testing.B) {
 		b.ReportAllocs()
 		b.SetBytes(int64(size))
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			bench.Reset()
 			bench.Write(buf[:size])
 			bench.Sum(sum[:0])
@@ -342,14 +342,14 @@ func benchmarkSize(b *testing.B, size int) {
 	b.Run("Sum224", func(b *testing.B) {
 		b.ReportAllocs()
 		b.SetBytes(int64(size))
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			Sum224(buf[:size])
 		}
 	})
 	b.Run("Sum256", func(b *testing.B) {
 		b.ReportAllocs()
 		b.SetBytes(int64(size))
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			Sum256(buf[:size])
 		}
 	})

--- a/src/crypto/sha512/sha512_test.go
+++ b/src/crypto/sha512/sha512_test.go
@@ -917,7 +917,7 @@ func benchmarkSize(b *testing.B, size int) {
 	b.Run("New", func(b *testing.B) {
 		b.ReportAllocs()
 		b.SetBytes(int64(size))
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			bench.Reset()
 			bench.Write(buf[:size])
 			bench.Sum(sum[:0])
@@ -926,14 +926,14 @@ func benchmarkSize(b *testing.B, size int) {
 	b.Run("Sum384", func(b *testing.B) {
 		b.ReportAllocs()
 		b.SetBytes(int64(size))
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			Sum384(buf[:size])
 		}
 	})
 	b.Run("Sum512", func(b *testing.B) {
 		b.ReportAllocs()
 		b.SetBytes(int64(size))
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			Sum512(buf[:size])
 		}
 	})

--- a/src/crypto/subtle/constant_time_test.go
+++ b/src/crypto/subtle/constant_time_test.go
@@ -131,7 +131,7 @@ var benchmarkGlobal uint8
 func BenchmarkConstantTimeByteEq(b *testing.B) {
 	var x, y uint8
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x, y = uint8(ConstantTimeByteEq(x, y)), x
 	}
 
@@ -141,7 +141,7 @@ func BenchmarkConstantTimeByteEq(b *testing.B) {
 func BenchmarkConstantTimeEq(b *testing.B) {
 	var x, y int
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x, y = ConstantTimeEq(int32(x), int32(y)), x
 	}
 
@@ -151,7 +151,7 @@ func BenchmarkConstantTimeEq(b *testing.B) {
 func BenchmarkConstantTimeLessOrEq(b *testing.B) {
 	var x, y int
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x, y = ConstantTimeLessOrEq(x, y), x
 	}
 

--- a/src/crypto/subtle/xor_test.go
+++ b/src/crypto/subtle/xor_test.go
@@ -81,7 +81,7 @@ func BenchmarkXORBytes(b *testing.B) {
 			s0 := data0[:size]
 			s1 := data1[:size]
 			b.SetBytes(int64(size))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				XORBytes(dst, s0, s1)
 			}
 		})

--- a/src/crypto/tls/cache_test.go
+++ b/src/crypto/tls/cache_test.go
@@ -95,7 +95,7 @@ func BenchmarkCertCache(b *testing.B) {
 		b.Run(fmt.Sprint(extra), func(b *testing.B) {
 			actives := make([]*activeCert, extra+1)
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				var err error
 				actives[0], err = cc.newCert(p.Bytes)
 				if err != nil {

--- a/src/crypto/tls/handshake_server_test.go
+++ b/src/crypto/tls/handshake_server_test.go
@@ -1293,7 +1293,7 @@ func benchmarkHandshakeServer(b *testing.B, version uint16, cipherSuite uint16, 
 	}()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		feeder <- struct{}{}
 		server := Server(serverConn, config)
 		if err := server.Handshake(); err != nil {

--- a/src/crypto/x509/x509_test.go
+++ b/src/crypto/x509/x509_test.go
@@ -3109,7 +3109,7 @@ func BenchmarkCreateCertificate(b *testing.B) {
 		k := tc.gen()
 		b.ResetTimer()
 		b.Run(tc.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_, err := CreateCertificate(rand.Reader, template, template, k.Public(), k)
 				if err != nil {
 					b.Fatalf("failed to create certificate: %s", err)
@@ -3361,7 +3361,7 @@ Qc4=
 			pemBlock, _ := pem.Decode([]byte(c.pem))
 			b.ReportAllocs()
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_, err := ParseCertificate(pemBlock.Bytes)
 				if err != nil {
 					b.Fatal(err)

--- a/src/database/sql/sql_test.go
+++ b/src/database/sql/sql_test.go
@@ -4643,7 +4643,7 @@ func TestTypedString(t *testing.T) {
 func BenchmarkConcurrentDBExec(b *testing.B) {
 	b.ReportAllocs()
 	ct := new(concurrentDBExecTest)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		doConcurrentTest(b, ct)
 	}
 }
@@ -4651,7 +4651,7 @@ func BenchmarkConcurrentDBExec(b *testing.B) {
 func BenchmarkConcurrentStmtQuery(b *testing.B) {
 	b.ReportAllocs()
 	ct := new(concurrentStmtQueryTest)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		doConcurrentTest(b, ct)
 	}
 }
@@ -4659,7 +4659,7 @@ func BenchmarkConcurrentStmtQuery(b *testing.B) {
 func BenchmarkConcurrentStmtExec(b *testing.B) {
 	b.ReportAllocs()
 	ct := new(concurrentStmtExecTest)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		doConcurrentTest(b, ct)
 	}
 }
@@ -4667,7 +4667,7 @@ func BenchmarkConcurrentStmtExec(b *testing.B) {
 func BenchmarkConcurrentTxQuery(b *testing.B) {
 	b.ReportAllocs()
 	ct := new(concurrentTxQueryTest)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		doConcurrentTest(b, ct)
 	}
 }
@@ -4675,7 +4675,7 @@ func BenchmarkConcurrentTxQuery(b *testing.B) {
 func BenchmarkConcurrentTxExec(b *testing.B) {
 	b.ReportAllocs()
 	ct := new(concurrentTxExecTest)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		doConcurrentTest(b, ct)
 	}
 }
@@ -4683,7 +4683,7 @@ func BenchmarkConcurrentTxExec(b *testing.B) {
 func BenchmarkConcurrentTxStmtQuery(b *testing.B) {
 	b.ReportAllocs()
 	ct := new(concurrentTxStmtQueryTest)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		doConcurrentTest(b, ct)
 	}
 }
@@ -4691,7 +4691,7 @@ func BenchmarkConcurrentTxStmtQuery(b *testing.B) {
 func BenchmarkConcurrentTxStmtExec(b *testing.B) {
 	b.ReportAllocs()
 	ct := new(concurrentTxStmtExecTest)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		doConcurrentTest(b, ct)
 	}
 }
@@ -4699,7 +4699,7 @@ func BenchmarkConcurrentTxStmtExec(b *testing.B) {
 func BenchmarkConcurrentRandom(b *testing.B) {
 	b.ReportAllocs()
 	ct := new(concurrentRandomTest)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		doConcurrentTest(b, ct)
 	}
 }
@@ -4755,7 +4755,7 @@ func BenchmarkGrabConn(b *testing.B) {
 	b.ReportAllocs()
 	c := new(Conn)
 	ctx := context.Background()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, release, err := c.grabConn(ctx)
 		if err != nil {
 			b.Fatal(err)

--- a/src/debug/elf/file_test.go
+++ b/src/debug/elf/file_test.go
@@ -1548,7 +1548,7 @@ func BenchmarkSymbols64(b *testing.B) {
 	}
 	defer f.Close()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		symbols, err := f.Symbols()
 		if err != nil {
 			b.Fatalf("Symbols(): got unexpected error %v", err)
@@ -1567,7 +1567,7 @@ func BenchmarkSymbols32(b *testing.B) {
 	}
 	defer f.Close()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		symbols, err := f.Symbols()
 		if err != nil {
 			b.Fatalf("Symbols(): got unexpected error %v", err)

--- a/src/debug/gosym/pclntab_test.go
+++ b/src/debug/gosym/pclntab_test.go
@@ -346,7 +346,7 @@ func Benchmark115(b *testing.B) {
 
 	b.Run("NewLineTable", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			sinkLineTable = NewLineTable(dat, textStart)
 		}
 	})
@@ -354,7 +354,7 @@ func Benchmark115(b *testing.B) {
 	pcln := NewLineTable(dat, textStart)
 	b.Run("NewTable", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			var err error
 			sinkTable, err = NewTable(nil, pcln)
 			if err != nil {
@@ -370,7 +370,7 @@ func Benchmark115(b *testing.B) {
 
 	b.Run("LineToPC", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			var f *Func
 			var pc uint64
 			pc, f, err = tab.LineToPC("/tmp/hello.go", 3)
@@ -391,7 +391,7 @@ func Benchmark115(b *testing.B) {
 
 	b.Run("PCToLine", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			file, line, fn := tab.PCToLine(0x105c280)
 			if file != "/tmp/hello.go" {
 				b.Fatalf("want name=/tmp/hello.go, got %q", file)

--- a/src/encoding/asn1/asn1_test.go
+++ b/src/encoding/asn1/asn1_test.go
@@ -1171,7 +1171,7 @@ func TestNonMinimalEncodedOID(t *testing.T) {
 
 func BenchmarkObjectIdentifierString(b *testing.B) {
 	oidPublicKeyRSA := ObjectIdentifier{1, 2, 840, 113549, 1, 1, 1}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = oidPublicKeyRSA.String()
 	}
 }

--- a/src/encoding/asn1/marshal_test.go
+++ b/src/encoding/asn1/marshal_test.go
@@ -313,7 +313,7 @@ func TestIssue11130(t *testing.T) {
 func BenchmarkMarshal(b *testing.B) {
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, test := range marshalTests {
 			Marshal(test.in)
 		}
@@ -398,7 +398,7 @@ func BenchmarkUnmarshal(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, testCase := range testData {
 			_, _ = Unmarshal(testCase.in, testCase.out)
 		}

--- a/src/encoding/base32/base32_test.go
+++ b/src/encoding/base32/base32_test.go
@@ -461,7 +461,7 @@ func BenchmarkEncode(b *testing.B) {
 	data := make([]byte, 8192)
 	buf := make([]byte, StdEncoding.EncodedLen(len(data)))
 	b.SetBytes(int64(len(data)))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		StdEncoding.Encode(buf, data)
 	}
 }
@@ -469,7 +469,7 @@ func BenchmarkEncode(b *testing.B) {
 func BenchmarkEncodeToString(b *testing.B) {
 	data := make([]byte, 8192)
 	b.SetBytes(int64(len(data)))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		StdEncoding.EncodeToString(data)
 	}
 }
@@ -479,14 +479,14 @@ func BenchmarkDecode(b *testing.B) {
 	StdEncoding.Encode(data, make([]byte, 8192))
 	buf := make([]byte, 8192)
 	b.SetBytes(int64(len(data)))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		StdEncoding.Decode(buf, data)
 	}
 }
 func BenchmarkDecodeString(b *testing.B) {
 	data := StdEncoding.EncodeToString(make([]byte, 8192))
 	b.SetBytes(int64(len(data)))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		StdEncoding.DecodeString(data)
 	}
 }

--- a/src/encoding/base64/base64_test.go
+++ b/src/encoding/base64/base64_test.go
@@ -520,7 +520,7 @@ func TestDecoderIssue15656(t *testing.T) {
 func BenchmarkEncodeToString(b *testing.B) {
 	data := make([]byte, 8192)
 	b.SetBytes(int64(len(data)))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		StdEncoding.EncodeToString(data)
 	}
 }
@@ -531,7 +531,7 @@ func BenchmarkDecodeString(b *testing.B) {
 		data := StdEncoding.EncodeToString(make([]byte, benchSize))
 		b.SetBytes(int64(len(data)))
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			StdEncoding.DecodeString(data)
 		}
 	}
@@ -544,7 +544,7 @@ func BenchmarkDecodeString(b *testing.B) {
 
 func BenchmarkNewEncoding(b *testing.B) {
 	b.SetBytes(int64(len(Encoding{}.decodeMap)))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		e := NewEncoding(encodeStd)
 		for _, v := range e.decodeMap {
 			_ = v

--- a/src/encoding/binary/binary_test.go
+++ b/src/encoding/binary/binary_test.go
@@ -600,7 +600,7 @@ func BenchmarkReadSlice1000Int32s(b *testing.B) {
 	buf := make([]byte, len(slice)*4)
 	b.SetBytes(int64(len(buf)))
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		bsr.remain = buf
 		Read(bsr, BigEndian, slice)
 	}
@@ -613,7 +613,7 @@ func BenchmarkReadStruct(b *testing.B) {
 	b.SetBytes(int64(dataSize(reflect.ValueOf(s))))
 	t := s
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		bsr.remain = buf.Bytes()
 		Read(bsr, BigEndian, &t)
 	}
@@ -626,7 +626,7 @@ func BenchmarkReadStruct(b *testing.B) {
 func BenchmarkWriteStruct(b *testing.B) {
 	b.SetBytes(int64(Size(&s)))
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Write(io.Discard, BigEndian, &s)
 	}
 }
@@ -637,7 +637,7 @@ func BenchmarkReadInts(b *testing.B) {
 	var r io.Reader = bsr
 	b.SetBytes(2 * (1 + 2 + 4 + 8))
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		bsr.remain = big
 		Read(r, BigEndian, &ls.Int8)
 		Read(r, BigEndian, &ls.Int16)
@@ -667,7 +667,7 @@ func BenchmarkWriteInts(b *testing.B) {
 	var w io.Writer = buf
 	b.SetBytes(2 * (1 + 2 + 4 + 8))
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf.Reset()
 		Write(w, BigEndian, s.Int8)
 		Write(w, BigEndian, s.Int16)
@@ -690,7 +690,7 @@ func BenchmarkWriteSlice1000Int32s(b *testing.B) {
 	var w io.Writer = buf
 	b.SetBytes(4 * 1000)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf.Reset()
 		Write(w, BigEndian, slice)
 	}
@@ -699,84 +699,84 @@ func BenchmarkWriteSlice1000Int32s(b *testing.B) {
 
 func BenchmarkPutUint16(b *testing.B) {
 	b.SetBytes(2)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		BigEndian.PutUint16(putbuf[:2], uint16(i))
 	}
 }
 
 func BenchmarkAppendUint16(b *testing.B) {
 	b.SetBytes(2)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		putbuf = BigEndian.AppendUint16(putbuf[:0], uint16(i))
 	}
 }
 
 func BenchmarkPutUint32(b *testing.B) {
 	b.SetBytes(4)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		BigEndian.PutUint32(putbuf[:4], uint32(i))
 	}
 }
 
 func BenchmarkAppendUint32(b *testing.B) {
 	b.SetBytes(4)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		putbuf = BigEndian.AppendUint32(putbuf[:0], uint32(i))
 	}
 }
 
 func BenchmarkPutUint64(b *testing.B) {
 	b.SetBytes(8)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		BigEndian.PutUint64(putbuf[:8], uint64(i))
 	}
 }
 
 func BenchmarkAppendUint64(b *testing.B) {
 	b.SetBytes(8)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		putbuf = BigEndian.AppendUint64(putbuf[:0], uint64(i))
 	}
 }
 
 func BenchmarkLittleEndianPutUint16(b *testing.B) {
 	b.SetBytes(2)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		LittleEndian.PutUint16(putbuf[:2], uint16(i))
 	}
 }
 
 func BenchmarkLittleEndianAppendUint16(b *testing.B) {
 	b.SetBytes(2)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		putbuf = LittleEndian.AppendUint16(putbuf[:0], uint16(i))
 	}
 }
 
 func BenchmarkLittleEndianPutUint32(b *testing.B) {
 	b.SetBytes(4)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		LittleEndian.PutUint32(putbuf[:4], uint32(i))
 	}
 }
 
 func BenchmarkLittleEndianAppendUint32(b *testing.B) {
 	b.SetBytes(4)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		putbuf = LittleEndian.AppendUint32(putbuf[:0], uint32(i))
 	}
 }
 
 func BenchmarkLittleEndianPutUint64(b *testing.B) {
 	b.SetBytes(8)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		LittleEndian.PutUint64(putbuf[:8], uint64(i))
 	}
 }
 
 func BenchmarkLittleEndianAppendUint64(b *testing.B) {
 	b.SetBytes(8)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		putbuf = LittleEndian.AppendUint64(putbuf[:0], uint64(i))
 	}
 }
@@ -787,7 +787,7 @@ func BenchmarkReadFloats(b *testing.B) {
 	var r io.Reader = bsr
 	b.SetBytes(4 + 8)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		bsr.remain = big[30:]
 		Read(r, BigEndian, &ls.Float32)
 		Read(r, BigEndian, &ls.Float64)
@@ -817,7 +817,7 @@ func BenchmarkWriteFloats(b *testing.B) {
 	var w io.Writer = buf
 	b.SetBytes(4 + 8)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf.Reset()
 		Write(w, BigEndian, s.Float32)
 		Write(w, BigEndian, s.Float64)
@@ -834,7 +834,7 @@ func BenchmarkReadSlice1000Float32s(b *testing.B) {
 	buf := make([]byte, len(slice)*4)
 	b.SetBytes(int64(len(buf)))
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		bsr.remain = buf
 		Read(bsr, BigEndian, slice)
 	}
@@ -846,7 +846,7 @@ func BenchmarkWriteSlice1000Float32s(b *testing.B) {
 	var w io.Writer = buf
 	b.SetBytes(4 * 1000)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf.Reset()
 		Write(w, BigEndian, slice)
 	}
@@ -859,7 +859,7 @@ func BenchmarkReadSlice1000Uint8s(b *testing.B) {
 	buf := make([]byte, len(slice))
 	b.SetBytes(int64(len(buf)))
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		bsr.remain = buf
 		Read(bsr, BigEndian, slice)
 	}
@@ -871,7 +871,7 @@ func BenchmarkWriteSlice1000Uint8s(b *testing.B) {
 	var w io.Writer = buf
 	b.SetBytes(1000)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf.Reset()
 		Write(w, BigEndian, slice)
 	}

--- a/src/encoding/binary/varint_test.go
+++ b/src/encoding/binary/varint_test.go
@@ -229,7 +229,7 @@ func TestNonCanonicalZero(t *testing.T) {
 func BenchmarkPutUvarint32(b *testing.B) {
 	buf := make([]byte, MaxVarintLen32)
 	b.SetBytes(4)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for j := uint(0); j < MaxVarintLen32; j++ {
 			PutUvarint(buf, 1<<(j*7))
 		}
@@ -239,7 +239,7 @@ func BenchmarkPutUvarint32(b *testing.B) {
 func BenchmarkPutUvarint64(b *testing.B) {
 	buf := make([]byte, MaxVarintLen64)
 	b.SetBytes(8)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for j := uint(0); j < MaxVarintLen64; j++ {
 			PutUvarint(buf, 1<<(j*7))
 		}

--- a/src/encoding/csv/writer_test.go
+++ b/src/encoding/csv/writer_test.go
@@ -102,7 +102,7 @@ var benchmarkWriteData = [][]string{
 }
 
 func BenchmarkWrite(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		w := NewWriter(&bytes.Buffer{})
 		err := w.WriteAll(benchmarkWriteData)
 		if err != nil {

--- a/src/encoding/gob/timing_test.go
+++ b/src/encoding/gob/timing_test.go
@@ -320,7 +320,7 @@ func BenchmarkDecodeMap(b *testing.B) {
 	bbuf := benchmarkBuf{data: buf.Bytes()}
 	b.ResetTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		var rm map[int]int
 		bbuf.reset()
 		dec := NewDecoder(&bbuf)

--- a/src/encoding/hex/hex_test.go
+++ b/src/encoding/hex/hex_test.go
@@ -254,7 +254,7 @@ func BenchmarkEncode(b *testing.B) {
 
 		b.Run(fmt.Sprintf("%v", size), func(b *testing.B) {
 			b.SetBytes(int64(size))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				Encode(sink, src)
 			}
 		})
@@ -268,7 +268,7 @@ func BenchmarkDecode(b *testing.B) {
 
 		b.Run(fmt.Sprintf("%v", size), func(b *testing.B) {
 			b.SetBytes(int64(size))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				Decode(sink, src)
 			}
 		})
@@ -281,7 +281,7 @@ func BenchmarkDump(b *testing.B) {
 
 		b.Run(fmt.Sprintf("%v", size), func(b *testing.B) {
 			b.SetBytes(int64(size))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				Dump(src)
 			}
 		})

--- a/src/encoding/json/bench_test.go
+++ b/src/encoding/json/bench_test.go
@@ -186,7 +186,7 @@ func benchMarshalBytes(n int) func(*testing.B) {
 		bytes.Repeat(sample, (n/len(sample))+1)[:n],
 	}
 	return func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			if _, err := Marshal(v); err != nil {
 				b.Fatalf("Marshal error: %v", err)
 			}
@@ -213,7 +213,7 @@ func benchMarshalBytesError(n int) func(*testing.B) {
 	dummy.Next = &dummy
 
 	return func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			if _, err := Marshal(v); err != nil {
 				b.Fatalf("Marshal error: %v", err)
 			}
@@ -295,7 +295,7 @@ func BenchmarkUnicodeDecoder(b *testing.B) {
 	dec := NewDecoder(r)
 	var out string
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if err := dec.Decode(&out); err != nil {
 			b.Fatalf("Decode error: %v", err)
 		}
@@ -315,7 +315,7 @@ func BenchmarkDecoderStream(b *testing.B) {
 	}
 	ones := strings.Repeat(" 1\n", 300000) + "\n\n\n"
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		if i%300000 == 0 {
 			buf.WriteString(ones)
 		}
@@ -488,7 +488,7 @@ func BenchmarkTypeFieldsCache(b *testing.B) {
 		ts := types[:nt]
 		b.Run(fmt.Sprintf("MissTypes%d", nt), func(b *testing.B) {
 			nc := runtime.GOMAXPROCS(0)
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				clearCache()
 				var wg sync.WaitGroup
 				for j := 0; j < nc; j++ {
@@ -559,7 +559,7 @@ func BenchmarkEncoderEncode(b *testing.B) {
 
 func BenchmarkNumberIsValid(b *testing.B) {
 	s := "-61657.61667E+61673"
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		isValidNumber(s)
 	}
 }
@@ -567,7 +567,7 @@ func BenchmarkNumberIsValid(b *testing.B) {
 func BenchmarkNumberIsValidRegexp(b *testing.B) {
 	var jsonNumberRegexp = regexp.MustCompile(`^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$`)
 	s := "-61657.61667E+61673"
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		jsonNumberRegexp.MatchString(s)
 	}
 }

--- a/src/encoding/pem/pem_test.go
+++ b/src/encoding/pem/pem_test.go
@@ -296,7 +296,7 @@ func TestFuzz(t *testing.T) {
 func BenchmarkEncode(b *testing.B) {
 	data := &Block{Bytes: make([]byte, 65536)}
 	b.SetBytes(int64(len(data.Bytes)))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Encode(io.Discard, data)
 	}
 }
@@ -306,7 +306,7 @@ func BenchmarkDecode(b *testing.B) {
 	data := EncodeToMemory(block)
 	b.SetBytes(int64(len(data)))
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Decode(data)
 	}
 }

--- a/src/errors/wrap_test.go
+++ b/src/errors/wrap_test.go
@@ -242,7 +242,7 @@ func BenchmarkIs(b *testing.B) {
 	err1 := errors.New("1")
 	err2 := multiErr{multiErr{multiErr{err1, errorT{"a"}}, errorT{"b"}}}
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if !errors.Is(err2, err1) {
 			b.Fatal("Is failed")
 		}
@@ -251,7 +251,7 @@ func BenchmarkIs(b *testing.B) {
 
 func BenchmarkAs(b *testing.B) {
 	err := multiErr{multiErr{multiErr{errors.New("a"), errorT{"a"}}, errorT{"b"}}}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		var target errorT
 		if !errors.As(err, &target) {
 			b.Fatal("As failed")

--- a/src/expvar/expvar_test.go
+++ b/src/expvar/expvar_test.go
@@ -335,7 +335,7 @@ func BenchmarkMapSetDifferentRandom(b *testing.B) {
 	v := new(Int)
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m := new(Map).Init()
 		for _, k := range keys {
 			m.Set(k, v)
@@ -405,7 +405,7 @@ func BenchmarkMapAddDifferentRandom(b *testing.B) {
 
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m := new(Map).Init()
 		for _, k := range keys {
 			m.Add(k, 1)
@@ -504,7 +504,7 @@ func BenchmarkMapString(b *testing.B) {
 	b.ResetTimer()
 
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = m.String()
 	}
 }

--- a/src/fmt/fmt_test.go
+++ b/src/fmt/fmt_test.go
@@ -1396,7 +1396,7 @@ func BenchmarkManyArgs(b *testing.B) {
 
 func BenchmarkFprintInt(b *testing.B) {
 	var buf bytes.Buffer
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf.Reset()
 		Fprint(&buf, 123456)
 	}
@@ -1405,7 +1405,7 @@ func BenchmarkFprintInt(b *testing.B) {
 func BenchmarkFprintfBytes(b *testing.B) {
 	data := []byte(string("0123456789"))
 	var buf bytes.Buffer
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf.Reset()
 		Fprintf(&buf, "%s", data)
 	}
@@ -1414,7 +1414,7 @@ func BenchmarkFprintfBytes(b *testing.B) {
 func BenchmarkFprintIntNoAlloc(b *testing.B) {
 	var x any = 123456
 	var buf bytes.Buffer
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf.Reset()
 		Fprint(&buf, x)
 	}

--- a/src/fmt/scan_test.go
+++ b/src/fmt/scan_test.go
@@ -1099,7 +1099,7 @@ func BenchmarkScanInts(b *testing.B) {
 	b.StopTimer()
 	ints := makeInts(intCount)
 	var r RecursiveInt
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf := bytes.NewBuffer(ints)
 		b.StartTimer()
 		scanInts(&r, buf)
@@ -1111,7 +1111,7 @@ func BenchmarkScanRecursiveInt(b *testing.B) {
 	b.StopTimer()
 	ints := makeInts(intCount)
 	var r RecursiveInt
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf := bytes.NewBuffer(ints)
 		b.StartTimer()
 		Fscan(buf, &r)
@@ -1123,7 +1123,7 @@ func BenchmarkScanRecursiveIntReaderWrapper(b *testing.B) {
 	b.StopTimer()
 	ints := makeInts(intCount)
 	var r RecursiveInt
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf := struct{ io.Reader }{strings.NewReader(string(ints))}
 		b.StartTimer()
 		Fscan(buf, &r)

--- a/src/go/build/build_test.go
+++ b/src/go/build/build_test.go
@@ -581,7 +581,7 @@ func BenchmarkImportVendor(b *testing.B) {
 	ctxt.GOPATH = filepath.Join(wd, "testdata/withvendor")
 	dir := filepath.Join(ctxt.GOPATH, "src/a/b")
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, err := ctxt.Import("c/d", dir, 0)
 		if err != nil {
 			b.Fatalf("cannot find vendored c/d from testdata src/a/b directory: %v", err)

--- a/src/go/constant/value_test.go
+++ b/src/go/constant/value_test.go
@@ -692,7 +692,7 @@ func BenchmarkStringAdd(b *testing.B) {
 		b.Run(fmt.Sprint(size), func(b *testing.B) {
 			b.ReportAllocs()
 			n := int64(0)
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x := MakeString(strings.Repeat("x", 100))
 				y := x
 				for j := 0; j < size-1; j++ {

--- a/src/go/format/benchmark_test.go
+++ b/src/go/format/benchmark_test.go
@@ -77,7 +77,7 @@ func BenchmarkFormat(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			b.ReportAllocs()
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				var err error
 				sink, err = format.Source(data)
 				if err != nil {

--- a/src/go/parser/performance_test.go
+++ b/src/go/parser/performance_test.go
@@ -22,7 +22,7 @@ func readFile(filename string) []byte {
 
 func BenchmarkParse(b *testing.B) {
 	b.SetBytes(int64(len(src)))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if _, err := ParseFile(token.NewFileSet(), "", src, ParseComments); err != nil {
 			b.Fatalf("benchmark failed due to parse error: %s", err)
 		}
@@ -31,7 +31,7 @@ func BenchmarkParse(b *testing.B) {
 
 func BenchmarkParseOnly(b *testing.B) {
 	b.SetBytes(int64(len(src)))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if _, err := ParseFile(token.NewFileSet(), "", src, ParseComments|SkipObjectResolution); err != nil {
 			b.Fatalf("benchmark failed due to parse error: %s", err)
 		}
@@ -40,7 +40,7 @@ func BenchmarkParseOnly(b *testing.B) {
 
 func BenchmarkResolve(b *testing.B) {
 	b.SetBytes(int64(len(src)))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		b.StopTimer()
 		fset := token.NewFileSet()
 		file, err := ParseFile(fset, "", src, SkipObjectResolution)

--- a/src/go/printer/performance_test.go
+++ b/src/go/printer/performance_test.go
@@ -74,7 +74,7 @@ func BenchmarkPrintFile(b *testing.B) {
 	}
 	b.ReportAllocs()
 	b.SetBytes(fileSize)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		testprint(io.Discard, fileNode)
 	}
 }
@@ -85,7 +85,7 @@ func BenchmarkPrintDecl(b *testing.B) {
 	}
 	b.ReportAllocs()
 	b.SetBytes(declSize)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		testprint(io.Discard, declNode)
 	}
 }

--- a/src/go/scanner/scanner_test.go
+++ b/src/go/scanner/scanner_test.go
@@ -880,7 +880,7 @@ func BenchmarkScan(b *testing.B) {
 	file := fset.AddFile("", fset.Base(), len(source))
 	var s Scanner
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		s.Init(file, source, nil, ScanComments)
 		for {
 			_, tok, _ := s.Scan()
@@ -912,7 +912,7 @@ func BenchmarkScanFiles(b *testing.B) {
 			b.SetBytes(int64(len(src)))
 			var s Scanner
 			b.StartTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				s.Init(file, src, nil, ScanComments)
 				for {
 					_, tok, _ := s.Scan()

--- a/src/go/token/position_bench_test.go
+++ b/src/go/token/position_bench_test.go
@@ -18,7 +18,7 @@ func BenchmarkSearchInts(b *testing.B) {
 		b.Errorf("got index = %d; want %d", r, x)
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		searchInts(data, x)
 	}
 }

--- a/src/go/types/lookup_test.go
+++ b/src/go/types/lookup_test.go
@@ -52,7 +52,7 @@ func BenchmarkLookupFieldOrMethod(b *testing.B) {
 	lookup()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		lookup()
 	}
 }

--- a/src/go/types/named_test.go
+++ b/src/go/types/named_test.go
@@ -57,7 +57,7 @@ type Inst = G[int]
 				// Access underlying once, to trigger any lazy calculation.
 				_ = test.typ.Underlying()
 				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					_ = test.typ.Underlying()
 				}
 			})
@@ -70,7 +70,7 @@ type Inst = G[int]
 				// Access underlying once, to trigger any lazy calculation.
 				_ = NewMethodSet(test.typ)
 				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					_ = NewMethodSet(test.typ)
 				}
 			})

--- a/src/go/types/self_test.go
+++ b/src/go/types/self_test.go
@@ -79,7 +79,7 @@ func runbench(b *testing.B, path string, ignoreFuncBodies, writeInfo bool) {
 
 	b.ResetTimer()
 	start := time.Now()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		conf := Config{
 			IgnoreFuncBodies: ignoreFuncBodies,
 			Importer:         importer.Default(),

--- a/src/hash/adler32/adler32_test.go
+++ b/src/hash/adler32/adler32_test.go
@@ -132,7 +132,7 @@ func BenchmarkAdler32KB(b *testing.B) {
 	in := make([]byte, 0, h.Size())
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		h.Reset()
 		h.Write(data)
 		h.Sum(in)

--- a/src/hash/crc32/crc32_test.go
+++ b/src/hash/crc32/crc32_test.go
@@ -333,7 +333,7 @@ func benchmark(b *testing.B, h hash.Hash32, n, alignment int64) {
 	in = in[:0]
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		h.Reset()
 		h.Write(data)
 		h.Sum(in)

--- a/src/hash/crc64/crc64_test.go
+++ b/src/hash/crc64/crc64_test.go
@@ -164,7 +164,7 @@ func bench(b *testing.B, poly uint64, size int64) {
 	in := make([]byte, 0, h.Size())
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		h.Reset()
 		h.Write(data)
 		h.Sum(in)

--- a/src/hash/fnv/fnv_test.go
+++ b/src/hash/fnv/fnv_test.go
@@ -247,7 +247,7 @@ func benchmarkKB(b *testing.B, h hash.Hash) {
 	in := make([]byte, 0, h.Size())
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		h.Reset()
 		h.Write(data)
 		h.Sum(in)

--- a/src/hash/maphash/maphash_test.go
+++ b/src/hash/maphash/maphash_test.go
@@ -221,7 +221,7 @@ func benchmarkSize(b *testing.B, size int) {
 
 	b.Run("Write", func(b *testing.B) {
 		b.SetBytes(int64(size))
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			h.Reset()
 			h.Write(buf)
 			h.Sum64()
@@ -231,7 +231,7 @@ func benchmarkSize(b *testing.B, size int) {
 	b.Run("Bytes", func(b *testing.B) {
 		b.SetBytes(int64(size))
 		seed := h.Seed()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			Bytes(seed, buf)
 		}
 	})
@@ -239,7 +239,7 @@ func benchmarkSize(b *testing.B, size int) {
 	b.Run("String", func(b *testing.B) {
 		b.SetBytes(int64(size))
 		seed := h.Seed()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			String(seed, s)
 		}
 	})

--- a/src/html/escape_test.go
+++ b/src/html/escape_test.go
@@ -126,14 +126,14 @@ var (
 
 func BenchmarkEscape(b *testing.B) {
 	n := 0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		n += len(EscapeString(benchEscapeData))
 	}
 }
 
 func BenchmarkEscapeNone(b *testing.B) {
 	n := 0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		n += len(EscapeString(benchEscapeNone))
 	}
 }
@@ -141,7 +141,7 @@ func BenchmarkEscapeNone(b *testing.B) {
 func BenchmarkUnescape(b *testing.B) {
 	s := EscapeString(benchEscapeData)
 	n := 0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		n += len(UnescapeString(s))
 	}
 }
@@ -149,21 +149,21 @@ func BenchmarkUnescape(b *testing.B) {
 func BenchmarkUnescapeNone(b *testing.B) {
 	s := EscapeString(benchEscapeNone)
 	n := 0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		n += len(UnescapeString(s))
 	}
 }
 
 func BenchmarkUnescapeSparse(b *testing.B) {
 	n := 0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		n += len(UnescapeString(benchUnescapeSparse))
 	}
 }
 
 func BenchmarkUnescapeDense(b *testing.B) {
 	n := 0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		n += len(UnescapeString(benchUnescapeDense))
 	}
 }

--- a/src/html/template/css_test.go
+++ b/src/html/template/css_test.go
@@ -243,13 +243,13 @@ func TestCSSValueFilter(t *testing.T) {
 }
 
 func BenchmarkCSSEscaper(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		cssEscaper("The <i>quick</i>,\r\n<span style='color:brown'>brown</span> fox jumps\u2028over the <canine class=\"lazy\">dog</canine>")
 	}
 }
 
 func BenchmarkCSSEscaperNoSpecials(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		cssEscaper("The quick, brown fox jumps over the lazy dog.")
 	}
 }
@@ -257,7 +257,7 @@ func BenchmarkCSSEscaperNoSpecials(b *testing.B) {
 func BenchmarkDecodeCSS(b *testing.B) {
 	s := []byte(`The \3c i\3equick\3c/i\3e,\d\A\3cspan style=\27 color:brown\27\3e brown\3c/span\3e fox jumps\2028over the \3c canine class=\22lazy\22 \3edog\3c/canine\3e`)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		decodeCSS(s)
 	}
 }
@@ -265,19 +265,19 @@ func BenchmarkDecodeCSS(b *testing.B) {
 func BenchmarkDecodeCSSNoSpecials(b *testing.B) {
 	s := []byte("The quick, brown fox jumps over the lazy dog.")
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		decodeCSS(s)
 	}
 }
 
 func BenchmarkCSSValueFilter(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		cssValueFilter(`  e\78preS\0Sio/**/n(alert(1337))`)
 	}
 }
 
 func BenchmarkCSSValueFilterOk(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		cssValueFilter(`Times New Roman`)
 	}
 }

--- a/src/html/template/escape_test.go
+++ b/src/html/template/escape_test.go
@@ -2139,7 +2139,7 @@ func BenchmarkEscapedExecute(b *testing.B) {
 	tmpl := Must(New("t").Parse(`<a onclick="alert('{{.}}')">{{.}}</a>`))
 	var buf bytes.Buffer
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		tmpl.Execute(&buf, "foo & 'bar' & baz")
 		buf.Reset()
 	}

--- a/src/html/template/html_test.go
+++ b/src/html/template/html_test.go
@@ -73,25 +73,25 @@ func TestStripTags(t *testing.T) {
 }
 
 func BenchmarkHTMLNospaceEscaper(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		htmlNospaceEscaper("The <i>quick</i>,\r\n<span style='color:brown'>brown</span> fox jumps\u2028over the <canine class=\"lazy\">dog</canine>")
 	}
 }
 
 func BenchmarkHTMLNospaceEscaperNoSpecials(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		htmlNospaceEscaper("The_quick,_brown_fox_jumps_over_the_lazy_dog.")
 	}
 }
 
 func BenchmarkStripTags(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		stripTags("The <i>quick</i>,\r\n<span style='color:brown'>brown</span> fox jumps\u2028over the <canine class=\"lazy\">dog</canine>")
 	}
 }
 
 func BenchmarkStripTagsNoSpecials(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		stripTags("The quick, brown fox jumps over the lazy dog.")
 	}
 }

--- a/src/html/template/js_test.go
+++ b/src/html/template/js_test.go
@@ -357,19 +357,19 @@ func TestIsJsMimeType(t *testing.T) {
 }
 
 func BenchmarkJSValEscaperWithNum(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		jsValEscaper(3.141592654)
 	}
 }
 
 func BenchmarkJSValEscaperWithStr(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		jsValEscaper("The <i>quick</i>,\r\n<span style='color:brown'>brown</span> fox jumps\u2028over the <canine class=\"lazy\">dog</canine>")
 	}
 }
 
 func BenchmarkJSValEscaperWithStrNoSpecials(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		jsValEscaper("The quick, brown fox jumps over the lazy dog")
 	}
 }
@@ -382,7 +382,7 @@ func BenchmarkJSValEscaperWithObj(b *testing.B) {
 		"The <i>quick</i>,\r\n<span style='color:brown'>brown</span> fox jumps\u2028over the <canine class=\"lazy\">dog</canine>\u2028",
 		42,
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		jsValEscaper(o)
 	}
 }
@@ -395,31 +395,31 @@ func BenchmarkJSValEscaperWithObjNoSpecials(b *testing.B) {
 		"The quick, brown fox jumps over the lazy dog",
 		42,
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		jsValEscaper(o)
 	}
 }
 
 func BenchmarkJSStrEscaperNoSpecials(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		jsStrEscaper("The quick, brown fox jumps over the lazy dog.")
 	}
 }
 
 func BenchmarkJSStrEscaper(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		jsStrEscaper("The <i>quick</i>,\r\n<span style='color:brown'>brown</span> fox jumps\u2028over the <canine class=\"lazy\">dog</canine>")
 	}
 }
 
 func BenchmarkJSRegexpEscaperNoSpecials(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		jsRegexpEscaper("The quick, brown fox jumps over the lazy dog")
 	}
 }
 
 func BenchmarkJSRegexpEscaper(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		jsRegexpEscaper("The <i>quick</i>,\r\n<span style='color:brown'>brown</span> fox jumps\u2028over the <canine class=\"lazy\">dog</canine>")
 	}
 }

--- a/src/html/template/transition_test.go
+++ b/src/html/template/transition_test.go
@@ -50,7 +50,7 @@ func BenchmarkTemplateSpecialTags(b *testing.B) {
 	html := strings.Repeat(h1, 100) + h2 + strings.Repeat(h1, 100) + h2
 
 	var buf bytes.Buffer
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		tmpl := Must(New("foo").Parse(html))
 		if err := tmpl.Execute(&buf, r); err != nil {
 			b.Fatal(err)

--- a/src/html/template/url_test.go
+++ b/src/html/template/url_test.go
@@ -133,37 +133,37 @@ func TestSrcsetFilter(t *testing.T) {
 }
 
 func BenchmarkURLEscaper(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		urlEscaper("http://example.com:80/foo?q=bar%20&baz=x+y#frag")
 	}
 }
 
 func BenchmarkURLEscaperNoSpecials(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		urlEscaper("TheQuickBrownFoxJumpsOverTheLazyDog.")
 	}
 }
 
 func BenchmarkURLNormalizer(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		urlNormalizer("The quick brown fox jumps over the lazy dog.\n")
 	}
 }
 
 func BenchmarkURLNormalizerNoSpecials(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		urlNormalizer("http://example.com:80/foo?q=bar%20&baz=x+y#frag")
 	}
 }
 
 func BenchmarkSrcsetFilter(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		srcsetFilterAndEscaper(" /foo/bar.png 200w, /baz/boo(1).png")
 	}
 }
 
 func BenchmarkSrcsetFilterNoSpecials(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		srcsetFilterAndEscaper("http://example.com:80/foo?q=bar%20&baz=x+y#frag")
 	}
 }

--- a/src/image/color/ycbcr_test.go
+++ b/src/image/color/ycbcr_test.go
@@ -180,17 +180,17 @@ func BenchmarkYCbCrToRGB(b *testing.B) {
 	// Low, middle, and high values can take
 	// different paths through the generated code.
 	b.Run("0", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			sink8, sink8, sink8 = YCbCrToRGB(0, 0, 0)
 		}
 	})
 	b.Run("128", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			sink8, sink8, sink8 = YCbCrToRGB(128, 128, 128)
 		}
 	})
 	b.Run("255", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			sink8, sink8, sink8 = YCbCrToRGB(255, 255, 255)
 		}
 	})
@@ -201,17 +201,17 @@ func BenchmarkRGBToYCbCr(b *testing.B) {
 	// Different values can take different paths
 	// through the generated code.
 	b.Run("0", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			sink8, sink8, sink8 = RGBToYCbCr(0, 0, 0)
 		}
 	})
 	b.Run("Cb", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			sink8, sink8, sink8 = RGBToYCbCr(0, 0, 255)
 		}
 	})
 	b.Run("Cr", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			sink8, sink8, sink8 = RGBToYCbCr(255, 0, 0)
 		}
 	})
@@ -223,19 +223,19 @@ func BenchmarkYCbCrToRGBA(b *testing.B) {
 	// different paths through the generated code.
 	b.Run("0", func(b *testing.B) {
 		c := YCbCr{0, 0, 0}
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			sink32, sink32, sink32, sink32 = c.RGBA()
 		}
 	})
 	b.Run("128", func(b *testing.B) {
 		c := YCbCr{128, 128, 128}
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			sink32, sink32, sink32, sink32 = c.RGBA()
 		}
 	})
 	b.Run("255", func(b *testing.B) {
 		c := YCbCr{255, 255, 255}
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			sink32, sink32, sink32, sink32 = c.RGBA()
 		}
 	})
@@ -247,19 +247,19 @@ func BenchmarkNYCbCrAToRGBA(b *testing.B) {
 	// different paths through the generated code.
 	b.Run("0", func(b *testing.B) {
 		c := NYCbCrA{YCbCr{0, 0, 0}, 0xff}
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			sink32, sink32, sink32, sink32 = c.RGBA()
 		}
 	})
 	b.Run("128", func(b *testing.B) {
 		c := NYCbCrA{YCbCr{128, 128, 128}, 0xff}
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			sink32, sink32, sink32, sink32 = c.RGBA()
 		}
 	})
 	b.Run("255", func(b *testing.B) {
 		c := NYCbCrA{YCbCr{255, 255, 255}, 0xff}
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			sink32, sink32, sink32, sink32 = c.RGBA()
 		}
 	})

--- a/src/image/draw/bench_test.go
+++ b/src/image/draw/bench_test.go
@@ -181,7 +181,7 @@ func bench(b *testing.B, dcm, scm, mcm color.Model, op Op) {
 	}
 
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		// Scatter the destination rectangle to draw into.
 		x := 3 * i % (dstw - srcw)
 		y := 7 * i % (dsth - srch)

--- a/src/image/gif/reader_test.go
+++ b/src/image/gif/reader_test.go
@@ -435,7 +435,7 @@ func BenchmarkDecode(b *testing.B) {
 	b.SetBytes(int64(cfg.Width * cfg.Height))
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Decode(bytes.NewReader(data))
 	}
 }

--- a/src/image/gif/writer_test.go
+++ b/src/image/gif/writer_test.go
@@ -667,7 +667,7 @@ func BenchmarkEncodeRandomPaletted(b *testing.B) {
 	b.SetBytes(640 * 480 * 1)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Encode(io.Discard, paletted, nil)
 	}
 }
@@ -690,7 +690,7 @@ func BenchmarkEncodeRandomRGBA(b *testing.B) {
 	b.SetBytes(640 * 480 * 4)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Encode(io.Discard, rgba, nil)
 	}
 }
@@ -707,7 +707,7 @@ func BenchmarkEncodeRealisticPaletted(b *testing.B) {
 	b.SetBytes(int64(bo.Dx() * bo.Dy() * 1))
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Encode(io.Discard, paletted, nil)
 	}
 }
@@ -728,7 +728,7 @@ func BenchmarkEncodeRealisticRGBA(b *testing.B) {
 	b.SetBytes(int64(bo.Dx() * bo.Dy() * 4))
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Encode(io.Discard, rgba, nil)
 	}
 }

--- a/src/image/image_test.go
+++ b/src/image/image_test.go
@@ -284,7 +284,7 @@ func BenchmarkAt(b *testing.B) {
 			m := tc.image()
 			b.ReportAllocs()
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				m.At(4, 5)
 			}
 		})
@@ -298,7 +298,7 @@ func BenchmarkSet(b *testing.B) {
 			m := tc.image()
 			b.ReportAllocs()
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				m.Set(4, 5, c)
 			}
 		})
@@ -309,7 +309,7 @@ func BenchmarkRGBAAt(b *testing.B) {
 	m := NewRGBA(Rect(0, 0, 10, 10))
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m.RGBAAt(4, 5)
 	}
 }
@@ -319,7 +319,7 @@ func BenchmarkRGBASetRGBA(b *testing.B) {
 	c := color.RGBA{0xff, 0xff, 0xff, 0x13}
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m.SetRGBA(4, 5, c)
 	}
 }
@@ -328,7 +328,7 @@ func BenchmarkRGBA64At(b *testing.B) {
 	m := NewRGBA64(Rect(0, 0, 10, 10))
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m.RGBA64At(4, 5)
 	}
 }
@@ -338,7 +338,7 @@ func BenchmarkRGBA64SetRGBA64(b *testing.B) {
 	c := color.RGBA64{0xffff, 0xffff, 0xffff, 0x1357}
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m.SetRGBA64(4, 5, c)
 	}
 }
@@ -347,7 +347,7 @@ func BenchmarkNRGBAAt(b *testing.B) {
 	m := NewNRGBA(Rect(0, 0, 10, 10))
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m.NRGBAAt(4, 5)
 	}
 }
@@ -357,7 +357,7 @@ func BenchmarkNRGBASetNRGBA(b *testing.B) {
 	c := color.NRGBA{0xff, 0xff, 0xff, 0x13}
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m.SetNRGBA(4, 5, c)
 	}
 }
@@ -366,7 +366,7 @@ func BenchmarkNRGBA64At(b *testing.B) {
 	m := NewNRGBA64(Rect(0, 0, 10, 10))
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m.NRGBA64At(4, 5)
 	}
 }
@@ -376,7 +376,7 @@ func BenchmarkNRGBA64SetNRGBA64(b *testing.B) {
 	c := color.NRGBA64{0xffff, 0xffff, 0xffff, 0x1357}
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m.SetNRGBA64(4, 5, c)
 	}
 }
@@ -385,7 +385,7 @@ func BenchmarkAlphaAt(b *testing.B) {
 	m := NewAlpha(Rect(0, 0, 10, 10))
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m.AlphaAt(4, 5)
 	}
 }
@@ -395,7 +395,7 @@ func BenchmarkAlphaSetAlpha(b *testing.B) {
 	c := color.Alpha{0x13}
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m.SetAlpha(4, 5, c)
 	}
 }
@@ -404,7 +404,7 @@ func BenchmarkAlpha16At(b *testing.B) {
 	m := NewAlpha16(Rect(0, 0, 10, 10))
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m.Alpha16At(4, 5)
 	}
 }
@@ -414,7 +414,7 @@ func BenchmarkAlphaSetAlpha16(b *testing.B) {
 	c := color.Alpha16{0x13}
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m.SetAlpha16(4, 5, c)
 	}
 }
@@ -423,7 +423,7 @@ func BenchmarkGrayAt(b *testing.B) {
 	m := NewGray(Rect(0, 0, 10, 10))
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m.GrayAt(4, 5)
 	}
 }
@@ -433,7 +433,7 @@ func BenchmarkGraySetGray(b *testing.B) {
 	c := color.Gray{0x13}
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m.SetGray(4, 5, c)
 	}
 }
@@ -442,7 +442,7 @@ func BenchmarkGray16At(b *testing.B) {
 	m := NewGray16(Rect(0, 0, 10, 10))
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m.Gray16At(4, 5)
 	}
 }
@@ -452,7 +452,7 @@ func BenchmarkGraySetGray16(b *testing.B) {
 	c := color.Gray16{0x13}
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m.SetGray16(4, 5, c)
 	}
 }

--- a/src/image/jpeg/dct_test.go
+++ b/src/image/jpeg/dct_test.go
@@ -15,7 +15,7 @@ import (
 func benchmarkDCT(b *testing.B, f func(*block)) {
 	b.StopTimer()
 	blocks := make([]block, 0, b.N*len(testBlocks))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		blocks = append(blocks, testBlocks[:]...)
 	}
 	b.StartTimer()

--- a/src/image/jpeg/reader_test.go
+++ b/src/image/jpeg/reader_test.go
@@ -516,7 +516,7 @@ func benchmarkDecode(b *testing.B, filename string) {
 	b.SetBytes(int64(cfg.Width * cfg.Height * 4))
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Decode(bytes.NewReader(data))
 	}
 }

--- a/src/image/jpeg/writer_test.go
+++ b/src/image/jpeg/writer_test.go
@@ -261,7 +261,7 @@ func BenchmarkEncodeRGBA(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	options := &Options{Quality: 90}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Encode(io.Discard, img, options)
 	}
 }
@@ -283,7 +283,7 @@ func BenchmarkEncodeYCbCr(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	options := &Options{Quality: 90}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Encode(io.Discard, img, options)
 	}
 }

--- a/src/image/png/paeth_test.go
+++ b/src/image/png/paeth_test.go
@@ -57,7 +57,7 @@ func TestPaeth(t *testing.T) {
 }
 
 func BenchmarkPaeth(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		paeth(uint8(i>>16), uint8(i>>8), uint8(i))
 	}
 }

--- a/src/image/png/reader_test.go
+++ b/src/image/png/reader_test.go
@@ -848,7 +848,7 @@ func benchmarkDecode(b *testing.B, filename string, bytesPerPixel int) {
 	b.SetBytes(int64(cfg.Width * cfg.Height * bytesPerPixel))
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Decode(bytes.NewReader(data))
 	}
 }

--- a/src/image/png/writer_test.go
+++ b/src/image/png/writer_test.go
@@ -283,7 +283,7 @@ func BenchmarkEncodeGray(b *testing.B) {
 	b.SetBytes(640 * 480 * 1)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Encode(io.Discard, img)
 	}
 }
@@ -308,7 +308,7 @@ func BenchmarkEncodeGrayWithBufferPool(b *testing.B) {
 	b.SetBytes(640 * 480 * 1)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		e.Encode(io.Discard, img)
 	}
 }
@@ -328,7 +328,7 @@ func BenchmarkEncodeNRGBOpaque(b *testing.B) {
 	b.SetBytes(640 * 480 * 4)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Encode(io.Discard, img)
 	}
 }
@@ -341,7 +341,7 @@ func BenchmarkEncodeNRGBA(b *testing.B) {
 	b.SetBytes(640 * 480 * 4)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Encode(io.Discard, img)
 	}
 }
@@ -354,7 +354,7 @@ func BenchmarkEncodePaletted(b *testing.B) {
 	b.SetBytes(640 * 480 * 1)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Encode(io.Discard, img)
 	}
 }
@@ -374,7 +374,7 @@ func BenchmarkEncodeRGBOpaque(b *testing.B) {
 	b.SetBytes(640 * 480 * 4)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Encode(io.Discard, img)
 	}
 }
@@ -401,7 +401,7 @@ func BenchmarkEncodeRGBA(b *testing.B) {
 	b.SetBytes(width * height * 4)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Encode(io.Discard, img)
 	}
 }

--- a/src/index/suffixarray/suffixarray_test.go
+++ b/src/index/suffixarray/suffixarray_test.go
@@ -488,7 +488,7 @@ func benchmarkNew(b *testing.B, random bool) {
 	}
 	b.StartTimer()
 	b.SetBytes(int64(len(data)))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		New(data)
 	}
 }
@@ -568,7 +568,7 @@ func BenchmarkNew(b *testing.B) {
 
 							b.SetBytes(int64(len(data)))
 							b.ReportAllocs()
-							for i := 0; i < b.N; i++ {
+							for range b.N {
 								New(data)
 							}
 						})
@@ -600,7 +600,7 @@ func BenchmarkSaveRestore(b *testing.B) {
 			b.SetBytes(int64(size))
 			b.StartTimer()
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				buf.Reset()
 				if err := x.Write(buf); err != nil {
 					b.Fatal(err)

--- a/src/internal/fuzz/encoding_test.go
+++ b/src/internal/fuzz/encoding_test.go
@@ -265,7 +265,7 @@ func BenchmarkMarshalCorpusFile(b *testing.B) {
 	for sz := 1; sz <= len(buf); sz <<= 1 {
 		sz := sz
 		b.Run(strconv.Itoa(sz), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				b.SetBytes(int64(sz))
 				marshalCorpusFile(buf[:sz])
 			}
@@ -286,7 +286,7 @@ func BenchmarkUnmarshalCorpusFile(b *testing.B) {
 		sz := sz
 		data := marshalCorpusFile(buf[:sz])
 		b.Run(strconv.Itoa(sz), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				b.SetBytes(int64(sz))
 				unmarshalCorpusFile(data)
 			}

--- a/src/internal/fuzz/mutator_test.go
+++ b/src/internal/fuzz/mutator_test.go
@@ -30,7 +30,7 @@ func BenchmarkMutatorBytes(b *testing.B) {
 			buf := make([]byte, size)
 			b.ResetTimer()
 
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				// resize buffer to the correct shape and reset the PCG
 				buf = buf[0:size]
 				m.r = newPcgRand()
@@ -58,7 +58,7 @@ func BenchmarkMutatorString(b *testing.B) {
 			buf := make([]byte, size)
 			b.ResetTimer()
 
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				// resize buffer to the correct shape and reset the PCG
 				buf = buf[0:size]
 				m.r = newPcgRand()
@@ -93,7 +93,7 @@ func BenchmarkMutatorAllBasicTypes(b *testing.B) {
 
 	for _, t := range types {
 		b.Run(fmt.Sprintf("%T", t), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				m.r = newPcgRand()
 				m.mutate([]any{t}, workerSharedMemSize)
 			}

--- a/src/internal/fuzz/worker_test.go
+++ b/src/internal/fuzz/worker_test.go
@@ -60,7 +60,7 @@ func BenchmarkWorkerFuzzOverhead(b *testing.B) {
 	ws.memMu <- mem
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ws.m = newMutator()
 		mem.setValue(encodedVals)
 		mem.header().count = 0
@@ -77,7 +77,7 @@ func BenchmarkWorkerPing(b *testing.B) {
 	}
 	b.SetParallelism(1)
 	w := newWorkerForTest(b)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if err := w.client.ping(context.Background()); err != nil {
 			b.Fatal(err)
 		}
@@ -197,7 +197,7 @@ func BenchmarkWorkerMinimize(b *testing.B) {
 				}
 				return time.Second, nil
 			}
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				b.SetBytes(int64(sz))
 				ws.minimize(ctx, minimizeArgs{})
 			}

--- a/src/internal/intern/intern_test.go
+++ b/src/internal/intern/intern_test.go
@@ -190,7 +190,7 @@ func TestGetByStringAllocs(t *testing.T) {
 
 func BenchmarkGetByString(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		v := GetByString(globalString)
 		sink = v.Get().(string)
 	}

--- a/src/internal/poll/splice_linux_test.go
+++ b/src/internal/poll/splice_linux_test.go
@@ -92,7 +92,7 @@ func TestSplicePipePool(t *testing.T) {
 
 func BenchmarkSplicePipe(b *testing.B) {
 	b.Run("SplicePipeWithPool", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			p, _, err := poll.GetPipe()
 			if err != nil {
 				continue
@@ -101,7 +101,7 @@ func BenchmarkSplicePipe(b *testing.B) {
 		}
 	})
 	b.Run("SplicePipeWithoutPool", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			p := poll.NewPipe()
 			if p == nil {
 				b.Skip("newPipe returned nil")

--- a/src/internal/trace/gc_test.go
+++ b/src/internal/trace/gc_test.go
@@ -168,7 +168,7 @@ func BenchmarkMMU(b *testing.B) {
 	mu := MutatorUtilization(events.Events, UtilSTW|UtilBackground|UtilAssist|UtilSweep)
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		mmuCurve := NewMMUCurve(mu)
 		xMin, xMax := time.Microsecond, time.Second
 		logMin, logMax := math.Log(float64(xMin)), math.Log(float64(xMax))

--- a/src/internal/zstd/zstd_test.go
+++ b/src/internal/zstd/zstd_test.go
@@ -327,7 +327,7 @@ func BenchmarkLarge(b *testing.B) {
 	r := NewReader(input)
 
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		input.Reset(compressed)
 		r.Reset(input)
 		io.Copy(io.Discard, r)

--- a/src/io/io_test.go
+++ b/src/io/io_test.go
@@ -180,7 +180,7 @@ func BenchmarkCopyNSmall(b *testing.B) {
 	buf := new(Buffer)
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		CopyN(buf, rd, 512)
 		rd.Reset(bs)
 	}
@@ -192,7 +192,7 @@ func BenchmarkCopyNLarge(b *testing.B) {
 	buf := new(Buffer)
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		CopyN(buf, rd, 32*1024)
 		rd.Reset(bs)
 	}

--- a/src/log/log_test.go
+++ b/src/log/log_test.go
@@ -214,7 +214,7 @@ func TestDiscard(t *testing.T) {
 
 func BenchmarkItoa(b *testing.B) {
 	dst := make([]byte, 0, 64)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		dst = dst[0:0]
 		itoa(&dst, 2015, 4)   // year
 		itoa(&dst, 1, 2)      // month
@@ -231,7 +231,7 @@ func BenchmarkPrintln(b *testing.B) {
 	var buf bytes.Buffer
 	l := New(&buf, "", LstdFlags)
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf.Reset()
 		l.Println(testString)
 	}
@@ -242,7 +242,7 @@ func BenchmarkPrintlnNoFlags(b *testing.B) {
 	var buf bytes.Buffer
 	l := New(&buf, "", 0)
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf.Reset()
 		l.Println(testString)
 	}
@@ -262,7 +262,7 @@ func BenchmarkConcurrent(b *testing.B) {
 	for i := runtime.NumCPU(); i > 0; i-- {
 		group.Add(1)
 		go func() {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				l.Output(0, "hello, world!")
 			}
 			defer group.Done()
@@ -274,7 +274,7 @@ func BenchmarkConcurrent(b *testing.B) {
 func BenchmarkDiscard(b *testing.B) {
 	l := New(io.Discard, "", LstdFlags|Lshortfile)
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		l.Printf("processing %d objects from bucket %q", 1234, "fizzbuzz")
 	}
 }

--- a/src/log/slog/handler_test.go
+++ b/src/log/slog/handler_test.go
@@ -707,7 +707,7 @@ func BenchmarkWriteTime(b *testing.B) {
 	tm := time.Date(2022, 3, 4, 5, 6, 7, 823456789, time.Local)
 	b.ResetTimer()
 	var buf []byte
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf = appendRFC3339Millis(buf[:0], tm)
 	}
 }

--- a/src/log/slog/json_handler_test.go
+++ b/src/log/slog/json_handler_test.go
@@ -182,7 +182,7 @@ func BenchmarkJSONHandler(b *testing.B) {
 				String("URL", "https://pkg.go.dev/golang.org/x/log/slog"))
 			b.ReportAllocs()
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				l.LogAttrs(ctx, LevelInfo, "this is a typical log message",
 					String("module", "github.com/google/go-cmp"),
 					String("version", "v1.23.4"),
@@ -244,7 +244,7 @@ func BenchmarkPreformatting(b *testing.B) {
 			l := New(NewJSONHandler(bench.wc, nil)).With(bench.attrs...)
 			b.ReportAllocs()
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				l.LogAttrs(ctx, LevelInfo, "this is a typical log message",
 					String("module", "github.com/google/go-cmp"),
 					String("version", "v1.23.4"),
@@ -262,7 +262,7 @@ func BenchmarkJSONEncoding(b *testing.B) {
 	defer buf.Free()
 	b.Run("json.Marshal", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			by, err := json.Marshal(value)
 			if err != nil {
 				b.Fatal(err)
@@ -273,7 +273,7 @@ func BenchmarkJSONEncoding(b *testing.B) {
 	})
 	b.Run("Encoder.Encode", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			if err := json.NewEncoder(buf).Encode(value); err != nil {
 				b.Fatal(err)
 			}

--- a/src/log/slog/logger_test.go
+++ b/src/log/slog/logger_test.go
@@ -596,13 +596,13 @@ func BenchmarkNopLog(b *testing.B) {
 	l := New(&captureHandler{})
 	b.Run("no attrs", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			l.LogAttrs(ctx, LevelInfo, "msg")
 		}
 	})
 	b.Run("attrs", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			l.LogAttrs(ctx, LevelInfo, "msg", Int("a", 1), String("b", "two"), Bool("c", true))
 		}
 	})
@@ -616,13 +616,13 @@ func BenchmarkNopLog(b *testing.B) {
 	})
 	b.Run("keys-values", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			l.Log(ctx, LevelInfo, "msg", "a", 1, "b", "two", "c", true)
 		}
 	})
 	b.Run("WithContext", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			l.LogAttrs(ctx, LevelInfo, "msg2", Int("a", 1), String("b", "two"), Bool("c", true))
 		}
 	})

--- a/src/log/slog/record_test.go
+++ b/src/log/slog/record_test.go
@@ -136,7 +136,7 @@ func BenchmarkPC(b *testing.B) {
 		b.Run(strconv.Itoa(depth), func(b *testing.B) {
 			b.ReportAllocs()
 			var x uintptr
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x = callerPC(depth)
 			}
 			_ = x
@@ -148,7 +148,7 @@ func BenchmarkRecord(b *testing.B) {
 	const nAttrs = nAttrsInline * 10
 	var a Attr
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		r := NewRecord(time.Time{}, LevelInfo, "", 0)
 		for j := 0; j < nAttrs; j++ {
 			r.AddAttrs(Int("k", j))

--- a/src/log/slog/value_access_benchmark_test.go
+++ b/src/log/slog/value_access_benchmark_test.go
@@ -36,7 +36,7 @@ func BenchmarkDispatch(b *testing.B) {
 		a  any
 	)
 	b.Run("switch-checked", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			for _, v := range vs {
 				switch v.Kind() {
 				case KindString:
@@ -68,7 +68,7 @@ func BenchmarkDispatch(b *testing.B) {
 
 	})
 	b.Run("As", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			for _, kv := range vs {
 				if v, ok := kv.AsString(); ok {
 					s = v
@@ -101,7 +101,7 @@ func BenchmarkDispatch(b *testing.B) {
 	b.Run("Visit", func(b *testing.B) {
 		v := &setVisitor{}
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			for _, kv := range vs {
 				kv.Visit(v)
 			}

--- a/src/log/slog/value_test.go
+++ b/src/log/slog/value_test.go
@@ -266,7 +266,7 @@ func BenchmarkUnsafeStrings(b *testing.B) {
 	}
 	b.ResetTimer()
 	var d string
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		copy(dst, src)
 		for _, a := range dst {
 			d = a.String()

--- a/src/maps/maps_test.go
+++ b/src/maps/maps_test.go
@@ -142,7 +142,7 @@ func BenchmarkMapClone(b *testing.B) {
 		m[i] = i
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		n = Clone(m)
 	}
 }

--- a/src/math/all_test.go
+++ b/src/math/all_test.go
@@ -3296,7 +3296,7 @@ var (
 
 func BenchmarkAcos(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Acos(.5)
 	}
 	GlobalF = x
@@ -3304,7 +3304,7 @@ func BenchmarkAcos(b *testing.B) {
 
 func BenchmarkAcosh(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Acosh(1.5)
 	}
 	GlobalF = x
@@ -3312,7 +3312,7 @@ func BenchmarkAcosh(b *testing.B) {
 
 func BenchmarkAsin(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Asin(.5)
 	}
 	GlobalF = x
@@ -3320,7 +3320,7 @@ func BenchmarkAsin(b *testing.B) {
 
 func BenchmarkAsinh(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Asinh(.5)
 	}
 	GlobalF = x
@@ -3328,7 +3328,7 @@ func BenchmarkAsinh(b *testing.B) {
 
 func BenchmarkAtan(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Atan(.5)
 	}
 	GlobalF = x
@@ -3336,7 +3336,7 @@ func BenchmarkAtan(b *testing.B) {
 
 func BenchmarkAtanh(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Atanh(.5)
 	}
 	GlobalF = x
@@ -3344,7 +3344,7 @@ func BenchmarkAtanh(b *testing.B) {
 
 func BenchmarkAtan2(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Atan2(.5, 1)
 	}
 	GlobalF = x
@@ -3352,7 +3352,7 @@ func BenchmarkAtan2(b *testing.B) {
 
 func BenchmarkCbrt(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Cbrt(10)
 	}
 	GlobalF = x
@@ -3360,7 +3360,7 @@ func BenchmarkCbrt(b *testing.B) {
 
 func BenchmarkCeil(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Ceil(.5)
 	}
 	GlobalF = x
@@ -3370,7 +3370,7 @@ var copysignNeg = -1.0
 
 func BenchmarkCopysign(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Copysign(.5, copysignNeg)
 	}
 	GlobalF = x
@@ -3378,7 +3378,7 @@ func BenchmarkCopysign(b *testing.B) {
 
 func BenchmarkCos(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Cos(.5)
 	}
 	GlobalF = x
@@ -3386,7 +3386,7 @@ func BenchmarkCos(b *testing.B) {
 
 func BenchmarkCosh(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Cosh(2.5)
 	}
 	GlobalF = x
@@ -3394,7 +3394,7 @@ func BenchmarkCosh(b *testing.B) {
 
 func BenchmarkErf(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Erf(.5)
 	}
 	GlobalF = x
@@ -3402,7 +3402,7 @@ func BenchmarkErf(b *testing.B) {
 
 func BenchmarkErfc(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Erfc(.5)
 	}
 	GlobalF = x
@@ -3410,7 +3410,7 @@ func BenchmarkErfc(b *testing.B) {
 
 func BenchmarkErfinv(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Erfinv(.5)
 	}
 	GlobalF = x
@@ -3418,7 +3418,7 @@ func BenchmarkErfinv(b *testing.B) {
 
 func BenchmarkErfcinv(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Erfcinv(.5)
 	}
 	GlobalF = x
@@ -3426,7 +3426,7 @@ func BenchmarkErfcinv(b *testing.B) {
 
 func BenchmarkExp(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Exp(.5)
 	}
 	GlobalF = x
@@ -3434,7 +3434,7 @@ func BenchmarkExp(b *testing.B) {
 
 func BenchmarkExpGo(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = ExpGo(.5)
 	}
 	GlobalF = x
@@ -3442,7 +3442,7 @@ func BenchmarkExpGo(b *testing.B) {
 
 func BenchmarkExpm1(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Expm1(.5)
 	}
 	GlobalF = x
@@ -3450,7 +3450,7 @@ func BenchmarkExpm1(b *testing.B) {
 
 func BenchmarkExp2(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Exp2(.5)
 	}
 	GlobalF = x
@@ -3458,7 +3458,7 @@ func BenchmarkExp2(b *testing.B) {
 
 func BenchmarkExp2Go(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Exp2Go(.5)
 	}
 	GlobalF = x
@@ -3468,7 +3468,7 @@ var absPos = .5
 
 func BenchmarkAbs(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Abs(absPos)
 	}
 	GlobalF = x
@@ -3477,7 +3477,7 @@ func BenchmarkAbs(b *testing.B) {
 
 func BenchmarkDim(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Dim(GlobalF, x)
 	}
 	GlobalF = x
@@ -3485,7 +3485,7 @@ func BenchmarkDim(b *testing.B) {
 
 func BenchmarkFloor(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Floor(.5)
 	}
 	GlobalF = x
@@ -3493,7 +3493,7 @@ func BenchmarkFloor(b *testing.B) {
 
 func BenchmarkMax(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Max(10, 3)
 	}
 	GlobalF = x
@@ -3501,7 +3501,7 @@ func BenchmarkMax(b *testing.B) {
 
 func BenchmarkMin(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Min(10, 3)
 	}
 	GlobalF = x
@@ -3509,7 +3509,7 @@ func BenchmarkMin(b *testing.B) {
 
 func BenchmarkMod(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Mod(10, 3)
 	}
 	GlobalF = x
@@ -3518,7 +3518,7 @@ func BenchmarkMod(b *testing.B) {
 func BenchmarkFrexp(b *testing.B) {
 	x := 0.0
 	y := 0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x, y = Frexp(8)
 	}
 	GlobalF = x
@@ -3527,7 +3527,7 @@ func BenchmarkFrexp(b *testing.B) {
 
 func BenchmarkGamma(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Gamma(2.5)
 	}
 	GlobalF = x
@@ -3535,7 +3535,7 @@ func BenchmarkGamma(b *testing.B) {
 
 func BenchmarkHypot(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Hypot(3, 4)
 	}
 	GlobalF = x
@@ -3543,7 +3543,7 @@ func BenchmarkHypot(b *testing.B) {
 
 func BenchmarkHypotGo(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = HypotGo(3, 4)
 	}
 	GlobalF = x
@@ -3551,7 +3551,7 @@ func BenchmarkHypotGo(b *testing.B) {
 
 func BenchmarkIlogb(b *testing.B) {
 	x := 0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Ilogb(.5)
 	}
 	GlobalI = x
@@ -3559,7 +3559,7 @@ func BenchmarkIlogb(b *testing.B) {
 
 func BenchmarkJ0(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = J0(2.5)
 	}
 	GlobalF = x
@@ -3567,7 +3567,7 @@ func BenchmarkJ0(b *testing.B) {
 
 func BenchmarkJ1(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = J1(2.5)
 	}
 	GlobalF = x
@@ -3575,7 +3575,7 @@ func BenchmarkJ1(b *testing.B) {
 
 func BenchmarkJn(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Jn(2, 2.5)
 	}
 	GlobalF = x
@@ -3583,7 +3583,7 @@ func BenchmarkJn(b *testing.B) {
 
 func BenchmarkLdexp(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Ldexp(.5, 2)
 	}
 	GlobalF = x
@@ -3592,7 +3592,7 @@ func BenchmarkLdexp(b *testing.B) {
 func BenchmarkLgamma(b *testing.B) {
 	x := 0.0
 	y := 0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x, y = Lgamma(2.5)
 	}
 	GlobalF = x
@@ -3601,7 +3601,7 @@ func BenchmarkLgamma(b *testing.B) {
 
 func BenchmarkLog(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Log(.5)
 	}
 	GlobalF = x
@@ -3609,7 +3609,7 @@ func BenchmarkLog(b *testing.B) {
 
 func BenchmarkLogb(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Logb(.5)
 	}
 	GlobalF = x
@@ -3617,7 +3617,7 @@ func BenchmarkLogb(b *testing.B) {
 
 func BenchmarkLog1p(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Log1p(.5)
 	}
 	GlobalF = x
@@ -3625,7 +3625,7 @@ func BenchmarkLog1p(b *testing.B) {
 
 func BenchmarkLog10(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Log10(.5)
 	}
 	GlobalF = x
@@ -3633,7 +3633,7 @@ func BenchmarkLog10(b *testing.B) {
 
 func BenchmarkLog2(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Log2(.5)
 	}
 	GlobalF += x
@@ -3642,7 +3642,7 @@ func BenchmarkLog2(b *testing.B) {
 func BenchmarkModf(b *testing.B) {
 	x := 0.0
 	y := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x, y = Modf(1.5)
 	}
 	GlobalF += x
@@ -3651,7 +3651,7 @@ func BenchmarkModf(b *testing.B) {
 
 func BenchmarkNextafter32(b *testing.B) {
 	x := float32(0.0)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Nextafter32(.5, 1)
 	}
 	GlobalF = float64(x)
@@ -3659,7 +3659,7 @@ func BenchmarkNextafter32(b *testing.B) {
 
 func BenchmarkNextafter64(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Nextafter(.5, 1)
 	}
 	GlobalF = x
@@ -3667,7 +3667,7 @@ func BenchmarkNextafter64(b *testing.B) {
 
 func BenchmarkPowInt(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Pow(2, 2)
 	}
 	GlobalF = x
@@ -3675,7 +3675,7 @@ func BenchmarkPowInt(b *testing.B) {
 
 func BenchmarkPowFrac(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Pow(2.5, 1.5)
 	}
 	GlobalF = x
@@ -3685,7 +3685,7 @@ var pow10pos = int(300)
 
 func BenchmarkPow10Pos(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Pow10(pow10pos)
 	}
 	GlobalF = x
@@ -3695,7 +3695,7 @@ var pow10neg = int(-300)
 
 func BenchmarkPow10Neg(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Pow10(pow10neg)
 	}
 	GlobalF = x
@@ -3705,7 +3705,7 @@ var roundNeg = float64(-2.5)
 
 func BenchmarkRound(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Round(roundNeg)
 	}
 	GlobalF = x
@@ -3713,7 +3713,7 @@ func BenchmarkRound(b *testing.B) {
 
 func BenchmarkRoundToEven(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = RoundToEven(roundNeg)
 	}
 	GlobalF = x
@@ -3721,7 +3721,7 @@ func BenchmarkRoundToEven(b *testing.B) {
 
 func BenchmarkRemainder(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Remainder(10, 3)
 	}
 	GlobalF = x
@@ -3731,7 +3731,7 @@ var signbitPos = 2.5
 
 func BenchmarkSignbit(b *testing.B) {
 	x := false
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Signbit(signbitPos)
 	}
 	GlobalB = x
@@ -3739,7 +3739,7 @@ func BenchmarkSignbit(b *testing.B) {
 
 func BenchmarkSin(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Sin(.5)
 	}
 	GlobalF = x
@@ -3748,7 +3748,7 @@ func BenchmarkSin(b *testing.B) {
 func BenchmarkSincos(b *testing.B) {
 	x := 0.0
 	y := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x, y = Sincos(.5)
 	}
 	GlobalF += x
@@ -3757,7 +3757,7 @@ func BenchmarkSincos(b *testing.B) {
 
 func BenchmarkSinh(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Sinh(2.5)
 	}
 	GlobalF = x
@@ -3766,7 +3766,7 @@ func BenchmarkSinh(b *testing.B) {
 func BenchmarkSqrtIndirect(b *testing.B) {
 	x, y := 0.0, 10.0
 	f := Sqrt
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x += f(y)
 	}
 	GlobalF = x
@@ -3774,7 +3774,7 @@ func BenchmarkSqrtIndirect(b *testing.B) {
 
 func BenchmarkSqrtLatency(b *testing.B) {
 	x := 10.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Sqrt(x)
 	}
 	GlobalF = x
@@ -3783,7 +3783,7 @@ func BenchmarkSqrtLatency(b *testing.B) {
 func BenchmarkSqrtIndirectLatency(b *testing.B) {
 	x := 10.0
 	f := Sqrt
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = f(x)
 	}
 	GlobalF = x
@@ -3791,7 +3791,7 @@ func BenchmarkSqrtIndirectLatency(b *testing.B) {
 
 func BenchmarkSqrtGoLatency(b *testing.B) {
 	x := 10.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = SqrtGo(x)
 	}
 	GlobalF = x
@@ -3813,7 +3813,7 @@ func isPrime(i int) bool {
 
 func BenchmarkSqrtPrime(b *testing.B) {
 	x := false
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = isPrime(100003)
 	}
 	GlobalB = x
@@ -3821,7 +3821,7 @@ func BenchmarkSqrtPrime(b *testing.B) {
 
 func BenchmarkTan(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Tan(.5)
 	}
 	GlobalF = x
@@ -3829,14 +3829,14 @@ func BenchmarkTan(b *testing.B) {
 
 func BenchmarkTanh(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Tanh(2.5)
 	}
 	GlobalF = x
 }
 func BenchmarkTrunc(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Trunc(.5)
 	}
 	GlobalF = x
@@ -3844,7 +3844,7 @@ func BenchmarkTrunc(b *testing.B) {
 
 func BenchmarkY0(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Y0(2.5)
 	}
 	GlobalF = x
@@ -3852,7 +3852,7 @@ func BenchmarkY0(b *testing.B) {
 
 func BenchmarkY1(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Y1(2.5)
 	}
 	GlobalF = x
@@ -3860,7 +3860,7 @@ func BenchmarkY1(b *testing.B) {
 
 func BenchmarkYn(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Yn(2, 2.5)
 	}
 	GlobalF = x
@@ -3868,7 +3868,7 @@ func BenchmarkYn(b *testing.B) {
 
 func BenchmarkFloat64bits(b *testing.B) {
 	y := uint64(0)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		y = Float64bits(roundNeg)
 	}
 	GlobalI = int(y)
@@ -3878,7 +3878,7 @@ var roundUint64 = uint64(5)
 
 func BenchmarkFloat64frombits(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Float64frombits(roundUint64)
 	}
 	GlobalF = x
@@ -3888,7 +3888,7 @@ var roundFloat32 = float32(-2.5)
 
 func BenchmarkFloat32bits(b *testing.B) {
 	y := uint32(0)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		y = Float32bits(roundFloat32)
 	}
 	GlobalI = int(y)
@@ -3898,7 +3898,7 @@ var roundUint32 = uint32(5)
 
 func BenchmarkFloat32frombits(b *testing.B) {
 	x := float32(0.0)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = Float32frombits(roundUint32)
 	}
 	GlobalF = float64(x)
@@ -3906,7 +3906,7 @@ func BenchmarkFloat32frombits(b *testing.B) {
 
 func BenchmarkFMA(b *testing.B) {
 	x := 0.0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = FMA(E, Pi, x)
 	}
 	GlobalF = x

--- a/src/math/big/arith_test.go
+++ b/src/math/big/arith_test.go
@@ -94,7 +94,7 @@ func BenchmarkAddVV(b *testing.B) {
 		z := make([]Word, n)
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
 			b.SetBytes(int64(n * _W))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				addVV(z, x, y)
 			}
 		})
@@ -111,7 +111,7 @@ func BenchmarkSubVV(b *testing.B) {
 		z := make([]Word, n)
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
 			b.SetBytes(int64(n * _W))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				subVV(z, x, y)
 			}
 		})
@@ -402,7 +402,7 @@ func BenchmarkAddVW(b *testing.B) {
 		z := make([]Word, n)
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
 			b.SetBytes(int64(n * _S))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				addVW(z, x, y)
 			}
 		})
@@ -420,7 +420,7 @@ func BenchmarkAddVWext(b *testing.B) {
 		z := make([]Word, n)
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
 			b.SetBytes(int64(n * _S))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				addVW(z, x, y)
 			}
 		})
@@ -437,7 +437,7 @@ func BenchmarkSubVW(b *testing.B) {
 		z := make([]Word, n)
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
 			b.SetBytes(int64(n * _S))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				subVW(z, x, y)
 			}
 		})
@@ -455,7 +455,7 @@ func BenchmarkSubVWext(b *testing.B) {
 		z := make([]Word, n)
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
 			b.SetBytes(int64(n * _S))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				subVW(z, x, y)
 			}
 		})
@@ -632,7 +632,7 @@ func BenchmarkMulAddVWW(b *testing.B) {
 		r := rndW()
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
 			b.SetBytes(int64(n * _W))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				mulAddVWW(z, x, y, r)
 			}
 		})
@@ -649,7 +649,7 @@ func BenchmarkAddMulVVW(b *testing.B) {
 		z := make([]Word, n)
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
 			b.SetBytes(int64(n * _W))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				addMulVVW(z, x, y)
 			}
 		})
@@ -665,7 +665,7 @@ func BenchmarkDivWVW(b *testing.B) {
 		z := make([]Word, n)
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
 			b.SetBytes(int64(n * _W))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				divWVW(z, 0, x, y)
 			}
 		})
@@ -683,12 +683,12 @@ func BenchmarkNonZeroShifts(b *testing.B) {
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
 			b.SetBytes(int64(n * _W))
 			b.Run("shrVU", func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					_ = shrVU(z, x, s)
 				}
 			})
 			b.Run("shlVU", func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					_ = shlVU(z, x, s)
 				}
 			})

--- a/src/math/big/decimal_test.go
+++ b/src/math/big/decimal_test.go
@@ -111,7 +111,7 @@ func TestDecimalRounding(t *testing.T) {
 var sink string
 
 func BenchmarkDecimalConversion(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for shift := -100; shift <= +100; shift++ {
 			var d decimal
 			d.init(natOne, shift)
@@ -126,7 +126,7 @@ func BenchmarkFloatString(b *testing.B) {
 		x.SetPrec(prec).SetRat(NewRat(1, 3))
 		b.Run(fmt.Sprintf("%v", prec), func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				sink = x.String()
 			}
 		})

--- a/src/math/big/float_test.go
+++ b/src/math/big/float_test.go
@@ -1831,7 +1831,7 @@ func BenchmarkFloatAdd(b *testing.B) {
 
 		b.Run(fmt.Sprintf("%v", prec), func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				z.Add(x, y)
 			}
 		})
@@ -1850,7 +1850,7 @@ func BenchmarkFloatSub(b *testing.B) {
 
 		b.Run(fmt.Sprintf("%v", prec), func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				z.Sub(x, y)
 			}
 		})

--- a/src/math/big/floatconv_test.go
+++ b/src/math/big/floatconv_test.go
@@ -710,7 +710,7 @@ func TestFloatFormat(t *testing.T) {
 }
 
 func BenchmarkParseFloatSmallExp(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, s := range []string{
 			"1e0",
 			"1e-1",
@@ -740,7 +740,7 @@ func BenchmarkParseFloatSmallExp(b *testing.B) {
 }
 
 func BenchmarkParseFloatLargeExp(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, s := range []string{
 			"1e0",
 			"1e-10",

--- a/src/math/big/gcd_test.go
+++ b/src/math/big/gcd_test.go
@@ -42,7 +42,7 @@ func runGCDExt(b *testing.B, aSize, bSize uint, calcXY bool) {
 		y = new(Int)
 	}
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		new(Int).GCD(x, y, aa, bb)
 	}
 }

--- a/src/math/big/hilbert_test.go
+++ b/src/math/big/hilbert_test.go
@@ -154,7 +154,7 @@ func TestHilbert(t *testing.T) {
 }
 
 func BenchmarkHilbert(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		doHilbert(nil, 10)
 	}
 }

--- a/src/math/big/int_test.go
+++ b/src/math/big/int_test.go
@@ -254,7 +254,7 @@ func TestBinomial(t *testing.T) {
 
 func BenchmarkBinomial(b *testing.B) {
 	var z Int
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		z.Binomial(1000, 990)
 	}
 }
@@ -489,7 +489,7 @@ func BenchmarkQuoRem(b *testing.B) {
 	r := new(Int)
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		q.QuoRem(y, x, r)
 	}
 }
@@ -656,7 +656,7 @@ func BenchmarkExp(b *testing.B) {
 	y, _ := new(Int).SetString("0xAC6BDB41324A9A9BF166DE5E1389582FAF72B6651987EE07FC3192943DB56050A37329CBB4A099ED8193E0757767A13DD52312AB4B03310DCD7F48A9DA04FD50E8083969EDB767B0CF6095179A163AB3661A05FBD5FAAAE82918A9962F0B93B855F97993EC975EEAA80D740ADBF4FF747359D041D5C33EA71D281E446B14773BCA97B43A23FB801676BD207A436C6481F1D2B9078717461A5B9D32E688F87748544523B524B0D57D5EA77A2775D2ECFA032CFBDBF52FB3786160279004E57AE6AF874E7303CE53299CCC041C7BC308D82A5698F3A8D0C38271AE35F8E9DBFBB694B5C803D89F7AE435DE236D525F54759B65E372FCD68EF20FA7111F9E4AFF72", 0)
 	n, _ := new(Int).SetString("0xAC6BDB41324A9A9BF166DE5E1389582FAF72B6651987EE07FC3192943DB56050A37329CBB4A099ED8193E0757767A13DD52312AB4B03310DCD7F48A9DA04FD50E8083969EDB767B0CF6095179A163AB3661A05FBD5FAAAE82918A9962F0B93B855F97993EC975EEAA80D740ADBF4FF747359D041D5C33EA71D281E446B14773BCA97B43A23FB801676BD207A436C6481F1D2B9078717461A5B9D32E688F87748544523B524B0D57D5EA77A2775D2ECFA032CFBDBF52FB3786160279004E57AE6AF874E7303CE53299CCC041C7BC308D82A5698F3A8D0C38271AE35F8E9DBFBB694B5C803D89F7AE435DE236D525F54759B65E372FCD68EF20FA7111F9E4AFF73", 0)
 	out := new(Int)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		out.Exp(x, y, n)
 	}
 }
@@ -689,7 +689,7 @@ func BenchmarkExpMont(b *testing.B) {
 		out := new(Int)
 		b.Run(mod.name, func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				out.Exp(x, y, n)
 			}
 		})
@@ -701,7 +701,7 @@ func BenchmarkExp2(b *testing.B) {
 	y, _ := new(Int).SetString("0xAC6BDB41324A9A9BF166DE5E1389582FAF72B6651987EE07FC3192943DB56050A37329CBB4A099ED8193E0757767A13DD52312AB4B03310DCD7F48A9DA04FD50E8083969EDB767B0CF6095179A163AB3661A05FBD5FAAAE82918A9962F0B93B855F97993EC975EEAA80D740ADBF4FF747359D041D5C33EA71D281E446B14773BCA97B43A23FB801676BD207A436C6481F1D2B9078717461A5B9D32E688F87748544523B524B0D57D5EA77A2775D2ECFA032CFBDBF52FB3786160279004E57AE6AF874E7303CE53299CCC041C7BC308D82A5698F3A8D0C38271AE35F8E9DBFBB694B5C803D89F7AE435DE236D525F54759B65E372FCD68EF20FA7111F9E4AFF72", 0)
 	n, _ := new(Int).SetString("0xAC6BDB41324A9A9BF166DE5E1389582FAF72B6651987EE07FC3192943DB56050A37329CBB4A099ED8193E0757767A13DD52312AB4B03310DCD7F48A9DA04FD50E8083969EDB767B0CF6095179A163AB3661A05FBD5FAAAE82918A9962F0B93B855F97993EC975EEAA80D740ADBF4FF747359D041D5C33EA71D281E446B14773BCA97B43A23FB801676BD207A436C6481F1D2B9078717461A5B9D32E688F87748544523B524B0D57D5EA77A2775D2ECFA032CFBDBF52FB3786160279004E57AE6AF874E7303CE53299CCC041C7BC308D82A5698F3A8D0C38271AE35F8E9DBFBB694B5C803D89F7AE435DE236D525F54759B65E372FCD68EF20FA7111F9E4AFF73", 0)
 	out := new(Int)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		out.Exp(x, y, n)
 	}
 }
@@ -1471,7 +1471,7 @@ func tri(n uint) *Int {
 func BenchmarkModSqrt225_Tonelli(b *testing.B) {
 	p := tri(225)
 	x := NewInt(2)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x.SetUint64(2)
 		x.modSqrtTonelliShanks(x, p)
 	}
@@ -1480,7 +1480,7 @@ func BenchmarkModSqrt225_Tonelli(b *testing.B) {
 func BenchmarkModSqrt225_3Mod4(b *testing.B) {
 	p := tri(225)
 	x := new(Int).SetUint64(2)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x.SetUint64(2)
 		x.modSqrt3Mod4Prime(x, p)
 	}
@@ -1491,7 +1491,7 @@ func BenchmarkModSqrt231_Tonelli(b *testing.B) {
 	p.Sub(p, intOne)
 	p.Sub(p, intOne) // tri(231) - 2 is a prime == 5 mod 8
 	x := new(Int).SetUint64(7)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x.SetUint64(7)
 		x.modSqrtTonelliShanks(x, p)
 	}
@@ -1502,7 +1502,7 @@ func BenchmarkModSqrt231_5Mod8(b *testing.B) {
 	p.Sub(p, intOne)
 	p.Sub(p, intOne) // tri(231) - 2 is a prime == 5 mod 8
 	x := new(Int).SetUint64(7)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x.SetUint64(7)
 		x.modSqrt5Mod8Prime(x, p)
 	}
@@ -1608,7 +1608,7 @@ func BenchmarkModInverse(b *testing.B) {
 	p.Sub(p, intOne)
 	x := new(Int).Sub(p, intOne)
 	z := new(Int)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		z.ModInverse(x, p)
 	}
 }
@@ -1819,7 +1819,7 @@ func BenchmarkSqrt(b *testing.B) {
 	n, _ := new(Int).SetString("1"+strings.Repeat("0", 1001), 10)
 	b.ResetTimer()
 	t := new(Int)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		t.Sqrt(n)
 	}
 }
@@ -1829,7 +1829,7 @@ func benchmarkIntSqr(b *testing.B, nwords int) {
 	x.abs = rndNat(nwords)
 	t := new(Int)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		t.Mul(x, x)
 	}
 }
@@ -1856,7 +1856,7 @@ func benchmarkDiv(b *testing.B, aSize, bSize int) {
 	y := new(Int)
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x.DivMod(aa, bb, y)
 	}
 }

--- a/src/math/big/nat_test.go
+++ b/src/math/big/nat_test.go
@@ -212,7 +212,7 @@ func BenchmarkMul(b *testing.B) {
 	mulx := rndNat(1e4)
 	muly := rndNat(1e4)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		var z nat
 		z.mul(mulx, muly)
 	}
@@ -223,7 +223,7 @@ func benchmarkNatMul(b *testing.B, nwords int) {
 	y := rndNat(nwords)
 	var z nat
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		z.mul(x, y)
 	}
 }
@@ -306,25 +306,25 @@ func BenchmarkZeroShifts(b *testing.B) {
 	x := rndNat(800)
 
 	b.Run("Shl", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			var z nat
 			z.shl(x, 0)
 		}
 	})
 	b.Run("ShlSame", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x.shl(x, 0)
 		}
 	})
 
 	b.Run("Shr", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			var z nat
 			z.shr(x, 0)
 		}
 	})
 	b.Run("ShrSame", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x.shr(x, 0)
 		}
 	})
@@ -572,7 +572,7 @@ func BenchmarkExp3Power(b *testing.B) {
 	} {
 		b.Run(fmt.Sprintf("%#x", y), func(b *testing.B) {
 			var z nat
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				z.expWW(x, y)
 			}
 		})
@@ -621,7 +621,7 @@ func TestFibo(t *testing.T) {
 }
 
 func BenchmarkFibo(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		fibo(1e0)
 		fibo(1e1)
 		fibo(1e2)
@@ -733,7 +733,7 @@ func benchmarkNatSqr(b *testing.B, nwords int) {
 	x := rndNat(nwords)
 	var z nat
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		z.sqr(x)
 	}
 }
@@ -815,7 +815,7 @@ func BenchmarkNatSetBytes(b *testing.B) {
 	buf := make([]byte, maxLength)
 	for _, l := range lengths {
 		b.Run(fmt.Sprint(l), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				n.setBytes(buf[:l])
 			}
 		})

--- a/src/math/big/natconv_test.go
+++ b/src/math/big/natconv_test.go
@@ -330,7 +330,7 @@ func TestScanPiParallel(t *testing.T) {
 }
 
 func BenchmarkScanPi(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		var x nat
 		x.scan(strings.NewReader(pi), 10, false)
 	}
@@ -367,7 +367,7 @@ func BenchmarkScan(b *testing.B) {
 				}
 				b.StartTimer()
 
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					z.scan(bytes.NewReader(s), base, false)
 				}
 			})
@@ -389,7 +389,7 @@ func BenchmarkString(b *testing.B) {
 				z.utoa(base) // warm divisor cache
 				b.StartTimer()
 
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					_ = z.utoa(base)
 				}
 			})
@@ -421,7 +421,7 @@ func LeafSizeHelper(b *testing.B, base, size int) {
 		_ = z.utoa(base)                 // warm divisor cache
 		b.StartTimer()
 
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = z.utoa(base)
 		}
 	}

--- a/src/math/big/prime_test.go
+++ b/src/math/big/prime_test.go
@@ -162,19 +162,19 @@ func BenchmarkProbablyPrime(b *testing.B) {
 	p, _ := new(Int).SetString("203956878356401977405765866929034577280193993314348263094772646453283062722701277632936616063144088173312372882677123879538709400158306567338328279154499698366071906766440037074217117805690872792848149112022286332144876183376326512083574821647933992961249917319836219304274280243803104015000563790123", 10)
 	for _, n := range []int{0, 1, 5, 10, 20} {
 		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				p.ProbablyPrime(n)
 			}
 		})
 	}
 
 	b.Run("Lucas", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			p.abs.probablyPrimeLucas()
 		}
 	})
 	b.Run("MillerRabinBase2", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			p.abs.probablyPrimeMillerRabin(1, true)
 		}
 	})

--- a/src/math/big/rat_test.go
+++ b/src/math/big/rat_test.go
@@ -696,7 +696,7 @@ func TestRatSetUint64(t *testing.T) {
 
 func BenchmarkRatCmp(b *testing.B) {
 	x, y := NewRat(4, 1), NewRat(7, 2)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x.Cmp(y)
 	}
 }

--- a/src/math/big/ratconv_test.go
+++ b/src/math/big/ratconv_test.go
@@ -709,7 +709,7 @@ func BenchmarkFloatPrecExact(b *testing.B) {
 		r.SetFrac(NewInt(1), d)
 
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				prec, ok := r.FloatPrec()
 				if prec != n || !ok {
 					b.Fatalf("got exact, ok = %d, %v; want %d, %v", prec, ok, uint64(n), true)
@@ -731,7 +731,7 @@ func BenchmarkFloatPrecMixed(b *testing.B) {
 		r.SetFrac(NewInt(1), d)
 
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				prec, ok := r.FloatPrec()
 				if prec != n || ok {
 					b.Fatalf("got exact, ok = %d, %v; want %d, %v", prec, ok, uint64(n), false)
@@ -754,7 +754,7 @@ func BenchmarkFloatPrecInexact(b *testing.B) {
 		r.SetFrac(NewInt(1), d)
 
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_, ok := r.FloatPrec()
 				if ok {
 					b.Fatalf("got unexpected ok")

--- a/src/math/bits/bits_test.go
+++ b/src/math/bits/bits_test.go
@@ -94,7 +94,7 @@ var Output int
 
 func BenchmarkLeadingZeros(b *testing.B) {
 	var s int
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += LeadingZeros(uint(Input) >> (uint(i) % UintSize))
 	}
 	Output = s
@@ -102,7 +102,7 @@ func BenchmarkLeadingZeros(b *testing.B) {
 
 func BenchmarkLeadingZeros8(b *testing.B) {
 	var s int
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += LeadingZeros8(uint8(Input) >> (uint(i) % 8))
 	}
 	Output = s
@@ -110,7 +110,7 @@ func BenchmarkLeadingZeros8(b *testing.B) {
 
 func BenchmarkLeadingZeros16(b *testing.B) {
 	var s int
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += LeadingZeros16(uint16(Input) >> (uint(i) % 16))
 	}
 	Output = s
@@ -118,7 +118,7 @@ func BenchmarkLeadingZeros16(b *testing.B) {
 
 func BenchmarkLeadingZeros32(b *testing.B) {
 	var s int
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += LeadingZeros32(uint32(Input) >> (uint(i) % 32))
 	}
 	Output = s
@@ -126,7 +126,7 @@ func BenchmarkLeadingZeros32(b *testing.B) {
 
 func BenchmarkLeadingZeros64(b *testing.B) {
 	var s int
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += LeadingZeros64(uint64(Input) >> (uint(i) % 64))
 	}
 	Output = s
@@ -195,7 +195,7 @@ func TestTrailingZeros(t *testing.T) {
 
 func BenchmarkTrailingZeros(b *testing.B) {
 	var s int
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += TrailingZeros(uint(Input) << (uint(i) % UintSize))
 	}
 	Output = s
@@ -203,7 +203,7 @@ func BenchmarkTrailingZeros(b *testing.B) {
 
 func BenchmarkTrailingZeros8(b *testing.B) {
 	var s int
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += TrailingZeros8(uint8(Input) << (uint(i) % 8))
 	}
 	Output = s
@@ -211,7 +211,7 @@ func BenchmarkTrailingZeros8(b *testing.B) {
 
 func BenchmarkTrailingZeros16(b *testing.B) {
 	var s int
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += TrailingZeros16(uint16(Input) << (uint(i) % 16))
 	}
 	Output = s
@@ -219,7 +219,7 @@ func BenchmarkTrailingZeros16(b *testing.B) {
 
 func BenchmarkTrailingZeros32(b *testing.B) {
 	var s int
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += TrailingZeros32(uint32(Input) << (uint(i) % 32))
 	}
 	Output = s
@@ -227,7 +227,7 @@ func BenchmarkTrailingZeros32(b *testing.B) {
 
 func BenchmarkTrailingZeros64(b *testing.B) {
 	var s int
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += TrailingZeros64(uint64(Input) << (uint(i) % 64))
 	}
 	Output = s
@@ -296,7 +296,7 @@ func testOnesCount(t *testing.T, x uint64, want int) {
 
 func BenchmarkOnesCount(b *testing.B) {
 	var s int
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		s += OnesCount(uint(Input))
 	}
 	Output = s
@@ -304,7 +304,7 @@ func BenchmarkOnesCount(b *testing.B) {
 
 func BenchmarkOnesCount8(b *testing.B) {
 	var s int
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		s += OnesCount8(uint8(Input))
 	}
 	Output = s
@@ -312,7 +312,7 @@ func BenchmarkOnesCount8(b *testing.B) {
 
 func BenchmarkOnesCount16(b *testing.B) {
 	var s int
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		s += OnesCount16(uint16(Input))
 	}
 	Output = s
@@ -320,7 +320,7 @@ func BenchmarkOnesCount16(b *testing.B) {
 
 func BenchmarkOnesCount32(b *testing.B) {
 	var s int
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		s += OnesCount32(uint32(Input))
 	}
 	Output = s
@@ -328,7 +328,7 @@ func BenchmarkOnesCount32(b *testing.B) {
 
 func BenchmarkOnesCount64(b *testing.B) {
 	var s int
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		s += OnesCount64(uint64(Input))
 	}
 	Output = s
@@ -410,7 +410,7 @@ func TestRotateLeft(t *testing.T) {
 
 func BenchmarkRotateLeft(b *testing.B) {
 	var s uint
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += RotateLeft(uint(Input), i)
 	}
 	Output = int(s)
@@ -418,7 +418,7 @@ func BenchmarkRotateLeft(b *testing.B) {
 
 func BenchmarkRotateLeft8(b *testing.B) {
 	var s uint8
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += RotateLeft8(uint8(Input), i)
 	}
 	Output = int(s)
@@ -426,7 +426,7 @@ func BenchmarkRotateLeft8(b *testing.B) {
 
 func BenchmarkRotateLeft16(b *testing.B) {
 	var s uint16
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += RotateLeft16(uint16(Input), i)
 	}
 	Output = int(s)
@@ -434,7 +434,7 @@ func BenchmarkRotateLeft16(b *testing.B) {
 
 func BenchmarkRotateLeft32(b *testing.B) {
 	var s uint32
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += RotateLeft32(uint32(Input), i)
 	}
 	Output = int(s)
@@ -442,7 +442,7 @@ func BenchmarkRotateLeft32(b *testing.B) {
 
 func BenchmarkRotateLeft64(b *testing.B) {
 	var s uint64
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += RotateLeft64(uint64(Input), i)
 	}
 	Output = int(s)
@@ -528,7 +528,7 @@ func testReverse(t *testing.T, x64, want64 uint64) {
 
 func BenchmarkReverse(b *testing.B) {
 	var s uint
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += Reverse(uint(i))
 	}
 	Output = int(s)
@@ -536,7 +536,7 @@ func BenchmarkReverse(b *testing.B) {
 
 func BenchmarkReverse8(b *testing.B) {
 	var s uint8
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += Reverse8(uint8(i))
 	}
 	Output = int(s)
@@ -544,7 +544,7 @@ func BenchmarkReverse8(b *testing.B) {
 
 func BenchmarkReverse16(b *testing.B) {
 	var s uint16
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += Reverse16(uint16(i))
 	}
 	Output = int(s)
@@ -552,7 +552,7 @@ func BenchmarkReverse16(b *testing.B) {
 
 func BenchmarkReverse32(b *testing.B) {
 	var s uint32
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += Reverse32(uint32(i))
 	}
 	Output = int(s)
@@ -560,7 +560,7 @@ func BenchmarkReverse32(b *testing.B) {
 
 func BenchmarkReverse64(b *testing.B) {
 	var s uint64
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += Reverse64(uint64(i))
 	}
 	Output = int(s)
@@ -624,7 +624,7 @@ func testReverseBytes(t *testing.T, x64, want64 uint64) {
 
 func BenchmarkReverseBytes(b *testing.B) {
 	var s uint
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += ReverseBytes(uint(i))
 	}
 	Output = int(s)
@@ -632,7 +632,7 @@ func BenchmarkReverseBytes(b *testing.B) {
 
 func BenchmarkReverseBytes16(b *testing.B) {
 	var s uint16
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += ReverseBytes16(uint16(i))
 	}
 	Output = int(s)
@@ -640,7 +640,7 @@ func BenchmarkReverseBytes16(b *testing.B) {
 
 func BenchmarkReverseBytes32(b *testing.B) {
 	var s uint32
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += ReverseBytes32(uint32(i))
 	}
 	Output = int(s)
@@ -648,7 +648,7 @@ func BenchmarkReverseBytes32(b *testing.B) {
 
 func BenchmarkReverseBytes64(b *testing.B) {
 	var s uint64
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += ReverseBytes64(uint64(i))
 	}
 	Output = int(s)
@@ -1180,7 +1180,7 @@ func TestRem64Overflow(t *testing.T) {
 
 func BenchmarkAdd(b *testing.B) {
 	var z, c uint
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		z, c = Add(uint(Input), uint(i), c)
 	}
 	Output = int(z + c)
@@ -1188,7 +1188,7 @@ func BenchmarkAdd(b *testing.B) {
 
 func BenchmarkAdd32(b *testing.B) {
 	var z, c uint32
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		z, c = Add32(uint32(Input), uint32(i), c)
 	}
 	Output = int(z + c)
@@ -1196,7 +1196,7 @@ func BenchmarkAdd32(b *testing.B) {
 
 func BenchmarkAdd64(b *testing.B) {
 	var z, c uint64
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		z, c = Add64(uint64(Input), uint64(i), c)
 	}
 	Output = int(z + c)
@@ -1207,7 +1207,7 @@ func BenchmarkAdd64multiple(b *testing.B) {
 	var z1 = uint64(Input)
 	var z2 = uint64(Input)
 	var z3 = uint64(Input)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		var c uint64
 		z0, c = Add64(z0, uint64(i), c)
 		z1, c = Add64(z1, uint64(i), c)
@@ -1219,7 +1219,7 @@ func BenchmarkAdd64multiple(b *testing.B) {
 
 func BenchmarkSub(b *testing.B) {
 	var z, c uint
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		z, c = Sub(uint(Input), uint(i), c)
 	}
 	Output = int(z + c)
@@ -1227,7 +1227,7 @@ func BenchmarkSub(b *testing.B) {
 
 func BenchmarkSub32(b *testing.B) {
 	var z, c uint32
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		z, c = Sub32(uint32(Input), uint32(i), c)
 	}
 	Output = int(z + c)
@@ -1235,7 +1235,7 @@ func BenchmarkSub32(b *testing.B) {
 
 func BenchmarkSub64(b *testing.B) {
 	var z, c uint64
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		z, c = Sub64(uint64(Input), uint64(i), c)
 	}
 	Output = int(z + c)
@@ -1246,7 +1246,7 @@ func BenchmarkSub64multiple(b *testing.B) {
 	var z1 = uint64(Input)
 	var z2 = uint64(Input)
 	var z3 = uint64(Input)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		var c uint64
 		z0, c = Sub64(z0, uint64(i), c)
 		z1, c = Sub64(z1, uint64(i), c)
@@ -1258,7 +1258,7 @@ func BenchmarkSub64multiple(b *testing.B) {
 
 func BenchmarkMul(b *testing.B) {
 	var hi, lo uint
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		hi, lo = Mul(uint(Input), uint(i))
 	}
 	Output = int(hi + lo)
@@ -1266,7 +1266,7 @@ func BenchmarkMul(b *testing.B) {
 
 func BenchmarkMul32(b *testing.B) {
 	var hi, lo uint32
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		hi, lo = Mul32(uint32(Input), uint32(i))
 	}
 	Output = int(hi + lo)
@@ -1274,7 +1274,7 @@ func BenchmarkMul32(b *testing.B) {
 
 func BenchmarkMul64(b *testing.B) {
 	var hi, lo uint64
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		hi, lo = Mul64(uint64(Input), uint64(i))
 	}
 	Output = int(hi + lo)
@@ -1282,7 +1282,7 @@ func BenchmarkMul64(b *testing.B) {
 
 func BenchmarkDiv(b *testing.B) {
 	var q, r uint
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		q, r = Div(1, uint(i), uint(Input))
 	}
 	Output = int(q + r)
@@ -1290,7 +1290,7 @@ func BenchmarkDiv(b *testing.B) {
 
 func BenchmarkDiv32(b *testing.B) {
 	var q, r uint32
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		q, r = Div32(1, uint32(i), uint32(Input))
 	}
 	Output = int(q + r)
@@ -1298,7 +1298,7 @@ func BenchmarkDiv32(b *testing.B) {
 
 func BenchmarkDiv64(b *testing.B) {
 	var q, r uint64
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		q, r = Div64(1, uint64(i), uint64(Input))
 	}
 	Output = int(q + r)

--- a/src/math/cmplx/cmath_test.go
+++ b/src/math/cmplx/cmath_test.go
@@ -1478,112 +1478,112 @@ func TestInfiniteLoopIntanSeries(t *testing.T) {
 }
 
 func BenchmarkAbs(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Abs(complex(2.5, 3.5))
 	}
 }
 func BenchmarkAcos(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Acos(complex(2.5, 3.5))
 	}
 }
 func BenchmarkAcosh(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Acosh(complex(2.5, 3.5))
 	}
 }
 func BenchmarkAsin(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Asin(complex(2.5, 3.5))
 	}
 }
 func BenchmarkAsinh(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Asinh(complex(2.5, 3.5))
 	}
 }
 func BenchmarkAtan(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Atan(complex(2.5, 3.5))
 	}
 }
 func BenchmarkAtanh(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Atanh(complex(2.5, 3.5))
 	}
 }
 func BenchmarkConj(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Conj(complex(2.5, 3.5))
 	}
 }
 func BenchmarkCos(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Cos(complex(2.5, 3.5))
 	}
 }
 func BenchmarkCosh(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Cosh(complex(2.5, 3.5))
 	}
 }
 func BenchmarkExp(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Exp(complex(2.5, 3.5))
 	}
 }
 func BenchmarkLog(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Log(complex(2.5, 3.5))
 	}
 }
 func BenchmarkLog10(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Log10(complex(2.5, 3.5))
 	}
 }
 func BenchmarkPhase(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Phase(complex(2.5, 3.5))
 	}
 }
 func BenchmarkPolar(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Polar(complex(2.5, 3.5))
 	}
 }
 func BenchmarkPow(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Pow(complex(2.5, 3.5), complex(2.5, 3.5))
 	}
 }
 func BenchmarkRect(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Rect(2.5, 1.5)
 	}
 }
 func BenchmarkSin(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Sin(complex(2.5, 3.5))
 	}
 }
 func BenchmarkSinh(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Sinh(complex(2.5, 3.5))
 	}
 }
 func BenchmarkSqrt(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Sqrt(complex(2.5, 3.5))
 	}
 }
 func BenchmarkTan(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Tan(complex(2.5, 3.5))
 	}
 }
 func BenchmarkTanh(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Tanh(complex(2.5, 3.5))
 	}
 }

--- a/src/mime/encodedword_test.go
+++ b/src/mime/encodedword_test.go
@@ -217,7 +217,7 @@ func TestCharsetDecoderError(t *testing.T) {
 }
 
 func BenchmarkQEncodeWord(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		QEncoding.Encode("UTF-8", "¡Hola, señor!")
 	}
 }
@@ -225,7 +225,7 @@ func BenchmarkQEncodeWord(b *testing.B) {
 func BenchmarkQDecodeWord(b *testing.B) {
 	dec := new(WordDecoder)
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		dec.Decode("=?utf-8?q?=C2=A1Hola,_se=C3=B1or!?=")
 	}
 }
@@ -233,7 +233,7 @@ func BenchmarkQDecodeWord(b *testing.B) {
 func BenchmarkQDecodeHeader(b *testing.B) {
 	dec := new(WordDecoder)
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		dec.DecodeHeader("=?utf-8?q?=C2=A1Hola,_se=C3=B1or!?=")
 	}
 }

--- a/src/mime/multipart/formdata_test.go
+++ b/src/mime/multipart/formdata_test.go
@@ -486,7 +486,7 @@ func BenchmarkReadForm(b *testing.B) {
 				}
 				b.Run(fmt.Sprintf("maxMemory=%v", maxMemory), func(b *testing.B) {
 					b.ReportAllocs()
-					for i := 0; i < b.N; i++ {
+					for range b.N {
 						fr := NewReader(bytes.NewReader(buf.Bytes()), fw.Boundary())
 						form, err := fr.ReadForm(maxMemory)
 						if err != nil {

--- a/src/mime/quotedprintable/writer_test.go
+++ b/src/mime/quotedprintable/writer_test.go
@@ -150,7 +150,7 @@ var testMsg = []byte("Quoted-Printable (QP) est un format d'encodage de données
 	"Enfin, un signe égal suivi par un saut de ligne (donc la suite des trois caractères de codes ASCII 61, 13 et 10) peut être inséré n'importe où, afin de limiter la taille des lignes produites si nécessaire. Une limite de 76 caractères par ligne est généralement respectée.\r\n")
 
 func BenchmarkWriter(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		w := NewWriter(io.Discard)
 		w.Write(testMsg)
 		w.Close()

--- a/src/net/dnsclient_unix_test.go
+++ b/src/net/dnsclient_unix_test.go
@@ -773,7 +773,7 @@ func BenchmarkGoLookupIP(b *testing.B) {
 	ctx := context.Background()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		goResolver.LookupIPAddr(ctx, "www.example.com")
 	}
 }
@@ -783,7 +783,7 @@ func BenchmarkGoLookupIPNoSuchHost(b *testing.B) {
 	ctx := context.Background()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		goResolver.LookupIPAddr(ctx, "some.nonexistent")
 	}
 }
@@ -807,7 +807,7 @@ func BenchmarkGoLookupIPWithBrokenNameServer(b *testing.B) {
 	ctx := context.Background()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		goResolver.LookupIPAddr(ctx, "www.example.com")
 	}
 }

--- a/src/net/http/cookie_test.go
+++ b/src/net/http/cookie_test.go
@@ -575,7 +575,7 @@ func BenchmarkCookieString(b *testing.B) {
 	var benchmarkCookieString string
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		benchmarkCookieString = c.String()
 	}
 	if have, want := benchmarkCookieString, wantCookieString; have != want {
@@ -614,7 +614,7 @@ func BenchmarkReadSetCookies(b *testing.B) {
 	var c []*Cookie
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		c = readSetCookies(header)
 	}
 	if !reflect.DeepEqual(c, wantCookies) {
@@ -643,7 +643,7 @@ func BenchmarkReadCookies(b *testing.B) {
 	var c []*Cookie
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		c = readCookies(header, "")
 	}
 	if !reflect.DeepEqual(c, wantCookies) {

--- a/src/net/http/header_test.go
+++ b/src/net/http/header_test.go
@@ -210,7 +210,7 @@ var buf bytes.Buffer
 
 func BenchmarkHeaderWriteSubset(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf.Reset()
 		testHeader.WriteSubset(&buf, nil)
 	}

--- a/src/net/http/http_test.go
+++ b/src/net/http/http_test.go
@@ -119,7 +119,7 @@ func BenchmarkCopyValues(b *testing.B) {
 		"j": {"1", "2"},
 		"m": nil,
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		dst := url.Values{"a": {"b"}, "b": {"2"}, "c": {"3"}, "d": {"4"}, "j": nil, "m": {"x"}}
 		copyValues(dst, src)
 		if valuesCount = len(dst["a"]); valuesCount != 6 {
@@ -194,7 +194,7 @@ const redirectURL = "/thisaredirect细雪withasciilettersのけぶabcdefghijk.ht
 func BenchmarkHexEscapeNonASCII(b *testing.B) {
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		hexEscapeNonASCII(redirectURL)
 	}
 }

--- a/src/net/http/httputil/reverseproxy_test.go
+++ b/src/net/http/httputil/reverseproxy_test.go
@@ -1055,7 +1055,7 @@ func BenchmarkServeHTTP(b *testing.B) {
 	r := httptest.NewRequest("GET", "/", nil)
 
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		proxy.ServeHTTP(w, r)
 	}
 }

--- a/src/net/http/mapping_test.go
+++ b/src/net/http/mapping_test.go
@@ -112,7 +112,7 @@ func BenchmarkFindChild(b *testing.B) {
 					entries = append(entries, entry[string, any]{c, nil})
 				}
 				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					findChildLinear(key, entries)
 				}
 			})
@@ -123,7 +123,7 @@ func BenchmarkFindChild(b *testing.B) {
 				}
 				var x any
 				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					x = m[key]
 				}
 				_ = x
@@ -135,7 +135,7 @@ func BenchmarkFindChild(b *testing.B) {
 				}
 				var x any
 				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					x, _ = h.find(key)
 				}
 				_ = x

--- a/src/net/http/request_test.go
+++ b/src/net/http/request_test.go
@@ -1266,7 +1266,7 @@ func benchmarkReadRequest(b *testing.B, request string) {
 	r := bufio.NewReader(&infiniteReader{buf: []byte(request)})
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, err := ReadRequest(r)
 		if err != nil {
 			b.Fatalf("failed to read request: %v", err)
@@ -1385,7 +1385,7 @@ func runFileAndServerBenchmarks(b *testing.B, mode testMode, f *os.File, n int64
 	cst := newClientServerTest(b, mode, handler).ts
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		// Perform some setup.
 		b.StopTimer()
 		if _, err := f.Seek(0, 0); err != nil {

--- a/src/net/http/routing_index_test.go
+++ b/src/net/http/routing_index_test.go
@@ -160,7 +160,7 @@ func BenchmarkMultiConflicts(b *testing.B) {
 		pats = append(pats, mustParsePattern(b, fmt.Sprintf("/a/b/{x}/d%d/", i)))
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		var idx routingIndex
 		for _, p := range pats {
 			got := indexConflicts(p, &idx)

--- a/src/net/http/serve_test.go
+++ b/src/net/http/serve_test.go
@@ -634,7 +634,7 @@ func benchmarkServeMux(b *testing.B, runHandler bool) {
 	rw := httptest.NewRecorder()
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, tt := range tests {
 			*rw = httptest.ResponseRecorder{}
 			h, pattern := mux.Handler(tt.req)
@@ -4965,7 +4965,7 @@ func benchmarkClientServer(b *testing.B, mode testMode) {
 	b.StartTimer()
 
 	c := ts.Client()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		res, err := c.Get(ts.URL)
 		if err != nil {
 			b.Fatal("Get:", err)
@@ -5157,7 +5157,7 @@ func BenchmarkClient(b *testing.B) {
 
 	// Do b.N requests to the server.
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		res, err := Get(url)
 		if err != nil {
 			b.Fatalf("Get: %v", err)
@@ -5198,7 +5198,7 @@ Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.3
 		rw.Write(res)
 	})
 	ln := new(oneConnListener)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		conn.readBuf.Reset()
 		conn.writeBuf.Reset()
 		conn.readBuf.Write(req)
@@ -5365,7 +5365,7 @@ Host: golang.org
 		closec: make(chan bool, 1),
 	}
 	ln := &oneConnListener{conn: conn}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		conn.Reader = bytes.NewReader(req)
 		ln.conn = conn
 		Serve(ln, h)
@@ -5383,7 +5383,7 @@ func benchmarkCloseNotifier(b *testing.B, mode testMode) {
 		sawClose <- true
 	})).ts
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		conn, err := net.Dial("tcp", ts.Listener.Addr().String())
 		if err != nil {
 			b.Fatalf("error dialing: %v", err)

--- a/src/net/http/server_test.go
+++ b/src/net/http/server_test.go
@@ -275,7 +275,7 @@ func BenchmarkServerMatch(b *testing.B) {
 	paths := []string{"/", "/notfound", "/admin/", "/admin/foo", "/contact", "/products",
 		"/products/", "/products/3/image.jpg"}
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		r, err := NewRequest("GET", "http://example.com/"+paths[i%len(paths)], nil)
 		if err != nil {
 			b.Fatal(err)

--- a/src/net/interface_test.go
+++ b/src/net/interface_test.go
@@ -301,7 +301,7 @@ func BenchmarkInterfaces(b *testing.B) {
 	b.ReportAllocs()
 	testHookUninstaller.Do(uninstallTestHooks)
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if _, err := Interfaces(); err != nil {
 			b.Fatal(err)
 		}
@@ -316,7 +316,7 @@ func BenchmarkInterfaceByIndex(b *testing.B) {
 	if ifi == nil {
 		b.Skip("loopback interface not found")
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if _, err := InterfaceByIndex(ifi.Index); err != nil {
 			b.Fatal(err)
 		}
@@ -331,7 +331,7 @@ func BenchmarkInterfaceByName(b *testing.B) {
 	if ifi == nil {
 		b.Skip("loopback interface not found")
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if _, err := InterfaceByName(ifi.Name); err != nil {
 			b.Fatal(err)
 		}
@@ -342,7 +342,7 @@ func BenchmarkInterfaceAddrs(b *testing.B) {
 	b.ReportAllocs()
 	testHookUninstaller.Do(uninstallTestHooks)
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if _, err := InterfaceAddrs(); err != nil {
 			b.Fatal(err)
 		}
@@ -357,7 +357,7 @@ func BenchmarkInterfacesAndAddrs(b *testing.B) {
 	if ifi == nil {
 		b.Skip("loopback interface not found")
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if _, err := ifi.Addrs(); err != nil {
 			b.Fatal(err)
 		}
@@ -372,7 +372,7 @@ func BenchmarkInterfacesAndMulticastAddrs(b *testing.B) {
 	if ifi == nil {
 		b.Skip("loopback interface not found")
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if _, err := ifi.MulticastAddrs(); err != nil {
 			b.Fatal(err)
 		}

--- a/src/net/ip_test.go
+++ b/src/net/ip_test.go
@@ -107,7 +107,7 @@ func TestLookupWithIP(t *testing.T) {
 func BenchmarkParseIP(b *testing.B) {
 	testHookUninstaller.Do(uninstallTestHooks)
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, tt := range parseIPTests {
 			ParseIP(tt.in)
 		}
@@ -117,7 +117,7 @@ func BenchmarkParseIP(b *testing.B) {
 func BenchmarkParseIPValidIPv4(b *testing.B) {
 	testHookUninstaller.Do(uninstallTestHooks)
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ParseIP("192.0.2.1")
 	}
 }
@@ -125,7 +125,7 @@ func BenchmarkParseIPValidIPv4(b *testing.B) {
 func BenchmarkParseIPValidIPv6(b *testing.B) {
 	testHookUninstaller.Do(uninstallTestHooks)
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ParseIP("2001:DB8::1")
 	}
 }
@@ -283,7 +283,7 @@ func BenchmarkIPString(b *testing.B) {
 func benchmarkIPString(b *testing.B, size int) {
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, tt := range ipStringTests {
 			if tt.in != nil && len(tt.in) == size {
 				sink = tt.in.String()
@@ -335,7 +335,7 @@ func TestIPMaskString(t *testing.T) {
 func BenchmarkIPMaskString(b *testing.B) {
 	testHookUninstaller.Do(uninstallTestHooks)
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, tt := range ipMaskStringTests {
 			sink = tt.in.String()
 		}

--- a/src/net/netip/netip_pkg_test.go
+++ b/src/net/netip/netip_pkg_test.go
@@ -104,7 +104,7 @@ func TestIPNextPrev(t *testing.T) {
 }
 
 func BenchmarkIPNextPrev(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		doNextPrev(b)
 	}
 }

--- a/src/net/netip/netip_test.go
+++ b/src/net/netip/netip_test.go
@@ -1548,7 +1548,7 @@ func BenchmarkBinaryMarshalRoundTrip(b *testing.B) {
 	for _, tc := range tests {
 		b.Run(tc.name, func(b *testing.B) {
 			ip := mustIP(tc.ip)
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				bt, err := ip.MarshalBinary()
 				if err != nil {
 					b.Fatal(err)
@@ -1565,7 +1565,7 @@ func BenchmarkBinaryMarshalRoundTrip(b *testing.B) {
 func BenchmarkStdIPv4(b *testing.B) {
 	b.ReportAllocs()
 	ips := []net.IP{}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ip := net.IPv4(8, 8, 8, 8)
 		ips = ips[:0]
 		for i := 0; i < 100; i++ {
@@ -1577,7 +1577,7 @@ func BenchmarkStdIPv4(b *testing.B) {
 func BenchmarkIPv4(b *testing.B) {
 	b.ReportAllocs()
 	ips := []Addr{}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ip := IPv4(8, 8, 8, 8)
 		ips = ips[:0]
 		for i := 0; i < 100; i++ {
@@ -1606,7 +1606,7 @@ func newip4i_v4(a, b, c, d byte) ip4i {
 func BenchmarkIPv4_inline(b *testing.B) {
 	b.ReportAllocs()
 	ips := []ip4i{}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ip := newip4i_v4(8, 8, 8, 8)
 		ips = ips[:0]
 		for i := 0; i < 100; i++ {
@@ -1618,7 +1618,7 @@ func BenchmarkIPv4_inline(b *testing.B) {
 func BenchmarkStdIPv6(b *testing.B) {
 	b.ReportAllocs()
 	ips := []net.IP{}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ip := net.ParseIP("2001:db8::1")
 		ips = ips[:0]
 		for i := 0; i < 100; i++ {
@@ -1630,7 +1630,7 @@ func BenchmarkStdIPv6(b *testing.B) {
 func BenchmarkIPv6(b *testing.B) {
 	b.ReportAllocs()
 	ips := []Addr{}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ip := mustIP("2001:db8::1")
 		ips = ips[:0]
 		for i := 0; i < 100; i++ {
@@ -1643,7 +1643,7 @@ func BenchmarkIPv4Contains(b *testing.B) {
 	b.ReportAllocs()
 	prefix := PrefixFrom(IPv4(192, 168, 1, 0), 24)
 	ip := IPv4(192, 168, 1, 1)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		prefix.Contains(ip)
 	}
 }
@@ -1652,7 +1652,7 @@ func BenchmarkIPv6Contains(b *testing.B) {
 	b.ReportAllocs()
 	prefix := MustParsePrefix("::1/128")
 	ip := MustParseAddr("::1")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		prefix.Contains(ip)
 	}
 }
@@ -1673,7 +1673,7 @@ func BenchmarkParseAddr(b *testing.B) {
 	for _, test := range parseBenchInputs {
 		b.Run(test.name, func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				sinkIP, _ = ParseAddr(test.ip)
 			}
 		})
@@ -1684,7 +1684,7 @@ func BenchmarkStdParseIP(b *testing.B) {
 	for _, test := range parseBenchInputs {
 		b.Run(test.name, func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				sinkStdIP = net.ParseIP(test.ip)
 			}
 		})
@@ -1696,7 +1696,7 @@ func BenchmarkIPString(b *testing.B) {
 		ip := MustParseAddr(test.ip)
 		b.Run(test.name, func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				sinkString = ip.String()
 			}
 		})
@@ -1708,7 +1708,7 @@ func BenchmarkIPStringExpanded(b *testing.B) {
 		ip := MustParseAddr(test.ip)
 		b.Run(test.name, func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				sinkString = ip.StringExpanded()
 			}
 		})
@@ -1718,7 +1718,7 @@ func BenchmarkIPStringExpanded(b *testing.B) {
 func BenchmarkIPMarshalText(b *testing.B) {
 	b.ReportAllocs()
 	ip := MustParseAddr("66.55.44.33")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sinkBytes, _ = ip.MarshalText()
 	}
 }
@@ -1729,7 +1729,7 @@ func BenchmarkAddrPortString(b *testing.B) {
 		ipp := AddrPortFrom(ip, 60000)
 		b.Run(test.name, func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				sinkString = ipp.String()
 			}
 		})
@@ -1742,7 +1742,7 @@ func BenchmarkAddrPortMarshalText(b *testing.B) {
 		ipp := AddrPortFrom(ip, 60000)
 		b.Run(test.name, func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				sinkBytes, _ = ipp.MarshalText()
 			}
 		})
@@ -1806,7 +1806,7 @@ func BenchmarkPrefixMasking(b *testing.B) {
 		b.Run(tt.name, func(b *testing.B) {
 			b.ReportAllocs()
 
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				sinkPrefix, _ = tt.ip.Prefix(tt.bits)
 			}
 		})
@@ -1816,7 +1816,7 @@ func BenchmarkPrefixMasking(b *testing.B) {
 func BenchmarkPrefixMarshalText(b *testing.B) {
 	b.ReportAllocs()
 	ipp := MustParsePrefix("66.55.44.33/22")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sinkBytes, _ = ipp.MarshalText()
 	}
 }
@@ -1832,7 +1832,7 @@ func BenchmarkParseAddrPort(b *testing.B) {
 		b.Run(test.name, func(b *testing.B) {
 			b.ReportAllocs()
 
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				sinkAddrPort, _ = ParseAddrPort(ipp)
 			}
 		})
@@ -2144,7 +2144,7 @@ var sink16 [16]byte
 
 func BenchmarkAs16(b *testing.B) {
 	addr := MustParseAddr("1::10")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sink16 = addr.As16()
 	}
 }

--- a/src/net/tcpsock_test.go
+++ b/src/net/tcpsock_test.go
@@ -764,7 +764,7 @@ func BenchmarkSetReadDeadline(b *testing.B) {
 	c.SetWriteDeadline(time.Now().Add(2 * time.Hour))
 	deadline := time.Now().Add(time.Hour)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		c.SetReadDeadline(deadline)
 		deadline = deadline.Add(1)
 	}

--- a/src/net/textproto/reader_test.go
+++ b/src/net/textproto/reader_test.go
@@ -497,7 +497,7 @@ func BenchmarkReadMIMEHeader(b *testing.B) {
 			br := bufio.NewReader(&buf)
 			r := NewReader(br)
 
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				buf.WriteString(set.headers)
 				if _, err := r.ReadMIMEHeader(); err != nil {
 					b.Fatal(err)
@@ -512,7 +512,7 @@ func BenchmarkUncommon(b *testing.B) {
 	var buf bytes.Buffer
 	br := bufio.NewReader(&buf)
 	r := NewReader(br)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		buf.WriteString("uncommon-header-for-benchmark: foo\r\n\r\n")
 		h, err := r.ReadMIMEHeader()
 		if err != nil {

--- a/src/net/udpsock_test.go
+++ b/src/net/udpsock_test.go
@@ -43,7 +43,7 @@ func BenchmarkUDP6LinkLocalUnicast(b *testing.B) {
 	defer c2.Close()
 
 	var buf [1]byte
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if _, err := c1.WriteTo(buf[:], c2.LocalAddr()); err != nil {
 			b.Fatal(err)
 		}
@@ -559,7 +559,7 @@ func BenchmarkReadWriteMsgUDPAddrPort(b *testing.B) {
 	buf := make([]byte, 8)
 	b.ResetTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _, err := conn.WriteMsgUDPAddrPort(buf, nil, addr)
 		if err != nil {
 			b.Fatal(err)
@@ -581,7 +581,7 @@ func BenchmarkWriteToReadFromUDP(b *testing.B) {
 	buf := make([]byte, 8)
 	b.ResetTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, err := conn.WriteTo(buf, addr)
 		if err != nil {
 			b.Fatal(err)
@@ -603,7 +603,7 @@ func BenchmarkWriteToReadFromUDPAddrPort(b *testing.B) {
 	buf := make([]byte, 8)
 	b.ResetTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, err := conn.WriteToUDPAddrPort(buf, addr)
 		if err != nil {
 			b.Fatal(err)

--- a/src/net/url/url_test.go
+++ b/src/net/url/url_test.go
@@ -644,7 +644,7 @@ func BenchmarkString(b *testing.B) {
 		}
 		b.StartTimer()
 		var g string
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			g = u.String()
 		}
 		b.StopTimer()
@@ -1118,7 +1118,7 @@ func TestResolvePath(t *testing.T) {
 
 func BenchmarkResolvePath(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		resolvePath("a/b/c", ".././d")
 	}
 }
@@ -2001,7 +2001,7 @@ func BenchmarkQueryEscape(b *testing.B) {
 		b.Run("", func(b *testing.B) {
 			b.ReportAllocs()
 			var g string
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				g = QueryEscape(tc.unescaped)
 			}
 			b.StopTimer()
@@ -2018,7 +2018,7 @@ func BenchmarkPathEscape(b *testing.B) {
 		b.Run("", func(b *testing.B) {
 			b.ReportAllocs()
 			var g string
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				g = PathEscape(tc.unescaped)
 			}
 			b.StopTimer()
@@ -2035,7 +2035,7 @@ func BenchmarkQueryUnescape(b *testing.B) {
 		b.Run("", func(b *testing.B) {
 			b.ReportAllocs()
 			var g string
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				g, _ = QueryUnescape(tc.query)
 			}
 			b.StopTimer()
@@ -2052,7 +2052,7 @@ func BenchmarkPathUnescape(b *testing.B) {
 		b.Run("", func(b *testing.B) {
 			b.ReportAllocs()
 			var g string
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				g, _ = PathUnescape(tc.path)
 			}
 			b.StopTimer()

--- a/src/os/env_test.go
+++ b/src/os/env_test.go
@@ -72,7 +72,7 @@ func BenchmarkExpand(b *testing.B) {
 	b.Run("noop", func(b *testing.B) {
 		var s string
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			s = Expand("tick tick tick tick", func(string) string { return "" })
 		}
 		global = s
@@ -80,7 +80,7 @@ func BenchmarkExpand(b *testing.B) {
 	b.Run("multiple", func(b *testing.B) {
 		var s string
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			s = Expand("$a $a $a $a", func(string) string { return "boom" })
 		}
 		global = s

--- a/src/os/exec/bench_test.go
+++ b/src/os/exec/bench_test.go
@@ -15,7 +15,7 @@ func BenchmarkExecHostname(b *testing.B) {
 		b.Fatalf("could not find hostname: %v", err)
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if err := Command(path).Run(); err != nil {
 			b.Fatalf("hostname: %v", err)
 		}

--- a/src/os/os_test.go
+++ b/src/os/os_test.go
@@ -497,7 +497,7 @@ func TestFileReadDir(t *testing.T) {
 
 func benchmarkReaddirname(path string, b *testing.B) {
 	var nentries int
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		f, err := Open(path)
 		if err != nil {
 			b.Fatalf("open %q failed: %v", path, err)
@@ -514,7 +514,7 @@ func benchmarkReaddirname(path string, b *testing.B) {
 
 func benchmarkReaddir(path string, b *testing.B) {
 	var nentries int
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		f, err := Open(path)
 		if err != nil {
 			b.Fatalf("open %q failed: %v", path, err)
@@ -531,7 +531,7 @@ func benchmarkReaddir(path string, b *testing.B) {
 
 func benchmarkReadDir(path string, b *testing.B) {
 	var nentries int
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		f, err := Open(path)
 		if err != nil {
 			b.Fatalf("open %q failed: %v", path, err)
@@ -560,7 +560,7 @@ func BenchmarkReadDir(b *testing.B) {
 
 func benchmarkStat(b *testing.B, path string) {
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, err := Stat(path)
 		if err != nil {
 			b.Fatalf("Stat(%q) failed: %v", path, err)
@@ -570,7 +570,7 @@ func benchmarkStat(b *testing.B, path string) {
 
 func benchmarkLstat(b *testing.B, path string) {
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, err := Lstat(path)
 		if err != nil {
 			b.Fatalf("Lstat(%q) failed: %v", path, err)

--- a/src/os/user/user_test.go
+++ b/src/os/user/user_test.go
@@ -45,7 +45,7 @@ func TestCurrent(t *testing.T) {
 }
 
 func BenchmarkCurrent(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Current()
 	}
 }

--- a/src/reflect/benchmark_test.go
+++ b/src/reflect/benchmark_test.go
@@ -37,61 +37,61 @@ var sinkAll struct {
 }
 
 func BenchmarkBool(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sinkAll.RawBool = sourceAll.Bool.Bool()
 	}
 }
 
 func BenchmarkString(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sinkAll.RawString = sourceAll.String.String()
 	}
 }
 
 func BenchmarkBytes(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sinkAll.RawBytes = sourceAll.Bytes.Bytes()
 	}
 }
 
 func BenchmarkNamedBytes(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sinkAll.RawBytes = sourceAll.NamedBytes.Bytes()
 	}
 }
 
 func BenchmarkBytesArray(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sinkAll.RawBytes = sourceAll.BytesArray.Bytes()
 	}
 }
 
 func BenchmarkSliceLen(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sinkAll.RawInt = sourceAll.SliceAny.Len()
 	}
 }
 
 func BenchmarkMapLen(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sinkAll.RawInt = sourceAll.MapStringAny.Len()
 	}
 }
 
 func BenchmarkStringLen(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sinkAll.RawInt = sourceAll.String.Len()
 	}
 }
 
 func BenchmarkArrayLen(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sinkAll.RawInt = sourceAll.BytesArray.Len()
 	}
 }
 
 func BenchmarkSliceCap(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sinkAll.RawInt = sourceAll.SliceAny.Cap()
 	}
 }
@@ -100,7 +100,7 @@ func BenchmarkDeepEqual(b *testing.B) {
 	for _, bb := range deepEqualPerfTests {
 		b.Run(ValueOf(bb.x).Type().String(), func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				sink = DeepEqual(bb.x, bb.y)
 			}
 		})
@@ -114,7 +114,7 @@ func BenchmarkMapsDeepEqual(b *testing.B) {
 	m2 := map[int]int{
 		1: 1, 2: 2,
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		DeepEqual(m1, m2)
 	}
 }
@@ -149,7 +149,7 @@ func BenchmarkIsZero(b *testing.B) {
 		name := source.Type().Field(i).Name
 		value := source.Field(i)
 		b.Run(name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				sink = value.IsZero()
 			}
 		})
@@ -179,17 +179,17 @@ func BenchmarkSetZero(b *testing.B) {
 		value := source.Field(i)
 		zero := Zero(value.Type())
 		b.Run(name+"/Direct", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				value.SetZero()
 			}
 		})
 		b.Run(name+"/CachedZero", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				value.Set(zero)
 			}
 		})
 		b.Run(name+"/NewZero", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				value.Set(Zero(value.Type()))
 			}
 		})
@@ -209,7 +209,7 @@ func BenchmarkSelect(b *testing.B) {
 	for _, numCases := range []int{1, 4, 8} {
 		b.Run(strconv.Itoa(numCases), func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_, _, _ = Select(cases[:numCases])
 			}
 		})
@@ -238,7 +238,7 @@ func BenchmarkCallMethod(b *testing.B) {
 	z := new(myint)
 
 	v := ValueOf(z.inc)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		v.Call(nil)
 	}
 }
@@ -399,7 +399,7 @@ func BenchmarkMap(b *testing.B) {
 		b.Run(tt.label, func(b *testing.B) {
 			b.Run("MapIndex", func(b *testing.B) {
 				b.ReportAllocs()
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					for j := tt.keys.Len() - 1; j >= 0; j-- {
 						tt.m.MapIndex(tt.keys.Index(j))
 					}
@@ -407,7 +407,7 @@ func BenchmarkMap(b *testing.B) {
 			})
 			b.Run("SetMapIndex", func(b *testing.B) {
 				b.ReportAllocs()
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					for j := tt.keys.Len() - 1; j >= 0; j-- {
 						tt.m.SetMapIndex(tt.keys.Index(j), tt.value)
 					}
@@ -420,7 +420,7 @@ func BenchmarkMap(b *testing.B) {
 func BenchmarkMapIterNext(b *testing.B) {
 	m := ValueOf(map[string]int{"a": 0, "b": 1, "c": 2, "d": 3})
 	it := m.MapRange()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for it.Next() {
 		}
 		it.Reset(m)

--- a/src/regexp/all_test.go
+++ b/src/regexp/all_test.go
@@ -591,7 +591,7 @@ func BenchmarkFind(b *testing.B) {
 	s := []byte("acbb" + wantSubs + "dd")
 	b.StartTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		subs := re.Find(s)
 		if string(subs) != wantSubs {
 			b.Fatalf("Find(%q) = %q; want %q", s, subs, wantSubs)
@@ -604,7 +604,7 @@ func BenchmarkFindAllNoMatches(b *testing.B) {
 	s := []byte("acddee")
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		all := re.FindAll(s, -1)
 		if all != nil {
 			b.Fatalf("FindAll(%q) = %q; want nil", s, all)
@@ -619,7 +619,7 @@ func BenchmarkFindString(b *testing.B) {
 	s := "acbb" + wantSubs + "dd"
 	b.StartTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		subs := re.FindString(s)
 		if subs != wantSubs {
 			b.Fatalf("FindString(%q) = %q; want %q", s, subs, wantSubs)
@@ -634,7 +634,7 @@ func BenchmarkFindSubmatch(b *testing.B) {
 	s := []byte("acbb" + wantSubs + "dd")
 	b.StartTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		subs := re.FindSubmatch(s)
 		if string(subs[0]) != wantSubs {
 			b.Fatalf("FindSubmatch(%q)[0] = %q; want %q", s, subs[0], wantSubs)
@@ -652,7 +652,7 @@ func BenchmarkFindStringSubmatch(b *testing.B) {
 	s := "acbb" + wantSubs + "dd"
 	b.StartTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		subs := re.FindStringSubmatch(s)
 		if subs[0] != wantSubs {
 			b.Fatalf("FindStringSubmatch(%q)[0] = %q; want %q", s, subs[0], wantSubs)
@@ -668,7 +668,7 @@ func BenchmarkLiteral(b *testing.B) {
 	b.StopTimer()
 	re := MustCompile("y")
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if !re.MatchString(x) {
 			b.Fatalf("no match!")
 		}
@@ -680,7 +680,7 @@ func BenchmarkNotLiteral(b *testing.B) {
 	b.StopTimer()
 	re := MustCompile(".y")
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if !re.MatchString(x) {
 			b.Fatalf("no match!")
 		}
@@ -692,7 +692,7 @@ func BenchmarkMatchClass(b *testing.B) {
 	x := strings.Repeat("xxxx", 20) + "w"
 	re := MustCompile("[abcdw]")
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if !re.MatchString(x) {
 			b.Fatalf("no match!")
 		}
@@ -706,7 +706,7 @@ func BenchmarkMatchClass_InRange(b *testing.B) {
 	x := strings.Repeat("bbbb", 20) + "c"
 	re := MustCompile("[ac]")
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if !re.MatchString(x) {
 			b.Fatalf("no match!")
 		}
@@ -718,7 +718,7 @@ func BenchmarkReplaceAll(b *testing.B) {
 	b.StopTimer()
 	re := MustCompile("[cjrw]")
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		re.ReplaceAllString(x, "")
 	}
 }
@@ -728,7 +728,7 @@ func BenchmarkAnchoredLiteralShortNonMatch(b *testing.B) {
 	x := []byte("abcdefghijklmnopqrstuvwxyz")
 	re := MustCompile("^zbc(d|e)")
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		re.Match(x)
 	}
 }
@@ -741,7 +741,7 @@ func BenchmarkAnchoredLiteralLongNonMatch(b *testing.B) {
 	}
 	re := MustCompile("^zbc(d|e)")
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		re.Match(x)
 	}
 }
@@ -751,7 +751,7 @@ func BenchmarkAnchoredShortMatch(b *testing.B) {
 	x := []byte("abcdefghijklmnopqrstuvwxyz")
 	re := MustCompile("^.bc(d|e)")
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		re.Match(x)
 	}
 }
@@ -764,7 +764,7 @@ func BenchmarkAnchoredLongMatch(b *testing.B) {
 	}
 	re := MustCompile("^.bc(d|e)")
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		re.Match(x)
 	}
 }
@@ -774,7 +774,7 @@ func BenchmarkOnePassShortA(b *testing.B) {
 	x := []byte("abcddddddeeeededd")
 	re := MustCompile("^.bc(d|e)*$")
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		re.Match(x)
 	}
 }
@@ -784,7 +784,7 @@ func BenchmarkNotOnePassShortA(b *testing.B) {
 	x := []byte("abcddddddeeeededd")
 	re := MustCompile(".bc(d|e)*$")
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		re.Match(x)
 	}
 }
@@ -794,7 +794,7 @@ func BenchmarkOnePassShortB(b *testing.B) {
 	x := []byte("abcddddddeeeededd")
 	re := MustCompile("^.bc(?:d|e)*$")
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		re.Match(x)
 	}
 }
@@ -804,7 +804,7 @@ func BenchmarkNotOnePassShortB(b *testing.B) {
 	x := []byte("abcddddddeeeededd")
 	re := MustCompile(".bc(?:d|e)*$")
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		re.Match(x)
 	}
 }
@@ -814,7 +814,7 @@ func BenchmarkOnePassLongPrefix(b *testing.B) {
 	x := []byte("abcdefghijklmnopqrstuvwxyz")
 	re := MustCompile("^abcdefghijklmnopqrstuvwxyz.*$")
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		re.Match(x)
 	}
 }
@@ -824,7 +824,7 @@ func BenchmarkOnePassLongNotPrefix(b *testing.B) {
 	x := []byte("abcdefghijklmnopqrstuvwxyz")
 	re := MustCompile("^.bcdefghijklmnopqrstuvwxyz.*$")
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		re.Match(x)
 	}
 }
@@ -864,7 +864,7 @@ func BenchmarkQuoteMetaAll(b *testing.B) {
 	s := string(specials)
 	b.SetBytes(int64(len(s)))
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sink = QuoteMeta(s)
 	}
 }
@@ -873,7 +873,7 @@ func BenchmarkQuoteMetaNone(b *testing.B) {
 	s := "abcdefghijklmnopqrstuvwxyz"
 	b.SetBytes(int64(len(s)))
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sink = QuoteMeta(s)
 	}
 }
@@ -888,7 +888,7 @@ func BenchmarkCompile(b *testing.B) {
 	for _, data := range compileBenchData {
 		b.Run(data.name, func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				if _, err := Compile(data.re); err != nil {
 					b.Fatal(err)
 				}

--- a/src/regexp/exec_test.go
+++ b/src/regexp/exec_test.go
@@ -666,7 +666,7 @@ func BenchmarkMatch(b *testing.B) {
 			t := makeText(size.n)
 			b.Run(data.name+"/"+size.name, func(b *testing.B) {
 				b.SetBytes(int64(size.n))
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					if r.Match(t) {
 						b.Fatal("match!")
 					}
@@ -690,7 +690,7 @@ func BenchmarkMatch_onepass_regex(b *testing.B) {
 		b.Run(size.name, func(b *testing.B) {
 			b.SetBytes(int64(size.n))
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				if !r.Match(t) {
 					b.Fatal("not match!")
 				}

--- a/src/regexp/syntax/prog_test.go
+++ b/src/regexp/syntax/prog_test.go
@@ -118,7 +118,7 @@ func TestCompile(t *testing.T) {
 }
 
 func BenchmarkEmptyOpContext(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		var r1 rune = -1
 		for _, r2 := range "foo, bar, baz\nsome input text.\n" {
 			EmptyOpContext(r1, r2)
@@ -132,7 +132,7 @@ var sink any
 
 func BenchmarkIsWordChar(b *testing.B) {
 	const chars = "Don't communicate by sharing memory, share memory by communicating."
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, r := range chars {
 			sink = IsWordChar(r)
 		}

--- a/src/runtime/callers_test.go
+++ b/src/runtime/callers_test.go
@@ -359,7 +359,7 @@ func callersCached(b *testing.B, n int) int {
 	if n <= 0 {
 		pcs := make([]uintptr, 32)
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			runtime.Callers(0, pcs)
 		}
 		b.StopTimer()
@@ -372,7 +372,7 @@ func callersInlined(b *testing.B, n int) int {
 	if n <= 0 {
 		pcs := make([]uintptr, 32)
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			runtime.Callers(0, pcs)
 		}
 		b.StopTimer()
@@ -389,7 +389,7 @@ func callersNoCache(b *testing.B, n int) int {
 	if n <= 0 {
 		pcs := make([]uintptr, 32)
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			runtime.Callers(0, pcs)
 		}
 		b.StopTimer()
@@ -442,7 +442,7 @@ func fpCallersCached(b *testing.B, n int) int {
 	if n <= 0 {
 		pcs := make([]uintptr, 32)
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			runtime.FPCallers(pcs)
 		}
 		b.StopTimer()

--- a/src/runtime/cgo/handle_test.go
+++ b/src/runtime/cgo/handle_test.go
@@ -84,7 +84,7 @@ func TestInvalidHandle(t *testing.T) {
 
 func BenchmarkHandle(b *testing.B) {
 	b.Run("non-concurrent", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for i := range b.N {
 			h := NewHandle(i)
 			_ = h.Value()
 			h.Delete()

--- a/src/runtime/chan_test.go
+++ b/src/runtime/chan_test.go
@@ -788,21 +788,21 @@ type struct0 struct{}
 func BenchmarkMakeChan(b *testing.B) {
 	b.Run("Byte", func(b *testing.B) {
 		var x chan byte
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x = make(chan byte, 8)
 		}
 		close(x)
 	})
 	b.Run("Int", func(b *testing.B) {
 		var x chan int
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x = make(chan int, 8)
 		}
 		close(x)
 	})
 	b.Run("Ptr", func(b *testing.B) {
 		var x chan *byte
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x = make(chan *byte, 8)
 		}
 		close(x)
@@ -810,21 +810,21 @@ func BenchmarkMakeChan(b *testing.B) {
 	b.Run("Struct", func(b *testing.B) {
 		b.Run("0", func(b *testing.B) {
 			var x chan struct0
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x = make(chan struct0, 8)
 			}
 			close(x)
 		})
 		b.Run("32", func(b *testing.B) {
 			var x chan struct32
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x = make(chan struct32, 8)
 			}
 			close(x)
 		})
 		b.Run("40", func(b *testing.B) {
 			var x chan struct40
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x = make(chan struct40, 8)
 			}
 			close(x)
@@ -1175,7 +1175,7 @@ func BenchmarkChanPopular(b *testing.B) {
 		d := make(chan bool)
 		a = append(a, d)
 		go func() {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				select {
 				case <-c:
 				case <-d:
@@ -1184,7 +1184,7 @@ func BenchmarkChanPopular(b *testing.B) {
 			wg.Done()
 		}()
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, d := range a {
 			d <- true
 		}

--- a/src/runtime/closure_test.go
+++ b/src/runtime/closure_test.go
@@ -9,13 +9,13 @@ import "testing"
 var s int
 
 func BenchmarkCallClosure(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		s += func(ii int) int { return 2 * ii }(i)
 	}
 }
 
 func BenchmarkCallClosure1(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		j := i
 		s += func(ii int) int { return 2*ii + j }(i)
 	}
@@ -24,7 +24,7 @@ func BenchmarkCallClosure1(b *testing.B) {
 var ss *int
 
 func BenchmarkCallClosure2(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		j := i
 		s += func() int {
 			ss = &j
@@ -38,7 +38,7 @@ func addr1(x int) *int {
 }
 
 func BenchmarkCallClosure3(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		ss = addr1(i)
 	}
 }
@@ -48,7 +48,7 @@ func addr2() (x int, p *int) {
 }
 
 func BenchmarkCallClosure4(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, ss = addr2()
 	}
 }

--- a/src/runtime/complex_test.go
+++ b/src/runtime/complex_test.go
@@ -15,7 +15,7 @@ func BenchmarkComplex128DivNormal(b *testing.B) {
 	d := 15 + 2i
 	n := 32 + 3i
 	res := 0i
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		n += 0.1i
 		res += n / d
 	}
@@ -26,7 +26,7 @@ func BenchmarkComplex128DivNisNaN(b *testing.B) {
 	d := cmplx.NaN()
 	n := 32 + 3i
 	res := 0i
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		n += 0.1i
 		res += n / d
 	}
@@ -37,7 +37,7 @@ func BenchmarkComplex128DivDisNaN(b *testing.B) {
 	d := 15 + 2i
 	n := cmplx.NaN()
 	res := 0i
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		d += 0.1i
 		res += n / d
 	}
@@ -48,7 +48,7 @@ func BenchmarkComplex128DivNisInf(b *testing.B) {
 	d := 15 + 2i
 	n := cmplx.Inf()
 	res := 0i
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		d += 0.1i
 		res += n / d
 	}
@@ -59,7 +59,7 @@ func BenchmarkComplex128DivDisInf(b *testing.B) {
 	d := cmplx.Inf()
 	n := 32 + 3i
 	res := 0i
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		n += 0.1i
 		res += n / d
 	}

--- a/src/runtime/gc_test.go
+++ b/src/runtime/gc_test.go
@@ -480,7 +480,7 @@ func BenchmarkAllocation(b *testing.B) {
 	ngo := runtime.GOMAXPROCS(0)
 	work := make(chan bool, b.N+ngo)
 	result := make(chan *T)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		work <- true
 	}
 	for i := 0; i < ngo; i++ {
@@ -624,7 +624,7 @@ func BenchmarkReadMemStats(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		runtime.ReadMemStats(&ms)
 	}
 
@@ -692,7 +692,7 @@ func BenchmarkReadMemStatsLatency(b *testing.B) {
 	// and measuring the latency.
 	b.ResetTimer()
 	var ms runtime.MemStats
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		// Sleep for a bit, otherwise we're just going to keep
 		// stopping the world and no one will get to do anything.
 		time.Sleep(100 * time.Millisecond)
@@ -873,7 +873,7 @@ func BenchmarkScanStackNoLocals(b *testing.B) {
 	}
 	ready.Wait()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		b.StartTimer()
 		runtime.GC()
 		runtime.GC()
@@ -897,7 +897,7 @@ func BenchmarkMSpanCountAlloc(b *testing.B) {
 			rand.Read(bits)
 
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				runtime.MSpanCountAlloc(s, bits)
 			}
 		})

--- a/src/runtime/hash_test.go
+++ b/src/runtime/hash_test.go
@@ -628,7 +628,7 @@ func randBytes(r *rand.Rand, b []byte) {
 func benchmarkHash(b *testing.B, n int) {
 	s := strings.Repeat("A", n)
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		StringHash(s, 0)
 	}
 	b.SetBytes(int64(n))
@@ -743,7 +743,7 @@ func BenchmarkAlignedLoad(b *testing.B) {
 	var buf [16]byte
 	p := unsafe.Pointer(&buf[0])
 	var s uint64
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		s += ReadUnaligned64(p)
 	}
 	sink = s
@@ -753,7 +753,7 @@ func BenchmarkUnalignedLoad(b *testing.B) {
 	var buf [16]byte
 	p := unsafe.Pointer(&buf[1])
 	var s uint64
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		s += ReadUnaligned64(p)
 	}
 	sink = s

--- a/src/runtime/iface_test.go
+++ b/src/runtime/iface_test.go
@@ -72,179 +72,179 @@ func TestCmpIfaceConcreteAlloc(t *testing.T) {
 }
 
 func BenchmarkEqEfaceConcrete(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = e == ts
 	}
 }
 
 func BenchmarkEqIfaceConcrete(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = i1 == ts
 	}
 }
 
 func BenchmarkNeEfaceConcrete(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = e != ts
 	}
 }
 
 func BenchmarkNeIfaceConcrete(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = i1 != ts
 	}
 }
 
 func BenchmarkConvT2EByteSized(b *testing.B) {
 	b.Run("bool", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			e = yes
 		}
 	})
 	b.Run("uint8", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			e = eight8
 		}
 	})
 }
 
 func BenchmarkConvT2ESmall(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		e = ts
 	}
 }
 
 func BenchmarkConvT2EUintptr(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		e = tm
 	}
 }
 
 func BenchmarkConvT2ELarge(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		e = tl
 	}
 }
 
 func BenchmarkConvT2ISmall(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		i1 = ts
 	}
 }
 
 func BenchmarkConvT2IUintptr(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		i1 = tm
 	}
 }
 
 func BenchmarkConvT2ILarge(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		i1 = tl
 	}
 }
 
 func BenchmarkConvI2E(b *testing.B) {
 	i2 = tm
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		e = i2
 	}
 }
 
 func BenchmarkConvI2I(b *testing.B) {
 	i2 = tm
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		i1 = i2
 	}
 }
 
 func BenchmarkAssertE2T(b *testing.B) {
 	e = tm
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		tm = e.(TM)
 	}
 }
 
 func BenchmarkAssertE2TLarge(b *testing.B) {
 	e = tl
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		tl = e.(TL)
 	}
 }
 
 func BenchmarkAssertE2I(b *testing.B) {
 	e = tm
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		i1 = e.(I1)
 	}
 }
 
 func BenchmarkAssertI2T(b *testing.B) {
 	i1 = tm
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		tm = i1.(TM)
 	}
 }
 
 func BenchmarkAssertI2I(b *testing.B) {
 	i1 = tm
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		i2 = i1.(I2)
 	}
 }
 
 func BenchmarkAssertI2E(b *testing.B) {
 	i1 = tm
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		e = i1.(any)
 	}
 }
 
 func BenchmarkAssertE2E(b *testing.B) {
 	e = tm
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		e_ = e
 	}
 }
 
 func BenchmarkAssertE2T2(b *testing.B) {
 	e = tm
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		tm, ok = e.(TM)
 	}
 }
 
 func BenchmarkAssertE2T2Blank(b *testing.B) {
 	e = tm
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, ok = e.(TM)
 	}
 }
 
 func BenchmarkAssertI2E2(b *testing.B) {
 	i1 = tm
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		e, ok = i1.(any)
 	}
 }
 
 func BenchmarkAssertI2E2Blank(b *testing.B) {
 	i1 = tm
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, ok = i1.(any)
 	}
 }
 
 func BenchmarkAssertE2E2(b *testing.B) {
 	e = tm
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		e_, ok = e.(any)
 	}
 }
 
 func BenchmarkAssertE2E2Blank(b *testing.B) {
 	e = tm
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, ok = e.(any)
 	}
 }
@@ -355,83 +355,83 @@ var (
 func BenchmarkConvT2Ezero(b *testing.B) {
 	b.Run("zero", func(b *testing.B) {
 		b.Run("16", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				e = zero16
 			}
 		})
 		b.Run("32", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				e = zero32
 			}
 		})
 		b.Run("64", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				e = zero64
 			}
 		})
 		b.Run("str", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				e = zerostr
 			}
 		})
 		b.Run("slice", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				e = zeroslice
 			}
 		})
 		b.Run("big", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				e = zerobig
 			}
 		})
 	})
 	b.Run("nonzero", func(b *testing.B) {
 		b.Run("str", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				e = nzstr
 			}
 		})
 		b.Run("slice", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				e = nzslice
 			}
 		})
 		b.Run("big", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				e = nzbig
 			}
 		})
 	})
 	b.Run("smallint", func(b *testing.B) {
 		b.Run("16", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				e = one16
 			}
 		})
 		b.Run("32", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				e = one32
 			}
 		})
 		b.Run("64", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				e = one64
 			}
 		})
 	})
 	b.Run("largeint", func(b *testing.B) {
 		b.Run("16", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				e = thousand16
 			}
 		})
 		b.Run("32", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				e = thousand32
 			}
 		})
 		b.Run("64", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				e = thousand64
 			}
 		})

--- a/src/runtime/internal/atomic/atomic_andor_test.go
+++ b/src/runtime/internal/atomic/atomic_andor_test.go
@@ -168,7 +168,7 @@ func TestOr64(t *testing.T) {
 func BenchmarkAnd32(b *testing.B) {
 	var x [128]uint32 // give x its own cache line
 	sink = &x
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		atomic.And32(&x[63], uint32(i))
 	}
 }
@@ -188,7 +188,7 @@ func BenchmarkAnd32Parallel(b *testing.B) {
 func BenchmarkAnd64(b *testing.B) {
 	var x [128]uint64 // give x its own cache line
 	sink = &x
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		atomic.And64(&x[63], uint64(i))
 	}
 }
@@ -208,7 +208,7 @@ func BenchmarkAnd64Parallel(b *testing.B) {
 func BenchmarkOr32(b *testing.B) {
 	var x [128]uint32 // give x its own cache line
 	sink = &x
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		atomic.Or32(&x[63], uint32(i))
 	}
 }
@@ -228,7 +228,7 @@ func BenchmarkOr32Parallel(b *testing.B) {
 func BenchmarkOr64(b *testing.B) {
 	var x [128]uint64 // give x its own cache line
 	sink = &x
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		atomic.Or64(&x[63], uint64(i))
 	}
 }

--- a/src/runtime/internal/atomic/bench_test.go
+++ b/src/runtime/internal/atomic/bench_test.go
@@ -14,7 +14,7 @@ var sink any
 func BenchmarkAtomicLoad64(b *testing.B) {
 	var x uint64
 	sink = &x
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = atomic.Load64(&x)
 	}
 }
@@ -22,7 +22,7 @@ func BenchmarkAtomicLoad64(b *testing.B) {
 func BenchmarkAtomicStore64(b *testing.B) {
 	var x uint64
 	sink = &x
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		atomic.Store64(&x, 0)
 	}
 }
@@ -30,7 +30,7 @@ func BenchmarkAtomicStore64(b *testing.B) {
 func BenchmarkAtomicLoad(b *testing.B) {
 	var x uint32
 	sink = &x
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = atomic.Load(&x)
 	}
 }
@@ -38,7 +38,7 @@ func BenchmarkAtomicLoad(b *testing.B) {
 func BenchmarkAtomicStore(b *testing.B) {
 	var x uint32
 	sink = &x
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		atomic.Store(&x, 0)
 	}
 }
@@ -46,7 +46,7 @@ func BenchmarkAtomicStore(b *testing.B) {
 func BenchmarkAnd8(b *testing.B) {
 	var x [512]uint8 // give byte its own cache line
 	sink = &x
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		atomic.And8(&x[255], uint8(i))
 	}
 }
@@ -54,7 +54,7 @@ func BenchmarkAnd8(b *testing.B) {
 func BenchmarkAnd(b *testing.B) {
 	var x [128]uint32 // give x its own cache line
 	sink = &x
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		atomic.And(&x[63], uint32(i))
 	}
 }
@@ -86,7 +86,7 @@ func BenchmarkAndParallel(b *testing.B) {
 func BenchmarkOr8(b *testing.B) {
 	var x [512]uint8 // give byte its own cache line
 	sink = &x
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		atomic.Or8(&x[255], uint8(i))
 	}
 }
@@ -94,7 +94,7 @@ func BenchmarkOr8(b *testing.B) {
 func BenchmarkOr(b *testing.B) {
 	var x [128]uint32 // give x its own cache line
 	sink = &x
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		atomic.Or(&x[63], uint32(i))
 	}
 }

--- a/src/runtime/internal/math/math_test.go
+++ b/src/runtime/internal/math/math_test.go
@@ -58,7 +58,7 @@ var x, y uintptr
 func BenchmarkMulUintptr(b *testing.B) {
 	x, y = 1, 2
 	b.Run("small", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			var overflow bool
 			SinkUintptr, overflow = MulUintptr(x, y)
 			if overflow {
@@ -68,7 +68,7 @@ func BenchmarkMulUintptr(b *testing.B) {
 	})
 	x, y = MaxUintptr, MaxUintptr-1
 	b.Run("large", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			var overflow bool
 			SinkUintptr, overflow = MulUintptr(x, y)
 			if overflow {

--- a/src/runtime/malloc_test.go
+++ b/src/runtime/malloc_test.go
@@ -319,21 +319,21 @@ func TestArenaCollision(t *testing.T) {
 }
 
 func BenchmarkMalloc8(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		p := new(int64)
 		Escape(p)
 	}
 }
 
 func BenchmarkMalloc16(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		p := new([2]int64)
 		Escape(p)
 	}
 }
 
 func BenchmarkMallocTypeInfo8(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		p := new(struct {
 			p [8 / unsafe.Sizeof(uintptr(0))]*int
 		})
@@ -342,7 +342,7 @@ func BenchmarkMallocTypeInfo8(b *testing.B) {
 }
 
 func BenchmarkMallocTypeInfo16(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		p := new(struct {
 			p [16 / unsafe.Sizeof(uintptr(0))]*int
 		})
@@ -355,7 +355,7 @@ type LargeStruct struct {
 }
 
 func BenchmarkMallocLargeStruct(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		p := make([]LargeStruct, 2)
 		Escape(p)
 	}
@@ -409,7 +409,7 @@ func benchHelper(b *testing.B, n int, read func(chan struct{})) {
 	b.ResetTimer()
 	GC()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, ch := range m {
 			if ch != nil {
 				ch <- struct{}{}
@@ -439,7 +439,7 @@ func BenchmarkGoroutineIdle(b *testing.B) {
 	GC()
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		GC()
 	}
 

--- a/src/runtime/map_benchmark_test.go
+++ b/src/runtime/map_benchmark_test.go
@@ -26,7 +26,7 @@ func BenchmarkHashStringSpeed(b *testing.B) {
 	}
 	idx := 0
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sum += m[strings[idx]]
 		idx++
 		if idx == size {
@@ -51,7 +51,7 @@ func BenchmarkHashBytesSpeed(b *testing.B) {
 	}
 	idx := 0
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if m[chunks[idx]] != idx {
 			b.Error("bad map entry for chunk")
 		}
@@ -74,7 +74,7 @@ func BenchmarkHashInt32Speed(b *testing.B) {
 	}
 	idx := 0
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sum += m[ints[idx]]
 		idx++
 		if idx == size {
@@ -95,7 +95,7 @@ func BenchmarkHashInt64Speed(b *testing.B) {
 	}
 	idx := 0
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sum += m[ints[idx]]
 		idx++
 		if idx == size {
@@ -117,7 +117,7 @@ func BenchmarkHashStringArraySpeed(b *testing.B) {
 	}
 	idx := 0
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sum += m[stringpairs[idx]]
 		idx++
 		if idx == size {
@@ -133,7 +133,7 @@ func BenchmarkMegMap(b *testing.B) {
 	}
 	key := strings.Repeat("X", 1<<20-1) + "k"
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _ = m[key]
 	}
 }
@@ -143,7 +143,7 @@ func BenchmarkMegOneMap(b *testing.B) {
 	m[strings.Repeat("X", 1<<20)] = true
 	key := strings.Repeat("Y", 1<<20)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _ = m[key]
 	}
 }
@@ -154,7 +154,7 @@ func BenchmarkMegEqMap(b *testing.B) {
 	key2 := strings.Repeat("X", 1<<20) // equal but different instance
 	m[key1] = true
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _ = m[key2]
 	}
 }
@@ -163,7 +163,7 @@ func BenchmarkMegEmptyMap(b *testing.B) {
 	m := make(map[string]bool)
 	key := strings.Repeat("X", 1<<20)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _ = m[key]
 	}
 }
@@ -172,7 +172,7 @@ func BenchmarkMegEmptyMapWithInterfaceKey(b *testing.B) {
 	m := make(map[any]bool)
 	key := strings.Repeat("X", 1<<20)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _ = m[key]
 	}
 }
@@ -184,7 +184,7 @@ func BenchmarkSmallStrMap(b *testing.B) {
 	}
 	key := "k"
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _ = m[key]
 	}
 }
@@ -201,7 +201,7 @@ func benchmarkMapStringKeysEight(b *testing.B, keySize int) {
 	}
 	key := strings.Repeat("K", keySize)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = m[key]
 	}
 }
@@ -212,7 +212,7 @@ func BenchmarkIntMap(b *testing.B) {
 		m[i] = true
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _ = m[7]
 	}
 }
@@ -225,7 +225,7 @@ func BenchmarkMapFirst(b *testing.B) {
 				m[i] = true
 			}
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_ = m[0]
 			}
 		})
@@ -239,7 +239,7 @@ func BenchmarkMapMid(b *testing.B) {
 				m[i] = true
 			}
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_ = m[n>>1]
 			}
 		})
@@ -253,7 +253,7 @@ func BenchmarkMapLast(b *testing.B) {
 				m[i] = true
 			}
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_ = m[n-1]
 			}
 		})
@@ -272,7 +272,7 @@ func BenchmarkMapCycle(b *testing.B) {
 	}
 	b.ResetTimer()
 	j := 0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		j = m[j]
 	}
 	sink = uint64(j)
@@ -303,14 +303,14 @@ func BenchmarkRepeatedLookupStrMapKey1M(b *testing.B) { benchmarkRepeatedLookup(
 func BenchmarkMakeMap(b *testing.B) {
 	b.Run("[Byte]Byte", func(b *testing.B) {
 		var m map[byte]byte
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			m = make(map[byte]byte, 10)
 		}
 		hugeSink = m
 	})
 	b.Run("[Int]Int", func(b *testing.B) {
 		var m map[int]int
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			m = make(map[int]int, 10)
 		}
 		hugeSink = m
@@ -319,14 +319,14 @@ func BenchmarkMakeMap(b *testing.B) {
 
 func BenchmarkNewEmptyMap(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = make(map[int]int)
 	}
 }
 
 func BenchmarkNewSmallMap(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		m := make(map[int]int)
 		m[0] = 0
 		m[1] = 1
@@ -339,7 +339,7 @@ func BenchmarkMapIter(b *testing.B) {
 		m[i] = true
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for range m {
 		}
 	}
@@ -348,7 +348,7 @@ func BenchmarkMapIter(b *testing.B) {
 func BenchmarkMapIterEmpty(b *testing.B) {
 	m := make(map[int]bool)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for range m {
 		}
 	}
@@ -363,7 +363,7 @@ func BenchmarkSameLengthMap(b *testing.B) {
 	m[s1] = true
 	m[s2] = true
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = m[s1]
 	}
 }
@@ -374,7 +374,7 @@ func BenchmarkBigKeyMap(b *testing.B) {
 	m := make(map[BigKey]bool)
 	k := BigKey{3, 4, 5}
 	m[k] = true
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = m[k]
 	}
 }
@@ -385,7 +385,7 @@ func BenchmarkBigValMap(b *testing.B) {
 	m := make(map[BigKey]BigVal)
 	k := BigKey{3, 4, 5}
 	m[k] = BigVal{6, 7, 8}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = m[k]
 	}
 }
@@ -393,7 +393,7 @@ func BenchmarkBigValMap(b *testing.B) {
 func BenchmarkSmallKeyMap(b *testing.B) {
 	m := make(map[int16]bool)
 	m[5] = true
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = m[5]
 	}
 }
@@ -402,7 +402,7 @@ func BenchmarkMapPopulate(b *testing.B) {
 	for size := 1; size < 1000000; size *= 10 {
 		b.Run(strconv.Itoa(size), func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				m := make(map[int]bool)
 				for j := 0; j < size; j++ {
 					m[j] = true
@@ -426,7 +426,7 @@ func BenchmarkComplexAlgMap(b *testing.B) {
 	m := make(map[ComplexAlgKey]bool)
 	var k ComplexAlgKey
 	m[k] = true
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = m[k]
 	}
 }
@@ -436,7 +436,7 @@ func BenchmarkGoMapClear(b *testing.B) {
 		for size := 1; size < 100000; size *= 10 {
 			b.Run(strconv.Itoa(size), func(b *testing.B) {
 				m := make(map[int]int, size)
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					m[0] = size // Add one element so len(m) != 0 avoiding fast paths.
 					clear(m)
 				}
@@ -447,7 +447,7 @@ func BenchmarkGoMapClear(b *testing.B) {
 		for size := 1; size < 100000; size *= 10 {
 			b.Run(strconv.Itoa(size), func(b *testing.B) {
 				m := make(map[float64]int, size)
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					m[1.0] = size // Add one element so len(m) != 0 avoiding fast paths.
 					clear(m)
 				}
@@ -464,7 +464,7 @@ func BenchmarkMapStringConversion(b *testing.B) {
 				b.ReportAllocs()
 				m := make(map[string]int)
 				m[string(bytes)] = 0
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					_ = m[string(bytes)]
 				}
 			})
@@ -473,7 +473,7 @@ func BenchmarkMapStringConversion(b *testing.B) {
 				type stringstruct struct{ s string }
 				m := make(map[stringstruct]int)
 				m[stringstruct{string(bytes)}] = 0
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					_ = m[stringstruct{string(bytes)}]
 				}
 			})
@@ -482,7 +482,7 @@ func BenchmarkMapStringConversion(b *testing.B) {
 				type stringarray [1]string
 				m := make(map[stringarray]int)
 				m[stringarray{string(bytes)}] = 0
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					_ = m[stringarray{string(bytes)}]
 				}
 			})
@@ -501,7 +501,7 @@ func BenchmarkMapInterfaceString(b *testing.B) {
 
 	key := (any)("A")
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		BoolSink = m[key]
 	}
 }
@@ -515,7 +515,7 @@ func BenchmarkMapInterfacePtr(b *testing.B) {
 
 	key := new(int)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		BoolSink = m[key]
 	}
 }
@@ -527,14 +527,14 @@ var (
 
 func BenchmarkNewEmptyMapHintLessThan8(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = make(map[int]int, hintLessThan8)
 	}
 }
 
 func BenchmarkNewEmptyMapHintGreaterThan8(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = make(map[int]int, hintGreaterThan8)
 	}
 }

--- a/src/runtime/map_test.go
+++ b/src/runtime/map_test.go
@@ -820,7 +820,7 @@ func TestMapBuckets(t *testing.T) {
 
 func benchmarkMapPop(b *testing.B, n int) {
 	m := map[int]int{}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for j := 0; j < n; j++ {
 			m[j] = j
 		}
@@ -875,14 +875,14 @@ func TestNonEscapingMap(t *testing.T) {
 
 func benchmarkMapAssignInt32(b *testing.B, n int) {
 	a := make(map[int32]int)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		a[int32(i&(n-1))] = i
 	}
 }
 
 func benchmarkMapOperatorAssignInt32(b *testing.B, n int) {
 	a := make(map[int32]int)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		a[int32(i&(n-1))] += i
 	}
 }
@@ -891,7 +891,7 @@ func benchmarkMapAppendAssignInt32(b *testing.B, n int) {
 	a := make(map[int32][]int)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		key := int32(i & (n - 1))
 		a[key] = append(a[key], i)
 	}
@@ -900,7 +900,7 @@ func benchmarkMapAppendAssignInt32(b *testing.B, n int) {
 func benchmarkMapDeleteInt32(b *testing.B, n int) {
 	a := make(map[int32]int, n)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		if len(a) == 0 {
 			b.StopTimer()
 			for j := i; j < i+n; j++ {
@@ -914,14 +914,14 @@ func benchmarkMapDeleteInt32(b *testing.B, n int) {
 
 func benchmarkMapAssignInt64(b *testing.B, n int) {
 	a := make(map[int64]int)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		a[int64(i&(n-1))] = i
 	}
 }
 
 func benchmarkMapOperatorAssignInt64(b *testing.B, n int) {
 	a := make(map[int64]int)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		a[int64(i&(n-1))] += i
 	}
 }
@@ -930,7 +930,7 @@ func benchmarkMapAppendAssignInt64(b *testing.B, n int) {
 	a := make(map[int64][]int)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		key := int64(i & (n - 1))
 		a[key] = append(a[key], i)
 	}
@@ -939,7 +939,7 @@ func benchmarkMapAppendAssignInt64(b *testing.B, n int) {
 func benchmarkMapDeleteInt64(b *testing.B, n int) {
 	a := make(map[int64]int, n)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		if len(a) == 0 {
 			b.StopTimer()
 			for j := i; j < i+n; j++ {
@@ -958,7 +958,7 @@ func benchmarkMapAssignStr(b *testing.B, n int) {
 	}
 	b.ResetTimer()
 	a := make(map[string]int)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		a[k[i&(n-1)]] = i
 	}
 }
@@ -970,7 +970,7 @@ func benchmarkMapOperatorAssignStr(b *testing.B, n int) {
 	}
 	b.ResetTimer()
 	a := make(map[string]string)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		key := k[i&(n-1)]
 		a[key] += key
 	}
@@ -984,7 +984,7 @@ func benchmarkMapAppendAssignStr(b *testing.B, n int) {
 	a := make(map[string][]string)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		key := k[i&(n-1)]
 		a[key] = append(a[key], key)
 	}
@@ -998,7 +998,7 @@ func benchmarkMapDeleteStr(b *testing.B, n int) {
 	a := make(map[string]int, n)
 	b.ResetTimer()
 	k := 0
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		if len(a) == 0 {
 			b.StopTimer()
 			for j := 0; j < n; j++ {
@@ -1019,7 +1019,7 @@ func benchmarkMapDeletePointer(b *testing.B, n int) {
 	a := make(map[*int]int, n)
 	b.ResetTimer()
 	k := 0
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		if len(a) == 0 {
 			b.StopTimer()
 			for j := 0; j < n; j++ {

--- a/src/runtime/memmove_test.go
+++ b/src/runtime/memmove_test.go
@@ -294,7 +294,7 @@ func BenchmarkMemmove(b *testing.B) {
 	benchmarkSizes(b, bufSizes, func(b *testing.B, n int) {
 		x := make([]byte, n)
 		y := make([]byte, n)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			copy(x, y)
 		}
 	})
@@ -303,7 +303,7 @@ func BenchmarkMemmove(b *testing.B) {
 func BenchmarkMemmoveOverlap(b *testing.B) {
 	benchmarkSizes(b, bufSizesOverlap, func(b *testing.B, n int) {
 		x := make([]byte, n+16)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			copy(x[16:n+16], x[:n])
 		}
 	})
@@ -313,7 +313,7 @@ func BenchmarkMemmoveUnalignedDst(b *testing.B) {
 	benchmarkSizes(b, bufSizes, func(b *testing.B, n int) {
 		x := make([]byte, n+1)
 		y := make([]byte, n)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			copy(x[1:], y)
 		}
 	})
@@ -322,7 +322,7 @@ func BenchmarkMemmoveUnalignedDst(b *testing.B) {
 func BenchmarkMemmoveUnalignedDstOverlap(b *testing.B) {
 	benchmarkSizes(b, bufSizesOverlap, func(b *testing.B, n int) {
 		x := make([]byte, n+16)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			copy(x[16:n+16], x[1:n+1])
 		}
 	})
@@ -332,7 +332,7 @@ func BenchmarkMemmoveUnalignedSrc(b *testing.B) {
 	benchmarkSizes(b, bufSizes, func(b *testing.B, n int) {
 		x := make([]byte, n)
 		y := make([]byte, n+1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			copy(x, y[1:])
 		}
 	})
@@ -346,14 +346,14 @@ func BenchmarkMemmoveUnalignedSrcDst(b *testing.B) {
 		for _, off := range []int{0, 1, 4, 7} {
 			b.Run(fmt.Sprint("f_", n, off), func(b *testing.B) {
 				b.SetBytes(int64(n))
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					copy(x[off:n+off], y[off:n+off])
 				}
 			})
 
 			b.Run(fmt.Sprint("b_", n, off), func(b *testing.B) {
 				b.SetBytes(int64(n))
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					copy(y[off:n+off], x[off:n+off])
 				}
 			})
@@ -364,7 +364,7 @@ func BenchmarkMemmoveUnalignedSrcDst(b *testing.B) {
 func BenchmarkMemmoveUnalignedSrcOverlap(b *testing.B) {
 	benchmarkSizes(b, bufSizesOverlap, func(b *testing.B, n int) {
 		x := make([]byte, n+1)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			copy(x[1:n+1], x[:n])
 		}
 	})
@@ -407,7 +407,7 @@ func BenchmarkMemclr(b *testing.B) {
 		x := make([]byte, n)
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
 			b.SetBytes(int64(n))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				MemclrBytes(x)
 			}
 		})
@@ -416,7 +416,7 @@ func BenchmarkMemclr(b *testing.B) {
 		x := make([]byte, m<<20)
 		b.Run(fmt.Sprint(m, "M"), func(b *testing.B) {
 			b.SetBytes(int64(m << 20))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				MemclrBytes(x)
 			}
 		})
@@ -429,7 +429,7 @@ func BenchmarkMemclrUnaligned(b *testing.B) {
 			x := make([]byte, n+off)
 			b.Run(fmt.Sprint(off, n), func(b *testing.B) {
 				b.SetBytes(int64(n))
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					MemclrBytes(x[off:])
 				}
 			})
@@ -441,7 +441,7 @@ func BenchmarkMemclrUnaligned(b *testing.B) {
 			x := make([]byte, (m<<20)+off)
 			b.Run(fmt.Sprint(off, m, "M"), func(b *testing.B) {
 				b.SetBytes(int64(m << 20))
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					MemclrBytes(x[off:])
 				}
 			})
@@ -452,7 +452,7 @@ func BenchmarkMemclrUnaligned(b *testing.B) {
 func BenchmarkGoMemclr(b *testing.B) {
 	benchmarkSizes(b, []int{5, 16, 64, 256}, func(b *testing.B, n int) {
 		x := make([]byte, n)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			for j := range x {
 				x[j] = 0
 			}
@@ -506,7 +506,7 @@ func BenchmarkMemclrRange(b *testing.B) {
 		}
 		b.Run(text, func(b *testing.B) {
 			b.SetBytes(int64(total))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				for _, clrLen := range t.data {
 					MemclrBytes(buffer[:clrLen])
 				}
@@ -519,7 +519,7 @@ func BenchmarkClearFat7(b *testing.B) {
 	p := new([7]byte)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [7]byte{}
 	}
 }
@@ -528,7 +528,7 @@ func BenchmarkClearFat8(b *testing.B) {
 	p := new([8 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [8 / 4]uint32{}
 	}
 }
@@ -537,7 +537,7 @@ func BenchmarkClearFat11(b *testing.B) {
 	p := new([11]byte)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [11]byte{}
 	}
 }
@@ -546,7 +546,7 @@ func BenchmarkClearFat12(b *testing.B) {
 	p := new([12 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [12 / 4]uint32{}
 	}
 }
@@ -555,7 +555,7 @@ func BenchmarkClearFat13(b *testing.B) {
 	p := new([13]byte)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [13]byte{}
 	}
 }
@@ -564,7 +564,7 @@ func BenchmarkClearFat14(b *testing.B) {
 	p := new([14]byte)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [14]byte{}
 	}
 }
@@ -573,7 +573,7 @@ func BenchmarkClearFat15(b *testing.B) {
 	p := new([15]byte)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [15]byte{}
 	}
 }
@@ -582,7 +582,7 @@ func BenchmarkClearFat16(b *testing.B) {
 	p := new([16 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [16 / 4]uint32{}
 	}
 }
@@ -591,7 +591,7 @@ func BenchmarkClearFat24(b *testing.B) {
 	p := new([24 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [24 / 4]uint32{}
 	}
 }
@@ -600,7 +600,7 @@ func BenchmarkClearFat32(b *testing.B) {
 	p := new([32 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [32 / 4]uint32{}
 	}
 }
@@ -609,7 +609,7 @@ func BenchmarkClearFat40(b *testing.B) {
 	p := new([40 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [40 / 4]uint32{}
 	}
 }
@@ -618,7 +618,7 @@ func BenchmarkClearFat48(b *testing.B) {
 	p := new([48 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [48 / 4]uint32{}
 	}
 }
@@ -627,7 +627,7 @@ func BenchmarkClearFat56(b *testing.B) {
 	p := new([56 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [56 / 4]uint32{}
 	}
 }
@@ -636,7 +636,7 @@ func BenchmarkClearFat64(b *testing.B) {
 	p := new([64 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [64 / 4]uint32{}
 	}
 }
@@ -645,7 +645,7 @@ func BenchmarkClearFat72(b *testing.B) {
 	p := new([72 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [72 / 4]uint32{}
 	}
 }
@@ -654,7 +654,7 @@ func BenchmarkClearFat128(b *testing.B) {
 	p := new([128 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [128 / 4]uint32{}
 	}
 }
@@ -663,7 +663,7 @@ func BenchmarkClearFat256(b *testing.B) {
 	p := new([256 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [256 / 4]uint32{}
 	}
 }
@@ -672,7 +672,7 @@ func BenchmarkClearFat512(b *testing.B) {
 	p := new([512 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [512 / 4]uint32{}
 	}
 }
@@ -681,7 +681,7 @@ func BenchmarkClearFat1024(b *testing.B) {
 	p := new([1024 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [1024 / 4]uint32{}
 	}
 }
@@ -690,7 +690,7 @@ func BenchmarkClearFat1032(b *testing.B) {
 	p := new([1032 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [1032 / 4]uint32{}
 	}
 }
@@ -699,7 +699,7 @@ func BenchmarkClearFat1040(b *testing.B) {
 	p := new([1040 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = [1040 / 4]uint32{}
 	}
 }
@@ -709,7 +709,7 @@ func BenchmarkCopyFat7(b *testing.B) {
 	p := new([7]byte)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -719,7 +719,7 @@ func BenchmarkCopyFat8(b *testing.B) {
 	p := new([8 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -729,7 +729,7 @@ func BenchmarkCopyFat11(b *testing.B) {
 	p := new([11]byte)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -739,7 +739,7 @@ func BenchmarkCopyFat12(b *testing.B) {
 	p := new([12 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -749,7 +749,7 @@ func BenchmarkCopyFat13(b *testing.B) {
 	p := new([13]byte)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -759,7 +759,7 @@ func BenchmarkCopyFat14(b *testing.B) {
 	p := new([14]byte)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -769,7 +769,7 @@ func BenchmarkCopyFat15(b *testing.B) {
 	p := new([15]byte)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -779,7 +779,7 @@ func BenchmarkCopyFat16(b *testing.B) {
 	p := new([16 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -789,7 +789,7 @@ func BenchmarkCopyFat24(b *testing.B) {
 	p := new([24 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -799,7 +799,7 @@ func BenchmarkCopyFat32(b *testing.B) {
 	p := new([32 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -809,7 +809,7 @@ func BenchmarkCopyFat64(b *testing.B) {
 	p := new([64 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -819,7 +819,7 @@ func BenchmarkCopyFat72(b *testing.B) {
 	p := new([72 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -829,7 +829,7 @@ func BenchmarkCopyFat128(b *testing.B) {
 	p := new([128 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -839,7 +839,7 @@ func BenchmarkCopyFat256(b *testing.B) {
 	p := new([256 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -849,7 +849,7 @@ func BenchmarkCopyFat512(b *testing.B) {
 	p := new([512 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -859,7 +859,7 @@ func BenchmarkCopyFat520(b *testing.B) {
 	p := new([520 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -869,7 +869,7 @@ func BenchmarkCopyFat1024(b *testing.B) {
 	p := new([1024 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -879,7 +879,7 @@ func BenchmarkCopyFat1032(b *testing.B) {
 	p := new([1032 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -889,7 +889,7 @@ func BenchmarkCopyFat1040(b *testing.B) {
 	p := new([1040 / 4]uint32)
 	Escape(p)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		*p = x
 	}
 }
@@ -928,7 +928,7 @@ func BenchmarkMemclrKnownSize1(b *testing.B) {
 	var x [1]int8
 
 	b.SetBytes(1)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for a := range x {
 			x[a] = 0
 		}
@@ -940,7 +940,7 @@ func BenchmarkMemclrKnownSize2(b *testing.B) {
 	var x [2]int8
 
 	b.SetBytes(2)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for a := range x {
 			x[a] = 0
 		}
@@ -952,7 +952,7 @@ func BenchmarkMemclrKnownSize4(b *testing.B) {
 	var x [4]int8
 
 	b.SetBytes(4)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for a := range x {
 			x[a] = 0
 		}
@@ -964,7 +964,7 @@ func BenchmarkMemclrKnownSize8(b *testing.B) {
 	var x [8]int8
 
 	b.SetBytes(8)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for a := range x {
 			x[a] = 0
 		}
@@ -976,7 +976,7 @@ func BenchmarkMemclrKnownSize16(b *testing.B) {
 	var x [16]int8
 
 	b.SetBytes(16)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for a := range x {
 			x[a] = 0
 		}
@@ -988,7 +988,7 @@ func BenchmarkMemclrKnownSize32(b *testing.B) {
 	var x [32]int8
 
 	b.SetBytes(32)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for a := range x {
 			x[a] = 0
 		}
@@ -1000,7 +1000,7 @@ func BenchmarkMemclrKnownSize64(b *testing.B) {
 	var x [64]int8
 
 	b.SetBytes(64)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for a := range x {
 			x[a] = 0
 		}
@@ -1012,7 +1012,7 @@ func BenchmarkMemclrKnownSize112(b *testing.B) {
 	var x [112]int8
 
 	b.SetBytes(112)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for a := range x {
 			x[a] = 0
 		}
@@ -1025,7 +1025,7 @@ func BenchmarkMemclrKnownSize128(b *testing.B) {
 	var x [128]int8
 
 	b.SetBytes(128)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for a := range x {
 			x[a] = 0
 		}
@@ -1038,7 +1038,7 @@ func BenchmarkMemclrKnownSize192(b *testing.B) {
 	var x [192]int8
 
 	b.SetBytes(192)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for a := range x {
 			x[a] = 0
 		}
@@ -1051,7 +1051,7 @@ func BenchmarkMemclrKnownSize248(b *testing.B) {
 	var x [248]int8
 
 	b.SetBytes(248)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for a := range x {
 			x[a] = 0
 		}
@@ -1064,7 +1064,7 @@ func BenchmarkMemclrKnownSize256(b *testing.B) {
 	var x [256]int8
 
 	b.SetBytes(256)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for a := range x {
 			x[a] = 0
 		}
@@ -1076,7 +1076,7 @@ func BenchmarkMemclrKnownSize512(b *testing.B) {
 	var x [512]int8
 
 	b.SetBytes(512)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for a := range x {
 			x[a] = 0
 		}
@@ -1088,7 +1088,7 @@ func BenchmarkMemclrKnownSize1024(b *testing.B) {
 	var x [1024]int8
 
 	b.SetBytes(1024)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for a := range x {
 			x[a] = 0
 		}
@@ -1100,7 +1100,7 @@ func BenchmarkMemclrKnownSize4096(b *testing.B) {
 	var x [4096]int8
 
 	b.SetBytes(4096)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for a := range x {
 			x[a] = 0
 		}
@@ -1112,7 +1112,7 @@ func BenchmarkMemclrKnownSize512KiB(b *testing.B) {
 	var x [524288]int8
 
 	b.SetBytes(524288)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for a := range x {
 			x[a] = 0
 		}

--- a/src/runtime/metrics_test.go
+++ b/src/runtime/metrics_test.go
@@ -443,7 +443,7 @@ func BenchmarkReadMetricsLatency(b *testing.B) {
 
 	// Hit metrics.Read continuously and measure.
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		start := time.Now()
 		metrics.Read(samples)
 		latencies = append(latencies, time.Since(start))

--- a/src/runtime/mpallocbits_test.go
+++ b/src/runtime/mpallocbits_test.go
@@ -320,7 +320,7 @@ func BenchmarkPallocBitsSummarize(b *testing.B) {
 		}
 		b.Run(fmt.Sprintf("Unpacked%02X", p), func(b *testing.B) {
 			checkPallocSum(b, buf.Summarize(), SummarizeSlow(buf))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				buf.Summarize()
 			}
 		})
@@ -542,7 +542,7 @@ func BenchmarkFindBitRange64(b *testing.B) {
 	for _, pattern := range patterns {
 		for _, size := range sizes {
 			b.Run(fmt.Sprintf("Pattern%02XSize%d", pattern, size), func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					FindBitRange64(pattern, size)
 				}
 			})

--- a/src/runtime/netpoll_os_test.go
+++ b/src/runtime/netpoll_os_test.go
@@ -18,7 +18,7 @@ func init() {
 
 func BenchmarkNetpollBreak(b *testing.B) {
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for j := 0; j < 10; j++ {
 			wg.Add(1)
 			go func() {

--- a/src/runtime/pprof/pprof_test.go
+++ b/src/runtime/pprof/pprof_test.go
@@ -1804,7 +1804,7 @@ func BenchmarkGoroutine(b *testing.B) {
 	benchWriteTo := func(b *testing.B) {
 		goroutineProf := Lookup("goroutine")
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			goroutineProf.WriteTo(io.Discard, 0)
 		}
 		b.StopTimer()
@@ -1813,7 +1813,7 @@ func BenchmarkGoroutine(b *testing.B) {
 	benchGoroutineProfile := func(b *testing.B) {
 		p := make([]runtime.StackRecord, 10000)
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			runtime.GoroutineProfile(p)
 		}
 		b.StopTimer()

--- a/src/runtime/proc_test.go
+++ b/src/runtime/proc_test.go
@@ -520,7 +520,7 @@ func BenchmarkPingPongHog(b *testing.B) {
 		done <- true
 	}()
 	go func() {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			ping <- <-pong
 		}
 		done <- true
@@ -691,7 +691,7 @@ func benchmarkCreateGoroutines(b *testing.B, procs int) {
 
 func BenchmarkCreateGoroutinesCapture(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		const N = 4
 		var wg sync.WaitGroup
 		wg.Add(N)
@@ -749,7 +749,7 @@ func BenchmarkCreateGoroutinesSingle(b *testing.B) {
 
 	var wg sync.WaitGroup
 	wg.Add(b.N)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		go func() {
 			wg.Done()
 		}()
@@ -760,7 +760,7 @@ func BenchmarkCreateGoroutinesSingle(b *testing.B) {
 func BenchmarkClosureCall(b *testing.B) {
 	sum := 0
 	off1 := 1
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		off2 := 2
 		func() {
 			sum += i + off1 + off2
@@ -826,7 +826,7 @@ func benchmarkWakeupParallel(b *testing.B, spin func(time.Duration)) {
 			done := make(chan struct{})
 			go func() {
 				<-start
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					// sender
 					spin(delay + wakeDelay)
 					ping <- struct{}{}
@@ -837,7 +837,7 @@ func benchmarkWakeupParallel(b *testing.B, spin func(time.Duration)) {
 				done <- struct{}{}
 			}()
 			go func() {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					// receiver
 					spin(delay)
 					<-ping

--- a/src/runtime/race/race_test.go
+++ b/src/runtime/race/race_test.go
@@ -220,7 +220,7 @@ func BenchmarkSyncLeak(b *testing.B) {
 		go func() {
 			defer wg.Done()
 			hold := make([][]uint32, H)
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				a := make([]uint32, S)
 				atomic.AddUint32(&a[rand.Intn(len(a))], 1)
 				hold[rand.Intn(len(hold))] = a
@@ -233,7 +233,7 @@ func BenchmarkSyncLeak(b *testing.B) {
 
 func BenchmarkStackLeak(b *testing.B) {
 	done := make(chan bool, 1)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		go func() {
 			growStack(rand.Intn(100))
 			done <- true

--- a/src/runtime/rand_test.go
+++ b/src/runtime/rand_test.go
@@ -45,7 +45,7 @@ var sink32 uint32
 func BenchmarkFastrandn(b *testing.B) {
 	for n := uint32(2); n <= 5; n++ {
 		b.Run(strconv.Itoa(int(n)), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				sink32 = Fastrandn(n)
 			}
 		})

--- a/src/runtime/runtime_test.go
+++ b/src/runtime/runtime_test.go
@@ -43,7 +43,7 @@ func errfn1() error {
 }
 
 func BenchmarkIfaceCmp100(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for j := 0; j < 100; j++ {
 			if errfn() == io.EOF {
 				b.Fatal("bad comparison")
@@ -53,7 +53,7 @@ func BenchmarkIfaceCmp100(b *testing.B) {
 }
 
 func BenchmarkIfaceCmpNil100(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for j := 0; j < 100; j++ {
 			if errfn1() == nil {
 				b.Fatal("bad comparison")
@@ -70,7 +70,7 @@ func BenchmarkEfaceCmpDiff(b *testing.B) {
 	efaceCmp1 = &x
 	y := 6
 	efaceCmp2 = &y
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for j := 0; j < 100; j++ {
 			if efaceCmp1 == efaceCmp2 {
 				b.Fatal("bad comparison")
@@ -82,7 +82,7 @@ func BenchmarkEfaceCmpDiff(b *testing.B) {
 func BenchmarkEfaceCmpDiffIndirect(b *testing.B) {
 	efaceCmp1 = [2]int{1, 2}
 	efaceCmp2 = [2]int{1, 2}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for j := 0; j < 100; j++ {
 			if efaceCmp1 != efaceCmp2 {
 				b.Fatal("bad comparison")
@@ -92,7 +92,7 @@ func BenchmarkEfaceCmpDiffIndirect(b *testing.B) {
 }
 
 func BenchmarkDefer(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		defer1()
 	}
 }
@@ -122,7 +122,7 @@ func defer2() {
 }
 
 func BenchmarkDeferMany(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		defer func(x, y, z int) {
 			if recover() != nil || x != 1 || y != 2 || z != 3 {
 				panic("bad recover")
@@ -132,7 +132,7 @@ func BenchmarkDeferMany(b *testing.B) {
 }
 
 func BenchmarkPanicRecover(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		defer3()
 	}
 }
@@ -371,7 +371,7 @@ func BenchmarkGoroutineProfile(b *testing.B) {
 			latencies := make([]time.Duration, 0, b.N)
 
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				start := time.Now()
 				ok := fn()
 				if !ok {

--- a/src/runtime/slice_test.go
+++ b/src/runtime/slice_test.go
@@ -19,21 +19,21 @@ func BenchmarkMakeSliceCopy(b *testing.B) {
 	b.Run("mallocmove", func(b *testing.B) {
 		b.Run("Byte", func(b *testing.B) {
 			var x []byte
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x = make([]byte, len(bytes))
 				copy(x, bytes)
 			}
 		})
 		b.Run("Int", func(b *testing.B) {
 			var x []int
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x = make([]int, len(ints))
 				copy(x, ints)
 			}
 		})
 		b.Run("Ptr", func(b *testing.B) {
 			var x []*byte
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x = make([]*byte, len(ptrs))
 				copy(x, ptrs)
 			}
@@ -43,21 +43,21 @@ func BenchmarkMakeSliceCopy(b *testing.B) {
 	b.Run("makecopy", func(b *testing.B) {
 		b.Run("Byte", func(b *testing.B) {
 			var x []byte
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x = make([]byte, 8*length)
 				copy(x, bytes)
 			}
 		})
 		b.Run("Int", func(b *testing.B) {
 			var x []int
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x = make([]int, length)
 				copy(x, ints)
 			}
 		})
 		b.Run("Ptr", func(b *testing.B) {
 			var x []*byte
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x = make([]*byte, length)
 				copy(x, ptrs)
 			}
@@ -67,21 +67,21 @@ func BenchmarkMakeSliceCopy(b *testing.B) {
 	b.Run("nilappend", func(b *testing.B) {
 		b.Run("Byte", func(b *testing.B) {
 			var x []byte
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x = append([]byte(nil), bytes...)
 				_ = x
 			}
 		})
 		b.Run("Int", func(b *testing.B) {
 			var x []int
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x = append([]int(nil), ints...)
 				_ = x
 			}
 		})
 		b.Run("Ptr", func(b *testing.B) {
 			var x []*byte
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x = append([]*byte(nil), ptrs...)
 				_ = x
 			}
@@ -99,28 +99,28 @@ func BenchmarkMakeSlice(b *testing.B) {
 	const length = 2
 	b.Run("Byte", func(b *testing.B) {
 		var x []byte
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x = make([]byte, length, 2*length)
 			_ = x
 		}
 	})
 	b.Run("Int16", func(b *testing.B) {
 		var x []int16
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x = make([]int16, length, 2*length)
 			_ = x
 		}
 	})
 	b.Run("Int", func(b *testing.B) {
 		var x []int
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x = make([]int, length, 2*length)
 			_ = x
 		}
 	})
 	b.Run("Ptr", func(b *testing.B) {
 		var x []*byte
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			x = make([]*byte, length, 2*length)
 			_ = x
 		}
@@ -128,21 +128,21 @@ func BenchmarkMakeSlice(b *testing.B) {
 	b.Run("Struct", func(b *testing.B) {
 		b.Run("24", func(b *testing.B) {
 			var x []struct24
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x = make([]struct24, length, 2*length)
 				_ = x
 			}
 		})
 		b.Run("32", func(b *testing.B) {
 			var x []struct32
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x = make([]struct32, length, 2*length)
 				_ = x
 			}
 		})
 		b.Run("40", func(b *testing.B) {
 			var x []struct40
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x = make([]struct40, length, 2*length)
 				_ = x
 			}
@@ -154,44 +154,44 @@ func BenchmarkMakeSlice(b *testing.B) {
 func BenchmarkGrowSlice(b *testing.B) {
 	b.Run("Byte", func(b *testing.B) {
 		x := make([]byte, 9)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = append([]byte(nil), x...)
 		}
 	})
 	b.Run("Int16", func(b *testing.B) {
 		x := make([]int16, 9)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = append([]int16(nil), x...)
 		}
 	})
 	b.Run("Int", func(b *testing.B) {
 		x := make([]int, 9)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = append([]int(nil), x...)
 		}
 	})
 	b.Run("Ptr", func(b *testing.B) {
 		x := make([]*byte, 9)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = append([]*byte(nil), x...)
 		}
 	})
 	b.Run("Struct", func(b *testing.B) {
 		b.Run("24", func(b *testing.B) {
 			x := make([]struct24, 9)
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_ = append([]struct24(nil), x...)
 			}
 		})
 		b.Run("32", func(b *testing.B) {
 			x := make([]struct32, 9)
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_ = append([]struct32(nil), x...)
 			}
 		})
 		b.Run("40", func(b *testing.B) {
 			x := make([]struct40, 9)
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_ = append([]struct40(nil), x...)
 			}
 		})
@@ -208,21 +208,21 @@ func BenchmarkExtendSlice(b *testing.B) {
 	var length = 4 // Use a variable to prevent stack allocation of slices.
 	b.Run("IntSlice", func(b *testing.B) {
 		s := make([]int, 0, length)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			s = append(s[:0:length/2], make([]int, length)...)
 		}
 		SinkIntSlice = s
 	})
 	b.Run("PointerSlice", func(b *testing.B) {
 		s := make([]*int, 0, length)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			s = append(s[:0:length/2], make([]*int, length)...)
 		}
 		SinkIntPointerSlice = s
 	})
 	b.Run("NoGrow", func(b *testing.B) {
 		s := make([]int, 0, length)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			s = append(s[:0:length], make([]int, length)...)
 		}
 		SinkIntSlice = s
@@ -233,7 +233,7 @@ func BenchmarkAppend(b *testing.B) {
 	b.StopTimer()
 	x := make([]int, 0, N)
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = x[0:0]
 		for j := 0; j < N; j++ {
 			x = append(x, j)
@@ -242,7 +242,7 @@ func BenchmarkAppend(b *testing.B) {
 }
 
 func BenchmarkAppendGrowByte(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		var x []byte
 		for j := 0; j < 1<<20; j++ {
 			x = append(x, byte(j))
@@ -252,7 +252,7 @@ func BenchmarkAppendGrowByte(b *testing.B) {
 
 func BenchmarkAppendGrowString(b *testing.B) {
 	var s string
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		var x []string
 		for j := 0; j < 1<<20; j++ {
 			x = append(x, s)
@@ -265,7 +265,7 @@ func BenchmarkAppendSlice(b *testing.B) {
 		b.Run(fmt.Sprint(length, "Bytes"), func(b *testing.B) {
 			x := make([]byte, 0, N)
 			y := make([]byte, length)
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x = x[0:0]
 				x = append(x, y...)
 			}
@@ -281,7 +281,7 @@ func BenchmarkAppendSliceLarge(b *testing.B) {
 	for _, length := range []int{1 << 10, 4 << 10, 16 << 10, 64 << 10, 256 << 10, 1024 << 10} {
 		y := make([]byte, length)
 		b.Run(fmt.Sprint(length, "Bytes"), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				blackhole = nil
 				blackhole = append(blackhole, y...)
 			}
@@ -299,7 +299,7 @@ func BenchmarkAppendStr(b *testing.B) {
 	} {
 		b.Run(fmt.Sprint(len(str), "Bytes"), func(b *testing.B) {
 			x := make([]byte, 0, N)
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				x = x[0:0]
 				x = append(x, str...)
 			}
@@ -311,7 +311,7 @@ func BenchmarkAppendSpecialCase(b *testing.B) {
 	b.StopTimer()
 	x := make([]int, 0, N)
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		x = x[0:0]
 		for j := 0; j < N; j++ {
 			if len(x) < cap(x) {
@@ -355,7 +355,7 @@ func BenchmarkCopy(b *testing.B) {
 		b.Run(fmt.Sprint(l, "Byte"), func(b *testing.B) {
 			s := make([]byte, l)
 			var n int
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				n = copy(buf, s)
 			}
 			b.SetBytes(int64(n))
@@ -363,7 +363,7 @@ func BenchmarkCopy(b *testing.B) {
 		b.Run(fmt.Sprint(l, "String"), func(b *testing.B) {
 			s := string(make([]byte, l))
 			var n int
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				n = copy(buf, s)
 			}
 			b.SetBytes(int64(n))
@@ -398,7 +398,7 @@ func BenchmarkAppendInPlace(b *testing.B) {
 		const C = 128
 
 		b.Run("Byte", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				sByte = make([]byte, C)
 				for j := 0; j < C; j++ {
 					sByte = append(sByte, 0x77)
@@ -407,7 +407,7 @@ func BenchmarkAppendInPlace(b *testing.B) {
 		})
 
 		b.Run("1Ptr", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				s1Ptr = make([]uintptr, C)
 				for j := 0; j < C; j++ {
 					s1Ptr = append(s1Ptr, 0x77)
@@ -416,7 +416,7 @@ func BenchmarkAppendInPlace(b *testing.B) {
 		})
 
 		b.Run("2Ptr", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				s2Ptr = make([][2]uintptr, C)
 				for j := 0; j < C; j++ {
 					s2Ptr = append(s2Ptr, [2]uintptr{0x77, 0x88})
@@ -425,7 +425,7 @@ func BenchmarkAppendInPlace(b *testing.B) {
 		})
 
 		b.Run("3Ptr", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				s3Ptr = make([][3]uintptr, C)
 				for j := 0; j < C; j++ {
 					s3Ptr = append(s3Ptr, [3]uintptr{0x77, 0x88, 0x99})
@@ -434,7 +434,7 @@ func BenchmarkAppendInPlace(b *testing.B) {
 		})
 
 		b.Run("4Ptr", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				s4Ptr = make([][4]uintptr, C)
 				for j := 0; j < C; j++ {
 					s4Ptr = append(s4Ptr, [4]uintptr{0x77, 0x88, 0x99, 0xAA})
@@ -448,7 +448,7 @@ func BenchmarkAppendInPlace(b *testing.B) {
 		const C = 5
 
 		b.Run("Byte", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				sByte = make([]byte, 0)
 				for j := 0; j < C; j++ {
 					sByte = append(sByte, 0x77)
@@ -458,7 +458,7 @@ func BenchmarkAppendInPlace(b *testing.B) {
 		})
 
 		b.Run("1Ptr", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				s1Ptr = make([]uintptr, 0)
 				for j := 0; j < C; j++ {
 					s1Ptr = append(s1Ptr, 0x77)
@@ -468,7 +468,7 @@ func BenchmarkAppendInPlace(b *testing.B) {
 		})
 
 		b.Run("2Ptr", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				s2Ptr = make([][2]uintptr, 0)
 				for j := 0; j < C; j++ {
 					s2Ptr = append(s2Ptr, [2]uintptr{0x77, 0x88})
@@ -478,7 +478,7 @@ func BenchmarkAppendInPlace(b *testing.B) {
 		})
 
 		b.Run("3Ptr", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				s3Ptr = make([][3]uintptr, 0)
 				for j := 0; j < C; j++ {
 					s3Ptr = append(s3Ptr, [3]uintptr{0x77, 0x88, 0x99})
@@ -488,7 +488,7 @@ func BenchmarkAppendInPlace(b *testing.B) {
 		})
 
 		b.Run("4Ptr", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				s4Ptr = make([][4]uintptr, 0)
 				for j := 0; j < C; j++ {
 					s4Ptr = append(s4Ptr, [4]uintptr{0x77, 0x88, 0x99, 0xAA})

--- a/src/runtime/stack_test.go
+++ b/src/runtime/stack_test.go
@@ -491,7 +491,7 @@ func TestStackPanic(t *testing.T) {
 
 func BenchmarkStackCopyPtr(b *testing.B) {
 	c := make(chan bool)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		go func() {
 			i := 1000000
 			countp(&i)
@@ -511,7 +511,7 @@ func countp(n *int) {
 
 func BenchmarkStackCopy(b *testing.B) {
 	c := make(chan bool)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		go func() {
 			count(1000000)
 			c <- true
@@ -529,7 +529,7 @@ func count(n int) int {
 
 func BenchmarkStackCopyNoCache(b *testing.B) {
 	c := make(chan bool)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		go func() {
 			count1(1000000)
 			c <- true
@@ -586,7 +586,7 @@ func Sum(n int64, p *stkobjT) {
 
 func BenchmarkStackCopyWithStkobj(b *testing.B) {
 	c := make(chan bool)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		go func() {
 			var s stkobjT
 			Sum(100000, &s)
@@ -604,7 +604,7 @@ func BenchmarkIssue18138(b *testing.B) {
 		c <- make([]byte, 1)
 	}
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		<-c // get token
 		go func() {
 			useStackPtrs(1000, false) // uses ~1MB max

--- a/src/runtime/string_test.go
+++ b/src/runtime/string_test.go
@@ -19,7 +19,7 @@ const sizeNoStack = 100
 func BenchmarkCompareStringEqual(b *testing.B) {
 	bytes := []byte("Hello Gophers!")
 	s1, s2 := string(bytes), string(bytes)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if s1 != s2 {
 			b.Fatal("s1 != s2")
 		}
@@ -29,7 +29,7 @@ func BenchmarkCompareStringEqual(b *testing.B) {
 func BenchmarkCompareStringIdentical(b *testing.B) {
 	s1 := "Hello Gophers!"
 	s2 := s1
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if s1 != s2 {
 			b.Fatal("s1 != s2")
 		}
@@ -39,7 +39,7 @@ func BenchmarkCompareStringIdentical(b *testing.B) {
 func BenchmarkCompareStringSameLength(b *testing.B) {
 	s1 := "Hello Gophers!"
 	s2 := "Hello, Gophers"
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if s1 == s2 {
 			b.Fatal("s1 == s2")
 		}
@@ -49,7 +49,7 @@ func BenchmarkCompareStringSameLength(b *testing.B) {
 func BenchmarkCompareStringDifferentLength(b *testing.B) {
 	s1 := "Hello Gophers!"
 	s2 := "Hello, Gophers!"
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if s1 == s2 {
 			b.Fatal("s1 == s2")
 		}
@@ -62,7 +62,7 @@ func BenchmarkCompareStringBigUnaligned(b *testing.B) {
 		bytes = append(bytes, "Hello Gophers!"...)
 	}
 	s1, s2 := string(bytes), "hello"+string(bytes)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if s1 != s2[len("hello"):] {
 			b.Fatal("s1 != s2")
 		}
@@ -76,7 +76,7 @@ func BenchmarkCompareStringBig(b *testing.B) {
 		bytes = append(bytes, "Hello Gophers!"...)
 	}
 	s1, s2 := string(bytes), string(bytes)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if s1 != s2 {
 			b.Fatal("s1 != s2")
 		}
@@ -86,7 +86,7 @@ func BenchmarkCompareStringBig(b *testing.B) {
 
 func BenchmarkConcatStringAndBytes(b *testing.B) {
 	s1 := []byte("Gophers!")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = "Hello " + string(s1)
 	}
 }
@@ -97,7 +97,7 @@ func BenchmarkSliceByteToString(b *testing.B) {
 	buf := []byte{'!'}
 	for n := 0; n < 8; n++ {
 		b.Run(strconv.Itoa(len(buf)), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				escapeString = string(buf)
 			}
 		})
@@ -118,7 +118,7 @@ func BenchmarkRuneCount(b *testing.B) {
 	b.Run("lenruneslice", func(b *testing.B) {
 		for _, sd := range stringdata {
 			b.Run(sd.name, func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					sinkInt += len([]rune(sd.data))
 				}
 			})
@@ -127,7 +127,7 @@ func BenchmarkRuneCount(b *testing.B) {
 	b.Run("rangeloop", func(b *testing.B) {
 		for _, sd := range stringdata {
 			b.Run(sd.name, func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					n := 0
 					for range sd.data {
 						n++
@@ -140,7 +140,7 @@ func BenchmarkRuneCount(b *testing.B) {
 	b.Run("utf8.RuneCountInString", func(b *testing.B) {
 		for _, sd := range stringdata {
 			b.Run(sd.name, func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					sinkInt += utf8.RuneCountInString(sd.data)
 				}
 			})
@@ -152,7 +152,7 @@ func BenchmarkRuneIterate(b *testing.B) {
 	b.Run("range", func(b *testing.B) {
 		for _, sd := range stringdata {
 			b.Run(sd.name, func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					for range sd.data {
 					}
 				}
@@ -162,7 +162,7 @@ func BenchmarkRuneIterate(b *testing.B) {
 	b.Run("range1", func(b *testing.B) {
 		for _, sd := range stringdata {
 			b.Run(sd.name, func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					for range sd.data {
 					}
 				}
@@ -172,7 +172,7 @@ func BenchmarkRuneIterate(b *testing.B) {
 	b.Run("range2", func(b *testing.B) {
 		for _, sd := range stringdata {
 			b.Run(sd.name, func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					for range sd.data {
 					}
 				}
@@ -185,7 +185,7 @@ func BenchmarkArrayEqual(b *testing.B) {
 	a1 := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 	a2 := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		if a1 != a2 {
 			b.Fatal("not equal")
 		}

--- a/src/runtime/symtab_test.go
+++ b/src/runtime/symtab_test.go
@@ -259,7 +259,7 @@ func BenchmarkFunc(b *testing.B) {
 	}
 	f := runtime.FuncForPC(pc)
 	b.Run("Name", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			name := f.Name()
 			if name != "runtime_test.BenchmarkFunc" {
 				b.Fatalf("unexpected name %q", name)
@@ -267,7 +267,7 @@ func BenchmarkFunc(b *testing.B) {
 		}
 	})
 	b.Run("Entry", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			pc := f.Entry()
 			if pc == 0 {
 				b.Fatal("zero PC")
@@ -275,7 +275,7 @@ func BenchmarkFunc(b *testing.B) {
 		}
 	})
 	b.Run("FileLine", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			file, line := f.FileLine(pc)
 			if !strings.HasSuffix(file, "symtab_test.go") || line == 0 {
 				b.Fatalf("unexpected file/line %q:%d", file, line)

--- a/src/runtime/syscall_windows_test.go
+++ b/src/runtime/syscall_windows_test.go
@@ -1305,7 +1305,7 @@ func BenchmarkChanToChanPing(b *testing.B) {
 }
 
 func BenchmarkOsYield(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		runtime.OsYield()
 	}
 }
@@ -1328,7 +1328,7 @@ func BenchmarkRunningGoProgram(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		cmd := exec.Command(exe)
 		out, err := cmd.CombinedOutput()
 		if err != nil {

--- a/src/runtime/vlop_arm_test.go
+++ b/src/runtime/vlop_arm_test.go
@@ -38,7 +38,7 @@ func randomNumerators() []uint32 {
 
 func bmUint32Div(divisor uint32, b *testing.B) {
 	var sum uint32
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sum += numerators[i&(numeratorsSize-1)] / divisor
 	}
 }
@@ -56,7 +56,7 @@ func BenchmarkUint32Div106956295(b *testing.B) { bmUint32Div(106956295, b) }
 
 func bmUint32Mod(divisor uint32, b *testing.B) {
 	var sum uint32
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sum += numerators[i&(numeratorsSize-1)] % divisor
 	}
 }

--- a/src/slices/slices_test.go
+++ b/src/slices/slices_test.go
@@ -131,7 +131,7 @@ func BenchmarkEqualFunc_Large(b *testing.B) {
 
 	xs := make([]Large, 1024)
 	ys := make([]Large, 1024)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = EqualFunc(xs, ys, func(x, y Large) bool { return x == y })
 	}
 }
@@ -393,7 +393,7 @@ func BenchmarkIndex_Large(b *testing.B) {
 	type Large [4 * 1024]byte
 
 	ss := make([]Large, 1024)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = Index(ss, Large{1})
 	}
 }
@@ -418,7 +418,7 @@ func BenchmarkIndexFunc_Large(b *testing.B) {
 	type Large [4 * 1024]byte
 
 	ss := make([]Large, 1024)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = IndexFunc(ss, func(e Large) bool {
 			return e == Large{1}
 		})
@@ -805,7 +805,7 @@ func BenchmarkCompact_Large(b *testing.B) {
 	type Large [4 * 1024]byte
 
 	ss := make([]Large, 1024)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = Compact(ss)
 	}
 }
@@ -877,7 +877,7 @@ func BenchmarkCompactFunc_Large(b *testing.B) {
 	type Large [4 * 1024]byte
 
 	ss := make([]Large, 1024)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = CompactFunc(ss, func(a, b Large) bool { return a == b })
 	}
 }

--- a/src/slices/sort_benchmark_test.go
+++ b/src/slices/sort_benchmark_test.go
@@ -20,7 +20,7 @@ func BenchmarkBinarySearchFloats(b *testing.B) {
 			midpoint := len(floats) / 2
 			needle := (floats[midpoint] + floats[midpoint+1]) / 2
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				slices.BinarySearch(floats, needle)
 			}
 		})
@@ -43,7 +43,7 @@ func BenchmarkBinarySearchFuncStruct(b *testing.B) {
 			needle := &myStruct{n: (structs[midpoint].n + structs[midpoint+1].n) / 2}
 			lessFunc := func(a, b *myStruct) int { return a.n - b.n }
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				slices.BinarySearchFunc(structs, needle, lessFunc)
 			}
 		})

--- a/src/sort/search_test.go
+++ b/src/sort/search_test.go
@@ -215,7 +215,7 @@ func TestSearchWrappersDontAlloc(t *testing.T) {
 }
 
 func BenchmarkSearchWrappers(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		runSearchWrappers()
 	}
 }

--- a/src/sort/sort_slices_benchmark_test.go
+++ b/src/sort/sort_slices_benchmark_test.go
@@ -54,7 +54,7 @@ func makeSortedStrings(n int) []string {
 const N = 100_000
 
 func BenchmarkSortInts(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		b.StopTimer()
 		ints := makeRandomInts(N)
 		b.StartTimer()
@@ -63,7 +63,7 @@ func BenchmarkSortInts(b *testing.B) {
 }
 
 func BenchmarkSlicesSortInts(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		b.StopTimer()
 		ints := makeRandomInts(N)
 		b.StartTimer()
@@ -72,7 +72,7 @@ func BenchmarkSlicesSortInts(b *testing.B) {
 }
 
 func BenchmarkSortIsSorted(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		b.StopTimer()
 		ints := makeSortedInts(N)
 		b.StartTimer()
@@ -81,7 +81,7 @@ func BenchmarkSortIsSorted(b *testing.B) {
 }
 
 func BenchmarkSlicesIsSorted(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		b.StopTimer()
 		ints := makeSortedInts(N)
 		b.StartTimer()
@@ -107,7 +107,7 @@ func makeRandomStrings(n int) []string {
 }
 
 func BenchmarkSortStrings(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		b.StopTimer()
 		ss := makeRandomStrings(N)
 		b.StartTimer()
@@ -116,7 +116,7 @@ func BenchmarkSortStrings(b *testing.B) {
 }
 
 func BenchmarkSlicesSortStrings(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		b.StopTimer()
 		ss := makeRandomStrings(N)
 		b.StartTimer()
@@ -128,7 +128,7 @@ func BenchmarkSortStrings_Sorted(b *testing.B) {
 	ss := makeSortedStrings(N)
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Sort(StringSlice(ss))
 	}
 }
@@ -137,7 +137,7 @@ func BenchmarkSlicesSortStrings_Sorted(b *testing.B) {
 	ss := makeSortedStrings(N)
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		slices.Sort(ss)
 	}
 }
@@ -182,7 +182,7 @@ func TestStructSorts(t *testing.T) {
 }
 
 func BenchmarkSortStructs(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		b.StopTimer()
 		ss := makeRandomStructs(N)
 		b.StartTimer()
@@ -192,7 +192,7 @@ func BenchmarkSortStructs(b *testing.B) {
 
 func BenchmarkSortFuncStructs(b *testing.B) {
 	cmpFunc := func(a, b *myStruct) int { return a.n - b.n }
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		b.StopTimer()
 		ss := makeRandomStructs(N)
 		b.StartTimer()

--- a/src/sort/sort_test.go
+++ b/src/sort/sort_test.go
@@ -214,7 +214,7 @@ func BenchmarkSortString1K(b *testing.B) {
 	}
 	data := make([]string, len(unsorted))
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		copy(data, unsorted)
 		b.StartTimer()
 		Strings(data)
@@ -230,7 +230,7 @@ func BenchmarkSortString1K_Slice(b *testing.B) {
 	}
 	data := make([]string, len(unsorted))
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		copy(data, unsorted)
 		b.StartTimer()
 		Slice(data, func(i, j int) bool { return data[i] < data[j] })
@@ -246,7 +246,7 @@ func BenchmarkStableString1K(b *testing.B) {
 	}
 	data := make([]string, len(unsorted))
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		copy(data, unsorted)
 		b.StartTimer()
 		Stable(StringSlice(data))
@@ -256,7 +256,7 @@ func BenchmarkStableString1K(b *testing.B) {
 
 func BenchmarkSortInt1K(b *testing.B) {
 	b.StopTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		data := make([]int, 1<<10)
 		for i := 0; i < len(data); i++ {
 			data[i] = i ^ 0x2cc
@@ -269,7 +269,7 @@ func BenchmarkSortInt1K(b *testing.B) {
 
 func BenchmarkSortInt1K_Sorted(b *testing.B) {
 	b.StopTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		data := make([]int, 1<<10)
 		for i := 0; i < len(data); i++ {
 			data[i] = i
@@ -282,7 +282,7 @@ func BenchmarkSortInt1K_Sorted(b *testing.B) {
 
 func BenchmarkSortInt1K_Reversed(b *testing.B) {
 	b.StopTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		data := make([]int, 1<<10)
 		for i := 0; i < len(data); i++ {
 			data[i] = len(data) - i
@@ -295,7 +295,7 @@ func BenchmarkSortInt1K_Reversed(b *testing.B) {
 
 func BenchmarkSortInt1K_Mod8(b *testing.B) {
 	b.StopTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		data := make([]int, 1<<10)
 		for i := 0; i < len(data); i++ {
 			data[i] = i % 8
@@ -313,7 +313,7 @@ func BenchmarkStableInt1K(b *testing.B) {
 		unsorted[i] = i ^ 0x2cc
 	}
 	data := make([]int, len(unsorted))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		copy(data, unsorted)
 		b.StartTimer()
 		Stable(IntSlice(data))
@@ -328,7 +328,7 @@ func BenchmarkStableInt1K_Slice(b *testing.B) {
 		unsorted[i] = i ^ 0x2cc
 	}
 	data := make([]int, len(unsorted))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		copy(data, unsorted)
 		b.StartTimer()
 		SliceStable(data, func(i, j int) bool { return data[i] < data[j] })
@@ -338,7 +338,7 @@ func BenchmarkStableInt1K_Slice(b *testing.B) {
 
 func BenchmarkSortInt64K(b *testing.B) {
 	b.StopTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		data := make([]int, 1<<16)
 		for i := 0; i < len(data); i++ {
 			data[i] = i ^ 0xcccc
@@ -351,7 +351,7 @@ func BenchmarkSortInt64K(b *testing.B) {
 
 func BenchmarkSortInt64K_Slice(b *testing.B) {
 	b.StopTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		data := make([]int, 1<<16)
 		for i := 0; i < len(data); i++ {
 			data[i] = i ^ 0xcccc
@@ -364,7 +364,7 @@ func BenchmarkSortInt64K_Slice(b *testing.B) {
 
 func BenchmarkStableInt64K(b *testing.B) {
 	b.StopTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		data := make([]int, 1<<16)
 		for i := 0; i < len(data); i++ {
 			data[i] = i ^ 0xcccc
@@ -721,7 +721,7 @@ func bench(b *testing.B, size int, algo func(Interface), name string) {
 	b.StopTimer()
 	data := make(intPairs, size)
 	x := ^uint32(0)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for n := size - 3; n <= size+3; n++ {
 			for i := 0; i < len(data); i++ {
 				x += x

--- a/src/strconv/atof_test.go
+++ b/src/strconv/atof_test.go
@@ -653,25 +653,25 @@ func TestParseFloatIncorrectBitSize(t *testing.T) {
 }
 
 func BenchmarkAtof64Decimal(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ParseFloat("33909", 64)
 	}
 }
 
 func BenchmarkAtof64Float(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ParseFloat("339.7784", 64)
 	}
 }
 
 func BenchmarkAtof64FloatExp(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ParseFloat("-5.09e75", 64)
 	}
 }
 
 func BenchmarkAtof64Big(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ParseFloat("123456789123456789123456789", 64)
 	}
 }
@@ -679,7 +679,7 @@ func BenchmarkAtof64Big(b *testing.B) {
 func BenchmarkAtof64RandomBits(b *testing.B) {
 	initAtof()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		ParseFloat(benchmarksRandomBits[i%1024], 64)
 	}
 }
@@ -687,7 +687,7 @@ func BenchmarkAtof64RandomBits(b *testing.B) {
 func BenchmarkAtof64RandomFloats(b *testing.B) {
 	initAtof()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		ParseFloat(benchmarksRandomNormal[i%1024], 64)
 	}
 }
@@ -700,7 +700,7 @@ func BenchmarkAtof64RandomLongFloats(b *testing.B) {
 	}
 	b.ResetTimer()
 	idx := 0
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ParseFloat(samples[idx], 64)
 		idx++
 		if idx == len(samples) {
@@ -710,19 +710,19 @@ func BenchmarkAtof64RandomLongFloats(b *testing.B) {
 }
 
 func BenchmarkAtof32Decimal(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ParseFloat("33909", 32)
 	}
 }
 
 func BenchmarkAtof32Float(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ParseFloat("339.778", 32)
 	}
 }
 
 func BenchmarkAtof32FloatExp(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ParseFloat("12.3456e32", 32)
 	}
 }
@@ -735,7 +735,7 @@ func BenchmarkAtof32Random(b *testing.B) {
 		float32strings[i] = FormatFloat(float64(math.Float32frombits(n)), 'g', -1, 32)
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		ParseFloat(float32strings[i%4096], 32)
 	}
 }
@@ -748,7 +748,7 @@ func BenchmarkAtof32RandomLong(b *testing.B) {
 		float32strings[i] = FormatFloat(float64(math.Float32frombits(n)), 'g', 20, 32)
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		ParseFloat(float32strings[i%4096], 32)
 	}
 }

--- a/src/strconv/atoi_test.go
+++ b/src/strconv/atoi_test.go
@@ -636,7 +636,7 @@ func benchmarkParseInt(b *testing.B, neg int) {
 	for _, cs := range cases {
 		b.Run(cs.name, func(b *testing.B) {
 			s := fmt.Sprintf("%d", cs.num*int64(neg))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				out, _ := ParseInt(s, 10, 64)
 				BenchSink += int(out)
 			}
@@ -668,7 +668,7 @@ func benchmarkAtoi(b *testing.B, neg int) {
 	for _, cs := range cases {
 		b.Run(cs.name, func(b *testing.B) {
 			s := fmt.Sprintf("%d", cs.num*int64(neg))
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				out, _ := Atoi(s)
 				BenchSink += out
 			}

--- a/src/strconv/ftoa_test.go
+++ b/src/strconv/ftoa_test.go
@@ -305,7 +305,7 @@ var ftoaBenches = []struct {
 func BenchmarkFormatFloat(b *testing.B) {
 	for _, c := range ftoaBenches {
 		b.Run(c.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				FormatFloat(c.float, c.fmt, c.prec, c.bitSize)
 			}
 		})
@@ -316,7 +316,7 @@ func BenchmarkAppendFloat(b *testing.B) {
 	dst := make([]byte, 30)
 	for _, c := range ftoaBenches {
 		b.Run(c.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				AppendFloat(dst[:0], c.float, c.fmt, c.prec, c.bitSize)
 			}
 		})

--- a/src/strconv/itoa_test.go
+++ b/src/strconv/itoa_test.go
@@ -170,7 +170,7 @@ func TestFormatUintVarlen(t *testing.T) {
 }
 
 func BenchmarkFormatInt(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, test := range itob64tests {
 			s := FormatInt(test.in, test.base)
 			BenchSink += len(s)
@@ -180,7 +180,7 @@ func BenchmarkFormatInt(b *testing.B) {
 
 func BenchmarkAppendInt(b *testing.B) {
 	dst := make([]byte, 0, 30)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, test := range itob64tests {
 			dst = AppendInt(dst[:0], test.in, test.base)
 			BenchSink += len(dst)
@@ -189,7 +189,7 @@ func BenchmarkAppendInt(b *testing.B) {
 }
 
 func BenchmarkFormatUint(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, test := range uitob64tests {
 			s := FormatUint(test.in, test.base)
 			BenchSink += len(s)
@@ -199,7 +199,7 @@ func BenchmarkFormatUint(b *testing.B) {
 
 func BenchmarkAppendUint(b *testing.B) {
 	dst := make([]byte, 0, 30)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, test := range uitob64tests {
 			dst = AppendUint(dst[:0], test.in, test.base)
 			BenchSink += len(dst)
@@ -211,7 +211,7 @@ func BenchmarkFormatIntSmall(b *testing.B) {
 	smallInts := []int64{7, 42}
 	for _, smallInt := range smallInts {
 		b.Run(Itoa(int(smallInt)), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				s := FormatInt(smallInt, 10)
 				BenchSink += len(s)
 			}
@@ -222,7 +222,7 @@ func BenchmarkFormatIntSmall(b *testing.B) {
 func BenchmarkAppendIntSmall(b *testing.B) {
 	dst := make([]byte, 0, 30)
 	const smallInt = 42
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		dst = AppendInt(dst[:0], smallInt, 10)
 		BenchSink += len(dst)
 	}

--- a/src/strconv/quote_test.go
+++ b/src/strconv/quote_test.go
@@ -92,13 +92,13 @@ func TestQuoteToGraphic(t *testing.T) {
 }
 
 func BenchmarkQuote(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Quote("\a\b\f\r\n\t\v\a\b\f\r\n\t\v\a\b\f\r\n\t\v")
 	}
 }
 
 func BenchmarkQuoteRune(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		QuoteRune('\a')
 	}
 }
@@ -106,7 +106,7 @@ func BenchmarkQuoteRune(b *testing.B) {
 var benchQuoteBuf []byte
 
 func BenchmarkAppendQuote(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		benchQuoteBuf = AppendQuote(benchQuoteBuf[:0], "\a\b\f\r\n\t\v\a\b\f\r\n\t\v\a\b\f\r\n\t\v")
 	}
 }
@@ -114,7 +114,7 @@ func BenchmarkAppendQuote(b *testing.B) {
 var benchQuoteRuneBuf []byte
 
 func BenchmarkAppendQuoteRune(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		benchQuoteRuneBuf = AppendQuoteRune(benchQuoteRuneBuf[:0], '\a')
 	}
 }
@@ -372,13 +372,13 @@ func testUnquote(t *testing.T, in, want string, wantErr error) {
 }
 
 func BenchmarkUnquoteEasy(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Unquote(`"Give me a rock, paper and scissors and I will move the world."`)
 	}
 }
 
 func BenchmarkUnquoteHard(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Unquote(`"\x47ive me a \x72ock, \x70aper and \x73cissors and \x49 will move the world."`)
 	}
 }

--- a/src/strings/builder_test.go
+++ b/src/strings/builder_test.go
@@ -342,7 +342,7 @@ func benchmarkBuilder(b *testing.B, f func(b *testing.B, numWrite int, grow bool
 
 func BenchmarkBuildString_Builder(b *testing.B) {
 	benchmarkBuilder(b, func(b *testing.B, numWrite int, grow bool) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			var buf Builder
 			if grow {
 				buf.Grow(len(someBytes) * numWrite)
@@ -358,7 +358,7 @@ func BenchmarkBuildString_Builder(b *testing.B) {
 func BenchmarkBuildString_WriteString(b *testing.B) {
 	someString := string(someBytes)
 	benchmarkBuilder(b, func(b *testing.B, numWrite int, grow bool) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			var buf Builder
 			if grow {
 				buf.Grow(len(someString) * numWrite)
@@ -373,7 +373,7 @@ func BenchmarkBuildString_WriteString(b *testing.B) {
 
 func BenchmarkBuildString_ByteBuffer(b *testing.B) {
 	benchmarkBuilder(b, func(b *testing.B, numWrite int, grow bool) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			var buf bytes.Buffer
 			if grow {
 				buf.Grow(len(someBytes) * numWrite)

--- a/src/strings/clone_test.go
+++ b/src/strings/clone_test.go
@@ -39,7 +39,7 @@ func TestClone(t *testing.T) {
 func BenchmarkClone(b *testing.B) {
 	var str = strings.Repeat("a", 42)
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		stringSink = strings.Clone(str)
 	}
 }

--- a/src/strings/replace_test.go
+++ b/src/strings/replace_test.go
@@ -422,7 +422,7 @@ func TestGenericTrieBuilding(t *testing.T) {
 func BenchmarkGenericNoMatch(b *testing.B) {
 	str := Repeat("A", 100) + Repeat("B", 100)
 	generic := NewReplacer("a", "A", "b", "B", "12", "123") // varying lengths forces generic
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		generic.Replace(str)
 	}
 }
@@ -430,14 +430,14 @@ func BenchmarkGenericNoMatch(b *testing.B) {
 func BenchmarkGenericMatch1(b *testing.B) {
 	str := Repeat("a", 100) + Repeat("b", 100)
 	generic := NewReplacer("a", "A", "b", "B", "12", "123")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		generic.Replace(str)
 	}
 }
 
 func BenchmarkGenericMatch2(b *testing.B) {
 	str := Repeat("It&apos;s &lt;b&gt;HTML&lt;/b&gt;!", 100)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		htmlUnescaper.Replace(str)
 	}
 }
@@ -446,7 +446,7 @@ func benchmarkSingleString(b *testing.B, pattern, text string) {
 	r := NewReplacer(pattern, "[match]")
 	b.SetBytes(int64(len(text)))
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		r.Replace(text)
 	}
 }
@@ -465,35 +465,35 @@ func BenchmarkSingleMatch(b *testing.B) {
 
 func BenchmarkByteByteNoMatch(b *testing.B) {
 	str := Repeat("A", 100) + Repeat("B", 100)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		capitalLetters.Replace(str)
 	}
 }
 
 func BenchmarkByteByteMatch(b *testing.B) {
 	str := Repeat("a", 100) + Repeat("b", 100)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		capitalLetters.Replace(str)
 	}
 }
 
 func BenchmarkByteStringMatch(b *testing.B) {
 	str := "<" + Repeat("a", 99) + Repeat("b", 99) + ">"
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		htmlEscaper.Replace(str)
 	}
 }
 
 func BenchmarkHTMLEscapeNew(b *testing.B) {
 	str := "I <3 to escape HTML & other text too."
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		htmlEscaper.Replace(str)
 	}
 }
 
 func BenchmarkHTMLEscapeOld(b *testing.B) {
 	str := "I <3 to escape HTML & other text too."
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		oldHTMLEscape(str)
 	}
 }
@@ -501,7 +501,7 @@ func BenchmarkHTMLEscapeOld(b *testing.B) {
 func BenchmarkByteStringReplacerWriteString(b *testing.B) {
 	str := Repeat("I <3 to escape HTML & other text too.", 100)
 	buf := new(bytes.Buffer)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		htmlEscaper.WriteString(buf, str)
 		buf.Reset()
 	}
@@ -510,7 +510,7 @@ func BenchmarkByteStringReplacerWriteString(b *testing.B) {
 func BenchmarkByteReplacerWriteString(b *testing.B) {
 	str := Repeat("abcdefghijklmnopqrstuvwxyz", 100)
 	buf := new(bytes.Buffer)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		capitalLetters.WriteString(buf, str)
 		buf.Reset()
 	}
@@ -519,7 +519,7 @@ func BenchmarkByteReplacerWriteString(b *testing.B) {
 // BenchmarkByteByteReplaces compares byteByteImpl against multiple Replaces.
 func BenchmarkByteByteReplaces(b *testing.B) {
 	str := Repeat("a", 100) + Repeat("b", 100)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Replace(Replace(str, "a", "A", -1), "b", "B", -1)
 	}
 }
@@ -536,7 +536,7 @@ func BenchmarkByteByteMap(b *testing.B) {
 		}
 		return r
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Map(fn, str)
 	}
 }
@@ -554,7 +554,7 @@ func BenchmarkMap(b *testing.B) {
 	b.Run("identity", func(b *testing.B) {
 		for _, md := range mapdata {
 			b.Run(md.name, func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					Map(mapidentity, md.data)
 				}
 			})
@@ -574,7 +574,7 @@ func BenchmarkMap(b *testing.B) {
 	b.Run("change", func(b *testing.B) {
 		for _, md := range mapdata {
 			b.Run(md.name, func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					Map(mapchange, md.data)
 				}
 			})

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -333,7 +333,7 @@ func BenchmarkIndexRune(b *testing.B) {
 	if got := IndexRune(benchmarkString, '☺'); got != 14 {
 		b.Fatalf("wrong index: expected 14, got=%d", got)
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		IndexRune(benchmarkString, '☺')
 	}
 }
@@ -344,7 +344,7 @@ func BenchmarkIndexRuneLongString(b *testing.B) {
 	if got := IndexRune(benchmarkLongString, '☺'); got != 114 {
 		b.Fatalf("wrong index: expected 114, got=%d", got)
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		IndexRune(benchmarkLongString, '☺')
 	}
 }
@@ -353,7 +353,7 @@ func BenchmarkIndexRuneFastPath(b *testing.B) {
 	if got := IndexRune(benchmarkString, 'v'); got != 17 {
 		b.Fatalf("wrong index: expected 17, got=%d", got)
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		IndexRune(benchmarkString, 'v')
 	}
 }
@@ -362,7 +362,7 @@ func BenchmarkIndex(b *testing.B) {
 	if got := Index(benchmarkString, "v"); got != 17 {
 		b.Fatalf("wrong index: expected 17, got=%d", got)
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Index(benchmarkString, "v")
 	}
 }
@@ -371,7 +371,7 @@ func BenchmarkLastIndex(b *testing.B) {
 	if got := Index(benchmarkString, "v"); got != 17 {
 		b.Fatalf("wrong index: expected 17, got=%d", got)
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		LastIndex(benchmarkString, "v")
 	}
 }
@@ -380,7 +380,7 @@ func BenchmarkIndexByte(b *testing.B) {
 	if got := IndexByte(benchmarkString, 'v'); got != 17 {
 		b.Fatalf("wrong index: expected 17, got=%d", got)
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		IndexByte(benchmarkString, 'v')
 	}
 }
@@ -754,7 +754,7 @@ func TestToValidUTF8(t *testing.T) {
 func BenchmarkToUpper(b *testing.B) {
 	for _, tc := range upperTests {
 		b.Run(tc.in, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				actual := ToUpper(tc.in)
 				if actual != tc.out {
 					b.Errorf("ToUpper(%q) = %q; want %q", tc.in, actual, tc.out)
@@ -767,7 +767,7 @@ func BenchmarkToUpper(b *testing.B) {
 func BenchmarkToLower(b *testing.B) {
 	for _, tc := range lowerTests {
 		b.Run(tc.in, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				actual := ToLower(tc.in)
 				if actual != tc.out {
 					b.Errorf("ToLower(%q) = %q; want %q", tc.in, actual, tc.out)
@@ -781,7 +781,7 @@ func BenchmarkMapNoChanges(b *testing.B) {
 	identity := func(r rune) rune {
 		return r
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Map(identity, "Some string that won't be modified.")
 	}
 }
@@ -873,7 +873,7 @@ func TestTrim(t *testing.T) {
 func BenchmarkTrim(b *testing.B) {
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, tc := range trimTests {
 			name := tc.f
 			var f func(string, string) string
@@ -912,7 +912,7 @@ func BenchmarkToValidUTF8(b *testing.B) {
 	b.ResetTimer()
 	for _, test := range tests {
 		b.Run(test.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				ToValidUTF8(test.input, replacement)
 			}
 		})
@@ -1578,7 +1578,7 @@ func TestEqualFold(t *testing.T) {
 
 func BenchmarkEqualFold(b *testing.B) {
 	b.Run("Tests", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			for _, tt := range EqualFoldTests {
 				if out := EqualFold(tt.s, tt.t); out != tt.out {
 					b.Fatal("wrong result")
@@ -1591,19 +1591,19 @@ func BenchmarkEqualFold(b *testing.B) {
 	const s2 = "abcDefGhijKz"
 
 	b.Run("ASCII", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			EqualFold(s1, s2)
 		}
 	})
 
 	b.Run("UnicodePrefix", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			EqualFold("αβδ"+s1, "ΑΒΔ"+s2)
 		}
 	})
 
 	b.Run("UnicodeSuffix", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			EqualFold(s1+"αβδ", s2+"ΑΒΔ")
 		}
 	})
@@ -1718,19 +1718,19 @@ func makeBenchInputHard() string {
 var benchInputHard = makeBenchInputHard()
 
 func benchmarkIndexHard(b *testing.B, sep string) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Index(benchInputHard, sep)
 	}
 }
 
 func benchmarkLastIndexHard(b *testing.B, sep string) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		LastIndex(benchInputHard, sep)
 	}
 }
 
 func benchmarkCountHard(b *testing.B, sep string) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Count(benchInputHard, sep)
 	}
 }
@@ -1754,13 +1754,13 @@ var benchInputTorture = Repeat("ABC", 1<<10) + "123" + Repeat("ABC", 1<<10)
 var benchNeedleTorture = Repeat("ABC", 1<<10+1)
 
 func BenchmarkIndexTorture(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Index(benchInputTorture, benchNeedleTorture)
 	}
 }
 
 func BenchmarkCountTorture(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Count(benchInputTorture, benchNeedleTorture)
 	}
 }
@@ -1768,7 +1768,7 @@ func BenchmarkCountTorture(b *testing.B) {
 func BenchmarkCountTortureOverlapping(b *testing.B) {
 	A := Repeat("ABC", 1<<20)
 	B := Repeat("ABC", 1<<10)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Count(A, B)
 	}
 }
@@ -1779,7 +1779,7 @@ func BenchmarkCountByte(b *testing.B) {
 		(indexSizes[len(indexSizes)-1]+len(benchmarkString)-1)/len(benchmarkString))
 	benchFunc := func(b *testing.B, benchStr string) {
 		b.SetBytes(int64(len(benchStr)))
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			Count(benchStr, "=")
 		}
 	}
@@ -1837,7 +1837,7 @@ func BenchmarkFields(b *testing.B) {
 					b.ReportAllocs()
 					b.SetBytes(int64(j))
 					data := sd.data[:j]
-					for i := 0; i < b.N; i++ {
+					for range b.N {
 						Fields(data)
 					}
 				})
@@ -1854,7 +1854,7 @@ func BenchmarkFieldsFunc(b *testing.B) {
 					b.ReportAllocs()
 					b.SetBytes(int64(j))
 					data := sd.data[:j]
-					for i := 0; i < b.N; i++ {
+					for range b.N {
 						FieldsFunc(data, unicode.IsSpace)
 					}
 				})
@@ -1864,31 +1864,31 @@ func BenchmarkFieldsFunc(b *testing.B) {
 }
 
 func BenchmarkSplitEmptySeparator(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Split(benchInputHard, "")
 	}
 }
 
 func BenchmarkSplitSingleByteSeparator(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Split(benchInputHard, "/")
 	}
 }
 
 func BenchmarkSplitMultiByteSeparator(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Split(benchInputHard, "hello")
 	}
 }
 
 func BenchmarkSplitNSingleByteSeparator(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		SplitN(benchInputHard, "/", 10)
 	}
 }
 
 func BenchmarkSplitNMultiByteSeparator(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		SplitN(benchInputHard, "hello", 10)
 	}
 }
@@ -1898,7 +1898,7 @@ func BenchmarkRepeat(b *testing.B) {
 	for _, n := range []int{5, 10} {
 		for _, c := range []int{0, 1, 2, 6} {
 			b.Run(fmt.Sprintf("%dx%d", n, c), func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					Repeat(s[:n], c)
 				}
 			})
@@ -1916,7 +1916,7 @@ func BenchmarkRepeatLarge(b *testing.B) {
 				continue
 			}
 			b.Run(fmt.Sprintf("%d/%d", 1<<j, k), func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					Repeat(s, n)
 				}
 				b.SetBytes(int64(n * len(s)))
@@ -1931,7 +1931,7 @@ func BenchmarkIndexAnyASCII(b *testing.B) {
 	for k := 1; k <= 2048; k <<= 4 {
 		for j := 1; j <= 64; j <<= 1 {
 			b.Run(fmt.Sprintf("%d:%d", k, j), func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					IndexAny(x[:k], cs[:j])
 				}
 			})
@@ -1945,7 +1945,7 @@ func BenchmarkIndexAnyUTF8(b *testing.B) {
 	for k := 1; k <= 2048; k <<= 4 {
 		for j := 1; j <= 64; j <<= 1 {
 			b.Run(fmt.Sprintf("%d:%d", k, j), func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					IndexAny(x[:k], cs[:j])
 				}
 			})
@@ -1959,7 +1959,7 @@ func BenchmarkLastIndexAnyASCII(b *testing.B) {
 	for k := 1; k <= 2048; k <<= 4 {
 		for j := 1; j <= 64; j <<= 1 {
 			b.Run(fmt.Sprintf("%d:%d", k, j), func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					LastIndexAny(x[:k], cs[:j])
 				}
 			})
@@ -1973,7 +1973,7 @@ func BenchmarkLastIndexAnyUTF8(b *testing.B) {
 	for k := 1; k <= 2048; k <<= 4 {
 		for j := 1; j <= 64; j <<= 1 {
 			b.Run(fmt.Sprintf("%d:%d", k, j), func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					LastIndexAny(x[:k], cs[:j])
 				}
 			})
@@ -1987,7 +1987,7 @@ func BenchmarkTrimASCII(b *testing.B) {
 		for j := 1; j <= 16; j <<= 1 {
 			b.Run(fmt.Sprintf("%d:%d", k, j), func(b *testing.B) {
 				x := Repeat(cs[:j], k) // Always matches set
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					Trim(x[:k], cs[:j])
 				}
 			})
@@ -1997,7 +1997,7 @@ func BenchmarkTrimASCII(b *testing.B) {
 
 func BenchmarkTrimByte(b *testing.B) {
 	x := "  the quick brown fox   "
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Trim(x, " ")
 	}
 }
@@ -2007,7 +2007,7 @@ func BenchmarkIndexPeriodic(b *testing.B) {
 	for _, skip := range [...]int{2, 4, 8, 16, 32, 64} {
 		b.Run(fmt.Sprintf("IndexPeriodic%d", skip), func(b *testing.B) {
 			s := Repeat("a"+Repeat(" ", skip-1), 1<<16/skip)
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				Index(s, key)
 			}
 		})
@@ -2020,7 +2020,7 @@ func BenchmarkJoin(b *testing.B) {
 		b.Run(strconv.Itoa(l), func(b *testing.B) {
 			b.ReportAllocs()
 			vals := vals[:l]
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				Join(vals, " and ")
 			}
 		})
@@ -2036,7 +2036,7 @@ func BenchmarkTrimSpace(b *testing.B) {
 	}
 	for _, test := range tests {
 		b.Run(test.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				TrimSpace(test.input)
 			}
 		})
@@ -2047,7 +2047,7 @@ var stringSink string
 
 func BenchmarkReplaceAll(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		stringSink = ReplaceAll("banana", "a", "<>")
 	}
 }

--- a/src/sync/cond_test.go
+++ b/src/sync/cond_test.go
@@ -283,7 +283,7 @@ func benchmarkCond(b *testing.B, waiters int) {
 
 	for routine := 0; routine < waiters+1; routine++ {
 		go func() {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				c.L.Lock()
 				if id == -1 {
 					c.L.Unlock()

--- a/src/sync/oncefunc_test.go
+++ b/src/sync/oncefunc_test.go
@@ -245,14 +245,14 @@ func doOnceFunc() {
 func BenchmarkOnceFunc(b *testing.B) {
 	b.Run("v=Once", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			// The baseline is direct use of sync.Once.
 			doOnceFunc()
 		}
 	})
 	b.Run("v=Global", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			// As of 3/2023, the compiler doesn't recognize that onceFunc is
 			// never mutated and is a closure that could be inlined.
 			// Too bad, because this is how OnceFunc will usually be used.
@@ -265,7 +265,7 @@ func BenchmarkOnceFunc(b *testing.B) {
 		// inlinable closure. This is the best case for OnceFunc, but probably
 		// not typical usage.
 		f := sync.OnceFunc(func() {})
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			f()
 		}
 	})
@@ -289,7 +289,7 @@ func BenchmarkOnceValue(b *testing.B) {
 	// See BenchmarkOnceFunc
 	b.Run("v=Once", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			if want, got := 42, doOnceValue(); want != got {
 				b.Fatalf("want %d, got %d", want, got)
 			}
@@ -297,7 +297,7 @@ func BenchmarkOnceValue(b *testing.B) {
 	})
 	b.Run("v=Global", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			if want, got := 42, onceValue(); want != got {
 				b.Fatalf("want %d, got %d", want, got)
 			}
@@ -306,7 +306,7 @@ func BenchmarkOnceValue(b *testing.B) {
 	b.Run("v=Local", func(b *testing.B) {
 		b.ReportAllocs()
 		onceValue := sync.OnceValue(func() int { return 42 })
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			if want, got := 42, onceValue(); want != got {
 				b.Fatalf("want %d, got %d", want, got)
 			}

--- a/src/sync/pool_test.go
+++ b/src/sync/pool_test.go
@@ -323,7 +323,7 @@ func BenchmarkPoolSTW(b *testing.B) {
 	var pauses []uint64
 
 	var p Pool
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		// Put a large number of items into a pool.
 		const N = 100000
 		var item any = 42

--- a/src/syscall/fs_wasip1_test.go
+++ b/src/syscall/fs_wasip1_test.go
@@ -68,7 +68,7 @@ func TestJoinPath(t *testing.T) {
 func BenchmarkJoinPath(b *testing.B) {
 	for _, test := range joinPathTests {
 		b.Run("", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				syscall.JoinPath(test.dir, test.file)
 			}
 		})

--- a/src/syscall/js/js_test.go
+++ b/src/syscall/js/js_test.go
@@ -590,7 +590,7 @@ func BenchmarkDOM(b *testing.B) {
 		b.Skip("Not a browser environment. Skipping.")
 	}
 	const data = "someString"
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		div := document.Call("createElement", "div")
 		div.Call("setAttribute", "id", "myDiv")
 		document.Get("body").Call("appendChild", div)

--- a/src/testing/benchmark_test.go
+++ b/src/testing/benchmark_test.go
@@ -166,7 +166,7 @@ func ExampleB_ReportMetric() {
 	// specific algorithm (in this case, sorting).
 	testing.Benchmark(func(b *testing.B) {
 		var compares int64
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			s := []int{5, 4, 3, 2, 1}
 			sort.Slice(s, func(i, j int) bool {
 				compares++

--- a/src/testing/helper_test.go
+++ b/src/testing/helper_test.go
@@ -106,7 +106,7 @@ func BenchmarkTBHelper(b *testing.B) {
 	}
 	b.ResetTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		if i&1 == 0 {
 			f1()
 		} else {

--- a/src/testing/sub_test.go
+++ b/src/testing/sub_test.go
@@ -546,7 +546,7 @@ func TestTRun(t *T) {
 
 func TestBRun(t *T) {
 	work := func(b *B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			time.Sleep(time.Nanosecond)
 		}
 	}
@@ -625,7 +625,7 @@ func TestBRun(t *T) {
 			const bufSize = 256
 			alloc := func(b *B) {
 				var buf [bufSize]byte
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					_ = append([]byte(nil), buf[:]...)
 				}
 			}
@@ -885,7 +885,7 @@ func TestBenchmark(t *T) {
 	res := Benchmark(func(b *B) {
 		for i := 0; i < 5; i++ {
 			b.Run("", func(b *B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					time.Sleep(time.Millisecond)
 				}
 			})

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -72,7 +72,7 @@
 // A sample benchmark function looks like this:
 //
 //	func BenchmarkRandInt(b *testing.B) {
-//	    for i := 0; i < b.N; i++ {
+//	    for range b.N {
 //	        rand.Int()
 //	    }
 //	}
@@ -91,7 +91,7 @@
 //	func BenchmarkBigLen(b *testing.B) {
 //	    big := NewBig()
 //	    b.ResetTimer()
-//	    for i := 0; i < b.N; i++ {
+//	    for range b.N {
 //	        big.Len()
 //	    }
 //	}

--- a/src/testing/testing_test.go
+++ b/src/testing/testing_test.go
@@ -61,7 +61,7 @@ func TestTempDirInBenchmark(t *testing.T) {
 	testing.Benchmark(func(b *testing.B) {
 		if !b.Run("test", func(b *testing.B) {
 			// Add a loop so that the test won't fail. See issue 38677.
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_ = b.TempDir()
 			}
 		}) {
@@ -595,7 +595,7 @@ func BenchmarkRacy(b *testing.B) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
 		b.Skipf("skipping intentionally-racy benchmark")
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		doRace()
 	}
 }
@@ -622,14 +622,14 @@ func BenchmarkSubRacy(b *testing.B) {
 
 	b.Run("non-racy", func(b *testing.B) {
 		tot := 0
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			tot++
 		}
 		_ = tot
 	})
 
 	b.Run("racy", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			doRace()
 		}
 	})

--- a/src/text/tabwriter/tabwriter_test.go
+++ b/src/text/tabwriter/tabwriter_test.go
@@ -662,7 +662,7 @@ func BenchmarkTable(b *testing.B) {
 			b.Run(fmt.Sprintf("%dx%d", w, h), func(b *testing.B) {
 				b.Run("new", func(b *testing.B) {
 					b.ReportAllocs()
-					for i := 0; i < b.N; i++ {
+					for range b.N {
 						w := NewWriter(io.Discard, 4, 4, 1, ' ', 0) // no particular reason for these settings
 						// Write the line h times.
 						for j := 0; j < h; j++ {
@@ -675,7 +675,7 @@ func BenchmarkTable(b *testing.B) {
 				b.Run("reuse", func(b *testing.B) {
 					b.ReportAllocs()
 					w := NewWriter(io.Discard, 4, 4, 1, ' ', 0) // no particular reason for these settings
-					for i := 0; i < b.N; i++ {
+					for range b.N {
 						// Write the line h times.
 						for j := 0; j < h; j++ {
 							w.Write(line)
@@ -694,7 +694,7 @@ func BenchmarkPyramid(b *testing.B) {
 		line := bytes.Repeat([]byte("a\t"), x)
 		b.Run(fmt.Sprintf("%d", x), func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				w := NewWriter(io.Discard, 4, 4, 1, ' ', 0) // no particular reason for these settings
 				// Write increasing prefixes of that line.
 				for j := 0; j < x; j++ {
@@ -716,7 +716,7 @@ func BenchmarkRagged(b *testing.B) {
 	for _, h := range [...]int{10, 100, 1000} {
 		b.Run(fmt.Sprintf("%d", h), func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				w := NewWriter(io.Discard, 4, 4, 1, ' ', 0) // no particular reason for these settings
 				// Write the lines in turn h times.
 				for j := 0; j < h; j++ {
@@ -744,7 +744,7 @@ lines
 
 func BenchmarkCode(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		w := NewWriter(io.Discard, 4, 4, 1, ' ', 0) // no particular reason for these settings
 		// The code is small, so it's reasonable for the tabwriter user
 		// to write it all at once, or buffer the writes.

--- a/src/text/template/parse/parse_test.go
+++ b/src/text/template/parse/parse_test.go
@@ -653,7 +653,7 @@ func TestLineNum(t *testing.T) {
 
 func BenchmarkParseLarge(b *testing.B) {
 	text := strings.Repeat("{{1234}}\n", 10000)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, err := New("bench").Parse(text, "", "", make(map[string]*Tree), builtins)
 		if err != nil {
 			b.Fatal(err)
@@ -669,7 +669,7 @@ func BenchmarkVariableString(b *testing.B) {
 	}
 	b.ResetTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sinkv = v.String()
 	}
 	if sinkv == "" {
@@ -702,7 +702,7 @@ func BenchmarkListString(b *testing.B) {
 	}
 	b.ResetTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		sinkl = tree.Root.String()
 	}
 	if sinkl == "" {

--- a/src/time/sleep_test.go
+++ b/src/time/sleep_test.go
@@ -668,7 +668,7 @@ func BenchmarkParallelTimerLatency(b *testing.B) {
 	const delay = Millisecond
 	var wg sync.WaitGroup
 	var count int32
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		wg.Add(timerCount)
 		atomic.StoreInt32(&count, 0)
 		for j := 0; j < timerCount; j++ {

--- a/src/time/time_test.go
+++ b/src/time/time_test.go
@@ -1413,46 +1413,46 @@ func TestDefaultLoc(t *testing.T) {
 }
 
 func BenchmarkNow(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		t = Now()
 	}
 }
 
 func BenchmarkNowUnixNano(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		u = Now().UnixNano()
 	}
 }
 
 func BenchmarkNowUnixMilli(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		u = Now().UnixMilli()
 	}
 }
 
 func BenchmarkNowUnixMicro(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		u = Now().UnixMicro()
 	}
 }
 
 func BenchmarkFormat(b *testing.B) {
 	t := Unix(1265346057, 0)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		t.Format("Mon Jan  2 15:04:05 2006")
 	}
 }
 
 func BenchmarkFormatRFC3339(b *testing.B) {
 	t := Unix(1265346057, 0)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		t.Format("2006-01-02T15:04:05Z07:00")
 	}
 }
 
 func BenchmarkFormatRFC3339Nano(b *testing.B) {
 	t := Unix(1265346057, 0)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		t.Format("2006-01-02T15:04:05.999999999Z07:00")
 	}
 }
@@ -1461,27 +1461,27 @@ func BenchmarkFormatNow(b *testing.B) {
 	// Like BenchmarkFormat, but easier, because the time zone
 	// lookup cache is optimized for the present.
 	t := Now()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		t.Format("Mon Jan  2 15:04:05 2006")
 	}
 }
 
 func BenchmarkMarshalJSON(b *testing.B) {
 	t := Now()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		t.MarshalJSON()
 	}
 }
 
 func BenchmarkMarshalText(b *testing.B) {
 	t := Now()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		t.MarshalText()
 	}
 }
 
 func BenchmarkParse(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Parse(ANSIC, "Mon Jan  2 15:04:05 2006")
 	}
 }
@@ -1489,7 +1489,7 @@ func BenchmarkParse(b *testing.B) {
 const testdataRFC3339UTC = "2020-08-22T11:27:43.123456789Z"
 
 func BenchmarkParseRFC3339UTC(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Parse(RFC3339, testdataRFC3339UTC)
 	}
 }
@@ -1497,7 +1497,7 @@ func BenchmarkParseRFC3339UTC(b *testing.B) {
 var testdataRFC3339UTCBytes = []byte(testdataRFC3339UTC)
 
 func BenchmarkParseRFC3339UTCBytes(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Parse(RFC3339, string(testdataRFC3339UTCBytes))
 	}
 }
@@ -1505,7 +1505,7 @@ func BenchmarkParseRFC3339UTCBytes(b *testing.B) {
 const testdataRFC3339TZ = "2020-08-22T11:27:43.123456789-02:00"
 
 func BenchmarkParseRFC3339TZ(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Parse(RFC3339, testdataRFC3339TZ)
 	}
 }
@@ -1513,13 +1513,13 @@ func BenchmarkParseRFC3339TZ(b *testing.B) {
 var testdataRFC3339TZBytes = []byte(testdataRFC3339TZ)
 
 func BenchmarkParseRFC3339TZBytes(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Parse(RFC3339, string(testdataRFC3339TZBytes))
 	}
 }
 
 func BenchmarkParseDuration(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ParseDuration("9007199254.740993ms")
 		ParseDuration("9007199254740993ns")
 	}
@@ -1527,42 +1527,42 @@ func BenchmarkParseDuration(b *testing.B) {
 
 func BenchmarkHour(b *testing.B) {
 	t := Now()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = t.Hour()
 	}
 }
 
 func BenchmarkSecond(b *testing.B) {
 	t := Now()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = t.Second()
 	}
 }
 
 func BenchmarkYear(b *testing.B) {
 	t := Now()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = t.Year()
 	}
 }
 
 func BenchmarkDay(b *testing.B) {
 	t := Now()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = t.Day()
 	}
 }
 
 func BenchmarkISOWeek(b *testing.B) {
 	t := Now()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _ = t.ISOWeek()
 	}
 }
 
 func BenchmarkGoString(b *testing.B) {
 	t := Now()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = t.GoString()
 	}
 }
@@ -1570,7 +1570,7 @@ func BenchmarkGoString(b *testing.B) {
 func BenchmarkUnmarshalText(b *testing.B) {
 	var t Time
 	in := []byte("2020-08-22T11:27:43.123456789-02:00")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		t.UnmarshalText(in)
 	}
 }

--- a/src/unicode/letter_test.go
+++ b/src/unicode/letter_test.go
@@ -469,7 +469,7 @@ func TestCalibrate(t *testing.T) {
 		blinear := func(b *testing.B) {
 			tab := tab
 			max := n*5 + 20
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				for j := 0; j <= max; j++ {
 					linear(tab, uint16(j))
 				}
@@ -478,7 +478,7 @@ func TestCalibrate(t *testing.T) {
 		bbinary := func(b *testing.B) {
 			tab := tab
 			max := n*5 + 20
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				for j := 0; j <= max; j++ {
 					binary(tab, uint16(j))
 				}

--- a/src/unicode/utf16/utf16_test.go
+++ b/src/unicode/utf16/utf16_test.go
@@ -180,7 +180,7 @@ func TestIsSurrogate(t *testing.T) {
 func BenchmarkDecodeValidASCII(b *testing.B) {
 	// "hello world"
 	data := []uint16{104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Decode(data)
 	}
 }
@@ -188,7 +188,7 @@ func BenchmarkDecodeValidASCII(b *testing.B) {
 func BenchmarkDecodeValidJapaneseChars(b *testing.B) {
 	// "日本語日本語日本語"
 	data := []uint16{26085, 26412, 35486, 26085, 26412, 35486, 26085, 26412, 35486}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Decode(data)
 	}
 }
@@ -201,7 +201,7 @@ func BenchmarkDecodeRune(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for j := 0; j < 5; j++ {
 			DecodeRune(rs[2*j], rs[2*j+1])
 		}
@@ -210,14 +210,14 @@ func BenchmarkDecodeRune(b *testing.B) {
 
 func BenchmarkEncodeValidASCII(b *testing.B) {
 	data := []rune{'h', 'e', 'l', 'l', 'o'}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Encode(data)
 	}
 }
 
 func BenchmarkEncodeValidJapaneseChars(b *testing.B) {
 	data := []rune{'日', '本', '語'}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Encode(data)
 	}
 }
@@ -225,7 +225,7 @@ func BenchmarkEncodeValidJapaneseChars(b *testing.B) {
 func BenchmarkAppendRuneValidASCII(b *testing.B) {
 	data := []rune{'h', 'e', 'l', 'l', 'o'}
 	a := make([]uint16, 0, len(data)*2)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, u := range data {
 			a = AppendRune(a, u)
 		}
@@ -236,7 +236,7 @@ func BenchmarkAppendRuneValidASCII(b *testing.B) {
 func BenchmarkAppendRuneValidJapaneseChars(b *testing.B) {
 	data := []rune{'日', '本', '語'}
 	a := make([]uint16, 0, len(data)*2)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, u := range data {
 			a = AppendRune(a, u)
 		}
@@ -245,7 +245,7 @@ func BenchmarkAppendRuneValidJapaneseChars(b *testing.B) {
 }
 
 func BenchmarkEncodeRune(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, u := range []rune{'𝓐', '𝓑', '𝓒', '𝓓', '𝓔'} {
 			EncodeRune(u)
 		}

--- a/src/unicode/utf8/utf8_test.go
+++ b/src/unicode/utf8/utf8_test.go
@@ -531,26 +531,26 @@ func TestValidRune(t *testing.T) {
 
 func BenchmarkRuneCountTenASCIIChars(b *testing.B) {
 	s := []byte("0123456789")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		RuneCount(s)
 	}
 }
 
 func BenchmarkRuneCountTenJapaneseChars(b *testing.B) {
 	s := []byte("日本語日本語日本語日")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		RuneCount(s)
 	}
 }
 
 func BenchmarkRuneCountInStringTenASCIIChars(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		RuneCountInString("0123456789")
 	}
 }
 
 func BenchmarkRuneCountInStringTenJapaneseChars(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		RuneCountInString("日本語日本語日本語日")
 	}
 }
@@ -559,64 +559,64 @@ var ascii100000 = strings.Repeat("0123456789", 10000)
 
 func BenchmarkValidTenASCIIChars(b *testing.B) {
 	s := []byte("0123456789")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Valid(s)
 	}
 }
 
 func BenchmarkValid100KASCIIChars(b *testing.B) {
 	s := []byte(ascii100000)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Valid(s)
 	}
 }
 
 func BenchmarkValidTenJapaneseChars(b *testing.B) {
 	s := []byte("日本語日本語日本語日")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Valid(s)
 	}
 }
 func BenchmarkValidLongMostlyASCII(b *testing.B) {
 	longMostlyASCII := []byte(longStringMostlyASCII)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Valid(longMostlyASCII)
 	}
 }
 
 func BenchmarkValidLongJapanese(b *testing.B) {
 	longJapanese := []byte(longStringJapanese)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		Valid(longJapanese)
 	}
 }
 
 func BenchmarkValidStringTenASCIIChars(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ValidString("0123456789")
 	}
 }
 
 func BenchmarkValidString100KASCIIChars(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ValidString(ascii100000)
 	}
 }
 
 func BenchmarkValidStringTenJapaneseChars(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ValidString("日本語日本語日本語日")
 	}
 }
 
 func BenchmarkValidStringLongMostlyASCII(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ValidString(longStringMostlyASCII)
 	}
 }
 
 func BenchmarkValidStringLongJapanese(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ValidString(longStringJapanese)
 	}
 }
@@ -640,42 +640,42 @@ func init() {
 
 func BenchmarkEncodeASCIIRune(b *testing.B) {
 	buf := make([]byte, UTFMax)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		EncodeRune(buf, 'a')
 	}
 }
 
 func BenchmarkEncodeJapaneseRune(b *testing.B) {
 	buf := make([]byte, UTFMax)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		EncodeRune(buf, '本')
 	}
 }
 
 func BenchmarkAppendASCIIRune(b *testing.B) {
 	buf := make([]byte, UTFMax)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		AppendRune(buf[:0], 'a')
 	}
 }
 
 func BenchmarkAppendJapaneseRune(b *testing.B) {
 	buf := make([]byte, UTFMax)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		AppendRune(buf[:0], '本')
 	}
 }
 
 func BenchmarkDecodeASCIIRune(b *testing.B) {
 	a := []byte{'a'}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		DecodeRune(a)
 	}
 }
 
 func BenchmarkDecodeJapaneseRune(b *testing.B) {
 	nihon := []byte("本")
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		DecodeRune(nihon)
 	}
 }
@@ -695,7 +695,7 @@ func BenchmarkFullRune(b *testing.B) {
 	}
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				boolSink = FullRune(bm.data)
 			}
 		})


### PR DESCRIPTION
Replace traditional 3-clause for loops with 'for range' in benchmark
tests to utilize the new range-over-integer feature.

This change simplifies loop constructs and leverages the readability
enhancements brought by proposal #61405. It affects benchmarks where
the index was not used within the loop body.

Ref https://go-review.googlesource.com/c/go/+/538718
For #61405.