### PR TITLE
runtime/cgo: ignore -Watomic-alignment in gcc_libinit.c

### DIFF
--- a/src/runtime/cgo/gcc_libinit.c
+++ b/src/runtime/cgo/gcc_libinit.c
@@ -4,6 +4,11 @@
 
 //go:build unix
 
+// When cross-compiling to linux/armv5, atomics are emulated and cause a
+// compiler warning. This results in a build failure since cgo uses
+// -Werror. See #65290.
+#pragma GCC diagnostic ignored "-Watomic-alignment"
+
 #include <pthread.h>
 #include <errno.h>
 #include <stdio.h>

--- a/src/runtime/cgo/gcc_libinit.c
+++ b/src/runtime/cgo/gcc_libinit.c
@@ -4,10 +4,12 @@
 
 //go:build unix
 
-// When cross-compiling to linux/armv5, atomics are emulated and cause a
-// compiler warning. This results in a build failure since cgo uses
-// -Werror. See #65290.
+// When cross-compiling with clang to linux/armv5, atomics are emulated
+// and cause a compiler warning. This results in a build failure since
+// cgo uses -Werror. See #65290.
+#if defined(__clang__)
 #pragma GCC diagnostic ignored "-Watomic-alignment"
+#endif
 
 #include <pthread.h>
 #include <errno.h>

--- a/src/runtime/cgo/gcc_libinit.c
+++ b/src/runtime/cgo/gcc_libinit.c
@@ -7,9 +7,8 @@
 // When cross-compiling with clang to linux/armv5, atomics are emulated
 // and cause a compiler warning. This results in a build failure since
 // cgo uses -Werror. See #65290.
-#if defined(__clang__)
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Watomic-alignment"
-#endif
 
 #include <pthread.h>
 #include <errno.h>


### PR DESCRIPTION
When cross-compiling a cgo program with CC=clang for Linux/ARMv5, 
atomic warnings cause build errors, as cgo uses -Werror.

These warnings seem to be harmless and come from the usage of
__atomic_load_n, which is emulated due to the lack of atomic
instructions in armv5.

Fixes #65290
