### PR TITLE
net/http: wrap client errors

### DIFF
--- a/src/net/http/client.go
+++ b/src/net/http/client.go
@@ -726,7 +726,7 @@ func (c *Client) do(req *Request) (retres *Response, reterr error) {
 			reqBodyClosed = true
 			if !deadline.IsZero() && didTimeout() {
 				err = &httpError{
-					err:     err.Error() + " (Client.Timeout exceeded while awaiting headers)",
+					err:     fmt.Errorf("%w (Client.Timeout exceeded while awaiting headers)", err),
 					timeout: true,
 				}
 			}
@@ -969,7 +969,7 @@ func (b *cancelTimerBody) Read(p []byte) (n int, err error) {
 	}
 	if b.reqDidTimeout() {
 		err = &httpError{
-			err:     err.Error() + " (Client.Timeout or context cancellation while reading body)",
+			err:     fmt.Errorf("%w (Client.Timeout exceeded or context cancellation while reading body)", err),
 			timeout: true,
 		}
 	}

--- a/src/net/http/client_test.go
+++ b/src/net/http/client_test.go
@@ -2154,6 +2154,5 @@ func testClientTimeoutReturnsContextDeadlineExceeded(t *testing.T, timeout time.
 	if !errors.Is(err, context.DeadlineExceeded) {
 		return fmt.Errorf("expected context.DeadlineExceeded, got %v", err)
 	}
-	t.Logf("passed with timeout %v", timeout)
 	return nil
 }

--- a/src/net/http/client_test.go
+++ b/src/net/http/client_test.go
@@ -2135,7 +2135,11 @@ func testClientTimeoutReturnsContextDeadlineExceededTimeouts(t *testing.T, mode 
 	runTimeSensitiveTest(t, []time.Duration{
 		5 * time.Millisecond,
 		10 * time.Millisecond,
-		12 * time.Millisecond,
+		50 * time.Millisecond,
+		100 * time.Millisecond,
+		500 * time.Millisecond,
+		time.Second,
+		5 * time.Second,
 	}, func(t *testing.T, d time.Duration) error {
 		return testClientTimeoutReturnsContextDeadlineExceeded(t, d, mode)
 	})

--- a/src/net/http/client_test.go
+++ b/src/net/http/client_test.go
@@ -2129,9 +2129,9 @@ func testProbeZeroLengthBody(t *testing.T, mode testMode) {
 }
 
 func TestClientTimeoutReturnsContextDeadlineExceeded(t *testing.T) {
-	run(t, testClientTimeoutErrorTimeSensitive)
+	run(t, testClientTimeoutReturnsContextDeadlineExceededTimeouts)
 }
-func testClientTimeoutErrorTimeSensitive(t *testing.T, mode testMode) {
+func testClientTimeoutReturnsContextDeadlineExceededTimeouts(t *testing.T, mode testMode) {
 	runTimeSensitiveTest(t, []time.Duration{
 		5 * time.Millisecond,
 		10 * time.Millisecond,

--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -2556,15 +2556,17 @@ type writeRequest struct {
 }
 
 type httpError struct {
-	err     string
+	err     error
 	timeout bool
 }
 
-func (e *httpError) Error() string   { return e.err }
-func (e *httpError) Timeout() bool   { return e.timeout }
-func (e *httpError) Temporary() bool { return true }
+func (e *httpError) Error() string        { return e.err.Error() }
+func (e *httpError) Timeout() bool        { return e.timeout }
+func (e *httpError) Temporary() bool      { return true }
+func (e *httpError) Is(target error) bool { return errors.Is(e.err, target) }
+func (e *httpError) Unwrap() error        { return e.err }
 
-var errTimeout error = &httpError{err: "net/http: timeout awaiting response headers", timeout: true}
+var errTimeout error = &httpError{err: errors.New("net/http: timeout awaiting response headers"), timeout: true}
 
 // errRequestCanceled is set to be identical to the one from h2 to facilitate
 // testing.


### PR DESCRIPTION
previously lowered this test timeout to 1ms per @neild, but this seems to be a touch too low to reliably pass in pipelines.

previous discussion and cl: https://go-review.googlesource.com/c/go/+/533119/comment/9133758c_cc35a308/

updates #65287
fixes #50856
