### PR TITLE
internal/bisect: replace atomicPointerDedup to simplify the code

### DIFF
--- a/src/internal/bisect/bisect.go
+++ b/src/internal/bisect/bisect.go
@@ -180,7 +180,6 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
-	"unsafe"
 )
 
 // New creates and returns a new Matcher implementing the given pattern.
@@ -311,22 +310,7 @@ type Matcher struct {
 	quiet   bool   // disables all reporting.  reset if verbose is true. use case is -d=fmahash=qn
 	enable  bool   // when true, list is for “enable and report” (when false, “disable and report”)
 	list    []cond // conditions; later ones win over earlier ones
-	dedup   atomicPointerDedup
-}
-
-// atomicPointerDedup is an atomic.Pointer[dedup],
-// but we are avoiding using Go 1.19's atomic.Pointer
-// until the bootstrap toolchain can be relied upon to have it.
-type atomicPointerDedup struct {
-	p unsafe.Pointer
-}
-
-func (p *atomicPointerDedup) Load() *dedup {
-	return (*dedup)(atomic.LoadPointer(&p.p))
-}
-
-func (p *atomicPointerDedup) CompareAndSwap(old, new *dedup) bool {
-	return atomic.CompareAndSwapPointer(&p.p, unsafe.Pointer(old), unsafe.Pointer(new))
+	dedup   atomic.Pointer[dedup]
 }
 
 // A cond is a single condition in the matcher.


### PR DESCRIPTION
"atomicPointerDedup" is a redundancy of "atomic.Pointer".

Since Go 1.22 now requires the final point release of Go 1.20  or
later for bootstrap, Go 1.19's atomic.Pointer can be used
without problems.

atomicPointerDedup is unnecessary and we can remove it now.