### PR TITLE
net/mail: enhance address parser to include support for domain literals

### DIFF
--- a/src/net/mail/message_test.go
+++ b/src/net/mail/message_test.go
@@ -390,6 +390,10 @@ func TestAddressParsingError(t *testing.T) {
 		18: {" group: null@example.com; (asd", "misformatted parenthetical comment"},
 		19: {" group: ; (asd", "misformatted parenthetical comment"},
 		20: {`(John) Doe <jdoe@machine.example>`, "missing word in phrase:"},
+		21: {"<jdoe@[" + string([]byte{0xed, 0xa0, 0x80}) + "192.168.0.1]>", "invalid utf-8 in domain-literal"},
+		22: {"<jdoe@[[192.168.0.1]>", "bad character in domain-literal"},
+		23: {"<jdoe@[192.168.0.1>", "unclosed domain-literal"},
+		24: {"<jdoe@[256.0.0.1]>", "invalid IP address in domain-literal"},
 	}
 
 	for i, tc := range mustErrTestCases {
@@ -806,6 +810,20 @@ func TestAddressParsing(t *testing.T) {
 				},
 			},
 		},
+		// Domain-literal
+		{
+			`jdoe@[192.168.0.1]`,
+			[]*Address{{
+				Address: "jdoe@[192.168.0.1]",
+			}},
+		},
+		{
+			`John Doe <jdoe@[192.168.0.1]>`,
+			[]*Address{{
+				Name:    "John Doe",
+				Address: "jdoe@[192.168.0.1]",
+			}},
+		},
 	}
 	for _, test := range tests {
 		if len(test.exp) == 1 {
@@ -956,6 +974,20 @@ func TestAddressParser(t *testing.T) {
 				},
 			},
 		},
+		// Domain-literal
+		{
+			`jdoe@[192.168.0.1]`,
+			[]*Address{{
+				Address: "jdoe@[192.168.0.1]",
+			}},
+		},
+		{
+			`John Doe <jdoe@[192.168.0.1]>`,
+			[]*Address{{
+				Name:    "John Doe",
+				Address: "jdoe@[192.168.0.1]",
+			}},
+		},
 	}
 
 	ap := AddressParser{WordDecoder: &mime.WordDecoder{
@@ -1062,6 +1094,15 @@ func TestAddressString(t *testing.T) {
 			&Address{Name: string([]byte{0xed, 0xa0, 0x80}), Address: "invalid-utf8@example.net"},
 			"=?utf-8?q?=ED=A0=80?= <invalid-utf8@example.net>",
 		},
+		// Domain-literal
+		{
+			&Address{Address: "bob@[192.168.0.1]"},
+			"<bob@[192.168.0.1]>",
+		},
+		{
+			&Address{Name: "Bob", Address: "bob@[192.168.0.1]"},
+			`"Bob" <bob@[192.168.0.1]>`,
+		},
 	}
 	for _, test := range tests {
 		s := test.addr.String()
@@ -1115,6 +1156,7 @@ func TestAddressParsingAndFormatting(t *testing.T) {
 		`<"."@example.com>`,
 		`<".."@example.com>`,
 		`<"0:"@0>`,
+		`<Bob@[192.168.0.1]>`,
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The existing implementation of the mail package conforms to RFC 5322
for parsing mail messages, but it lacks support for domain literals. This
patch addresses this limitation by adding support for domain literals in
the address parser.

The Addr-Spec Specification, defined in RFC 5322 Section 3.4.1,
outlines the format for email addresses:
https://datatracker.ietf.org/doc/html/rfc5322\#section-3.4.1

Fixes #60206