### PR TITLE
x/tools/gowork: use forward slash for relative paths across all platforms 

### DIFF
--- a/src/cmd/go/internal/workcmd/use.go
+++ b/src/cmd/go/internal/workcmd/use.go
@@ -7,18 +7,18 @@
 package workcmd
 
 import (
-	"context"
-	"fmt"
-	"io/fs"
-	"os"
-	"path/filepath"
-
 	"cmd/go/internal/base"
 	"cmd/go/internal/fsys"
 	"cmd/go/internal/gover"
 	"cmd/go/internal/modload"
 	"cmd/go/internal/str"
 	"cmd/go/internal/toolchain"
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"golang.org/x/mod/modfile"
 )
@@ -86,6 +86,9 @@ func workUse(ctx context.Context, gowork string, wf *modfile.WorkFile, args []st
 			abs = filepath.Clean(use.Path)
 		} else {
 			abs = filepath.Join(workDir, use.Path)
+			// use forward slash for relative paths for portability
+			// TODO: @bcmills (should i include a check for GOOS to windows)?
+			abs = strings.Replace(abs, "\\", "/", -1) // See golang.org/issue/64851
 		}
 		haveDirs[abs] = append(haveDirs[abs], use.Path)
 	}


### PR DESCRIPTION
Enforces forward slack `/` over `\` in go.work file for rel paths in windows imbuing cross platform development

Fixes #64851
