### PR TITLE
encoding/xml: add indent to xml.Comment

### DIFF
--- a/src/encoding/xml/marshal.go
+++ b/src/encoding/xml/marshal.go
@@ -225,9 +225,11 @@ func (enc *Encoder) EncodeToken(t Token) error {
 		if bytes.Contains(t, endComment) {
 			return fmt.Errorf("xml: EncodeToken of Comment containing --> marker")
 		}
+    p.writeIndent(1)
 		p.WriteString("<!--")
 		p.Write(t)
 		p.WriteString("-->")
+    p.writeIndent(-1)
 		return p.cachedWriteError()
 	case ProcInst:
 		// First token to be encoded which is also a ProcInst with target of xml


### PR DESCRIPTION
Add indent before and after xml.Comment

With this change the comment is added with indent at the start, like StartElement and indent at the end, like EndElement.
Fixes #56340