### PR TITLE
container/heap: avoid the term "heap invariants"

### DIFF
--- a/src/container/heap/example_pq_test.go
+++ b/src/container/heap/example_pq_test.go
@@ -67,7 +67,7 @@ func Example_priorityQueue() {
 	}
 
 	// Create a priority queue, put the items in it, and
-	// establish the priority queue (heap) invariants.
+	// bring the items into order to produce a valid heap.
 	pq := make(PriorityQueue, len(items))
 	i := 0
 	for value, priority := range items {

--- a/src/container/heap/heap.go
+++ b/src/container/heap/heap.go
@@ -20,7 +20,7 @@ import "sort"
 // The Interface type describes the requirements
 // for a type using the routines in this package.
 // Any type that implements it may be used as a
-// min-heap with the following invariants (established after
+// min-heap with the following property (established after
 // [Init] has been called or if the data is empty or sorted):
 //
 //	!h.Less(j, i) for 0 <= i < h.Len() and 2*i+1 <= j <= 2*i+2 and j < h.Len()
@@ -34,9 +34,9 @@ type Interface interface {
 	Pop() any   // remove and return element Len() - 1.
 }
 
-// Init establishes the heap invariants required by the other routines in this package.
-// Init is idempotent with respect to the heap invariants
-// and may be called whenever the heap invariants may have been invalidated.
+// Init orders the items of h so that the heap property is fulfilled.
+// Init is idempotent and may be called whenever
+// the heap may have become unordered.
 // The complexity is O(n) where n = h.Len().
 func Init(h Interface) {
 	// heapify

--- a/src/container/heap/heap_test.go
+++ b/src/container/heap/heap_test.go
@@ -39,14 +39,14 @@ func (h myHeap) verify(t *testing.T, i int) {
 	j2 := 2*i + 2
 	if j1 < n {
 		if h.Less(j1, i) {
-			t.Errorf("heap invariant invalidated [%d] = %d > [%d] = %d", i, h[i], j1, h[j1])
+			t.Errorf("heap is invalid: [%d] = %d > [%d] = %d", i, h[i], j1, h[j1])
 			return
 		}
 		h.verify(t, j1)
 	}
 	if j2 < n {
 		if h.Less(j2, i) {
-			t.Errorf("heap invariant invalidated [%d] = %d > [%d] = %d", i, h[i], j1, h[j2])
+			t.Errorf("heap is invalid: [%d] = %d > [%d] = %d", i, h[i], j1, h[j2])
 			return
 		}
 		h.verify(t, j2)


### PR DESCRIPTION
"Heap invariant(s)" seems to be a sparsely used term and might confuse
readers. "Heap property" is likely a more commonly understood synonym
for it. Also, the term "heap property" was already used in the package
comment, so it is more consistent to use it solely.

Additionally, it is now explicitly mentioned that the Init function may
reorder items. This will hopefully further clarify the purpose of this
function.

Fixes #65492