### PR TITLE
deadlocks: not if there is a deferpool

### DIFF
--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -5916,6 +5916,9 @@ func checkdead() {
 		if len(pp.timers) > 0 {
 			return
 		}
+		if len(pp.deferpool) > 0 {
+			return
+		}
 	}
 
 	unlock(&sched.lock) // unlock so that GODEBUG=scheddetail=1 doesn't hang

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -5917,6 +5917,7 @@ func checkdead() {
 			return
 		}
 		if len(pp.deferpool) > 0 {
+			// fix: issue#64894
 			return
 		}
 	}


### PR DESCRIPTION
Fix #64894

Check if there is a defer pool useful incases where all goroutines in IOWAIT.