### PR TITLE
regexp: remove reference to external RE2 wiki from the docs

### DIFF
--- a/src/regexp/regexp.go
+++ b/src/regexp/regexp.go
@@ -6,8 +6,6 @@
 //
 // The syntax of the regular expressions accepted is the same
 // general syntax used by Perl, Python, and other languages.
-// More precisely, it is the syntax accepted by RE2 and described at
-// https://golang.org/s/re2syntax, except for \C.
 // For an overview of the syntax, see the [regexp/syntax] package.
 //
 // The regexp implementation provided by this package is


### PR DESCRIPTION
The regexp docs point to the google/re2 syntax page, which
causes confusion since users expect feature parity with RE2, which might
not be the case if you are using an older version of Go.

In regexp/syntax/doc.go there is already an autogenerated syntax based
on RE2 and we already link to that in the docs, so removing the external
link does not result in any loss of information.

Fixes #64108