### PR TITLE
net/smtp: remove mention of crlf

### DIFF
--- a/src/net/smtp/smtp.go
+++ b/src/net/smtp/smtp.go
@@ -307,11 +307,11 @@ var testHookStartTLS func(*tls.Config) // nil, except for tests
 // The addresses in the to parameter are the SMTP RCPT addresses.
 //
 // The msg parameter should be an RFC 822-style email with headers
-// first, a blank line, and then the message body. The lines of msg
-// should be CRLF terminated. The msg headers should usually include
-// fields such as "From", "To", "Subject", and "Cc".  Sending "Bcc"
-// messages is accomplished by including an email address in the to
-// parameter but not including it in the msg headers.
+// first, a blank line, and then the message body. The msg headers
+// should usually include fields such as "From", "To", "Subject",
+// and "Cc".  Sending "Bcc" messages is accomplished by including an
+// email address in the to parameter but not including it in the msg
+// headers.
 //
 // The SendMail function and the net/smtp package are low-level
 // mechanisms and provide no support for DKIM signing, MIME


### PR DESCRIPTION
The docs states that lines needs to be CRLF terminated, but this isn't
quite true. The package uses Writer.DotWriter() from the net/textproto
package, which automatically does LF to CRLF conversion.

Update the documentation to avoid people from cargo-culting CRLF
conversion going forward.
