### PR TITLE
math/rand.go: fixed typo to explicitly state syntax

### DIFF
--- a/src/math/rand/rand.go
+++ b/src/math/rand/rand.go
@@ -389,7 +389,7 @@ func (fs *runtimeSource) read(p []byte, readVal *int64, readPos *int8) (n int, e
 //
 // Deprecated: As of Go 1.20 there is no reason to call Seed with
 // a random value. Programs that call Seed with a known value to get
-// a specific sequence of results should use New(NewSource(seed)) to
+// a specific sequence of results should use rand.New(NewSource(seed)) to
 // obtain a local random generator.
 func Seed(seed int64) {
 	orig := globalRandGenerator.Load()


### PR DESCRIPTION
Adding the package identifier in front of the function helps newer developers understand the exact syntax required for using the new function for generating a random number from source.




