### PR TITLE
net/http: make Request.Clone create fresh copies for matches and otherValues

### DIFF
--- a/src/net/http/pprof/testdata/delta_mutex.go
+++ b/src/net/http/pprof/testdata/delta_mutex.go
@@ -17,8 +17,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"net/http/pprof"
 	"net/http/httptest"
+	"net/http/pprof"
 	"runtime"
 )
 

--- a/src/net/http/pprof/testdata/delta_mutex.go
+++ b/src/net/http/pprof/testdata/delta_mutex.go
@@ -17,8 +17,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"net/http/httptest"
 	"net/http/pprof"
+	"net/http/httptest"
 	"runtime"
 )
 

--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -397,6 +397,20 @@ func (r *Request) Clone(ctx context.Context) *Request {
 	r2.Form = cloneURLValues(r.Form)
 	r2.PostForm = cloneURLValues(r.PostForm)
 	r2.MultipartForm = cloneMultipartForm(r.MultipartForm)
+
+	// See issue 64911.
+	if s := r.matches; s != nil {
+		s2 := make([]string, len(s))
+		copy(s2, s)
+		r2.matches = s2
+	}
+	if s := r2.otherValues; s != nil {
+		s2 := make(map[string]string, len(s))
+		for k, v := range s {
+			s2[k] = v
+		}
+		r2.otherValues = s2
+	}
 	return r2
 }
 

--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -398,13 +398,13 @@ func (r *Request) Clone(ctx context.Context) *Request {
 	r2.PostForm = cloneURLValues(r.PostForm)
 	r2.MultipartForm = cloneMultipartForm(r.MultipartForm)
 
-	// See issue 64911.
+	// Copy matches and otherValues. See issue 61410.
 	if s := r.matches; s != nil {
 		s2 := make([]string, len(s))
 		copy(s2, s)
 		r2.matches = s2
 	}
-	if s := r2.otherValues; s != nil {
+	if s := r.otherValues; s != nil {
 		s2 := make(map[string]string, len(s))
 		for k, v := range s {
 			s2[k] = v
@@ -1441,6 +1441,8 @@ func (r *Request) PathValue(name string) string {
 	return r.otherValues[name]
 }
 
+// SetPathValue sets name to value, so that subsequent calls to r.PathValue(name)
+// return value.
 func (r *Request) SetPathValue(name, value string) {
 	if i := r.patIndex(name); i >= 0 {
 		r.matches[i] = value

--- a/src/net/http/request_test.go
+++ b/src/net/http/request_test.go
@@ -1053,6 +1053,21 @@ func TestRequestCloneTransferEncoding(t *testing.T) {
 	}
 }
 
+func TestRequestClonePathValues(t *testing.T) {
+	orig, err := http.NewRequest("GET", "https://example.com/", nil)
+	if err != nil {
+		panic(err)
+	}
+	orig.SetPathValue("orig", "orig")
+
+	copy := orig.Clone(context.Background())
+	copy.SetPathValue("copy", "copy")
+
+	if orig.PathValue("copy") != "" {
+		t.Fatal("orig.PathValue is changed")
+	}
+}
+
 // Issue 34878: verify we don't panic when including basic auth (Go 1.13 regression)
 func TestNoPanicOnRoundTripWithBasicAuth(t *testing.T) { run(t, testNoPanicWithBasicAuth) }
 func testNoPanicWithBasicAuth(t *testing.T, mode testMode) {

--- a/src/net/http/request_test.go
+++ b/src/net/http/request_test.go
@@ -1054,17 +1054,23 @@ func TestRequestCloneTransferEncoding(t *testing.T) {
 }
 
 func TestRequestClonePathValue(t *testing.T) {
-	orig, err := http.NewRequest("GET", "https://example.com/", nil)
-	if err != nil {
-		panic(err)
-	}
+	orig, _ := http.NewRequest("GET", "https://example.org/", nil)
 	orig.SetPathValue("orig", "orig")
 
 	copy := orig.Clone(context.Background())
 	copy.SetPathValue("copy", "copy")
 
-	if orig.PathValue("copy") != "" {
-		t.Fatal("orig.PathValue is changed")
+	if orig.PathValue("copy") != "" { // should not be changed
+		t.Fatal(`orig.PathValue("copy") != ""`)
+	}
+	if orig.PathValue("orig") != "orig" {
+		t.Fatal(`orig.PathValue("orig") != "orig"`)
+	}
+	if copy.PathValue("orig") != "orig" {
+		t.Fatal(`copy.PathValue("orig") != "orig"`)
+	}
+	if copy.PathValue("copy") != "copy" {
+		t.Fatal(`copy.PathValue("copy") != "copy"`)
 	}
 }
 

--- a/src/net/http/request_test.go
+++ b/src/net/http/request_test.go
@@ -1053,7 +1053,7 @@ func TestRequestCloneTransferEncoding(t *testing.T) {
 	}
 }
 
-func TestRequestClonePathValues(t *testing.T) {
+func TestRequestClonePathValue(t *testing.T) {
 	orig, err := http.NewRequest("GET", "https://example.com/", nil)
 	if err != nil {
 		panic(err)

--- a/src/net/http/request_test.go
+++ b/src/net/http/request_test.go
@@ -1053,24 +1053,30 @@ func TestRequestCloneTransferEncoding(t *testing.T) {
 	}
 }
 
+// Ensure that Request.Clone works correctly with PathValue.
+// See issue #64911.
 func TestRequestClonePathValue(t *testing.T) {
-	orig, _ := http.NewRequest("GET", "https://example.org/", nil)
-	orig.SetPathValue("orig", "orig")
+	req, _ := http.NewRequest("GET", "https://example.org/", nil)
+	req.SetPathValue("p1", "orig")
 
-	copy := orig.Clone(context.Background())
-	copy.SetPathValue("copy", "copy")
+	clonedReq := req.Clone(context.Background())
+	clonedReq.SetPathValue("p2", "copy")
 
-	if orig.PathValue("copy") != "" { // should not be changed
-		t.Fatal(`orig.PathValue("copy") != ""`)
+	// Ensure that any modifications to the cloned
+	// request do not pollute the original request.
+	if g, w := req.PathValue("p2"), ""; g != w {
+		t.Fatalf("p2 mismatch got %q, want %q", g, w)
 	}
-	if orig.PathValue("orig") != "orig" {
-		t.Fatal(`orig.PathValue("orig") != "orig"`)
+	if g, w := req.PathValue("p1"), "orig"; g != w {
+		t.Fatalf("p1 mismatch got %q, want %q", g, w)
 	}
-	if copy.PathValue("orig") != "orig" {
-		t.Fatal(`copy.PathValue("orig") != "orig"`)
+
+	// Assert on the changes to the cloned request.
+	if g, w := clonedReq.PathValue("p1"), "orig"; g != w {
+		t.Fatalf("p1 mismatch got %q, want %q", g, w)
 	}
-	if copy.PathValue("copy") != "copy" {
-		t.Fatal(`copy.PathValue("copy") != "copy"`)
+	if g, w := clonedReq.PathValue("p2"), "copy"; g != w {
+		t.Fatalf("p2 mismatch got %q, want %q", g, w)
 	}
 }
 

--- a/src/net/http/request_test.go
+++ b/src/net/http/request_test.go
@@ -1054,7 +1054,7 @@ func TestRequestCloneTransferEncoding(t *testing.T) {
 }
 
 // Ensure that Request.Clone works correctly with PathValue.
-// See issue #64911.
+// See issue 64911.
 func TestRequestClonePathValue(t *testing.T) {
 	req, _ := http.NewRequest("GET", "https://example.org/", nil)
 	req.SetPathValue("p1", "orig")


### PR DESCRIPTION
This change fixes Request.Clone to correctly work with SetPathValue
by creating fresh copies for matches and otherValues so that
SetPathValue for cloned requests doesn't pollute the original request.

While here, also added a doc for Request.SetPathValue.

Fixes #64911