### PR TITLE
runtime/debug: stack test fail when GOROOT='/usr/local/go/'

### DIFF
--- a/src/runtime/debug/stack_test.go
+++ b/src/runtime/debug/stack_test.go
@@ -105,7 +105,12 @@ func TestStack(t *testing.T) {
 	}
 	filePrefix := ""
 	if fileGoroot != "" {
-		filePrefix = filepath.ToSlash(fileGoroot) + "/src/"
+		fileGoroot = filepath.ToSlash(filepath.Clean(fileGoroot))
+		if fileGoroot == "/" {
+			filePrefix = "/src/"
+		} else {
+			filePrefix = fileGoroot + "/src/"
+		}
 	}
 
 	n := 0


### PR DESCRIPTION
Fixes https://github.com/golang/go/issues/65506
