### PR TITLE
cmd/go/internal/work/security.go: allow direct linking of Windows .lib static libraries

### DIFF
--- a/src/cmd/go/internal/work/security.go
+++ b/src/cmd/go/internal/work/security.go
@@ -213,8 +213,8 @@ var validLinkerFlags = []*lazyregexp.Regexp{
 	re(`-Wl,-z,(no)?execstack`),
 	re(`-Wl,-z,relro`),
 
-	re(`[a-zA-Z0-9_/].*\.(a|o|obj|dll|dylib|so|tbd)`), // direct linker inputs: x.o or libfoo.so (but not -foo.o or @foo.o)
-	re(`\./.*\.(a|o|obj|dll|dylib|so|tbd)`),
+	re(`[a-zA-Z0-9_/].*\.(a|lib|o|obj|dll|dylib|so|tbd)`), // direct linker inputs: x.o or libfoo.so (but not -foo.o or @foo.o)
+	re(`\./.*\.(a|lib|o|obj|dll|dylib|so|tbd)`),
 }
 
 var validLinkerFlagsWithNextArg = []string{


### PR DESCRIPTION
allow direct linking of Windows .lib static libraries

Windows static libraries ends with extension .lib. 
cgo refused to link with those requiring renaming them to .a or using `-Wl,-Bstatic -lmylib -Wl,-Bdynamic` as a workaround.

This PR adds `.lib` files to cgo LDFLAGS allowlist. 