### PR TITLE
reflect: delete TODO pass safe to packEface don't need to copy if safe==true

### DIFF
--- a/src/reflect/deepequal.go
+++ b/src/reflect/deepequal.go
@@ -171,7 +171,7 @@ func deepValueEqual(v1, v2 Value, visited map[visit]bool) bool {
 		return v1.Complex() == v2.Complex()
 	default:
 		// Normal equality suffices
-		return valueInterface(v1, false) == valueInterface(v2, false)
+		return valueInterface(v1) == valueInterface(v2)
 	}
 }
 

--- a/src/reflect/deepequal.go
+++ b/src/reflect/deepequal.go
@@ -171,7 +171,7 @@ func deepValueEqual(v1, v2 Value, visited map[visit]bool) bool {
 		return v1.Complex() == v2.Complex()
 	default:
 		// Normal equality suffices
-		return valueInterface(v1) == valueInterface(v2)
+		return valueInterface(v1, false) == valueInterface(v2, false)
 	}
 }
 

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -129,8 +129,6 @@ func packEface(v Value) any {
 		// Value is indirect, and so is the interface we're making.
 		ptr := v.ptr
 		if v.flag&flagAddr != 0 {
-			// TODO: pass safe boolean from valueInterface so
-			// we don't need to copy if safe==true?
 			c := unsafe_New(t)
 			typedmemmove(t, c, ptr)
 			ptr = c
@@ -1522,7 +1520,6 @@ func valueInterface(v Value, safe bool) any {
 		})(v.ptr)
 	}
 
-	// TODO: pass safe to packEface so we don't need to copy if safe==true?
 	return packEface(v)
 }
 


### PR DESCRIPTION
valueInterface not copy result in the follow incorrect behavior
w1.  x := ValueOf(&v).Elem()
r1.  iface := Value.Interface()
w2.  x.Set() or x.SetT()

The write operation of W2 will be observed by the read operation of r1,
but the existing behavior is not.

The valueInterface in deepValueEqual can, in theory, pass safe==true to not copy the object,
but there is no benchmark to indicate that the memory allocation has changed,
maybe we don't actually need safe==true here.

