### PR TITLE
net/http: explain when HTTP/2 is disabled

### DIFF
--- a/src/net/http/doc.go
+++ b/src/net/http/doc.go
@@ -98,13 +98,12 @@ currently supported:
 
 Please report any issues before disabling HTTP/2 support: https://golang.org/s/http2bug
 
-The http package's Transport and Server both automatically enable
-HTTP/2 support for simple configurations. To enable HTTP/2 for more
-complex configurations, to use lower-level HTTP/2 features, or to use
-a newer version of Go's http2 package, import "golang.org/x/net/http2"
+Configuring a custom dialer or TLS config disables HTTP/2
+support. To re-enable HTTP/2 for those more complex configurations,
+set Transport.ForceAttemptHTTP2 to true or import "golang.org/x/net/http2"
 directly and use its ConfigureTransport and/or ConfigureServer
 functions. Manually configuring HTTP/2 via the golang.org/x/net/http2
 package takes precedence over the net/http package's built-in HTTP/2
-support.
+support and can be used to access lower-level HTTP/2 features.
 */
 package http

--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -137,6 +137,7 @@ type Transport struct {
 	// A RoundTrip call that initiates a dial may end up using
 	// a connection dialed previously when the earlier connection
 	// becomes idle before the later DialContext completes.
+	// If non-nil, automatic HTTP/2 support is disabled. See ForceAttemptHTTP2.
 	DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
 
 	// Dial specifies the dial function for creating unencrypted TCP connections.
@@ -149,6 +150,7 @@ type Transport struct {
 	// Deprecated: Use DialContext instead, which allows the transport
 	// to cancel dials as soon as they are no longer needed.
 	// If both are set, DialContext takes priority.
+	// If non-nil, automatic HTTP/2 support is disabled. See ForceAttemptHTTP2.
 	Dial func(network, addr string) (net.Conn, error)
 
 	// DialTLSContext specifies an optional dial function for creating
@@ -161,6 +163,8 @@ type Transport struct {
 	// requests and the TLSClientConfig and TLSHandshakeTimeout
 	// are ignored. The returned net.Conn is assumed to already be
 	// past the TLS handshake.
+	//
+	// If non-nil, automatic HTTP/2 support is disabled. See ForceAttemptHTTP2.
 	DialTLSContext func(ctx context.Context, network, addr string) (net.Conn, error)
 
 	// DialTLS specifies an optional dial function for creating
@@ -169,12 +173,13 @@ type Transport struct {
 	// Deprecated: Use DialTLSContext instead, which allows the transport
 	// to cancel dials as soon as they are no longer needed.
 	// If both are set, DialTLSContext takes priority.
+	// If non-nil, automatic HTTP/2 support is disabled. See ForceAttemptHTTP2.
 	DialTLS func(network, addr string) (net.Conn, error)
 
 	// TLSClientConfig specifies the TLS configuration to use with
 	// tls.Client.
 	// If nil, the default configuration is used.
-	// If non-nil, HTTP/2 support may not be enabled by default.
+	// If non-nil, automatic HTTP/2 support is disabled. See ForceAttemptHTTP2.
 	TLSClientConfig *tls.Config
 
 	// TLSHandshakeTimeout specifies the maximum amount of time to


### PR DESCRIPTION
Previously the docs simply said HTTP/2 is disabled for "simple configurations." Instead, say which specific configurations disable HTTP/2.

Also, the sentence "... Transport and Server both automatically enable HTTP/2 support for simple configurations" was redundant with the sentence at the start of the section:

"Starting with Go 1.6, the http package has transparent support for the HTTP/2 protocol when using HTTPS."

Several fields of Transport can disable HTTP/2 support, but only one (TLSClientConfig) was documented to do so. Add consistent documentation to each of them.

Background:

For letsencrypt/boulder, we're adding DoH support to talk to Unbound. Unbound requires HTTP/2. We configured a custom root certificate since our internal Unbound uses an internal PKI. We were puzzled to get errors and had trouble tracking down why [HTTP/2 wasn't happening](https://github.com/letsencrypt/boulder/pull/7215), despite checking the docs several times. Hopefully this change can make things clearer for future readers.