### PR TITLE
time: extend docs for t.UnixNano

### DIFF
--- a/src/time/time.go
+++ b/src/time/time.go
@@ -1237,7 +1237,8 @@ func (t Time) UnixMicro() int64 {
 // in nanoseconds cannot be represented by an int64 (a date before the year
 // 1678 or after 2262). Note that this means the result of calling UnixNano
 // on the zero Time is undefined. The result does not depend on the
-// location associated with t.
+// location associated with t. Use time.Unix(0, ns) to parse the integer
+// back to a Time struct.
 func (t Time) UnixNano() int64 {
 	return (t.unixSec())*1e9 + int64(t.nsec())
 }

--- a/src/time/time.go
+++ b/src/time/time.go
@@ -1237,7 +1237,7 @@ func (t Time) UnixMicro() int64 {
 // in nanoseconds cannot be represented by an int64 (a date before the year
 // 1678 or after 2262). Note that this means the result of calling UnixNano
 // on the zero Time is undefined. The result does not depend on the
-// location associated with t. Use time.Unix(0, ns) to parse the integer
+// location associated with t. Use time.Unix(0, ns) to convert the integer
 // back to a Time struct.
 func (t Time) UnixNano() int64 {
 	return (t.unixSec())*1e9 + int64(t.nsec())


### PR DESCRIPTION
Extend the documentation of t.UnixNano(). New users are confused why there is no time.UnixNano() to convert the integer back to a Time struct.

