### PR TITLE
net/http: support TCP half-close when HTTP is upgraded in ReverseProxy

### DIFF
--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -2429,6 +2429,13 @@ func (b *readWriteCloserBody) Read(p []byte) (n int, err error) {
 	return b.ReadWriteCloser.Read(p)
 }
 
+func (b *readWriteCloserBody) CloseWrite() error {
+	if cw, ok := b.ReadWriteCloser.(interface{ CloseWrite() error }); ok {
+		return cw.CloseWrite()
+	}
+	return nil
+}
+
 // nothingWrittenError wraps a write errors which ended up writing zero bytes.
 type nothingWrittenError struct {
 	error


### PR DESCRIPTION
Rather than closing all sockets immediately when the one side gets
an EOF, this CL closes the write stream on the socket to inform the
transfer is finished.

Fixes #35892