### PR TITLE
reflect: optimize DeepEqual for slice types

### DIFF
--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -1087,7 +1087,8 @@ var deepEqualTests = []DeepEqualTest{
 	{MyBytes{1, 2, 3}, MyBytes{1, 2, 3}, true},
 	{[]int32{1, 2, 3}, []int32{1, 2, 3}, true},
 	{p1, p2, true},
-	{ptr(1), ptr(1), true},
+	{[]*int{ptr(1), ptr(2)}, []*int{ptr(1), ptr(2)}, true},
+	{[]int32{1, 2, 3, 4}[:3], []int32{1, 2, 3, 5}[:3], true},
 
 	// Inequalities
 	{1, 2, false},
@@ -1110,6 +1111,8 @@ var deepEqualTests = []DeepEqualTest{
 	{[][]int{{1}}, [][]int{{2}}, false},
 	{&structWithSelfPtr{p: &structWithSelfPtr{s: "a"}}, &structWithSelfPtr{p: &structWithSelfPtr{s: "b"}}, false},
 	{[]int32{1, 2, 3}, []int32{2, 1, 3}, false},
+	{[]*int{ptr(1), ptr(2)}, []*int{ptr(2), ptr(1)}, false},
+	{[]int32{1, 2, 3, 4}, []int32{1, 2, 3, 5}, false},
 
 	// Fun with floating point.
 	{math.NaN(), math.NaN(), false},
@@ -1290,6 +1293,8 @@ var deepEqualPerfTests = []struct {
 
 	{x: [6]byte{'a', 'b', 'c', 'a', 'b', 'c'}, y: [6]byte{'a', 'b', 'c', 'a', 'b', 'c'}},
 	{x: [][6]byte{[6]byte{'a', 'b', 'c', 'a', 'b', 'c'}}, y: [][6]byte{[6]byte{'a', 'b', 'c', 'a', 'b', 'c'}}},
+
+	{x: make([]int16, 10240), y: make([]int16, 10240)},
 }
 
 func TestDeepEqualAllocs(t *testing.T) {

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -1054,7 +1054,19 @@ func init() {
 	cycleMap2["cycle"] = cycleMap2
 	cycleMap3 = map[string]any{}
 	cycleMap3["different"] = cycleMap3
+
+	p1.b = append(p1.b, p2, p1, p1)
+	p2.b = append(p2.b, p1, p2, p1)
 }
+
+type slicePtr struct {
+	b []*slicePtr
+}
+
+var (
+	p1 = new(slicePtr)
+	p2 = new(slicePtr)
+)
 
 var deepEqualTests = []DeepEqualTest{
 	// Equalities
@@ -1073,6 +1085,8 @@ var deepEqualTests = []DeepEqualTest{
 	{[]byte{1, 2, 3}, []byte{1, 2, 3}, true},
 	{[]MyByte{1, 2, 3}, []MyByte{1, 2, 3}, true},
 	{MyBytes{1, 2, 3}, MyBytes{1, 2, 3}, true},
+	{[]int32{1, 2, 3}, []int32{1, 2, 3}, true},
+	{p1, p2, true},
 
 	// Inequalities
 	{1, 2, false},
@@ -1094,6 +1108,7 @@ var deepEqualTests = []DeepEqualTest{
 	{fn3, fn3, false},
 	{[][]int{{1}}, [][]int{{2}}, false},
 	{&structWithSelfPtr{p: &structWithSelfPtr{s: "a"}}, &structWithSelfPtr{p: &structWithSelfPtr{s: "b"}}, false},
+	{[]int32{1, 2, 3}, []int32{2, 1, 3}, false},
 
 	// Fun with floating point.
 	{math.NaN(), math.NaN(), false},

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -1087,6 +1087,7 @@ var deepEqualTests = []DeepEqualTest{
 	{MyBytes{1, 2, 3}, MyBytes{1, 2, 3}, true},
 	{[]int32{1, 2, 3}, []int32{1, 2, 3}, true},
 	{p1, p2, true},
+	{ptr(1), ptr(1), true},
 
 	// Inequalities
 	{1, 2, false},
@@ -1146,6 +1147,10 @@ var deepEqualTests = []DeepEqualTest{
 	{&loopy1, &loopy2, true},
 	{&cycleMap1, &cycleMap2, true},
 	{&cycleMap1, &cycleMap3, false},
+}
+
+func ptr[T any](a T) *T {
+	return &a
 }
 
 func TestDeepEqual(t *testing.T) {

--- a/src/reflect/benchmark_test.go
+++ b/src/reflect/benchmark_test.go
@@ -120,7 +120,7 @@ func BenchmarkMapsDeepEqual(b *testing.B) {
 }
 
 func BenchmarkBigSliceDeepEqual(b *testing.B) {
-	var s1, s2 = make([]int16, 1024), make([]int16, 1024)
+	var s1, s2 = make([]int16, 10240), make([]int16, 10240)
 	s2[2] = 9
 	for i := 0; i < b.N; i++ {
 		DeepEqual(s1, s2)

--- a/src/reflect/benchmark_test.go
+++ b/src/reflect/benchmark_test.go
@@ -119,14 +119,6 @@ func BenchmarkMapsDeepEqual(b *testing.B) {
 	}
 }
 
-func BenchmarkBigSliceDeepEqual(b *testing.B) {
-	var s1, s2 = make([]int16, 10240), make([]int16, 10240)
-	s2[2] = 9
-	for i := 0; i < b.N; i++ {
-		DeepEqual(s1, s2)
-	}
-}
-
 func BenchmarkIsZero(b *testing.B) {
 	type Int4 struct {
 		a, b, c, d int

--- a/src/reflect/benchmark_test.go
+++ b/src/reflect/benchmark_test.go
@@ -119,6 +119,14 @@ func BenchmarkMapsDeepEqual(b *testing.B) {
 	}
 }
 
+func BenchmarkBigSliceDeepEqual(b *testing.B) {
+	var s1, s2 = make([]int16, 1024), make([]int16, 1024)
+	s2[2] = 9
+	for i := 0; i < b.N; i++ {
+		DeepEqual(s1, s2)
+	}
+}
+
 func BenchmarkIsZero(b *testing.B) {
 	type Int4 struct {
 		a, b, c, d int

--- a/src/reflect/deepequal.go
+++ b/src/reflect/deepequal.go
@@ -193,7 +193,7 @@ func isDeepEqualRawMemory(typ *abi.Type) (ok bool) {
 	//
 	// The reason is DeepEqual can't determine whether two pointer values are equal by comparing them byte by byte.
 	// Doing so would report unequal when it shouldn't,
-	// in the case where two pointers are different but point to the same contents 
+	// in the case where two pointers are different but point to the same contents
 	// (e.g. two *int32s that point to different int32s,
 	// both of which contain the same value).
 

--- a/src/reflect/deepequal.go
+++ b/src/reflect/deepequal.go
@@ -201,7 +201,7 @@ func isDeepEqualRawMemory(typ *abi.Type) (ok bool) {
 	switch typ.Kind() {
 	case abi.Int8, abi.Int16, abi.Int32, abi.Int64, abi.Uintptr, abi.Uint8, abi.Uint16, abi.Uint32, abi.Uint64, abi.Bool:
 		return true
-	case abi.Array, abi.Slice:
+	case abi.Array:
 		return isDeepEqualRawMemory(typ.Elem())
 	}
 	return false

--- a/src/reflect/deepequal.go
+++ b/src/reflect/deepequal.go
@@ -184,19 +184,18 @@ func deepValueEqual(v1, v2 Value, visited map[visit]bool) bool {
 	}
 }
 
-// isDeepEqualRawMemory reports
-// DeepEqual can determine whether depths is equal
-// by comparing byte by byte equality
+// isDeepEqualRawMemory reports whether DeepEqual can compare
+// two instances of a type by just comparing their raw memory contents.
 func isDeepEqualRawMemory(typ *abi.Type) (ok bool) {
 	// Note: Here is an incorrect implementation :
 	//
-	//	return typ.TFlag==abi.TFlagRegularMemory
+	//	return typ.TFlag&abi.TFlagRegularMemory != 0
 	//
-	// The reason is DeepEqual can't
-	// determine whether two pointer values are equal in depth by comparing them byte by byte
-	// because when deeequal
-	// perform a second and subsequent comparison of two previously compared pointer values,
-	// it treats them as equal
+	// The reason is DeepEqual can't determine whether two pointer values are equal by comparing them byte by byte.
+	// Doing so would report unequal when it shouldn't,
+	// in the case where two pointers are different but point to the same contents 
+	// (e.g. two *int32s that point to different int32s,
+	// both of which contain the same value).
 
 	return typ.PtrBytes == 0 && typ.TFlag&abi.TFlagRegularMemory != 0
 }

--- a/src/reflect/deepequal.go
+++ b/src/reflect/deepequal.go
@@ -106,7 +106,7 @@ func deepValueEqual(v1, v2 Value, visited map[visit]bool) bool {
 		if v1.UnsafePointer() == v2.UnsafePointer() {
 			return true
 		}
-		if v1.typ_.TFlag == abi.TFlagRegularMemory {
+		if v1.typ_.TFlag&abi.TFlagRegularMemory != 0 {
 			return bytealg.Equal(
 				unsafe.Slice((*byte)(v1.ptr), v1.typ_.Elem().Size_*uintptr(v1.Len())),
 				unsafe.Slice((*byte)(v2.ptr), v2.typ_.Elem().Size_*uintptr(v2.Len())),

--- a/src/reflect/deepequal.go
+++ b/src/reflect/deepequal.go
@@ -7,6 +7,7 @@
 package reflect
 
 import (
+	"internal/abi"
 	"internal/bytealg"
 	"unsafe"
 )
@@ -105,9 +106,11 @@ func deepValueEqual(v1, v2 Value, visited map[visit]bool) bool {
 		if v1.UnsafePointer() == v2.UnsafePointer() {
 			return true
 		}
-		// Special case for []byte, which is common.
-		if v1.Type().Elem().Kind() == Uint8 {
-			return bytealg.Equal(v1.Bytes(), v2.Bytes())
+		if v1.typ_.TFlag == abi.TFlagRegularMemory {
+			return bytealg.Equal(
+				unsafe.Slice((*byte)(v1.ptr), v1.typ_.Elem().Size_*uintptr(v1.Len())),
+				unsafe.Slice((*byte)(v2.ptr), v2.typ_.Elem().Size_*uintptr(v2.Len())),
+			)
 		}
 		for i := 0; i < v1.Len(); i++ {
 			if !deepValueEqual(v1.Index(i), v2.Index(i), visited) {


### PR DESCRIPTION
DeepEqual optimize for some types 
by comparing two instances of the same type by comparing the raw memory contents

goos: windows
goarch: amd64
pkg: reflect
cpu: AMD Ryzen 7 7840HS w/ Radeon 780M Graphics
                          │    old.txt    │               new.txt               │
                          │    sec/op     │   sec/op     vs base                │
DeepEqual/[]int8-16           55.33n ± 2%   46.89n ± 1%  -15.26% (p=0.000 n=10)
DeepEqual/[]int16-16          55.55n ± 3%   46.86n ± 2%  -15.65% (p=0.000 n=10)
DeepEqual/[]int32-16          56.11n ± 1%   46.66n ± 1%  -16.83% (p=0.000 n=10)
DeepEqual/[]int64-16          55.91n ± 2%   46.62n ± 1%  -16.62% (p=0.000 n=10)
DeepEqual/[]int-16            55.58n ± 1%   46.86n ± 1%  -15.70% (p=0.000 n=10)
DeepEqual/[]uint8-16          49.30n ± 3%   46.71n ± 1%   -5.26% (p=0.000 n=10)
DeepEqual/[]uint16-16         55.90n ± 1%   46.81n ± 1%  -16.26% (p=0.000 n=10)
DeepEqual/[]uint32-16         55.33n ± 4%   46.93n ± 1%  -15.20% (p=0.000 n=10)
DeepEqual/[]uint64-16         55.77n ± 1%   46.92n ± 1%  -15.87% (p=0.000 n=10)
DeepEqual/[]uint-16           55.52n ± 3%   46.86n ± 5%  -15.60% (p=0.000 n=10)
DeepEqual/[]uintptr-16        55.68n ± 2%   46.73n ± 2%  -16.08% (p=0.000 n=10)
DeepEqual/[]float32-16        55.30n ± 2%   53.16n ± 2%   -3.88% (p=0.000 n=10)
DeepEqual/[]float64-16        55.82n ± 1%   53.23n ± 2%   -4.65% (p=0.000 n=10)
DeepEqual/[]complex64-16      55.51n ± 2%   53.73n ± 1%   -3.21% (p=0.000 n=10)
DeepEqual/[]complex128-16     55.62n ± 3%   53.50n ± 2%   -3.81% (p=0.000 n=10)
DeepEqual/[]bool-16           55.56n ± 3%   47.16n ± 1%  -15.13% (p=0.000 n=10)
DeepEqual/[]string-16         56.12n ± 3%   53.38n ± 2%   -4.88% (p=0.000 n=10)
DeepEqual/[]uint8#01-16       49.73n ± 3%   46.76n ± 2%   -5.97% (p=0.000 n=10)
DeepEqual/[][]uint8-16        92.81n ± 1%   89.34n ± 2%   -3.73% (p=0.000 n=10)
DeepEqual/[6]uint8-16         76.88n ± 1%   74.58n ± 1%   -3.00% (p=0.000 n=10)
DeepEqual/[][6]uint8-16      117.25n ± 1%   47.09n ± 2%  -59.83% (p=0.000 n=10)
DeepEqual/[]int16#01-16     91562.5n ± 2%   322.4n ± 2%  -99.65% (p=0.000 n=10)
geomean                       82.85n        55.41n       -33.12%