### PR TITLE
runtime: optimize eqslice

### DIFF
--- a/src/runtime/mprof.go
+++ b/src/runtime/mprof.go
@@ -296,7 +296,7 @@ func stkbucket(typ bucketType, size uintptr, stk []uintptr, alloc bool) *bucket 
 	// first check optimistically, without the lock
 	for b := (*bucket)(bh[i].Load()); b != nil; b = b.next {
 		bstk := b.stk()
-		if b.typ == typ && b.hash == h && b.size == size && bytealg.Equal(*(*[]byte)(unsafe.Pointer(&bstk)), *(*[]byte)(unsafe.Pointer(&stk))) {
+		if b.typ == typ && b.hash == h && b.size == size && bytealg.Equal(unsafe.Slice((*byte)(unsafe.Pointer(&bstk)), len(bstk)*8), unsafe.Slice((*byte)(unsafe.Pointer(&stk)), len(stk)*8)) {
 			return b
 		}
 	}
@@ -309,7 +309,7 @@ func stkbucket(typ bucketType, size uintptr, stk []uintptr, alloc bool) *bucket 
 	// check again under the insertion lock
 	for b := (*bucket)(bh[i].Load()); b != nil; b = b.next {
 		bstk := b.stk()
-		if b.typ == typ && b.hash == h && b.size == size && bytealg.Equal(*(*[]byte)(unsafe.Pointer(&bstk)), *(*[]byte)(unsafe.Pointer(&stk))) {
+		if b.typ == typ && b.hash == h && b.size == size && bytealg.Equal(unsafe.Slice((*byte)(unsafe.Pointer(&bstk)), len(bstk)*8), unsafe.Slice((*byte)(unsafe.Pointer(&stk)), len(stk)*8)) {
 			unlock(&profInsertLock)
 			return b
 		}

--- a/src/runtime/mprof.go
+++ b/src/runtime/mprof.go
@@ -9,6 +9,7 @@ package runtime
 
 import (
 	"internal/abi"
+	"internal/bytealg"
 	"runtime/internal/atomic"
 	"runtime/internal/sys"
 	"unsafe"
@@ -338,15 +339,7 @@ func stkbucket(typ bucketType, size uintptr, stk []uintptr, alloc bool) *bucket 
 }
 
 func eqslice(x, y []uintptr) bool {
-	if len(x) != len(y) {
-		return false
-	}
-	for i, xi := range x {
-		if xi != y[i] {
-			return false
-		}
-	}
-	return true
+	return bytealg.Equal(*(*[]byte)(unsafe.Pointer(&x)), *(*[]byte)(unsafe.Pointer(&y)))
 }
 
 // mProf_NextCycle publishes the next heap profile cycle and creates a

--- a/src/runtime/mprof.go
+++ b/src/runtime/mprof.go
@@ -296,7 +296,7 @@ func stkbucket(typ bucketType, size uintptr, stk []uintptr, alloc bool) *bucket 
 	// first check optimistically, without the lock
 	for b := (*bucket)(bh[i].Load()); b != nil; b = b.next {
 		bstk := b.stk()
-		if b.typ == typ && b.hash == h && b.size == size && bytealg.Equal(unsafe.Slice((*byte)(unsafe.Pointer(&bstk)), len(bstk)*8), unsafe.Slice((*byte)(unsafe.Pointer(&stk)), len(stk)*8)) {
+		if b.typ == typ && b.hash == h && b.size == size && bytealg.Equal(unsafe.Slice((*byte)((*slice)(unsafe.Pointer(&bstk)).array), len(bstk)*8), unsafe.Slice((*byte)(((*slice)(unsafe.Pointer(&stk))).array), len(stk)*8)) {
 			return b
 		}
 	}
@@ -309,7 +309,7 @@ func stkbucket(typ bucketType, size uintptr, stk []uintptr, alloc bool) *bucket 
 	// check again under the insertion lock
 	for b := (*bucket)(bh[i].Load()); b != nil; b = b.next {
 		bstk := b.stk()
-		if b.typ == typ && b.hash == h && b.size == size && bytealg.Equal(unsafe.Slice((*byte)(unsafe.Pointer(&bstk)), len(bstk)*8), unsafe.Slice((*byte)(unsafe.Pointer(&stk)), len(stk)*8)) {
+		if b.typ == typ && b.hash == h && b.size == size && bytealg.Equal(unsafe.Slice((*byte)((*slice)(unsafe.Pointer(&bstk)).array), len(bstk)*8), unsafe.Slice((*byte)(((*slice)(unsafe.Pointer(&stk))).array), len(stk)*8)) {
 			unlock(&profInsertLock)
 			return b
 		}


### PR DESCRIPTION
This will reuse runtime.memequal when actually comparing slice data.