### PR TITLE
encoding/gob: remove panic on nil pointer values in EncodeValue

### DIFF
--- a/src/encoding/gob/encoder.go
+++ b/src/encoding/gob/encoder.go
@@ -171,7 +171,7 @@ func (enc *Encoder) sendType(w io.Writer, state *encoderState, origt reflect.Typ
 
 // Encode transmits the data item represented by the empty interface value,
 // guaranteeing that all necessary type information has been transmitted first.
-// Passing a nil pointer to Encoder will panic, as they cannot be transmitted by gob.
+// Passing a nil pointer to Encoder will return an error.
 func (enc *Encoder) Encode(e any) error {
 	return enc.EncodeValue(reflect.ValueOf(e))
 }
@@ -214,13 +214,13 @@ func (enc *Encoder) sendTypeId(state *encoderState, ut *userTypeInfo) {
 
 // EncodeValue transmits the data item represented by the reflection value,
 // guaranteeing that all necessary type information has been transmitted first.
-// Passing a nil pointer to EncodeValue will panic, as they cannot be transmitted by gob.
+// Passing a nil pointer to EncodeValue will return an error.
 func (enc *Encoder) EncodeValue(value reflect.Value) error {
 	if value.Kind() == reflect.Invalid {
 		return errors.New("gob: cannot encode nil value")
 	}
 	if value.Kind() == reflect.Pointer && value.IsNil() {
-		panic("gob: cannot encode nil pointer of type " + value.Type().String())
+		return errors.New("gob: cannot encode nil pointer of type " + value.Type().String())
 	}
 
 	// Make sure we're single-threaded through here, so multiple


### PR DESCRIPTION
Remove the intentional panic that was previously encountered
when EncodeValue was passed nil values.

Previously, we panicked so as to maintain logical cohesion, like
one would encounter when dereferencing a nil pointer in Go code.
However, that makes for a not-great developer experience, thus
this change instead returns an error that users can inspect.

This CL also updates unit and encoder tests.

Fixes #31664