### PR TITLE
net/http: allow empty login in .netrc

### DIFF
--- a/src/cmd/go/internal/auth/netrc.go
+++ b/src/cmd/go/internal/auth/netrc.go
@@ -61,7 +61,7 @@ func parseNetrc(data string) []netrcLine {
 				// new-line characters) is encountered.”
 				inMacro = true
 			}
-			if l.machine != "" && l.login != "" && l.password != "" {
+			if l.machine != "" && l.password != "" {
 				nrc = append(nrc, l)
 				l = netrcLine{}
 			}

--- a/src/cmd/go/internal/auth/netrc_test.go
+++ b/src/cmd/go/internal/auth/netrc_test.go
@@ -49,6 +49,7 @@ password too-late-in-file
 func TestParseNetrc(t *testing.T) {
 	lines := parseNetrc(testNetrc)
 	want := []netrcLine{
+		{"incomplete", "", "none"},
 		{"api.github.com", "user", "pwd"},
 		{"test.host", "user2", "pwd2"},
 		{"oneline", "user3", "pwd3"},

--- a/src/cmd/go/internal/auth/netrc_test.go
+++ b/src/cmd/go/internal/auth/netrc_test.go
@@ -34,6 +34,9 @@ machine hasmacro.too macdef ignore-next-lines login user4 password pwd4
   login nobody
   password nothing
 
+machine empty.login
+  password mysupergitlabtoken
+
 default
 login anonymous
 password gopher@golang.org
@@ -50,6 +53,7 @@ func TestParseNetrc(t *testing.T) {
 		{"test.host", "user2", "pwd2"},
 		{"oneline", "user3", "pwd3"},
 		{"hasmacro.too", "user4", "pwd4"},
+		{"empty.login", "", "mysupergitlabtoken"},
 	}
 
 	if !reflect.DeepEqual(lines, want) {


### PR DESCRIPTION
Curl successfully parses the netrc file without a login field. 
Where is it needed?
For example, GitLab uses only the password from the authorization header.

Fixes #65260