### PR TITLE
syscall/zerrors_openbsd: add missed EBADMSG

### DIFF
--- a/src/syscall/zerrors_openbsd_386.go
+++ b/src/syscall/zerrors_openbsd_386.go
@@ -1330,6 +1330,7 @@ const (
 	EALREADY        = Errno(0x25)
 	EAUTH           = Errno(0x50)
 	EBADF           = Errno(0x9)
+	EBADMSG         = Errno(0x5c)
 	EBADRPC         = Errno(0x48)
 	EBUSY           = Errno(0x10)
 	ECANCELED       = Errno(0x58)

--- a/src/syscall/zerrors_openbsd_amd64.go
+++ b/src/syscall/zerrors_openbsd_amd64.go
@@ -1329,6 +1329,7 @@ const (
 	EALREADY        = Errno(0x25)
 	EAUTH           = Errno(0x50)
 	EBADF           = Errno(0x9)
+	EBADMSG         = Errno(0x5c)
 	EBADRPC         = Errno(0x48)
 	EBUSY           = Errno(0x10)
 	ECANCELED       = Errno(0x58)

--- a/src/syscall/zerrors_openbsd_arm.go
+++ b/src/syscall/zerrors_openbsd_arm.go
@@ -1329,6 +1329,7 @@ const (
 	EALREADY        = Errno(0x25)
 	EAUTH           = Errno(0x50)
 	EBADF           = Errno(0x9)
+	EBADMSG         = Errno(0x5c)
 	EBADRPC         = Errno(0x48)
 	EBUSY           = Errno(0x10)
 	ECANCELED       = Errno(0x58)


### PR DESCRIPTION
Some tables where generated a while ago and lead to missed EBADMSG.

And some a new one for ppc64 and riscv64 have it.