### PR TITLE
database/sql: wrap errors with %w in driverArgsConnLocked

### DIFF
--- a/src/database/sql/convert.go
+++ b/src/database/sql/convert.go
@@ -192,7 +192,7 @@ func driverArgsConnLocked(ci driver.Conn, ds *driverStmt, args []any) ([]driver.
 			}
 			goto nextCheck
 		default:
-			return nil, fmt.Errorf("sql: converting argument %s type: %v", describeNamedValue(nv), err)
+			return nil, fmt.Errorf("sql: converting argument %s type: %w", describeNamedValue(nv), err)
 		}
 	}
 

--- a/src/database/sql/driver/types.go
+++ b/src/database/sql/driver/types.go
@@ -34,6 +34,10 @@ type ValueConverter interface {
 
 // Valuer is the interface providing the Value method.
 //
+// Errors returned by the [Value] method are wrapped by the database/sql package.
+// This allows callers to use [errors.Is] for precise error handling after operations
+// like [database/sql.Query], [database/sql.Exec], or [database/sql.QueryRow].
+//
 // Types implementing Valuer interface are able to convert
 // themselves to a driver [Value].
 type Valuer interface {


### PR DESCRIPTION
Use fmt.Errorf %w verb to wrap errors in driverArgsConnLocked,
which allows for easier unwrapping and checking of error types.

Add tests in sql_test.go to ensure that Stmt.Exec and Stmt.Query
correctly wrap underlying Valuer errors, adhering to the new change.

Fixes #64707.
