### PR TITLE
sync: eliminate global Mutex in (*Pool).pinSlow operations

### DIFF
--- a/src/sync/pool.go
+++ b/src/sync/pool.go
@@ -280,7 +280,7 @@ const shardPoolsSize = 256
 
 var (
 	// allPools is the set of pools that have non-empty primary
-	// caches. Protected by either 1) allPoolsMu and pinning or 2)
+	// caches. Protected by either 1) lock of elem or 2)
 	// STW.
 	allPools [shardPoolsSize]struct {
 		lock Mutex

--- a/src/sync/pool_test.go
+++ b/src/sync/pool_test.go
@@ -393,3 +393,12 @@ func BenchmarkPoolExpensiveNew(b *testing.B) {
 	b.ReportMetric(float64(mstats2.NumGC-mstats1.NumGC)/float64(b.N), "GCs/op")
 	b.ReportMetric(float64(nNew)/float64(b.N), "New/op")
 }
+
+func BenchmarkPoolpinSlow(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			var p Pool
+			p.Get()
+		}
+	})
+}


### PR DESCRIPTION
goos: windows
goarch: amd64
pkg: sync
cpu: AMD Ryzen 7 7840HS w/ Radeon 780M Graphics
                    │    old.txt    │                new.txt                │
                    │    sec/op     │    sec/op      vs base                │
Pool-16               0.9467n ±  2%   0.9390n ±  3%        ~ (p=0.353 n=10)
PoolOverflow-16        188.5n ±  1%    188.8n ±  1%        ~ (p=0.239 n=10)
PoolStarvation-16      2.573µ ±  1%    2.619µ ±  1%   +1.79% (p=0.000 n=10)
PoolSTW-16             9.140µ ± 60%   10.863µ ± 99%        ~ (p=0.110 n=10)
PoolExpensiveNew-16     1.556 ±  1%     1.553 ±  1%        ~ (p=0.853 n=10)
PoolpinSlow-16         494.3n ±  4%    269.8n ±  5%  -45.42% (p=0.000 n=10)
geomean                3.844µ          3.583µ         -6.81%

Removing the mutex in pinslow can cause this:
go test -count=100 sync
fatal error: schedule: holding locks
So don't try ShardedValue after wait for go.dev/issue/18802 to finish.

shardPoolsSize is 256 because the current size benchmark shows 
that the performance improvement has not significantly affected BenchmarkPoolSTW.
Larger shardPoolsSize, for example shardPoolsSize is 512,
There are more performance improvements as follows:
goos: windows
goarch: amd64
pkg: sync
cpu: AMD Ryzen 7 7840HS w/ Radeon 780M Graphics
                    │    old.txt    │                new.txt                │
                    │    sec/op     │    sec/op      vs base                │
Pool-16               0.9467n ±  2%   0.9257n ±  2%   -2.22% (p=0.014 n=10)
PoolOverflow-16        188.5n ±  1%    187.5n ±  1%        ~ (p=0.127 n=10)
PoolStarvation-16      2.573µ ±  1%    2.610µ ±  2%   +1.44% (p=0.019 n=10)
PoolSTW-16             9.140µ ± 60%   16.817µ ± 78%  +84.00% (p=0.011 n=10)
PoolExpensiveNew-16     1.556 ±  1%     1.559 ±  1%        ~ (p=0.123 n=10)
PoolpinSlow-16         494.3n ±  4%    253.4n ±  4%  -48.74% (p=0.000 n=10)
geomean                3.844µ          3.800µ         -1.16%

Because of the drastic changes in BenchmarkPoolSTW, 
this CL do not shardPoolsSize is 512 to obtain a greater performance improvement.

Fixes #24479