### PR TITLE
mime/multipart: add WriteFile method for file streaming support

### DIFF
--- a/api/go1.txt
+++ b/api/go1.txt
@@ -4337,6 +4337,7 @@ pkg mime/multipart, method (*Writer) CreateFormFile(string, string) (io.Writer, 
 pkg mime/multipart, method (*Writer) CreatePart(textproto.MIMEHeader) (io.Writer, error)
 pkg mime/multipart, method (*Writer) FormDataContentType() string
 pkg mime/multipart, method (*Writer) WriteField(string, string) error
+pkg mime/multipart, method (*Writer) WriteFile(string, string, io.Reader) error
 pkg mime/multipart, type File interface { Close, Read, ReadAt, Seek }
 pkg mime/multipart, type File interface, Close() error
 pkg mime/multipart, type File interface, Read([]uint8) (int, error)

--- a/src/mime/multipart/writer.go
+++ b/src/mime/multipart/writer.go
@@ -165,6 +165,16 @@ func (w *Writer) WriteField(fieldname, value string) error {
 	return err
 }
 
+// WriteFile calls CreateFormFile and adds the given stream to the multipart form directly from an io.Reader.
+func (w *Writer) WriteFile(fieldname, filename string, src io.Reader) error {
+	p, err := w.CreateFormFile(fieldname, filename)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(p, src)
+	return err
+}
+
 // Close finishes the multipart message and writes the trailing
 // boundary end line to the output.
 func (w *Writer) Close() error {

--- a/src/mime/multipart/writer_test.go
+++ b/src/mime/multipart/writer_test.go
@@ -29,6 +29,10 @@ func TestWriter(t *testing.T) {
 			t.Fatalf("WriteField: %v", err)
 		}
 		part.Write([]byte("val"))
+		err = w.WriteFile("myfile2", "my-file2.txt", strings.NewReader("val2"))
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
 		err = w.Close()
 		if err != nil {
 			t.Fatalf("Close: %v", err)
@@ -72,6 +76,21 @@ func TestWriter(t *testing.T) {
 	}
 	if e, g := "val", string(slurp); e != g {
 		t.Errorf("part 2: want contents %q, got %q", e, g)
+	}
+
+	part, err = r.NextPart()
+	if err != nil {
+		t.Fatalf("part 3: %v", err)
+	}
+	if g, e := part.FormName(), "myfile2"; g != e {
+		t.Errorf("part 3: want form name %q, got %q", e, g)
+	}
+	slurp, err = io.ReadAll(part)
+	if err != nil {
+		t.Fatalf("part 3: ReadAll: %v", err)
+	}
+	if e, g := "val2", string(slurp); e != g {
+		t.Errorf("part 3: want contents %q, got %q", e, g)
 	}
 
 	part, err = r.NextPart()


### PR DESCRIPTION
This change modifies Go to include a new WriteFile method in the mime/multipart.Writer
type. The method is designed to facilitate the addition of files to multipart forms
when the file content comes from an io.Reader. This feature is particularly useful
for handling file content from streaming sources or managing large files that are
not practical to load entirely into memory.

The WriteFile method encapsulates the creation of a multipart file part and the
subsequent copying of file content from an io.Reader into the multipart body. It
manages the setup of the file part header and provides an efficient means to stream
content directly into the multipart form, thereby enhancing the multipart.Writer
type's capabilities in handling file uploads.

This addition offers an improved approach for handling file uploads in web
applications, especially where file content is sourced from diverse origins such
as network streams or large files on disk.

There is no corresponding issue for this PR. It is a standalone enhancement aimed
at boosting the multipart package's functionality in managing file uploads.


