### PR TITLE
iter: fix race instrumentation for Pull2

### DIFF
--- a/src/iter/iter.go
+++ b/src/iter/iter.go
@@ -14,8 +14,7 @@ package iter
 import (
 	"internal/race"
 	"unsafe"
-	_ "unsafe"
-) // for linkname
+)
 
 // Seq is an iterator over sequences of individual values.
 // When called as seq(yield), seq calls yield(v) for each value v in the sequence,


### PR DESCRIPTION
Pull2 tests are failing with -race, giving false-positive race conditions
due to bad race instrumentation.

No tests for this as it should be caught by the race builders. The only
reason it was not caught is because it is behind GOEXPERIMENT=rangefunc.

Fixes #64651