### PR TITLE
net/http: allow multiple spaces between method and path in mux patterns

### DIFF
--- a/doc/next/6-stdlib/99-minor/net/http/64910.md
+++ b/doc/next/6-stdlib/99-minor/net/http/64910.md
@@ -1,2 +1,2 @@
-The patterns used by [`net/http.ServeMux`](//net#http.ServeMux) allow
+The patterns used by [`net/http.ServeMux`](//net/http#ServeMux) allow
 multiple spaces matching regexp '[ \t]+'.

--- a/doc/next/6-stdlib/99-minor/net/http/64910.md
+++ b/doc/next/6-stdlib/99-minor/net/http/64910.md
@@ -1,0 +1,1 @@
+Allow multiple spaces in patterns like “GET /foo”.

--- a/doc/next/6-stdlib/99-minor/net/http/64910.md
+++ b/doc/next/6-stdlib/99-minor/net/http/64910.md
@@ -1,1 +1,2 @@
-Allow multiple spaces in patterns like “GET /foo”.
+The patterns used by [`net/http.ServeMux`](//net#http.ServeMux) allow
+multiple spaces matching regexp '[ \t]+'.

--- a/src/net/http/pattern.go
+++ b/src/net/http/pattern.go
@@ -92,14 +92,10 @@ func parsePattern(s string) (_ *pattern, err error) {
 		}
 	}()
 
-	cutFunc := func(s string) (before, after string, found bool) {
-		if i := strings.IndexAny(s, " \t"); i >= 0 {
-			return s[:i], strings.TrimSpace(s[i+1:]), true
-		}
-		return s, "", false
+	method, rest, found := s, "", false
+	if i := strings.IndexAny(s, " \t"); i >= 0 {
+		method, rest, found = s[:i], strings.TrimSpace(s[i+1:]), true
 	}
-
-	method, rest, found := cutFunc(s)
 	if !found {
 		rest = method
 		method = ""

--- a/src/net/http/pattern.go
+++ b/src/net/http/pattern.go
@@ -92,7 +92,17 @@ func parsePattern(s string) (_ *pattern, err error) {
 		}
 	}()
 
-	method, rest, found := strings.Cut(s, " ")
+	cutFunc := func(s string) (before, after string, found bool) {
+		if i := strings.IndexFunc(s, func(r rune) bool { return r == ' ' }); i >= 0 {
+			if j := strings.IndexFunc(s[i+1:], func(r rune) bool { return r != ' ' }); j >= 0 {
+				return s[:i], s[i+1:][j:], true
+			}
+			return s[:i], "", true
+		}
+		return s, "", false
+	}
+
+	method, rest, found := cutFunc(s)
 	if !found {
 		rest = method
 		method = ""

--- a/src/net/http/pattern.go
+++ b/src/net/http/pattern.go
@@ -94,7 +94,7 @@ func parsePattern(s string) (_ *pattern, err error) {
 
 	method, rest, found := s, "", false
 	if i := strings.IndexAny(s, " \t"); i >= 0 {
-		method, rest, found = s[:i], strings.TrimSpace(s[i+1:]), true
+		method, rest, found = s[:i], strings.Trim(s[i+1:], " \t"), true
 	}
 	if !found {
 		rest = method

--- a/src/net/http/pattern.go
+++ b/src/net/http/pattern.go
@@ -76,7 +76,7 @@ type segment struct {
 //     a literal or a wildcard of the form "{name}", "{name...}", or "{$}".
 //
 // METHOD, HOST and PATH are all optional; that is, the string can be "/".
-// If METHOD is present, it must be followed by a single space.
+// If METHOD is present, it must be followed by at least one ' ' or '\t'.
 // Wildcard names must be valid Go identifiers.
 // The "{$}" and "{name...}" wildcard must occur at the end of PATH.
 // PATH may end with a '/'.

--- a/src/net/http/pattern.go
+++ b/src/net/http/pattern.go
@@ -94,7 +94,7 @@ func parsePattern(s string) (_ *pattern, err error) {
 
 	method, rest, found := s, "", false
 	if i := strings.IndexAny(s, " \t"); i >= 0 {
-		method, rest, found = s[:i], strings.Trim(s[i+1:], " \t"), true
+		method, rest, found = s[:i], strings.TrimLeft(s[i+1:], " \t"), true
 	}
 	if !found {
 		rest = method

--- a/src/net/http/pattern.go
+++ b/src/net/http/pattern.go
@@ -93,11 +93,8 @@ func parsePattern(s string) (_ *pattern, err error) {
 	}()
 
 	cutFunc := func(s string) (before, after string, found bool) {
-		if i := strings.IndexFunc(s, func(r rune) bool { return r == ' ' }); i >= 0 {
-			if j := strings.IndexFunc(s[i+1:], func(r rune) bool { return r != ' ' }); j >= 0 {
-				return s[:i], s[i+1:][j:], true
-			}
-			return s[:i], "", true
+		if i := strings.IndexAny(s, " \t"); i >= 0 {
+			return s[:i], strings.TrimSpace(s[i+1:]), true
 		}
 		return s, "", false
 	}

--- a/src/net/http/pattern.go
+++ b/src/net/http/pattern.go
@@ -76,7 +76,7 @@ type segment struct {
 //     a literal or a wildcard of the form "{name}", "{name...}", or "{$}".
 //
 // METHOD, HOST and PATH are all optional; that is, the string can be "/".
-// If METHOD is present, it must be followed by at least one ' ' or '\t'.
+// If METHOD is present, it must be followed by at least one space or tab.
 // Wildcard names must be valid Go identifiers.
 // The "{$}" and "{name...}" wildcard must occur at the end of PATH.
 // PATH may end with a '/'.

--- a/src/net/http/pattern_test.go
+++ b/src/net/http/pattern_test.go
@@ -98,7 +98,7 @@ func TestParsePattern(t *testing.T) {
 			"/%61%62/%7b/%",
 			pattern{segments: []segment{lit("ab"), lit("{"), lit("%")}},
 		},
-		// Allow multiple spaces between method and path.
+		// Allow multiple spaces matching regexp '[ \t]+' between method and path.
 		{
 			"GET\t  /",
 			pattern{method: "GET", segments: []segment{multi("")}},

--- a/src/net/http/pattern_test.go
+++ b/src/net/http/pattern_test.go
@@ -98,6 +98,23 @@ func TestParsePattern(t *testing.T) {
 			"/%61%62/%7b/%",
 			pattern{segments: []segment{lit("ab"), lit("{"), lit("%")}},
 		},
+		// Allow multiple spaces between method and path.
+		{
+			"GET  /",
+			pattern{method: "GET", segments: []segment{multi("")}},
+		},
+		{
+			"POST   example.com/foo/{w}",
+			pattern{
+				method:   "POST",
+				host:     "example.com",
+				segments: []segment{lit("foo"), wild("w")},
+			},
+		},
+		{
+			"DELETE    example.com/a/{foo12}/{$}",
+			pattern{method: "DELETE", host: "example.com", segments: []segment{lit("a"), wild("foo12"), lit("/")}},
+		},
 	} {
 		got := mustParsePattern(t, test.in)
 		if !got.equal(&test.want) {

--- a/src/net/http/pattern_test.go
+++ b/src/net/http/pattern_test.go
@@ -100,11 +100,11 @@ func TestParsePattern(t *testing.T) {
 		},
 		// Allow multiple spaces between method and path.
 		{
-			"GET  /",
+			"GET\t  /",
 			pattern{method: "GET", segments: []segment{multi("")}},
 		},
 		{
-			"POST   example.com/foo/{w}",
+			"POST \t  example.com/foo/{w}",
 			pattern{
 				method:   "POST",
 				host:     "example.com",
@@ -112,7 +112,7 @@ func TestParsePattern(t *testing.T) {
 			},
 		},
 		{
-			"DELETE    example.com/a/{foo12}/{$}",
+			"DELETE    \texample.com/a/{foo12}/{$}",
 			pattern{method: "DELETE", host: "example.com", segments: []segment{lit("a"), wild("foo12"), lit("/")}},
 		},
 	} {

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -2335,7 +2335,7 @@ func RedirectHandler(url string, code int) Handler {
 //	[METHOD ][HOST]/[PATH]
 //
 // All three parts are optional; "/" is a valid pattern.
-// If METHOD is present, it must be followed by a single space.
+// If METHOD is present, it must be followed by at least one ' ' or '\t'.
 //
 // Literal (that is, non-wildcard) parts of a pattern match
 // the corresponding parts of a request case-sensitively.

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -2335,7 +2335,7 @@ func RedirectHandler(url string, code int) Handler {
 //	[METHOD ][HOST]/[PATH]
 //
 // All three parts are optional; "/" is a valid pattern.
-// If METHOD is present, it must be followed by at least one ' ' or '\t'.
+// If METHOD is present, it must be followed by at least one space or tab.
 //
 // Literal (that is, non-wildcard) parts of a pattern match
 // the corresponding parts of a request case-sensitively.


### PR DESCRIPTION
Fixes #64910