### PR TITLE
cmd/go/internal/envcmd: show GODEBUG in 'go env' output

### DIFF
--- a/src/cmd/go/internal/envcmd/env.go
+++ b/src/cmd/go/internal/envcmd/env.go
@@ -104,6 +104,7 @@ func MkEnv() []cfg.EnvVar {
 		{Name: "GOTOOLDIR", Value: build.ToolDir},
 		{Name: "GOVCS", Value: cfg.GOVCS},
 		{Name: "GOVERSION", Value: runtime.Version()},
+		{Name: "GODEBUG", Value: os.Getenv("GODEBUG")},
 	}
 
 	if work.GccgoBin != "" {
@@ -530,7 +531,7 @@ func checkEnvWrite(key, val string) error {
 	switch key {
 	case "GOEXE", "GOGCCFLAGS", "GOHOSTARCH", "GOHOSTOS", "GOMOD", "GOWORK", "GOTOOLDIR", "GOVERSION":
 		return fmt.Errorf("%s cannot be modified", key)
-	case "GOENV":
+	case "GOENV", "GODEBUG":
 		return fmt.Errorf("%s can only be set using the OS environment", key)
 	}
 

--- a/src/cmd/go/testdata/script/env_write.txt
+++ b/src/cmd/go/testdata/script/env_write.txt
@@ -65,14 +65,16 @@ go env -u GOPATH
 ! stderr .+
 
 # go env -w rejects unknown or bad variables
-! go env -w GODEBUG=gctrace=1
-stderr 'unknown go command variable GODEBUG'
+! go env -w GOGC=off
+stderr 'unknown go command variable GOGC'
 ! go env -w GOEXE=.bat
 stderr 'GOEXE cannot be modified'
 ! go env -w GOVERSION=customversion
 stderr 'GOVERSION cannot be modified'
 ! go env -w GOENV=/env
 stderr 'GOENV can only be set using the OS environment'
+! go env -w GODEBUG=gctrace=1
+stderr 'GODEBUG can only be set using the OS environment'
 
 # go env -w can set multiple variables
 env CC=


### PR DESCRIPTION
Fixes #65777