### PR TITLE
cmd/go: show GODEBUG from environment variable by 'go env'

### DIFF
--- a/doc/next/3-tools.md
+++ b/doc/next/3-tools.md
@@ -2,5 +2,8 @@
 
 ### Go command {#go-command}
 
+<!-- https://go.dev/cl/565095 -->
+Show `GODEBUG` from environment variable by `go env`.
+
 ### Cgo {#cgo}
 

--- a/src/cmd/go/internal/envcmd/env.go
+++ b/src/cmd/go/internal/envcmd/env.go
@@ -104,6 +104,7 @@ func MkEnv() []cfg.EnvVar {
 		{Name: "GOTOOLDIR", Value: build.ToolDir},
 		{Name: "GOVCS", Value: cfg.GOVCS},
 		{Name: "GOVERSION", Value: runtime.Version()},
+		{Name: "GODEBUG", Value: os.Getenv("GODEBUG")},
 	}
 
 	if work.GccgoBin != "" {


### PR DESCRIPTION
Fixes #65777