### PR TITLE
cmd/cgo: create temporary objdir by default

### DIFF
--- a/src/cmd/cgo/main.go
+++ b/src/cmd/cgo/main.go
@@ -387,8 +387,14 @@ func main() {
 	if *objDir == "" {
 		// make sure that _obj directory exists, so that we can write
 		// all the output files there.
-		os.Mkdir("_obj", 0777)
-		*objDir = "_obj"
+		var tmpdir string
+		tmpdir, err = os.MkdirTemp("", "cgo-obj")
+		if err != nil {
+			fatalf("%v", err)
+			os.Exit(2)
+		}
+		defer os.Remove(tmpdir)
+		*objDir = tmpdir
 	}
 	*objDir += string(filepath.Separator)
 

--- a/src/cmd/go/testdata/script/build_cwd_newline.txt
+++ b/src/cmd/go/testdata/script/build_cwd_newline.txt
@@ -44,11 +44,11 @@ go list -compiled -e -f '{{with .CompiledGoFiles}}{{.}}{{end}}' .
 # The cgo tool should only accept the source file if the working directory
 # is not written in line directives in the resulting files.
 
-[cgo] ! go tool cgo main.go
+[cgo] ! go tool cgo -objdir _obj main.go
 [cgo] stderr 'cgo: input path contains newline character: .*uh-oh'
 [cgo] ! exists _obj
 
-[cgo] go tool cgo -trimpath=$PWD main.go
+[cgo] go tool cgo -objdir _obj -trimpath=$PWD main.go
 [cgo] grep '//line main\.go:1:1' _obj/main.cgo1.go
 [cgo] ! grep 'uh-oh' _obj/main.cgo1.go
 [cgo] rm _obj


### PR DESCRIPTION
As a part of an invocation of `go tool cgo`, temporary files are created and placed in an "object directory". This directory can be specified with the -objdir flag, and it defaults to _obj within the current directory.

There are some issues with this:
1. It is racy in conditions where this tool is invoked in parallel within the same directory
2. it creates unexpected clutter (the objdir is not cleaned up at all post-invocation)
3. it fails when the current directory is not writable (with a somewhat misleading error, e.g "Fatal error: can't create _obj/_cgo_.o: No such file or directory")

I believe that creating a temporary directory and removing it afterwards would be a better default, as it would avoid these issues.
Anything that explicitly sets the `-objdir` flag would be left unchanged, and the current default behaviour could be restored simply by explicitly setting `-objdir` to  `_obj`

Fixes #64621