### PR TITLE
types2: add hint that there's a string-folded equivalent struct field

### DIFF
--- a/src/cmd/compile/internal/types2/expr.go
+++ b/src/cmd/compile/internal/types2/expr.go
@@ -1186,7 +1186,11 @@ func (check *Checker) exprInternal(T *target, x *operand, e syntax.Expr, hint Ty
 					}
 					i := fieldIndex(utyp.fields, check.pkg, key.Value)
 					if i < 0 {
-						check.errorf(kv.Key, MissingLitField, "unknown field %s in struct literal of type %s", key.Value, base)
+						if v, exists := sameFieldExistsWithDifferentCase(utyp.fields, key.Value); exists {
+							check.errorf(kv.Key, MissingLitField, "unknown field %s in struct literal of type %s (but does have %v)", key.Value, base, v)
+						} else {
+							check.errorf(kv.Key, MissingLitField, "unknown field %s in struct literal of type %s", key.Value, base)
+						}
 						continue
 					}
 					fld := fields[i]

--- a/src/cmd/compile/internal/types2/testdata/local/issue65075.go
+++ b/src/cmd/compile/internal/types2/testdata/local/issue65075.go
@@ -5,5 +5,5 @@ type Issue60575 struct{
 }
 
 func f() {
-	_ = &Issue60575{Id: "foo"} // ERROR "unknown field 'Id' in struct literal of type local.S (but does have ID)"
+	_ = &Issue60575{Id: "foo"} // ERROR "unknown field 'Id' in struct literal of type local.Issue60575 (but does have ID)"
 }

--- a/src/cmd/compile/internal/types2/testdata/local/issue65075.go
+++ b/src/cmd/compile/internal/types2/testdata/local/issue65075.go
@@ -1,0 +1,9 @@
+package local
+
+type Issue60575 struct{
+	ID string
+}
+
+func f() {
+	_ = &Issue60575{Id: "foo"} // ERROR "unknown field 'Id' in struct literal of type local.S (but does have ID)"
+}

--- a/src/cmd/compile/internal/types2/util.go
+++ b/src/cmd/compile/internal/types2/util.go
@@ -26,7 +26,6 @@ func cmpPos(p, q syntax.Pos) int { return p.Cmp(q) }
 
 func sameFieldExistsWithDifferentCase(fields []*Var, name string) (other *Var, exists bool) {
 	for _, f := range fields {
-		print(f.Name(), " ", name, "\n")
 		if strings.EqualFold(f.Name(), name) {
 			return f, true
 		}

--- a/src/cmd/compile/internal/types2/util.go
+++ b/src/cmd/compile/internal/types2/util.go
@@ -9,7 +9,10 @@
 
 package types2
 
-import "cmd/compile/internal/syntax"
+import (
+	"cmd/compile/internal/syntax"
+	"strings"
+)
 
 // cmpPos compares the positions p and q and returns a result r as follows:
 //
@@ -20,3 +23,13 @@ import "cmd/compile/internal/syntax"
 // If p and q are in different files, p is before q if the filename
 // of p sorts lexicographically before the filename of q.
 func cmpPos(p, q syntax.Pos) int { return p.Cmp(q) }
+
+func sameFieldExistsWithDifferentCase(fields []*Var, name string) (other *Var, exists bool) {
+	for _, f := range fields {
+		print(f.Name(), " ", name, "\n")
+		if strings.EqualFold(f.Name(), name) {
+			return f, true
+		}
+	}
+	return nil, false
+}


### PR DESCRIPTION
This change modifies Go to print a hint that there's a stringfolded (as in case-insensitive) equivalent field when the field is not found with its own case, if any string-folded field is found.
Fixes #65075