### PR TITLE
net: enable mptcp by default

### DIFF
--- a/src/net/dial.go
+++ b/src/net/dial.go
@@ -18,9 +18,7 @@ const (
 	// See go.dev/issue/31510
 	defaultTCPKeepAlive = 15 * time.Second
 
-	// For the moment, MultiPath TCP is not used by default
-	// See go.dev/issue/56539
-	defaultMPTCPEnabled = false
+	defaultMPTCPEnabled = true
 )
 
 var multipathtcp = godebug.New("multipathtcp")
@@ -43,11 +41,11 @@ func (m *mptcpStatus) get() bool {
 		return false
 	}
 
-	// If MPTCP is forced via GODEBUG=multipathtcp=1
-	if multipathtcp.Value() == "1" {
+	// If MPTCP is disabled via GODEBUG=multipathtcp=0
+	if multipathtcp.Value() == "0" {
 		multipathtcp.IncNonDefault()
 
-		return true
+		return false
 	}
 
 	return defaultMPTCPEnabled


### PR DESCRIPTION
When #56539 was accepted, it was decided[1] that MPTCP
would be opt-in for a release or two, and then made opt-out.
    
[1] https://go.dev/issue/56539#issuecomment-1309294637
    
Updates #56539
