### PR TITLE
reflect: fix isRegularMemory at case Array

### DIFF
--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -2156,7 +2156,11 @@ func isValidFieldName(fieldName string) bool {
 func isRegularMemory(t Type) bool {
 	switch t.Kind() {
 	case Array:
-		return isRegularMemory(t.Elem())
+		elem := t.Elem()
+		if isRegularMemory(elem) {
+			return true
+		}
+		return elem.Comparable() && t.Len() == 0
 	case Int8, Int16, Int32, Int64, Int, Uint8, Uint16, Uint32, Uint64, Uint, Uintptr, Chan, Pointer, Bool, UnsafePointer:
 		return true
 	case Struct:

--- a/src/reflect/type_test.go
+++ b/src/reflect/type_test.go
@@ -78,6 +78,9 @@ func TestIsRegularMemory(t *testing.T) {
 		}{})}, true},
 		{"map[int][int]", args{reflect.TypeOf(map[int]int{})}, false},
 		{"[4]chan int", args{reflect.TypeOf([4]chan int{})}, true},
+		{"[0]struct{_ S}", args{reflect.TypeOf([0]struct {
+			_ S
+		}{})}, true},
 		{"struct{i int; _ S}", args{reflect.TypeOf(struct {
 			i int
 			_ S


### PR DESCRIPTION
To match cmd/compile/internal/compare.IsRegularMemory,
this CL adds code for empty arrays of comparable element type.