### PR TITLE
runtime/cgo: mark fatalf as noreturn

### DIFF
--- a/src/runtime/cgo/libcgo.h
+++ b/src/runtime/cgo/libcgo.h
@@ -76,7 +76,7 @@ void x_cgo_getstackbound(uintptr bounds[2]);
 /*
  * Prints error then calls abort. For linux and android.
  */
-void fatalf(const char* format, ...);
+void fatalf(const char* format, ...) __attribute__ ((noreturn));
 
 /*
  * Registers the current mach thread port for EXC_BAD_ACCESS processing.


### PR DESCRIPTION
Fixes #64553