### PR TITLE
cmd/internal/moddeps: fix test fail when the last element of GOROOT start with a dot or underscore

### DIFF
--- a/src/cmd/internal/moddeps/moddeps_test.go
+++ b/src/cmd/internal/moddeps/moddeps_test.go
@@ -454,24 +454,22 @@ func findGorootModules(t *testing.T) []gorootModule {
 			if err != nil {
 				return err
 			}
-			if path != root {
-				if info.IsDir() && (info.Name() == "vendor" || info.Name() == "testdata") {
-					return filepath.SkipDir
-				}
-				if info.IsDir() && path == filepath.Join(testenv.GOROOT(t), "pkg") {
-					// GOROOT/pkg contains generated artifacts, not source code.
-					//
-					// In https://golang.org/issue/37929 it was observed to somehow contain
-					// a module cache, so it is important to skip. (That helps with the
-					// running time of this test anyway.)
-					return filepath.SkipDir
-				}
-				if info.IsDir() && (strings.HasPrefix(info.Name(), "_") || strings.HasPrefix(info.Name(), ".")) {
-					// _ and . prefixed directories can be used for internal modules
-					// without a vendor directory that don't contribute to the build
-					// but might be used for example as code generators.
-					return filepath.SkipDir
-				}
+			if info.IsDir() && path != root && (info.Name() == "vendor" || info.Name() == "testdata") {
+				return filepath.SkipDir
+			}
+			if info.IsDir() && path == filepath.Join(testenv.GOROOT(t), "pkg") {
+				// GOROOT/pkg contains generated artifacts, not source code.
+				//
+				// In https://golang.org/issue/37929 it was observed to somehow contain
+				// a module cache, so it is important to skip. (That helps with the
+				// running time of this test anyway.)
+				return filepath.SkipDir
+			}
+			if info.IsDir() && path != root && (strings.HasPrefix(info.Name(), "_") || strings.HasPrefix(info.Name(), ".")) {
+				// _ and . prefixed directories can be used for internal modules
+				// without a vendor directory that don't contribute to the build
+				// but might be used for example as code generators.
+				return filepath.SkipDir
 			}
 			if info.IsDir() || info.Name() != "go.mod" {
 				return nil

--- a/src/cmd/internal/moddeps/moddeps_test.go
+++ b/src/cmd/internal/moddeps/moddeps_test.go
@@ -454,22 +454,24 @@ func findGorootModules(t *testing.T) []gorootModule {
 			if err != nil {
 				return err
 			}
-			if info.IsDir() && (info.Name() == "vendor" || info.Name() == "testdata") {
-				return filepath.SkipDir
-			}
-			if info.IsDir() && path == filepath.Join(testenv.GOROOT(t), "pkg") {
-				// GOROOT/pkg contains generated artifacts, not source code.
-				//
-				// In https://golang.org/issue/37929 it was observed to somehow contain
-				// a module cache, so it is important to skip. (That helps with the
-				// running time of this test anyway.)
-				return filepath.SkipDir
-			}
-			if info.IsDir() && (strings.HasPrefix(info.Name(), "_") || strings.HasPrefix(info.Name(), ".")) {
-				// _ and . prefixed directories can be used for internal modules
-				// without a vendor directory that don't contribute to the build
-				// but might be used for example as code generators.
-				return filepath.SkipDir
+			if path != root {
+				if info.IsDir() && (info.Name() == "vendor" || info.Name() == "testdata") {
+					return filepath.SkipDir
+				}
+				if info.IsDir() && path == filepath.Join(testenv.GOROOT(t), "pkg") {
+					// GOROOT/pkg contains generated artifacts, not source code.
+					//
+					// In https://golang.org/issue/37929 it was observed to somehow contain
+					// a module cache, so it is important to skip. (That helps with the
+					// running time of this test anyway.)
+					return filepath.SkipDir
+				}
+				if info.IsDir() && (strings.HasPrefix(info.Name(), "_") || strings.HasPrefix(info.Name(), ".")) {
+					// _ and . prefixed directories can be used for internal modules
+					// without a vendor directory that don't contribute to the build
+					// but might be used for example as code generators.
+					return filepath.SkipDir
+				}
 			}
 			if info.IsDir() || info.Name() != "go.mod" {
 				return nil


### PR DESCRIPTION
Fixes #54221