### PR TITLE
archive/tar: FileInfoNames change FileInfoHeader behavior only in unix

### DIFF
--- a/src/archive/tar/common.go
+++ b/src/archive/tar/common.go
@@ -717,20 +717,21 @@ func FileInfoHeader(fi fs.FileInfo, link string) (*Header, error) {
 			}
 		}
 	}
-	if iface, ok := fi.(FileInfoNames); ok {
-		var err error
-		if loadUidAndGid != nil {
+	// use FileInfoNames only on unix
+	if loadUidAndGid != nil {
+		if iface, ok := fi.(FileInfoNames); ok {
+			var err error
 			loadUidAndGid(fi, &h.Uid, &h.Gid)
+			h.Gname, err = iface.Gname(h.Gid)
+			if err != nil {
+				return nil, err
+			}
+			h.Uname, err = iface.Uname(h.Uid)
+			if err != nil {
+				return nil, err
+			}
+			return h, nil
 		}
-		h.Gname, err = iface.Gname(h.Gid)
-		if err != nil {
-			return nil, err
-		}
-		h.Uname, err = iface.Uname(h.Uid)
-		if err != nil {
-			return nil, err
-		}
-		return h, nil
 	}
 	if sysStat != nil {
 		return h, sysStat(fi, h)

--- a/src/archive/tar/common.go
+++ b/src/archive/tar/common.go
@@ -644,7 +644,7 @@ const (
 //
 // If fi implements [FileInfoNames]
 // the Gname and Uname of the header are
-// provided by the methods of the interface.
+// only in unix provided by the methods of the interface.
 func FileInfoHeader(fi fs.FileInfo, link string) (*Header, error) {
 	if fi == nil {
 		return nil, errors.New("archive/tar: FileInfo is nil")
@@ -738,9 +738,9 @@ func FileInfoHeader(fi fs.FileInfo, link string) (*Header, error) {
 	return h, nil
 }
 
-// FileInfoNames extends [FileInfo] to translate UID/GID to names.
+// FileInfoNames extends [fs.FileInfo] to translate UID/GID to names.
 // Passing an instance of this to [FileInfoHeader] permits the caller
-// to control UID/GID resolution.
+// to control UID/GID resolution only in unix.
 type FileInfoNames interface {
 	fs.FileInfo
 	// Uname should translate a UID into a user name.


### PR DESCRIPTION
Because it seems that this interface is designed to avoid any id ->name lookups.
The behavior of any id ->name lookups only exists in Unix systems.

For now the non-Unix FileInfoNames change FileInfoHeader behavior implementation is only Unless fs.FileInfo.Sys() provides tar.Header,  FileInfoNames.Uname and FileInfoNames.Gname simply receive uid and gid of 0.

So go1.22 does not provide FileInfoNames change FileInfoHeader behavior is better on non-Unix.

fix invalid documentation links incidentally.

For #65245