### PR TITLE
cmd/cgo: update outdated docs about cgocheck2

### DIFF
--- a/src/cmd/cgo/doc.go
+++ b/src/cmd/cgo/doc.go
@@ -402,7 +402,8 @@ controlled by the cgocheck setting of the GODEBUG environment
 variable. The default setting is GODEBUG=cgocheck=1, which implements
 reasonably cheap dynamic checks. These checks may be disabled
 entirely using GODEBUG=cgocheck=0. Complete checking of pointer
-handling, at some cost in run time, is available via GODEBUG=cgocheck=2.
+handling, at some cost in run time, is available by setting
+GOEXPERIMENT=cgocheck2 at build time.
 
 It is possible to defeat this enforcement by using the unsafe package,
 and of course there is nothing stopping the C code from doing anything


### PR DESCRIPTION
Setting GODEBUG=cgocheck=2 now panics with a message
such as "fatal error: cgocheck > 1 mode is no longer supported at runtime.
Use GOEXPERIMENT=cgocheck2 at build time instead."