### PR TITLE
path/filepath: simplify chdir and error handling in tests

### DIFF
--- a/src/path/filepath/match_test.go
+++ b/src/path/filepath/match_test.go
@@ -337,20 +337,8 @@ func TestWindowsGlob(t *testing.T) {
 	}
 
 	// test relative paths
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = os.Chdir(tmpDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		err := os.Chdir(wd)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
+	chdir(t, tmpDir)
+
 	for _, test := range tests {
 		err := test.globRel("")
 		if err != nil {

--- a/src/path/filepath/path_test.go
+++ b/src/path/filepath/path_test.go
@@ -544,30 +544,18 @@ func chdir(t *testing.T, dir string) {
 
 	t.Cleanup(func() {
 		if err := os.Chdir(olddir); err != nil {
-			t.Errorf("restore original working directory %s: %v", olddir, err)
-			os.Exit(1)
+			t.Fatalf("restore original working directory %s: %v", olddir, err)
 		}
 	})
 }
 
-func chtmpdir(t *testing.T) (restore func()) {
-	oldwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("chtmpdir: %v", err)
-	}
-	d, err := os.MkdirTemp("", "test")
-	if err != nil {
-		t.Fatalf("chtmpdir: %v", err)
-	}
-	if err := os.Chdir(d); err != nil {
-		t.Fatalf("chtmpdir: %v", err)
-	}
-	return func() {
-		if err := os.Chdir(oldwd); err != nil {
-			t.Fatalf("chtmpdir: %v", err)
-		}
+func chtmpdir(t *testing.T) string {
+	d := t.TempDir()
+	chdir(t, d)
+	t.Cleanup(func() {
 		os.RemoveAll(d)
-	}
+	})
+	return d
 }
 
 // tempDirCanonical returns a temporary directory for the test to use, ensuring
@@ -597,21 +585,7 @@ func TestWalkDir(t *testing.T) {
 }
 
 func testWalk(t *testing.T, walk func(string, fs.WalkDirFunc) error, errVisit int) {
-	if runtime.GOOS == "ios" {
-		restore := chtmpdir(t)
-		defer restore()
-	}
-
-	tmpDir := t.TempDir()
-
-	origDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal("finding working dir:", err)
-	}
-	if err = os.Chdir(tmpDir); err != nil {
-		t.Fatal("entering temp dir:", err)
-	}
-	defer os.Chdir(origDir)
+	chtmpdir(t)
 
 	makeTree(t)
 	errors := make([]error, 0, 10)
@@ -620,7 +594,7 @@ func testWalk(t *testing.T, walk func(string, fs.WalkDirFunc) error, errVisit in
 		return mark(d, err, &errors, clear)
 	}
 	// Expect no errors.
-	err = walk(tree.name, markFn)
+	err := walk(tree.name, markFn)
 	if err != nil {
 		t.Fatalf("no error expected, found: %s", err)
 	}
@@ -1249,7 +1223,7 @@ func TestEvalSymlinks(t *testing.T) {
 func TestEvalSymlinksIsNotExist(t *testing.T) {
 	testenv.MustHaveSymlink(t)
 
-	defer chtmpdir(t)()
+	chtmpdir(t)
 
 	_, err := filepath.EvalSymlinks("notexist")
 	if !os.IsNotExist(err) {
@@ -1332,8 +1306,7 @@ func TestRelativeSymlinkToAbsolute(t *testing.T) {
 	testenv.MustHaveSymlink(t)
 	// Not parallel: uses os.Chdir.
 
-	tmpDir := t.TempDir()
-	chdir(t, tmpDir)
+	tmpDir := chtmpdir(t)
 
 	// Create "link" in the current working directory as a symlink to an arbitrary
 	// absolute path. On macOS, this path is likely to begin with a symlink
@@ -1385,19 +1358,10 @@ var absTests = []string{
 }
 
 func TestAbs(t *testing.T) {
-	root := t.TempDir()
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal("getwd failed: ", err)
-	}
-	err = os.Chdir(root)
-	if err != nil {
-		t.Fatal("chdir failed: ", err)
-	}
-	defer os.Chdir(wd)
+	root := chtmpdir(t)
 
 	for _, dir := range absTestDirs {
-		err = os.Mkdir(dir, 0777)
+		err := os.Mkdir(dir, 0777)
 		if err != nil {
 			t.Fatal("Mkdir failed: ", err)
 		}
@@ -1416,7 +1380,7 @@ func TestAbs(t *testing.T) {
 		absTests = append(absTests, extra...)
 	}
 
-	err = os.Chdir(absTestDirs[0])
+	err := os.Chdir(absTestDirs[0])
 	if err != nil {
 		t.Fatal("chdir failed: ", err)
 	}
@@ -1451,17 +1415,7 @@ func TestAbs(t *testing.T) {
 // We test it separately from all other absTests because the empty string is not
 // a valid path, so it can't be used with os.Stat.
 func TestAbsEmptyString(t *testing.T) {
-	root := t.TempDir()
-
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal("getwd failed: ", err)
-	}
-	err = os.Chdir(root)
-	if err != nil {
-		t.Fatal("chdir failed: ", err)
-	}
-	defer os.Chdir(wd)
+	root := chtmpdir(t)
 
 	info, err := os.Stat(root)
 	if err != nil {
@@ -1687,20 +1641,9 @@ func TestBug3486(t *testing.T) { // https://golang.org/issue/3486
 }
 
 func testWalkSymlink(t *testing.T, mklink func(target, link string) error) {
-	tmpdir := t.TempDir()
+	tmpdir := chtmpdir(t)
 
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(wd)
-
-	err = os.Chdir(tmpdir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = mklink(tmpdir, "link")
+	err := mklink(tmpdir, "link")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1814,12 +1757,7 @@ func TestEvalSymlinksAboveRoot(t *testing.T) {
 func TestEvalSymlinksAboveRootChdir(t *testing.T) {
 	testenv.MustHaveSymlink(t)
 
-	tmpDir, err := os.MkdirTemp("", "TestEvalSymlinksAboveRootChdir")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-	chdir(t, tmpDir)
+	chtmpdir(t)
 
 	subdir := filepath.Join("a", "b")
 	if err := os.MkdirAll(subdir, 0777); err != nil {


### PR DESCRIPTION
This change simplifies the test code for changing directories by
utilizing t.TempDir() within chtmpdir function. It also replaces os.Exit(1)
with t.Fatalf to handle errors more consistently with Go's testing
practice.

The cleanup process is now managed with t.Cleanup, ensuring that any
created temporary directories are removed without the need for a
deferred restore function.

Updates #45182
