### PR TITLE
reflect: add Overflow methods to Type

### DIFF
--- a/api/next/60427.txt
+++ b/api/next/60427.txt
@@ -1,4 +1,4 @@
-pkg reflect, method (Type) OverflowComplex(complex128) bool #60427
-pkg reflect, method (Type) OverflowFloat(float64) bool #60427
-pkg reflect, method (Type) OverflowInt(int64) bool #60427
-pkg reflect, method (Type) OverflowUint(uint64) bool #60427
+pkg reflect, type Type interface, OverflowComplex(complex128) bool #60427
+pkg reflect, type Type interface, OverflowFloat(float64) bool #60427
+pkg reflect, type Type interface, OverflowInt(int64) bool #60427
+pkg reflect, type Type interface, OverflowUint(uint64) bool #60427

--- a/api/next/60427.txt
+++ b/api/next/60427.txt
@@ -1,0 +1,4 @@
+pkg reflect, method (Type) OverflowComplex(complex128) bool #60427
+pkg reflect, method (Type) OverflowFloat(float64) bool #60427
+pkg reflect, method (Type) OverflowInt(int64) bool #60427
+pkg reflect, method (Type) OverflowUint(uint64) bool #60427

--- a/doc/next/6-stdlib/99-minor/reflect/60427.md
+++ b/doc/next/6-stdlib/99-minor/reflect/60427.md
@@ -1,6 +1,6 @@
-The new methods synonymous with the method of the same name in [`reflect.Value`](/reflect.Value)
-are added to [`reflect.Type`](/reflect.Type):
-1. [`OverflowComplex`](/reflect.Type#OverflowComplex)
-2. [`OverflowFloat`](/reflect.Type#OverflowFloat)
-3. [`OverflowInt`](/reflect.Type#OverflowInt)
-4. [`OverflowUint`](/reflect.Type#OverflowUint)
+The new methods synonymous with the method of the same name in [`reflect.Value`](/pkg/reflect#Value)
+are added to [`reflect.Type`](/pkg/reflect#Type):
+1. [`OverflowComplex`](/pkg/reflect#Type.OverflowComplex)
+2. [`OverflowFloat`](/pkg/reflect#Type.OverflowFloat)
+3. [`OverflowInt`](/pkg/reflect#Type.OverflowInt)
+4. [`OverflowUint`](/pkg/reflect#Type.OverflowUint)

--- a/doc/next/6-stdlib/99-minor/reflect/60427.md
+++ b/doc/next/6-stdlib/99-minor/reflect/60427.md
@@ -1,0 +1,6 @@
+The new methods synonymous with the method of the same name in [`reflect.Value`](/reflect.Value)
+are added to [`reflect.Type`](/reflect.Type):
+1. [`OverflowComplex`](/reflect.Type#OverflowComplex)
+2. [`OverflowFloat`](/reflect.Type#OverflowFloat)
+3. [`OverflowInt`](/reflect.Type#OverflowInt)
+4. [`OverflowUint`](/reflect.Type#OverflowUint)

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -4827,7 +4827,7 @@ func TestComparable(t *testing.T) {
 	}
 }
 
-func TestOverflow(t *testing.T) {
+func TestValueOverflow(t *testing.T) {
 	if ovf := V(float64(0)).OverflowFloat(1e300); ovf {
 		t.Errorf("%v wrongly overflows float64", 1e300)
 	}
@@ -4862,6 +4862,45 @@ func TestOverflow(t *testing.T) {
 	}
 	ovfUint32 := uint64(1 << 32)
 	if ovf := V(uint32(0)).OverflowUint(ovfUint32); !ovf {
+		t.Errorf("%v should overflow uint32", ovfUint32)
+	}
+}
+
+func TestTypeOverflow(t *testing.T) {
+	if ovf := TypeFor[float64]().OverflowFloat(1e300); ovf {
+		t.Errorf("%v wrongly overflows float64", 1e300)
+	}
+
+	maxFloat32 := float64((1<<24 - 1) << (127 - 23))
+	if ovf := TypeFor[float32]().OverflowFloat(maxFloat32); ovf {
+		t.Errorf("%v wrongly overflows float32", maxFloat32)
+	}
+	ovfFloat32 := float64((1<<24-1)<<(127-23) + 1<<(127-52))
+	if ovf := TypeFor[float32]().OverflowFloat(ovfFloat32); !ovf {
+		t.Errorf("%v should overflow float32", ovfFloat32)
+	}
+	if ovf := TypeFor[float32]().OverflowFloat(-ovfFloat32); !ovf {
+		t.Errorf("%v should overflow float32", -ovfFloat32)
+	}
+
+	maxInt32 := int64(0x7fffffff)
+	if ovf := TypeFor[int32]().OverflowInt(maxInt32); ovf {
+		t.Errorf("%v wrongly overflows int32", maxInt32)
+	}
+	if ovf := TypeFor[int32]().OverflowInt(-1 << 31); ovf {
+		t.Errorf("%v wrongly overflows int32", -int64(1)<<31)
+	}
+	ovfInt32 := int64(1 << 31)
+	if ovf := TypeFor[int32]().OverflowInt(ovfInt32); !ovf {
+		t.Errorf("%v should overflow int32", ovfInt32)
+	}
+
+	maxUint32 := uint64(0xffffffff)
+	if ovf := TypeFor[uint32]().OverflowUint(maxUint32); ovf {
+		t.Errorf("%v wrongly overflows uint32", maxUint32)
+	}
+	ovfUint32 := uint64(1 << 32)
+	if ovf := TypeFor[uint32]().OverflowUint(ovfUint32); !ovf {
 		t.Errorf("%v should overflow uint32", ovfUint32)
 	}
 }

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -323,7 +323,7 @@ func (t *rtype) OverflowComplex(x complex128) bool {
 	case Complex128:
 		return false
 	}
-	panic("reflect: OverflowComplexof non-complex type " + t.String())
+	panic("reflect: OverflowComplex of non-complex type " + t.String())
 }
 
 // OverflowFloat reports whether the float64 x cannot be represented by type t.
@@ -336,7 +336,7 @@ func (t *rtype) OverflowFloat(x float64) bool {
 	case Float64:
 		return false
 	}
-	panic("reflect: OverflowFloat non-float type " + t.String())
+	panic("reflect: OverflowFloat of non-float type " + t.String())
 }
 
 // OverflowInt reports whether the int64 x cannot be represented by type t.
@@ -349,7 +349,7 @@ func (t *rtype) OverflowInt(x int64) bool {
 		trunc := (x << (64 - bitSize)) >> (64 - bitSize)
 		return x != trunc
 	}
-	panic("reflect: OverflowInt non-int type " + t.String())
+	panic("reflect: OverflowInt of non-int type " + t.String())
 }
 
 // OverflowUint reports whether the uint64 x cannot be represented by type t.
@@ -362,7 +362,7 @@ func (t *rtype) OverflowUint(x uint64) bool {
 		trunc := (x << (64 - bitSize)) >> (64 - bitSize)
 		return x != trunc
 	}
-	panic("reflect: OverflowUint non-uint type " + t.String())
+	panic("reflect: OverflowUint of non-uint type " + t.String())
 }
 
 func (t *rtype) common() *abi.Type {

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -358,7 +358,7 @@ func (t *rtype) OverflowUint(x uint64) bool {
 	k := t.Kind()
 	switch k {
 	case Uint, Uintptr, Uint8, Uint16, Uint32, Uint64:
-		bitSize := t.Size() * 8 // ok to use v.typ_ directly as Size doesn't escape
+		bitSize := t.Size() * 8
 		trunc := (x << (64 - bitSize)) >> (64 - bitSize)
 		return x != trunc
 	}

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -225,9 +225,6 @@ type Type interface {
 	// It panics if i is not in the range [0, NumOut()).
 	Out(i int) Type
 
-	common() *abi.Type
-	uncommon() *uncommonType
-
 	// OverflowComplex reports whether the complex128 x cannot be represented by type t.
 	// It panics if t's Kind is not Complex64 or Complex128.
 	OverflowComplex(x complex128) bool
@@ -243,6 +240,9 @@ type Type interface {
 	// OverflowUint reports whether the uint64 x cannot be represented by type t.
 	// It panics if t's Kind is not Uint, Uintptr, Uint8, Uint16, Uint32, or Uint64.
 	OverflowUint(x uint64) bool
+
+	common() *abi.Type
+	uncommon() *uncommonType
 }
 
 // BUG(rsc): FieldByName and related functions consider struct field names to be equal


### PR DESCRIPTION
This CL adds new methods synonymous with the method of the same name
in reflect.Value to reflect.Type: OverflowComplex, OverflowFloat, OverflowInt, OverflowUint.

Fixes #60427