### PR TITLE
strings: make use of sizeclasses in (*Builder).Grow

### DIFF
--- a/src/bytes/bytes.go
+++ b/src/bytes/bytes.go
@@ -525,7 +525,7 @@ func Join(s [][]byte, sep []byte) []byte {
 		n += len(v)
 	}
 
-	b := bytealg.MakeNoZero(n)
+	b := bytealg.MakeNoZero(n)[:n:n]
 	bp := copy(b, s[0])
 	for _, v := range s[1:] {
 		bp += copy(b[bp:], sep)
@@ -610,7 +610,7 @@ func Repeat(b []byte, count int) []byte {
 			chunkMax = len(b)
 		}
 	}
-	nb := bytealg.MakeNoZero(n)
+	nb := bytealg.MakeNoZero(n)[:n:n]
 	bp := copy(nb, b)
 	for bp < n {
 		chunk := bp
@@ -640,7 +640,7 @@ func ToUpper(s []byte) []byte {
 			// Just return a copy.
 			return append([]byte(""), s...)
 		}
-		b := bytealg.MakeNoZero(len(s))
+		b := bytealg.MakeNoZero(len(s))[:len(s):len(s)]
 		for i := 0; i < len(s); i++ {
 			c := s[i]
 			if 'a' <= c && c <= 'z' {
@@ -670,7 +670,7 @@ func ToLower(s []byte) []byte {
 		if !hasUpper {
 			return append([]byte(""), s...)
 		}
-		b := bytealg.MakeNoZero(len(s))
+		b := bytealg.MakeNoZero(len(s))[:len(s):len(s)]
 		for i := 0; i < len(s); i++ {
 			c := s[i]
 			if 'A' <= c && c <= 'Z' {

--- a/src/internal/bytealg/bytealg.go
+++ b/src/internal/bytealg/bytealg.go
@@ -119,4 +119,4 @@ func MakeNoZero(n int) []byte
 // MakeNoZeroAtLeast makes a slice of length and capacity of at least n Bytes
 // without zeroing the bytes. It is the caller's responsibility to ensure
 // uninitialized bytes do not leak to the end user.
-func MakeNoZeroAtLeast(n int) []byte
+func MakeNoZeroAtLeast(n int, noscan bool) []byte

--- a/src/internal/bytealg/bytealg.go
+++ b/src/internal/bytealg/bytealg.go
@@ -112,6 +112,7 @@ func LastIndexRabinKarp[T string | []byte](s, sep T) int {
 }
 
 // MakeNoZero makes a slice of length n and capacity of at least n Bytes
-// without zeroing the bytes. It is the caller's responsibility to
-// ensure uninitialized bytes do not leak to the end user.
+// without zeroing the bytes (including the bytes between len and cap).
+// It is the caller's responsibility to ensure uninitialized bytes
+// do not leak to the end user.
 func MakeNoZero(n int) []byte

--- a/src/internal/bytealg/bytealg.go
+++ b/src/internal/bytealg/bytealg.go
@@ -119,4 +119,4 @@ func MakeNoZero(n int) []byte
 // MakeNoZeroAtLeast makes a slice of length and capacity of at least n Bytes
 // without zeroing the bytes. It is the caller's responsibility to ensure
 // uninitialized bytes do not leak to the end user.
-func MakeNoZeroAtLeast(n int, noscan bool) []byte
+func MakeNoZeroAtLeast(n int) []byte

--- a/src/internal/bytealg/bytealg.go
+++ b/src/internal/bytealg/bytealg.go
@@ -115,3 +115,8 @@ func LastIndexRabinKarp[T string | []byte](s, sep T) int {
 // It is the caller's responsibility to ensure uninitialized bytes
 // do not leak to the end user.
 func MakeNoZero(n int) []byte
+
+// MakeNoZeroAtLeat makes a slice of length and capacity of at least n Bytes
+// without zeroing the bytes. It is the caller's responsibility to ensure
+// uninitialized bytes do not leak to the end user.
+func MakeNoZeroAtLeast(n int) []byte

--- a/src/internal/bytealg/bytealg.go
+++ b/src/internal/bytealg/bytealg.go
@@ -116,7 +116,7 @@ func LastIndexRabinKarp[T string | []byte](s, sep T) int {
 // do not leak to the end user.
 func MakeNoZero(n int) []byte
 
-// MakeNoZeroAtLeat makes a slice of length and capacity of at least n Bytes
+// MakeNoZeroAtLeast makes a slice of length and capacity of at least n Bytes
 // without zeroing the bytes. It is the caller's responsibility to ensure
 // uninitialized bytes do not leak to the end user.
 func MakeNoZeroAtLeast(n int) []byte

--- a/src/internal/bytealg/bytealg.go
+++ b/src/internal/bytealg/bytealg.go
@@ -111,12 +111,7 @@ func LastIndexRabinKarp[T string | []byte](s, sep T) int {
 	return -1
 }
 
-// MakeNoZero makes a slice of length and capacity n without zeroing the bytes.
-// It is the caller's responsibility to ensure uninitialized bytes
-// do not leak to the end user.
+// MakeNoZero makes a slice of length n and capacity of at least n Bytes
+// without zeroing the bytes. It is the caller's responsibility to
+// ensure uninitialized bytes do not leak to the end user.
 func MakeNoZero(n int) []byte
-
-// MakeNoZeroAtLeast makes a slice of length and capacity of at least n Bytes
-// without zeroing the bytes. It is the caller's responsibility to ensure
-// uninitialized bytes do not leak to the end user.
-func MakeNoZeroAtLeast(n int) []byte

--- a/src/runtime/slice.go
+++ b/src/runtime/slice.go
@@ -366,6 +366,6 @@ func bytealg_MakeNoZero(len int) []byte {
 	if uintptr(len) > maxAlloc {
 		panicmakeslicelen()
 	}
-	l := roundupsize(uintptr(len), true)
-	return unsafe.Slice((*byte)(mallocgc(uintptr(l), nil, false)), l)[:len]
+	cap := roundupsize(uintptr(len), true)
+	return unsafe.Slice((*byte)(mallocgc(uintptr(cap), nil, false)), cap)[:len]
 }

--- a/src/runtime/slice.go
+++ b/src/runtime/slice.go
@@ -370,10 +370,10 @@ func bytealg_MakeNoZero(len int) []byte {
 }
 
 //go:linkname bytealg_MakeNoZeroAtLeast internal/bytealg.MakeNoZeroAtLeast
-func bytealg_MakeNoZeroAtLeast(len int, noscan bool) []byte {
+func bytealg_MakeNoZeroAtLeast(len int) []byte {
 	if uintptr(len) > maxAlloc {
 		panicmakeslicelen()
 	}
-	l := roundupsize(uintptr(len), noscan)
+	l := roundupsize(uintptr(len), true)
 	return unsafe.Slice((*byte)(mallocgc(l, nil, false)), l)
 }

--- a/src/runtime/slice.go
+++ b/src/runtime/slice.go
@@ -370,10 +370,10 @@ func bytealg_MakeNoZero(len int) []byte {
 }
 
 //go:linkname bytealg_MakeNoZeroAtLeast internal/bytealg.MakeNoZeroAtLeast
-func bytealg_MakeNoZeroAtLeast(len int) []byte {
+func bytealg_MakeNoZeroAtLeast(len int, noscan bool) []byte {
 	if uintptr(len) > maxAlloc {
 		panicmakeslicelen()
 	}
-	l := roundupsize(uintptr(len), true)
+	l := roundupsize(uintptr(len), noscan)
 	return unsafe.Slice((*byte)(mallocgc(l, nil, false)), l)
 }

--- a/src/runtime/slice.go
+++ b/src/runtime/slice.go
@@ -368,3 +368,12 @@ func bytealg_MakeNoZero(len int) []byte {
 	}
 	return unsafe.Slice((*byte)(mallocgc(uintptr(len), nil, false)), len)
 }
+
+//go:linkname bytealg_MakeNoZeroAtLeast internal/bytealg.MakeNoZeroAtLeast
+func bytealg_MakeNoZeroAtLeast(len int) []byte {
+	if uintptr(len) > maxAlloc {
+		panicmakeslicelen()
+	}
+	l := roundupsize(uintptr(len), true)
+	return unsafe.Slice((*byte)(mallocgc(l, nil, false)), l)
+}

--- a/src/runtime/slice.go
+++ b/src/runtime/slice.go
@@ -366,14 +366,6 @@ func bytealg_MakeNoZero(len int) []byte {
 	if uintptr(len) > maxAlloc {
 		panicmakeslicelen()
 	}
-	return unsafe.Slice((*byte)(mallocgc(uintptr(len), nil, false)), len)
-}
-
-//go:linkname bytealg_MakeNoZeroAtLeast internal/bytealg.MakeNoZeroAtLeast
-func bytealg_MakeNoZeroAtLeast(len int) []byte {
-	if uintptr(len) > maxAlloc {
-		panicmakeslicelen()
-	}
 	l := roundupsize(uintptr(len), true)
-	return unsafe.Slice((*byte)(mallocgc(l, nil, false)), l)
+	return unsafe.Slice((*byte)(mallocgc(uintptr(l), nil, false)), l)[:len]
 }

--- a/src/strings/builder.go
+++ b/src/strings/builder.go
@@ -66,7 +66,7 @@ func (b *Builder) Reset() {
 // grow copies the buffer to a new, larger buffer so that there are at least n
 // bytes of capacity beyond len(b.buf).
 func (b *Builder) grow(n int) {
-	buf := bytealg.MakeNoZeroAtLeast(2*cap(b.buf)+n, true)[:len(b.buf)]
+	buf := bytealg.MakeNoZeroAtLeast(2*cap(b.buf) + n)[:len(b.buf)]
 	copy(buf, b.buf)
 	b.buf = buf
 }

--- a/src/strings/builder.go
+++ b/src/strings/builder.go
@@ -66,7 +66,7 @@ func (b *Builder) Reset() {
 // grow copies the buffer to a new, larger buffer so that there are at least n
 // bytes of capacity beyond len(b.buf).
 func (b *Builder) grow(n int) {
-	buf := bytealg.MakeNoZeroAtLeast(2*cap(b.buf) + n)[:len(b.buf)]
+	buf := bytealg.MakeNoZeroAtLeast(2*cap(b.buf)+n, true)[:len(b.buf)]
 	copy(buf, b.buf)
 	b.buf = buf
 }

--- a/src/strings/builder.go
+++ b/src/strings/builder.go
@@ -66,7 +66,7 @@ func (b *Builder) Reset() {
 // grow copies the buffer to a new, larger buffer so that there are at least n
 // bytes of capacity beyond len(b.buf).
 func (b *Builder) grow(n int) {
-	buf := bytealg.MakeNoZero(2*cap(b.buf) + n)[:len(b.buf)]
+	buf := bytealg.MakeNoZeroAtLeast(2*cap(b.buf) + n)[:len(b.buf)]
 	copy(buf, b.buf)
 	b.buf = buf
 }

--- a/src/strings/builder.go
+++ b/src/strings/builder.go
@@ -15,7 +15,11 @@ import (
 // Do not copy a non-zero Builder.
 type Builder struct {
 	addr *Builder // of receiver, to detect copies by value
-	buf  []byte
+
+	// External users should never get direct access to this buffer, since
+	// the slice at some point will be converted to a string using unsafe, also
+	// data between len(buf) and cap(buf) might be uninitialized.
+	buf []byte
 }
 
 // noescape hides a pointer from escape analysis. It is the identity function

--- a/src/strings/builder.go
+++ b/src/strings/builder.go
@@ -66,7 +66,7 @@ func (b *Builder) Reset() {
 // grow copies the buffer to a new, larger buffer so that there are at least n
 // bytes of capacity beyond len(b.buf).
 func (b *Builder) grow(n int) {
-	buf := bytealg.MakeNoZeroAtLeast(2*cap(b.buf) + n)[:len(b.buf)]
+	buf := bytealg.MakeNoZero(2*cap(b.buf) + n)[:len(b.buf)]
 	copy(buf, b.buf)
 	b.buf = buf
 }

--- a/src/strings/builder_test.go
+++ b/src/strings/builder_test.go
@@ -385,3 +385,16 @@ func BenchmarkBuildString_ByteBuffer(b *testing.B) {
 		}
 	})
 }
+
+func TestBuilderGrowSizeclasses(t *testing.T) {
+	s := Repeat("a", 19)
+	allocs := testing.AllocsPerRun(100, func() {
+		var b Builder
+		b.Grow(18)
+		b.WriteString(s)
+		_ = b.String()
+	})
+	if allocs > 1 {
+		t.Fatalf("unexpected amount of allocations: %v, want: 1", allocs)
+	}
+}


### PR DESCRIPTION
Fixes #64833