### PR TITLE
hash/maphash: parallel run test

### DIFF
--- a/src/hash/maphash/smhasher_test.go
+++ b/src/hash/maphash/smhasher_test.go
@@ -29,6 +29,7 @@ var fixedSeed = MakeSeed()
 // hash should not depend on values outside key.
 // hash should not depend on alignment.
 func TestSmhasherSanity(t *testing.T) {
+	t.Parallel()
 	r := rand.New(rand.NewSource(1234))
 	const REP = 10
 	const KEYMAX = 128
@@ -107,6 +108,7 @@ func (s *hashSet) check(t *testing.T) {
 
 // a string plus adding zeros must make distinct hashes
 func TestSmhasherAppendedZeros(t *testing.T) {
+	t.Parallel()
 	s := "hello" + strings.Repeat("\x00", 256)
 	h := newHashSet()
 	for i := 0; i <= len(s); i++ {
@@ -117,6 +119,7 @@ func TestSmhasherAppendedZeros(t *testing.T) {
 
 // All 0-3 byte strings have distinct hashes.
 func TestSmhasherSmallKeys(t *testing.T) {
+	t.Parallel()
 	h := newHashSet()
 	var b [3]byte
 	for i := 0; i < 256; i++ {
@@ -138,6 +141,7 @@ func TestSmhasherSmallKeys(t *testing.T) {
 
 // Different length strings of all zeros have distinct hashes.
 func TestSmhasherZeros(t *testing.T) {
+	t.Parallel()
 	N := 256 * 1024
 	if testing.Short() {
 		N = 1024
@@ -158,6 +162,7 @@ func TestSmhasherTwoNonzero(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping in short mode")
 	}
+	t.Parallel()
 	h := newHashSet()
 	for n := 2; n <= 16; n++ {
 		twoNonZero(h, n)
@@ -200,6 +205,7 @@ func TestSmhasherCyclic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping in short mode")
 	}
+	t.Parallel()
 	r := rand.New(rand.NewSource(1234))
 	const REPEAT = 8
 	const N = 1000000
@@ -229,6 +235,7 @@ func TestSmhasherSparse(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping in short mode")
 	}
+	t.Parallel()
 	sparse(t, 32, 6)
 	sparse(t, 40, 6)
 	sparse(t, 48, 5)
@@ -267,6 +274,7 @@ func TestSmhasherPermutation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping in short mode")
 	}
+	t.Parallel()
 	permutation(t, []uint32{0, 1, 2, 3, 4, 5, 6, 7}, 8)
 	permutation(t, []uint32{0, 1 << 29, 2 << 29, 3 << 29, 4 << 29, 5 << 29, 6 << 29, 7 << 29}, 8)
 	permutation(t, []uint32{0, 1}, 20)
@@ -407,6 +415,7 @@ func windowed(t *testing.T, k key) {
 	if testing.Short() {
 		t.Skip("Skipping in short mode")
 	}
+	t.Parallel()
 	const BITS = 16
 
 	for r := 0; r < k.bits(); r++ {
@@ -429,6 +438,7 @@ func TestSmhasherText(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping in short mode")
 	}
+	t.Parallel()
 	text(t, "Foo", "Bar")
 	text(t, "FooBar", "")
 	text(t, "", "FooBar")
@@ -463,6 +473,7 @@ func TestSmhasherSeed(t *testing.T) {
 	if unsafe.Sizeof(uintptr(0)) == 4 {
 		t.Skip("32-bit platforms don't have ideal seed-input distributions (see issue 33988)")
 	}
+	t.Parallel()
 	h := newHashSet()
 	const N = 100000
 	s := "hello"


### PR DESCRIPTION
This reduces the go test hash/maphash time
by more than half.
