### PR TITLE
regexp/syntax: allow extended Unicode characters in capture names

### DIFF
--- a/src/regexp/syntax/doc.go
+++ b/src/regexp/syntax/doc.go
@@ -7,12 +7,12 @@
 /*
 Package syntax parses regular expressions into parse trees and compiles
 parse trees into programs. Most clients of regular expressions will use the
-facilities of package regexp (such as Compile and Match) instead of this package.
+facilities of package [regexp] (such as [regexp.Compile] and [regexp.Match]) instead of this package.
 
 # Syntax
 
-The regular expression syntax understood by this package when parsing with the Perl flag is as follows.
-Parts of the syntax can be disabled by passing alternate flags to Parse.
+The regular expression syntax understood by this package when parsing with the [Perl] flag is as follows.
+Parts of the syntax can be disabled by passing alternate flags to [Parse].
 
 Single characters:
 
@@ -137,6 +137,6 @@ ASCII character classes:
 	[[:word:]]     word characters (== [0-9A-Za-z_])
 	[[:xdigit:]]   hex digit (== [0-9A-Fa-f])
 
-Unicode character classes are those in unicode.Categories and unicode.Scripts.
+Unicode character classes are those in [unicode.Categories] and [unicode.Scripts].
 */
 package syntax

--- a/src/regexp/syntax/parse_test.go
+++ b/src/regexp/syntax/parse_test.go
@@ -160,7 +160,9 @@ var parseTests = []parseTest{
 
 	// Test named captures
 	{`(?P<name>a)`, `cap{name:lit{a}}`},
+	{`(?P<中文>a)`, `cap{中文:lit{a}}`},
 	{`(?<name>a)`, `cap{name:lit{a}}`},
+	{`(?<中文>a)`, `cap{中文:lit{a}}`},
 
 	// Case-folded literals
 	{`[Aa]`, `litfold{A}`},


### PR DESCRIPTION
Based on re2's change: https://code-review.googlesource.com/c/re2/+/59130

Fixes #64678