### PR TITLE
cmd/go/internal/vcs: use git log to avoid unnecessary objects

### DIFF
--- a/src/cmd/go/internal/vcs/vcs.go
+++ b/src/cmd/go/internal/vcs/vcs.go
@@ -331,12 +331,12 @@ func gitStatus(vcsGit *Cmd, rootDir string) (Status, error) {
 	}
 	uncommitted := len(out) > 0
 
-	// "git status" works for empty repositories, but "git show" does not.
-	// Assume there are no commits in the repo when "git show" fails with
+	// "git status" works for empty repositories, but "git log" does not.
+	// Assume there are no commits in the repo when "git log" fails with
 	// uncommitted files and skip tagging revision / committime.
 	var rev string
 	var commitTime time.Time
-	out, err = vcsGit.runOutputVerboseOnly(rootDir, "-c log.showsignature=false show -s --format=%H:%ct")
+	out, err = vcsGit.runOutputVerboseOnly(rootDir, "-c log.showsignature=false log -1 --format=%H:%ct")
 	if err != nil && !uncommitted {
 		return Status{}, err
 	} else if err == nil {

--- a/src/cmd/go/testdata/script/build_git_missing_tree.txt
+++ b/src/cmd/go/testdata/script/build_git_missing_tree.txt
@@ -1,0 +1,51 @@
+# Regression test for https://go.dev/issue/65339.
+# Unnecessary git tree object required
+
+[short] skip 'constructs a local git repo'
+[!git] skip
+
+env GIT_AUTHOR_NAME='Go Gopher'
+env GIT_AUTHOR_EMAIL='gopher@golang.org'
+env GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
+env GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
+
+# Create 2 commit
+env GIT_COMMITTER_DATE=2024-01-30T10:52:00+08:00
+env GIT_AUTHOR_DATE=2024-01-30T10:52:00+08:00
+
+cd $WORK/repo
+exec git init
+exec git add go.mod main.go
+exec git commit -m 'initial commit'
+
+env GIT_COMMITTER_DATE=2024-01-30T10:53:00+08:00
+env GIT_AUTHOR_DATE=2024-01-30T10:53:00+08:00
+exec git add extra.go
+exec git commit -m 'add extra.go'
+
+# Assume the tree object from initial commit is not available (e.g. partial clone)
+exec git log --pretty=%T
+cmp stdout $WORK/.git-trees
+
+rm .git/objects/66/400c89b45cc96da36d232844dbf9ea5daa6bcf
+
+# Build the module, which should succeed
+go build -v -buildvcs=true -o test
+go version -m test
+stdout '^\tbuild\tvcs.revision=fe3c8204d2332a731166269932dd23760c1b576a$'
+
+-- $WORK/repo/go.mod --
+module github.com/golang/issue65339
+
+go 1.20
+-- $WORK/repo/main.go --
+package main
+
+func main() {
+	println("hello, world")
+}
+-- $WORK/repo/extra.go --
+package main
+-- $WORK/.git-trees --
+ac724c6e5e3f86815e057ff58a639cab613abf28
+66400c89b45cc96da36d232844dbf9ea5daa6bcf

--- a/src/cmd/go/testdata/script/version_buildvcs_git.txt
+++ b/src/cmd/go/testdata/script/version_buildvcs_git.txt
@@ -119,7 +119,7 @@ rm $GOBIN/d$GOEXE
 go list -x ./...
 stdout -count=3 '^example.com'
 stderr -count=1 '^git status'
-stderr -count=1 '^git -c log.showsignature=false show'
+stderr -count=1 '^git -c log.showsignature=false log'
 
 -- $WORK/fakebin/git --
 #!/bin/sh


### PR DESCRIPTION
"git show" by default shows the diff from the previous commit. "-s"
suppress all output from the diff machinery. But it will still try to
fetch the relevant objects, which may be unavailable if the repository
is a partial clone.

Use "git log" instead, which only needs the commit object.
    
Fixes #65339