### PR TITLE
net: document LookupTXT behavior with multiple strings per record

### DIFF
--- a/src/net/lookup.go
+++ b/src/net/lookup.go
@@ -629,6 +629,9 @@ func (r *Resolver) LookupNS(ctx context.Context, name string) ([]*NS, error) {
 
 // LookupTXT returns the DNS TXT records for the given domain name.
 //
+// If a DNS TXT record holds multiple strings, they are concatenated as a
+// single string.
+//
 // LookupTXT uses [context.Background] internally; to specify the context, use
 // [Resolver.LookupTXT].
 func LookupTXT(name string) ([]string, error) {
@@ -636,6 +639,9 @@ func LookupTXT(name string) ([]string, error) {
 }
 
 // LookupTXT returns the DNS TXT records for the given domain name.
+//
+// If a DNS TXT record holds multiple strings, they are concatenated as a
+// single string.
 func (r *Resolver) LookupTXT(ctx context.Context, name string) ([]string, error) {
 	return r.lookupTXT(ctx, name)
 }


### PR DESCRIPTION
CL 8966 ("net: allow a dns TXT record to contain more than
one <character-string>") concatenates strings in a TXT record. Document
that behavior, since it's not obvious whether the strings will be
concatenated or accumulated in the returned slice.