### PR TITLE
errors: unwrap joinError to avoid deeply-nested joins

### DIFF
--- a/src/errors/join_test.go
+++ b/src/errors/join_test.go
@@ -37,6 +37,9 @@ func TestJoin(t *testing.T) {
 	}, {
 		errs: []error{err1, nil, err2},
 		want: []error{err1, err2},
+	}, {
+		errs: []error{errors.Join(err1, err2), err1, err2},
+		want: []error{err1, err2, err1, err2},
 	}} {
 		got := errors.Join(test.errs...).(interface{ Unwrap() []error }).Unwrap()
 		if !reflect.DeepEqual(got, test.want) {


### PR DESCRIPTION
This PR is a quick proposal to unwrap `joinError` (and only `joinError`)
when calling `errors.Join`. While I don't think we should unwrap
everything, this is an internal structure that has only internally
semantic meaning. Therefore, I think it makes sense to special-case
`joinError` and unwrapped the contained errors on `joinError`.

Pros:
- More closely mirrors how other error joining packages in the ecosystem
  behave.

- Even though `Unwrap() []error` isn't a public API, this will ensure
  that the method behaves as end-users expect for `errors.Join`,
  returning the list of joined errors.

Cons:
- Introduces type assertion and could result in a performance
  regression, since we're not pre-computing the slice length. This could
  be addressed if there's interest in pursuing this. I also think there's
  a reasonable argument to be made about the benefits realized from this
  change when printing the error.

- Users could be depending on the broken behavior, but that seems
  unlikely since `joinError` is an internal API.

I could not find any corresponding issues, but "errors" and "unwrap" are
not particularly unique keywords, so apologies if I missed them.