### PR TITLE
sync: support for sharded values

### DIFF
--- a/src/runtime/runtime1.go
+++ b/src/runtime/runtime1.go
@@ -659,3 +659,10 @@ func reflect_addReflectOff(ptr unsafe.Pointer) int32 {
 	reflectOffsUnlock()
 	return id
 }
+
+// sync_goid return goid field of getg()
+//
+//go:linkname sync_goid sync.goid
+func sync_goid() uint64 {
+	return getg().goid
+}

--- a/src/runtime/runtime1.go
+++ b/src/runtime/runtime1.go
@@ -660,9 +660,12 @@ func reflect_addReflectOff(ptr unsafe.Pointer) int32 {
 	return id
 }
 
-// sync_goid return goid field of getg()
+// sync_pid return pid
 //
-//go:linkname sync_goid sync.goid
-func sync_goid() uint64 {
-	return getg().goid
+//go:linkname sync_pid sync.pid
+func sync_pid() uint64 {
+	gp := getg()
+	mp := gp.m
+
+	return uint64(mp.p.ptr().id)
 }

--- a/src/sync/sharded.go
+++ b/src/sync/sharded.go
@@ -7,7 +7,12 @@ import (
 // Sharded is a container of values of the same type
 // have n data of type T.
 //
-// the same goroutine uses the same T-type data.
+// On a best effort basis, the runtime will strongly associate a given value
+// with a CPU core.  That is to say, retrieving a value twice on the same CPU
+// core will return the same value with high probablity.  Note that the runtime
+// cannot guarantee this fact, and clients must assume that retrieved values
+// can be shared between concurrently executing goroutines.
+//
 // it is safe to call all methods from multiple goroutines.
 //
 // zero value is unavailable
@@ -37,7 +42,7 @@ func NewSharded[T any](n uint) Sharded[T] {
 // Get get one of n data of type T from [Sharded]
 func (s *Sharded[T]) Get() *T {
 	// If zero value is use, slice access is out of bounds.
-	return &s.data[int(goid())%len(s.data)].v
+	return &s.data[int(pid())%len(s.data)].v
 }
 
 // Range Call f for all data of type T in [Sharded]
@@ -51,4 +56,4 @@ func (s *Sharded[T]) Range(f func(*T)) {
 }
 
 // Implemented in runtime/runtime1.go
-func goid() uint64
+func pid() uint64

--- a/src/sync/sharded.go
+++ b/src/sync/sharded.go
@@ -1,0 +1,54 @@
+package sync
+
+import (
+	"internal/cpu"
+)
+
+// Sharded is a container of values of the same type
+// have n data of type T.
+//
+// the same goroutine uses the same T-type data.
+// it is safe to call all methods from multiple goroutines.
+//
+// zero value is unavailable
+// must be initialized use [NewSharded]
+type Sharded[T any] struct {
+	data []value[T]
+}
+
+type value[T any] struct {
+	_ cpu.CacheLinePad // prevent false sharing
+	v T
+	_ cpu.CacheLinePad // prevent false sharing
+}
+
+// NewSharded make a [Sharded]
+//
+// must n != 0 , otherwise panic will occur
+func NewSharded[T any](n uint) Sharded[T] {
+	if n == 0 {
+		panic("sync: create zero value Sharded")
+	}
+	return Sharded[T]{
+		data: make([]value[T], n),
+	}
+}
+
+// Get get one of n data of type T from [Sharded]
+func (s *Sharded[T]) Get() *T {
+	// If zero value is use, slice access is out of bounds.
+	return &s.data[int(goid())%len(s.data)].v
+}
+
+// Range Call f for all data of type T in [Sharded]
+func (s *Sharded[T]) Range(f func(*T)) {
+	if len(s.data) == 0 {
+		panic("sync: use no initialized of Sharded")
+	}
+	for i := range s.data {
+		f(&s.data[i].v)
+	}
+}
+
+// Implemented in runtime/runtime1.go
+func goid() uint64

--- a/src/sync/sharded_test.go
+++ b/src/sync/sharded_test.go
@@ -1,0 +1,120 @@
+package sync_test
+
+import (
+	"runtime"
+	. "sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestZeroSharded(t *testing.T) {
+	var s Sharded[int]
+	defer func() {
+		p := recover()
+		if p == nil {
+			t.Fatal("use zero value Sharded should panic")
+		}
+	}()
+	s.Get()
+}
+
+func TestCreateZeroSharded(t *testing.T) {
+	defer func() {
+		p := recover()
+		if p == nil {
+			t.Fatal("create zero value Sharded should panic")
+		}
+	}()
+	var _ Sharded[int] = NewSharded[int](0)
+}
+
+func TestSharedRace(t *testing.T) {
+	maxprocs := uint(runtime.GOMAXPROCS(0))
+	var s = NewSharded[atomic.Int64](maxprocs)
+	var wg WaitGroup
+	wg.Add(int(maxprocs))
+	for range maxprocs {
+		go func() {
+			defer wg.Done()
+			for range 10000 {
+				s.Get().Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestSharedOneP(t *testing.T) {
+	var s = NewSharded[atomic.Int64](uint(runtime.GOMAXPROCS(0)))
+	for range 10000 {
+		s.Get().Add(1)
+	}
+	if load := s.Get().Load(); load != int64(10000) {
+		t.Fatalf("expected %d, got %d", 1000, load)
+	}
+}
+
+func TestSharedRange(t *testing.T) {
+	maxprocs := uint(runtime.GOMAXPROCS(0))
+	var s = NewSharded[atomic.Int64](maxprocs)
+	var wg WaitGroup
+	wg.Add(int(maxprocs))
+	for range maxprocs {
+		go func() {
+			defer wg.Done()
+			for range 10000 {
+				s.Get().Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	i := int64(0)
+	s.Range(func(v *atomic.Int64) {
+		i += v.Load()
+	})
+	if i != 10000*int64(maxprocs) {
+		t.Fatalf("Sharded use after got %d want %d", i, 10000*int64(maxprocs))
+	}
+}
+
+func BenchmarkSharedAtomicInt64(b *testing.B) {
+	maxprocs := uint(runtime.GOMAXPROCS(0))
+	for range b.N {
+		var s = NewSharded[atomic.Int64](maxprocs)
+		var wg WaitGroup
+		wg.Add(int(maxprocs))
+		for range maxprocs {
+			go func() {
+				defer wg.Done()
+				for range 10000 {
+					s.Get().Add(1)
+				}
+			}()
+		}
+		wg.Wait()
+	}
+}
+
+func ExampleSharded() {
+	maxprocs := uint(runtime.GOMAXPROCS(0))
+	// create a Sharded to use as a counter
+	var s = NewSharded[atomic.Int64](maxprocs)
+	var wg WaitGroup
+	wg.Add(int(maxprocs))
+	for range maxprocs {
+		go func() {
+			defer wg.Done()
+			for range 10000 {
+				// increment the value of the counter
+				s.Get().Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	// when no further counters are added
+	// get the counter value
+	i := int64(0)
+	s.Range(func(v *atomic.Int64) {
+		i += v.Load()
+	})
+}


### PR DESCRIPTION
This CL deliberately makes the zero value of Sharded unusable. 
Purpose to force that NewSharded initialization must be used. 
And because Sharded methods only have read operations. 
So Sharded can operate without locks or atoms,
and multiple goroutines can use a Sharded at the same time.

goos: windows
goarch: amd64
pkg: sync
cpu: AMD Ryzen 7 7840HS w/ Radeon 780M Graphics
BenchmarkSharedAtomicInt64/1-16              726           1608184 ns/op
BenchmarkSharedAtomicInt64/2-16             1828            646521 ns/op
BenchmarkSharedAtomicInt64/4-16             3958            316261 ns/op
BenchmarkSharedAtomicInt64/8-16             6428            172238 ns/op
BenchmarkSharedAtomicInt64/16-16           16488             73966 ns/op

Fixes #18802
