### PR TITLE
context: update doc comment to link to context interface

### DIFF
--- a/src/context/context.go
+++ b/src/context/context.go
@@ -231,7 +231,7 @@ type CancelFunc func()
 // or when the parent context's Done channel is closed, whichever happens first.
 //
 // Canceling this context releases resources associated with it, so code should
-// call cancel as soon as the operations running in this Context complete.
+// call cancel as soon as the operations running in this [Context] complete.
 func WithCancel(parent Context) (ctx Context, cancel CancelFunc) {
 	c := withCancel(parent)
 	return c, func() { c.cancel(true, Canceled, nil) }


### PR DESCRIPTION
Linking to the Context interface in the WithCancel doc comment makes
it more consistent with the WithDeadline and WithTimeout doc comments.