### PR TITLE
net/http: check server shutting down before processing the request

### DIFF
--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -1966,6 +1966,9 @@ func (c *conn) serve(ctx context.Context) {
 			// If we read any bytes off the wire, we're active.
 			c.setState(c.rwc, StateActive, runHooks)
 		}
+		if c.server.shuttingDown() {
+			return
+		}
 		if err != nil {
 			const errorHeaders = "\r\nContent-Type: text/plain; charset=utf-8\r\nConnection: close\r\n\r\n"
 


### PR DESCRIPTION
The root cause of issue #65802 is a small race condition that occurs between 
two events:

1. During the HTTP server shutdown, a connection in an idle state is identified 
and closed.
2. The connection, although idle, has just finished reading a complete request 
before being closed and hasn't yet updated its state to active.

In this scenario, despite the connection being closed, the request continues to 
be processed. This not only wastes server resources but also prevents the 
client request from being retried.

Fixes #65802 