### PR TITLE
runtime,time: clean duplicate definitions time.runtimeTimer and runtime.timer

### DIFF
--- a/src/cmd/internal/objabi/pkgspecial.go
+++ b/src/cmd/internal/objabi/pkgspecial.go
@@ -57,6 +57,8 @@ var runtimePkgs = []string{
 	"internal/godebugs",
 	"internal/goexperiment",
 	"internal/goos",
+
+	"sync/atomic",
 }
 
 // extraNoInstrumentPkgs is the set of packages in addition to runtimePkgs that

--- a/src/cmd/internal/objabi/pkgspecial.go
+++ b/src/cmd/internal/objabi/pkgspecial.go
@@ -58,7 +58,7 @@ var runtimePkgs = []string{
 	"internal/goexperiment",
 	"internal/goos",
 
-	"sync/atomic",
+	"internal/runtime/timer",
 }
 
 // extraNoInstrumentPkgs is the set of packages in addition to runtimePkgs that

--- a/src/go/build/deps_test.go
+++ b/src/go/build/deps_test.go
@@ -115,7 +115,7 @@ var depsRules = `
 	unicode !< path;
 
 	# SYSCALL is RUNTIME plus the packages necessary for basic system calls.
-	RUNTIME, unicode/utf8, unicode/utf16, internal/runtime/timer
+	RUNTIME, unicode/utf8, unicode/utf16
 	< internal/syscall/windows/sysdll, syscall/js
 	< syscall
 	< internal/syscall/unix, internal/syscall/windows, internal/syscall/windows/registry

--- a/src/go/build/deps_test.go
+++ b/src/go/build/deps_test.go
@@ -50,8 +50,10 @@ var depsRules = `
 	  unicode/utf8, unicode/utf16, unicode,
 	  unsafe;
 
-	# These packages depend only on internal/goarch and unsafe.
-	internal/goarch, unsafe
+	unsafe < sync/atomic;
+
+	# These packages depend only on internal/goarch and unsafe and sync/atomic.
+	internal/goarch, unsafe, sync/atomic
 	< internal/abi, internal/chacha8rand;
 
 	unsafe < maps;
@@ -73,7 +75,6 @@ var depsRules = `
 	< runtime/internal/atomic
 	< runtime/internal/math
 	< runtime
-	< sync/atomic
 	< internal/race
 	< internal/msan
 	< internal/asan
@@ -423,7 +424,7 @@ var depsRules = `
 	< net/mail;
 
 	NONE < crypto/internal/boring/sig, crypto/internal/boring/syso;
-	sync/atomic < crypto/internal/boring/bcache, crypto/internal/boring/fipstls;
+	sync/atomic,unsafe < crypto/internal/boring/bcache, crypto/internal/boring/fipstls;
 	crypto/internal/boring/sig, crypto/internal/boring/fipstls < crypto/tls/fipsonly;
 
 	# CRYPTO is core crypto algorithms - no cgo, fmt, net.

--- a/src/go/build/deps_test.go
+++ b/src/go/build/deps_test.go
@@ -48,7 +48,7 @@ var depsRules = `
 	  internal/trace/traceviewer/format,
 	  log/internal,
 	  unicode/utf8, unicode/utf16, unicode,
-	  unsafe;
+	  unsafe, internal/runtime/timer;
 
 	unsafe < sync/atomic;
 
@@ -66,7 +66,8 @@ var depsRules = `
 	internal/goarch,
 	internal/godebugs,
 	internal/goexperiment,
-	internal/goos
+	internal/goos,
+	internal/runtime/timer
 	< internal/bytealg
 	< internal/itoa
 	< internal/unsafeheader
@@ -115,7 +116,7 @@ var depsRules = `
 	unicode !< path;
 
 	# SYSCALL is RUNTIME plus the packages necessary for basic system calls.
-	RUNTIME, unicode/utf8, unicode/utf16
+	RUNTIME, unicode/utf8, unicode/utf16, internal/runtime/timer
 	< internal/syscall/windows/sysdll, syscall/js
 	< syscall
 	< internal/syscall/unix, internal/syscall/windows, internal/syscall/windows/registry
@@ -424,7 +425,7 @@ var depsRules = `
 	< net/mail;
 
 	NONE < crypto/internal/boring/sig, crypto/internal/boring/syso;
-	sync/atomic,unsafe < crypto/internal/boring/bcache, crypto/internal/boring/fipstls;
+	sync/atomic < crypto/internal/boring/bcache, crypto/internal/boring/fipstls;
 	crypto/internal/boring/sig, crypto/internal/boring/fipstls < crypto/tls/fipsonly;
 
 	# CRYPTO is core crypto algorithms - no cgo, fmt, net.

--- a/src/go/build/deps_test.go
+++ b/src/go/build/deps_test.go
@@ -50,10 +50,8 @@ var depsRules = `
 	  unicode/utf8, unicode/utf16, unicode,
 	  unsafe, internal/runtime/timer;
 
-	unsafe < sync/atomic;
-
-	# These packages depend only on internal/goarch and unsafe and sync/atomic.
-	internal/goarch, unsafe, sync/atomic
+	# These packages depend only on internal/goarch and unsafe.
+	internal/goarch, unsafe
 	< internal/abi, internal/chacha8rand;
 
 	unsafe < maps;
@@ -76,6 +74,7 @@ var depsRules = `
 	< runtime/internal/atomic
 	< runtime/internal/math
 	< runtime
+	< sync/atomic
 	< internal/race
 	< internal/msan
 	< internal/asan

--- a/src/internal/abi/type.go
+++ b/src/internal/abi/type.go
@@ -5,6 +5,7 @@
 package abi
 
 import (
+	"sync/atomic"
 	"unsafe"
 )
 
@@ -780,3 +781,28 @@ const (
 // we raised the limit to 2048, so that even 32-bit systems are guaranteed to
 // use bitmaps for objects up to 64 kB in size.
 const MaxPtrmaskBytes = 2048
+
+// Package time knows the layout of this structure.
+type Timer struct {
+	// If this timer is on a heap, which P's heap it is on.
+	// puintptr rather than *p to match uintptr in the versions
+	// of this struct defined in other packages.
+	Pp uintptr
+
+	// Timer wakes up at when, and then at when+period, ... (period > 0 only)
+	// each time calling f(arg, now) in the timer goroutine, so f must be
+	// a well-behaved function and not block.
+	//
+	// when must be positive on an active timer.
+	When   int64
+	Period int64
+	F      func(any, uintptr)
+	Arg    any
+	Seq    uintptr
+
+	// What to set the when field to in timerModifiedXX status.
+	Nextwhen int64
+
+	// The status field holds one of the values below.
+	Status atomic.Uint32
+}

--- a/src/internal/abi/type.go
+++ b/src/internal/abi/type.go
@@ -5,7 +5,6 @@
 package abi
 
 import (
-	"sync/atomic"
 	"unsafe"
 )
 
@@ -781,28 +780,3 @@ const (
 // we raised the limit to 2048, so that even 32-bit systems are guaranteed to
 // use bitmaps for objects up to 64 kB in size.
 const MaxPtrmaskBytes = 2048
-
-// Package time knows the layout of this structure.
-type Timer struct {
-	// If this timer is on a heap, which P's heap it is on.
-	// puintptr rather than *p to match uintptr in the versions
-	// of this struct defined in other packages.
-	Pp uintptr
-
-	// Timer wakes up at when, and then at when+period, ... (period > 0 only)
-	// each time calling f(arg, now) in the timer goroutine, so f must be
-	// a well-behaved function and not block.
-	//
-	// when must be positive on an active timer.
-	When   int64
-	Period int64
-	F      func(any, uintptr)
-	Arg    any
-	Seq    uintptr
-
-	// What to set the when field to in timerModifiedXX status.
-	Nextwhen int64
-
-	// The status field holds one of the values below.
-	Status atomic.Uint32
-}

--- a/src/internal/runtime/timer/timer.go
+++ b/src/internal/runtime/timer/timer.go
@@ -44,6 +44,7 @@ type Timer struct {
 	Seq    uintptr
 
 	// Fields below may only be modified by the runtime.
+
 	// If this timer is on a heap, which P's heap it is on.
 	// uintptr rather than *runtime.p because p isn't accessible from here.
 	Pp uintptr

--- a/src/internal/runtime/timer/timer.go
+++ b/src/internal/runtime/timer/timer.go
@@ -1,10 +1,41 @@
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package timer
 
-// Package time knows the layout of this structure.
+// Timer is use to share the same timer value with runtime and time
+//
+// Code outside runtime has to be careful in using a timer value.
+//
+// Code that creates a new timer value can set the When, Period, F,
+// Arg, and Seq fields.
+// A new timer value may be passed to addtimer (called by time.startTimer).
+// After doing that no fields may be touched.
+//
+// An active timer (one that has been passed to addtimer) may be
+// passed to deltimer (time.stopTimer), after which it is no longer an
+// active timer.  It is an inactive timer.
+// In an inactive timer the period, f, arg, and seq fields may be modified,
+// but not the when field.
+// It's OK to just drop an inactive timer and let the GC collect it.
+// It's not OK to pass an inactive timer to addtimer.
+// Only newly allocated timer values may be passed to addtimer.
+//
+// An active timer may be passed to modtimer.  No fields may be touched.
+// It remains an active timer.
+//
+// An inactive timer may be passed to resettimer to turn into an
+// active timer with an updated when field.
+// It's OK to pass a newly allocated timer value to resettimer.
+//
+// Timer operations are addtimer, deltimer, modtimer, resettimer,
+// cleantimers, adjusttimers, and runtimer.
 type Timer struct {
 	// If this timer is on a heap, which P's heap it is on.
-	// puintptr rather than *p to match uintptr in the versions
-	// of this struct defined in other packages.
+	// uintptr rather than *runtime.p because p isn't accessible from here.
+	//
+	// Only use at runtime.
 	Pp uintptr
 
 	// Timer wakes up at when, and then at when+period, ... (period > 0 only)
@@ -19,8 +50,11 @@ type Timer struct {
 	Seq    uintptr
 
 	// What to set the when field to in timerModifiedXX status.
+	// Only use at runtime.
 	Nextwhen int64
 
-	// The status field holds one of the values below.
+	// Status holds a value from runtime/time.go
+	// Only use at runtime.
+	// TODO: use atomic.Uint32
 	Status uint32
 }

--- a/src/internal/runtime/timer/timer.go
+++ b/src/internal/runtime/timer/timer.go
@@ -4,7 +4,7 @@
 
 package timer
 
-// Timer is use to share the same timer value with runtime and time
+// Timer is a runtime-managed timer.
 //
 // Code outside runtime has to be careful in using a timer value.
 //
@@ -32,12 +32,6 @@ package timer
 // Timer operations are addtimer, deltimer, modtimer, resettimer,
 // cleantimers, adjusttimers, and runtimer.
 type Timer struct {
-	// If this timer is on a heap, which P's heap it is on.
-	// uintptr rather than *runtime.p because p isn't accessible from here.
-	//
-	// Only use at runtime.
-	Pp uintptr
-
 	// Timer wakes up at when, and then at when+period, ... (period > 0 only)
 	// each time calling f(arg, now) in the timer goroutine, so f must be
 	// a well-behaved function and not block.
@@ -49,12 +43,13 @@ type Timer struct {
 	Arg    any
 	Seq    uintptr
 
+	// Fields below may only be modified by the runtime.
+	// If this timer is on a heap, which P's heap it is on.
+	// uintptr rather than *runtime.p because p isn't accessible from here.
+	Pp uintptr
 	// What to set the when field to in timerModifiedXX status.
-	// Only use at runtime.
 	Nextwhen int64
-
 	// Status holds a value from runtime/time.go
-	// Only use at runtime.
 	// TODO: use atomic.Uint32
 	Status uint32
 }

--- a/src/internal/runtime/timer/timer.go
+++ b/src/internal/runtime/timer/timer.go
@@ -1,0 +1,26 @@
+package timer
+
+// Package time knows the layout of this structure.
+type Timer struct {
+	// If this timer is on a heap, which P's heap it is on.
+	// puintptr rather than *p to match uintptr in the versions
+	// of this struct defined in other packages.
+	Pp uintptr
+
+	// Timer wakes up at when, and then at when+period, ... (period > 0 only)
+	// each time calling f(arg, now) in the timer goroutine, so f must be
+	// a well-behaved function and not block.
+	//
+	// when must be positive on an active timer.
+	When   int64
+	Period int64
+	F      func(any, uintptr)
+	Arg    any
+	Seq    uintptr
+
+	// What to set the when field to in timerModifiedXX status.
+	Nextwhen int64
+
+	// The status field holds one of the values below.
+	Status uint32
+}

--- a/src/runtime/mgcscavenge.go
+++ b/src/runtime/mgcscavenge.go
@@ -361,8 +361,8 @@ func (s *scavengerState) init() {
 	s.g = getg()
 
 	s.timer = new(timer)
-	s.timer.arg = s
-	s.timer.f = func(s any, _ uintptr) {
+	s.timer.Arg = s
+	s.timer.F = func(s any, _ uintptr) {
 		s.(*scavengerState).wake()
 	}
 

--- a/src/runtime/mgcscavenge.go
+++ b/src/runtime/mgcscavenge.go
@@ -92,6 +92,7 @@ package runtime
 
 import (
 	"internal/goos"
+	"internal/runtime/timer"
 	"runtime/internal/atomic"
 	"runtime/internal/sys"
 	"unsafe"
@@ -285,7 +286,7 @@ type scavengerState struct {
 	parked bool
 
 	// timer is the timer used for the scavenger to sleep.
-	timer *timer
+	timer *timer.Timer
 
 	// sysmonWake signals to sysmon that it should wake the scavenger.
 	sysmonWake atomic.Uint32
@@ -360,7 +361,7 @@ func (s *scavengerState) init() {
 	lockInit(&s.lock, lockRankScavenge)
 	s.g = getg()
 
-	s.timer = new(timer)
+	s.timer = new(timer.Timer)
 	s.timer.Arg = s
 	s.timer.F = func(s any, _ uintptr) {
 		s.(*scavengerState).wake()

--- a/src/runtime/netpoll.go
+++ b/src/runtime/netpoll.go
@@ -391,14 +391,14 @@ func poll_runtime_pollSetDeadline(pd *pollDesc, d int64, mode int) {
 	if combo {
 		rtf = netpollDeadline
 	}
-	if pd.rt.f == nil {
+	if pd.rt.F == nil {
 		if pd.rd > 0 {
-			pd.rt.f = rtf
+			pd.rt.F = rtf
 			// Copy current seq into the timer arg.
 			// Timer func will check the seq against current descriptor seq,
 			// if they differ the descriptor was reused or timers were reset.
-			pd.rt.arg = pd.makeArg()
-			pd.rt.seq = pd.rseq
+			pd.rt.Arg = pd.makeArg()
+			pd.rt.Seq = pd.rseq
 			resettimer(&pd.rt, pd.rd)
 		}
 	} else if pd.rd != rd0 || combo != combo0 {
@@ -407,14 +407,14 @@ func poll_runtime_pollSetDeadline(pd *pollDesc, d int64, mode int) {
 			modtimer(&pd.rt, pd.rd, 0, rtf, pd.makeArg(), pd.rseq)
 		} else {
 			deltimer(&pd.rt)
-			pd.rt.f = nil
+			pd.rt.F = nil
 		}
 	}
-	if pd.wt.f == nil {
+	if pd.wt.F == nil {
 		if pd.wd > 0 && !combo {
-			pd.wt.f = netpollWriteDeadline
-			pd.wt.arg = pd.makeArg()
-			pd.wt.seq = pd.wseq
+			pd.wt.F = netpollWriteDeadline
+			pd.wt.Arg = pd.makeArg()
+			pd.wt.Seq = pd.wseq
 			resettimer(&pd.wt, pd.wd)
 		}
 	} else if pd.wd != wd0 || combo != combo0 {
@@ -423,7 +423,7 @@ func poll_runtime_pollSetDeadline(pd *pollDesc, d int64, mode int) {
 			modtimer(&pd.wt, pd.wd, 0, netpollWriteDeadline, pd.makeArg(), pd.wseq)
 		} else {
 			deltimer(&pd.wt)
-			pd.wt.f = nil
+			pd.wt.F = nil
 		}
 	}
 	// If we set the new deadline in the past, unblock currently pending IO if any.
@@ -460,13 +460,13 @@ func poll_runtime_pollUnblock(pd *pollDesc) {
 	delta := int32(0)
 	rg = netpollunblock(pd, 'r', false, &delta)
 	wg = netpollunblock(pd, 'w', false, &delta)
-	if pd.rt.f != nil {
+	if pd.rt.F != nil {
 		deltimer(&pd.rt)
-		pd.rt.f = nil
+		pd.rt.F = nil
 	}
-	if pd.wt.f != nil {
+	if pd.wt.F != nil {
 		deltimer(&pd.wt)
-		pd.wt.f = nil
+		pd.wt.F = nil
 	}
 	unlock(&pd.lock)
 	if rg != nil {
@@ -633,7 +633,7 @@ func netpolldeadlineimpl(pd *pollDesc, seq uintptr, read, write bool) {
 	delta := int32(0)
 	var rg *g
 	if read {
-		if pd.rd <= 0 || pd.rt.f == nil {
+		if pd.rd <= 0 || pd.rt.F == nil {
 			throw("runtime: inconsistent read deadline")
 		}
 		pd.rd = -1
@@ -642,7 +642,7 @@ func netpolldeadlineimpl(pd *pollDesc, seq uintptr, read, write bool) {
 	}
 	var wg *g
 	if write {
-		if pd.wd <= 0 || pd.wt.f == nil && !read {
+		if pd.wd <= 0 || pd.wt.F == nil && !read {
 			throw("runtime: inconsistent write deadline")
 		}
 		pd.wd = -1

--- a/src/runtime/netpoll.go
+++ b/src/runtime/netpoll.go
@@ -7,6 +7,7 @@
 package runtime
 
 import (
+	"internal/runtime/timer"
 	"runtime/internal/atomic"
 	"runtime/internal/sys"
 	"unsafe"
@@ -102,14 +103,14 @@ type pollDesc struct {
 
 	lock    mutex // protects the following fields
 	closing bool
-	user    uint32    // user settable cookie
-	rseq    uintptr   // protects from stale read timers
-	rt      timer     // read deadline timer (set if rt.f != nil)
-	rd      int64     // read deadline (a nanotime in the future, -1 when expired)
-	wseq    uintptr   // protects from stale write timers
-	wt      timer     // write deadline timer
-	wd      int64     // write deadline (a nanotime in the future, -1 when expired)
-	self    *pollDesc // storage for indirect interface. See (*pollDesc).makeArg.
+	user    uint32      // user settable cookie
+	rseq    uintptr     // protects from stale read timers
+	rt      timer.Timer // read deadline timer (set if rt.f != nil)
+	rd      int64       // read deadline (a nanotime in the future, -1 when expired)
+	wseq    uintptr     // protects from stale write timers
+	wt      timer.Timer // write deadline timer
+	wd      int64       // write deadline (a nanotime in the future, -1 when expired)
+	self    *pollDesc   // storage for indirect interface. See (*pollDesc).makeArg.
 }
 
 // pollInfo is the bits needed by netpollcheckerr, stored atomically,

--- a/src/runtime/runtime2.go
+++ b/src/runtime/runtime2.go
@@ -8,6 +8,7 @@ import (
 	"internal/abi"
 	"internal/chacha8rand"
 	"internal/goarch"
+	"internal/runtime/timer"
 	"runtime/internal/atomic"
 	"runtime/internal/sys"
 	"unsafe"
@@ -505,7 +506,7 @@ type g struct {
 	waiting       *sudog         // sudog structures this g is waiting on (that have a valid elem ptr); in lock order
 	cgoCtxt       []uintptr      // cgo traceback context
 	labels        unsafe.Pointer // profiler labels
-	timer         *timer         // cached timer for time.Sleep
+	timer         *timer.Timer   // cached timer for time.Sleep
 	selectDone    atomic.Uint32  // are we participating in a select and did someone win the race?
 
 	coroarg *coro // argument during coroutine transfers
@@ -758,7 +759,7 @@ type p struct {
 	// Actions to take at some time. This is used to implement the
 	// standard library's time package.
 	// Must hold timersLock to access.
-	timers []*timer
+	timers []*timer.Timer
 
 	// Number of timers in P's heap.
 	numTimers atomic.Uint32

--- a/src/runtime/trace2.go
+++ b/src/runtime/trace2.go
@@ -920,8 +920,8 @@ func newWakeableSleep() *wakeableSleep {
 	lockInit(&s.lock, lockRankWakeableSleep)
 	s.wakeup = make(chan struct{}, 1)
 	s.timer = new(timer)
-	s.timer.arg = s
-	s.timer.f = func(s any, _ uintptr) {
+	s.timer.Arg = s
+	s.timer.F = func(s any, _ uintptr) {
 		s.(*wakeableSleep).wake()
 	}
 	return s

--- a/src/runtime/trace2.go
+++ b/src/runtime/trace2.go
@@ -22,6 +22,7 @@
 package runtime
 
 import (
+	"internal/runtime/timer"
 	"runtime/internal/atomic"
 	"unsafe"
 )
@@ -907,7 +908,7 @@ const defaultTraceAdvancePeriod = 1e9 // 1 second.
 // close to free up resources. Once close is called, init
 // must be called before another use.
 type wakeableSleep struct {
-	timer *timer
+	timer *timer.Timer
 
 	// lock protects access to wakeup, but not send/recv on it.
 	lock   mutex
@@ -919,7 +920,7 @@ func newWakeableSleep() *wakeableSleep {
 	s := new(wakeableSleep)
 	lockInit(&s.lock, lockRankWakeableSleep)
 	s.wakeup = make(chan struct{}, 1)
-	s.timer = new(timer)
+	s.timer = new(timer.Timer)
 	s.timer.Arg = s
 	s.timer.F = func(s any, _ uintptr) {
 		s.(*wakeableSleep).wake()

--- a/src/time/internal_test.go
+++ b/src/time/internal_test.go
@@ -4,6 +4,8 @@
 
 package time
 
+import "internal/runtime/timer"
+
 func init() {
 	// Force US/Pacific for time zone tests.
 	ForceUSPacificForTesting()
@@ -47,7 +49,7 @@ func CheckRuntimeTimerPeriodOverflow() {
 	// We manually create a runtimeTimer with huge period, but that expires
 	// immediately. The public Timer interface would require waiting for
 	// the entire period before the first update.
-	r := &runtimeTimer{
+	r := &timer.Timer{
 		When:   runtimeNano(),
 		Period: 1<<63 - 1,
 		F:      empty,

--- a/src/time/internal_test.go
+++ b/src/time/internal_test.go
@@ -48,10 +48,10 @@ func CheckRuntimeTimerPeriodOverflow() {
 	// immediately. The public Timer interface would require waiting for
 	// the entire period before the first update.
 	r := &runtimeTimer{
-		when:   runtimeNano(),
-		period: 1<<63 - 1,
-		f:      empty,
-		arg:    nil,
+		When:   runtimeNano(),
+		Period: 1<<63 - 1,
+		F:      empty,
+		Arg:    nil,
 	}
 	startTimer(r)
 	defer stopTimer(r)

--- a/src/time/sleep.go
+++ b/src/time/sleep.go
@@ -4,9 +4,11 @@
 
 package time
 
-import "internal/abi"
+import (
+	"internal/runtime/timer"
+)
 
-type runtimeTimer = abi.Timer
+type runtimeTimer = timer.Timer
 
 // Sleep pauses the current goroutine for at least the duration d.
 // A negative or zero duration causes Sleep to return immediately.
@@ -29,10 +31,10 @@ func when(d Duration) int64 {
 	return t
 }
 
-func startTimer(*abi.Timer)
-func stopTimer(*abi.Timer) bool
-func resetTimer(*abi.Timer, int64) bool
-func modTimer(t *abi.Timer, when, period int64, f func(any, uintptr), arg any, seq uintptr)
+func startTimer(*timer.Timer)
+func stopTimer(*timer.Timer) bool
+func resetTimer(*timer.Timer, int64) bool
+func modTimer(t *timer.Timer, when, period int64, f func(any, uintptr), arg any, seq uintptr)
 
 // The Timer type represents a single event.
 // When the Timer expires, the current time will be sent on C,

--- a/src/time/sleep.go
+++ b/src/time/sleep.go
@@ -8,8 +8,6 @@ import (
 	"internal/runtime/timer"
 )
 
-type runtimeTimer = timer.Timer
-
 // Sleep pauses the current goroutine for at least the duration d.
 // A negative or zero duration causes Sleep to return immediately.
 func Sleep(d Duration)
@@ -42,7 +40,7 @@ func modTimer(t *timer.Timer, when, period int64, f func(any, uintptr), arg any,
 // A Timer must be created with NewTimer or AfterFunc.
 type Timer struct {
 	C <-chan Time
-	r runtimeTimer
+	r timer.Timer
 }
 
 // Stop prevents the Timer from firing.
@@ -80,7 +78,7 @@ func NewTimer(d Duration) *Timer {
 	c := make(chan Time, 1)
 	t := &Timer{
 		C: c,
-		r: runtimeTimer{
+		r: timer.Timer{
 			When: when(d),
 			F:    sendTime,
 			Arg:  c,
@@ -156,7 +154,7 @@ func After(d Duration) <-chan Time {
 // The returned Timer's C field is not used and will be nil.
 func AfterFunc(d Duration, f func()) *Timer {
 	t := &Timer{
-		r: runtimeTimer{
+		r: timer.Timer{
 			When: when(d),
 			F:    goFunc,
 			Arg:  f,

--- a/src/time/tick.go
+++ b/src/time/tick.go
@@ -4,11 +4,13 @@
 
 package time
 
+import "internal/runtime/timer"
+
 // A Ticker holds a channel that delivers “ticks” of a clock
 // at intervals.
 type Ticker struct {
 	C <-chan Time // The channel on which the ticks are delivered.
-	r runtimeTimer
+	r timer.Timer
 }
 
 // NewTicker returns a new Ticker containing a channel that will send
@@ -27,7 +29,7 @@ func NewTicker(d Duration) *Ticker {
 	c := make(chan Time, 1)
 	t := &Ticker{
 		C: c,
-		r: runtimeTimer{
+		r: timer.Timer{
 			When:   when(d),
 			Period: int64(d),
 			F:      sendTime,

--- a/src/time/tick.go
+++ b/src/time/tick.go
@@ -28,10 +28,10 @@ func NewTicker(d Duration) *Ticker {
 	t := &Ticker{
 		C: c,
 		r: runtimeTimer{
-			when:   when(d),
-			period: int64(d),
-			f:      sendTime,
-			arg:    c,
+			When:   when(d),
+			Period: int64(d),
+			F:      sendTime,
+			Arg:    c,
 		},
 	}
 	startTimer(&t.r)
@@ -52,10 +52,10 @@ func (t *Ticker) Reset(d Duration) {
 	if d <= 0 {
 		panic("non-positive interval for Ticker.Reset")
 	}
-	if t.r.f == nil {
+	if t.r.F == nil {
 		panic("time: Reset called on uninitialized Ticker")
 	}
-	modTimer(&t.r, when(d), int64(d), t.r.f, t.r.arg, t.r.seq)
+	modTimer(&t.r, when(d), int64(d), t.r.F, t.r.Arg, t.r.Seq)
 }
 
 // Tick is a convenience wrapper for NewTicker providing access to the ticking


### PR DESCRIPTION
Fixes #64549
For #65355