### PR TITLE
cmd/compile: use quotes to wrap user-supplied token

### DIFF
--- a/src/cmd/compile/internal/syntax/parser.go
+++ b/src/cmd/compile/internal/syntax/parser.go
@@ -267,7 +267,9 @@ func (p *parser) syntaxErrorAt(pos Pos, msg string) {
 	// determine token string
 	var tok string
 	switch p.tok {
-	case _Name, _Semi:
+	case _Name:
+		tok = "\"" + p.lit + "\""
+	case _Semi:
 		tok = p.lit
 	case _Literal:
 		tok = "literal " + p.lit

--- a/src/cmd/compile/internal/syntax/parser.go
+++ b/src/cmd/compile/internal/syntax/parser.go
@@ -268,7 +268,7 @@ func (p *parser) syntaxErrorAt(pos Pos, msg string) {
 	var tok string
 	switch p.tok {
 	case _Name:
-		tok = "\"" + p.lit + "\""
+		tok = "`" + p.lit + "'"
 	case _Semi:
 		tok = p.lit
 	case _Literal:

--- a/src/cmd/compile/internal/syntax/testdata/issue20789.go
+++ b/src/cmd/compile/internal/syntax/testdata/issue20789.go
@@ -6,4 +6,4 @@
 // Line 9 must end in EOF for this test (no newline).
 
 package e
-func([<-chan<-[func /* ERROR unexpected u */ u){go
+func([<-chan<-[func /* ERROR unexpected `u' */ u){go

--- a/src/cmd/compile/internal/syntax/testdata/issue47704.go
+++ b/src/cmd/compile/internal/syntax/testdata/issue47704.go
@@ -7,7 +7,7 @@ package p
 func _() {
 	_ = m[] // ERROR expected operand
 	_ = m[x,]
-	_ = m[x /* ERROR unexpected a */ a b c d]
+	_ = m[x /* ERROR unexpected `a' */ a b c d]
 }
 
 // test case from the issue

--- a/src/cmd/compile/internal/syntax/testdata/issue49205.go
+++ b/src/cmd/compile/internal/syntax/testdata/issue49205.go
@@ -7,7 +7,7 @@ package p
 // test case from issue
 
 type _ interface{
-	m /* ERROR unexpected int in interface type; possibly missing semicolon or newline or } */ int
+	m /* ERROR unexpected `int' in interface type; possibly missing semicolon or newline or } */ int
 }
 
 // other cases where the fix for this issue affects the error message
@@ -16,12 +16,12 @@ const (
 	x int = 10 /* ERROR unexpected literal "foo" in grouped declaration; possibly missing semicolon or newline or \) */ "foo"
 )
 
-var _ = []int{1, 2, 3 /* ERROR unexpected int in composite literal; possibly missing comma or } */ int }
+var _ = []int{1, 2, 3 /* ERROR unexpected `int' in composite literal; possibly missing comma or } */ int }
 
 type _ struct {
 	x y /* ERROR syntax error: unexpected comma in struct type; possibly missing semicolon or newline or } */ ,
 }
 
-func f(a, b c /* ERROR unexpected d in parameter list; possibly missing comma or \) */ d) {
-	f(a, b, c /* ERROR unexpected d in argument list; possibly missing comma or \) */ d)
+func f(a, b c /* ERROR unexpected `d' in parameter list; possibly missing comma or \) */ d) {
+	f(a, b, c /* ERROR unexpected `d' in argument list; possibly missing comma or \) */ d)
 }

--- a/src/cmd/compile/internal/syntax/testdata/issue52391.go
+++ b/src/cmd/compile/internal/syntax/testdata/issue52391.go
@@ -13,5 +13,5 @@ type _ interface {
 	(int) | (string)
 	(int) | ~(string)
 	(/* ERROR unexpected ~ */ ~int)
-	(int /* ERROR unexpected \| */ | /* ERROR unexpected string */ string /* ERROR unexpected \) */ )
+	(int /* ERROR unexpected \| */ | /* ERROR unexpected `string' */ string /* ERROR unexpected \) */ )
 }

--- a/src/cmd/compile/internal/syntax/testdata/issue65970.go
+++ b/src/cmd/compile/internal/syntax/testdata/issue65970.go
@@ -1,0 +1,14 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package p
+
+import (
+	"fmt"
+)
+
+func f() {
+	int status // ERROR syntax error: unexpected "status" at end of statement
+	fmt.Println(status)
+}

--- a/src/cmd/compile/internal/syntax/testdata/issue65970.go
+++ b/src/cmd/compile/internal/syntax/testdata/issue65970.go
@@ -9,6 +9,6 @@ import (
 )
 
 func f() {
-	int status // ERROR syntax error: unexpected "status" at end of statement
+	int status // ERROR syntax error: unexpected `status' at end of statement
 	fmt.Println(status)
 }

--- a/test/fixedbugs/issue20789.go
+++ b/test/fixedbugs/issue20789.go
@@ -10,4 +10,4 @@
 // there yet, so put it here for now. See also #20800.)
 
 package e
-func([<-chan<-[func u){go // ERROR "unexpected u"
+func([<-chan<-[func u){go // ERROR "unexpected `u'"

--- a/test/fixedbugs/issue23664.go
+++ b/test/fixedbugs/issue23664.go
@@ -9,9 +9,9 @@
 package p
 
 func f() {
-	if f() true { // ERROR "unexpected true, expected {"
+	if f() true { // ERROR "unexpected `true', expected {"
 	}
 	
-	switch f() true { // ERROR "unexpected true, expected {"
+	switch f() true { // ERROR "unexpected `true', expected {"
 	}
 }


### PR DESCRIPTION
Use quotes to wrap user-supplied token in the syntax error message.
Updates #65790