### PR TITLE
container/heap: simplify examples for ease of reading

### DIFF
--- a/src/container/heap/example_intheap_test.go
+++ b/src/container/heap/example_intheap_test.go
@@ -16,19 +16,12 @@ type IntHeap []int
 func (h IntHeap) Len() int           { return len(h) }
 func (h IntHeap) Less(i, j int) bool { return h[i] < h[j] }
 func (h IntHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
-
-func (h *IntHeap) Push(x any) {
-	// Push and Pop use pointer receivers because they modify the slice's length,
-	// not just its contents.
-	*h = append(*h, x.(int))
-}
+func (h *IntHeap) Push(x any)        { *h = append(*h, x.(int)) }
 
 func (h *IntHeap) Pop() any {
 	old := *h
-	n := len(old)
-	x := old[n-1]
-	*h = old[0 : n-1]
-	return x
+	*h = old[:len(old)-1]
+	return old[len(old)-1]
 }
 
 // This example inserts several ints into an IntHeap, checks the minimum,

--- a/src/container/heap/example_pq_test.go
+++ b/src/container/heap/example_pq_test.go
@@ -35,25 +35,21 @@ func (pq PriorityQueue) Swap(i, j int) {
 }
 
 func (pq *PriorityQueue) Push(x any) {
-	n := len(*pq)
 	item := x.(*Item)
-	item.index = n
+	item.index = len(*pq)
 	*pq = append(*pq, item)
 }
 
 func (pq *PriorityQueue) Pop() any {
 	old := *pq
-	n := len(old)
-	item := old[n-1]
-	old[n-1] = nil  // don't stop the GC from reclaiming the item eventually
-	item.index = -1 // for safety
-	*pq = old[0 : n-1]
+	item := old[len(old)-1]
+	old[len(old)-1] = nil // don't stop the GC from reclaiming the item eventually
+	item.index = -1       // for safety
+	*pq = old[:len(old)-1]
 	return item
 }
 
-// update modifies the priority and value of an Item in the queue.
-func (pq *PriorityQueue) update(item *Item, value string, priority int) {
-	item.value = value
+func (pq *PriorityQueue) updatePriority(item *Item, priority int) {
 	item.priority = priority
 	heap.Fix(pq, item.index)
 }
@@ -61,32 +57,19 @@ func (pq *PriorityQueue) update(item *Item, value string, priority int) {
 // This example creates a PriorityQueue with some items, adds and manipulates an item,
 // and then removes the items in priority order.
 func Example_priorityQueue() {
-	// Some items and their priorities.
-	items := map[string]int{
-		"banana": 3, "apple": 2, "pear": 4,
-	}
-
-	// Create a priority queue, put the items in it, and
+	// Create a priority queue, with some items in it, and
 	// establish the priority queue (heap) invariants.
-	pq := make(PriorityQueue, len(items))
-	i := 0
-	for value, priority := range items {
-		pq[i] = &Item{
-			value:    value,
-			priority: priority,
-			index:    i,
-		}
-		i++
+	pq := PriorityQueue{
+		&Item{index: 0, priority: 3, value: "banana"},
+		&Item{index: 1, priority: 2, value: "apple"},
+		&Item{index: 2, priority: 4, value: "pear"},
 	}
 	heap.Init(&pq)
 
 	// Insert a new item and then modify its priority.
-	item := &Item{
-		value:    "orange",
-		priority: 1,
-	}
+	item := &Item{priority: 1, value: "orange"}
 	heap.Push(&pq, item)
-	pq.update(item, item.value, 5)
+	pq.updatePriority(item, 5)
 
 	// Take the items out; they arrive in decreasing priority order.
 	for pq.Len() > 0 {


### PR DESCRIPTION
In order to increase the focus on the container/heap package and ease
reading, the use of unnecessary indirection through variables, an unused
method parameter, a general explanation about method receivers and complex
construction code have been removed from the examples.
