### PR TITLE
container/heap: remove confusing claim of memory leak

### DIFF
--- a/src/container/heap/example_pq_test.go
+++ b/src/container/heap/example_pq_test.go
@@ -45,7 +45,7 @@ func (pq *PriorityQueue) Pop() any {
 	old := *pq
 	n := len(old)
 	item := old[n-1]
-	old[n-1] = nil  // avoid memory leak
+	old[n-1] = nil  // don't stop the GC from reclaiming the item eventually
 	item.index = -1 // for safety
 	*pq = old[0 : n-1]
 	return item


### PR DESCRIPTION
The term "memory leak" was misused here, as the memory is still referenced
by the slice.

Fixes #65403