### PR TITLE
cmd/compile/internal/test: prevent failures in go tool dist test -msan

### DIFF
--- a/src/cmd/compile/internal/test/issue53888_test.go
+++ b/src/cmd/compile/internal/test/issue53888_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !race
+//go:build !race && !msan
 
 package test
 


### PR DESCRIPTION
This test is already marked with !race, but when running the tests with
-msan it allocates memory which throws off the test assertions. Marking
it !msan as well.

For #64256