### PR TITLE
cmd/cgo/internal/testsanitizers: check for go build and cgo in fuzzer and msan tests

### DIFF
--- a/src/cmd/cgo/internal/testsanitizers/libfuzzer_test.go
+++ b/src/cmd/cgo/internal/testsanitizers/libfuzzer_test.go
@@ -7,11 +7,14 @@
 package sanitizers_test
 
 import (
+	"internal/testenv"
 	"strings"
 	"testing"
 )
 
 func TestLibFuzzer(t *testing.T) {
+	testenv.MustHaveGoBuild(t)
+	testenv.MustHaveCGO(t)
 	goos, err := goEnv("GOOS")
 	if err != nil {
 		t.Fatal(err)

--- a/src/cmd/cgo/internal/testsanitizers/msan_test.go
+++ b/src/cmd/cgo/internal/testsanitizers/msan_test.go
@@ -8,11 +8,14 @@ package sanitizers_test
 
 import (
 	"internal/platform"
+	"internal/testenv"
 	"strings"
 	"testing"
 )
 
 func TestMSAN(t *testing.T) {
+	testenv.MustHaveGoBuild(t)
+	testenv.MustHaveCGO(t)
 	goos, err := goEnv("GOOS")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Make sure the platform we are running the tests on can compile programs
and has cgo support in order to run the fuzzer and msan tests. This is the
same approach used by the asan tests, which share the same requirements.

Fixes #64626