### PR TITLE
cmd/go: update docs for go test -benchmem

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -3116,6 +3116,7 @@
 //
 //	-benchmem
 //	    Print memory allocation statistics for benchmarks.
+//	    Allocations made in C or using C.malloc are not counted. 
 //
 //	-blockprofile block.out
 //	    Write a goroutine blocking profile to the specified file

--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -3116,7 +3116,7 @@
 //
 //	-benchmem
 //	    Print memory allocation statistics for benchmarks.
-//	    Allocations made in C or using C.malloc are not counted. 
+//	    Allocations made in C or using C.malloc are not counted.
 //
 //	-blockprofile block.out
 //	    Write a goroutine blocking profile to the specified file

--- a/src/cmd/go/internal/test/test.go
+++ b/src/cmd/go/internal/test/test.go
@@ -353,6 +353,7 @@ profile the tests during execution:
 
 	-benchmem
 	    Print memory allocation statistics for benchmarks.
+	    Allocations made in C or using C.malloc are not counted.
 
 	-blockprofile block.out
 	    Write a goroutine blocking profile to the specified file


### PR DESCRIPTION
Mention that the allocation counter doesn't count allocations made using
C.malloc (cgo) or in C.