### PR TITLE
doc/go1.23: document database/sql wrap errors

### DIFF
--- a/doc/next/6-stdlib/99-minor/database/sql/64707.md
+++ b/doc/next/6-stdlib/99-minor/database/sql/64707.md
@@ -1,0 +1,4 @@
+Errors returned by [`driver.Valuer`](/database/sql/driver#Driver)
+implementations are now wrapped for improved error handling during
+operations like [`Query`](/database/sql#DB.Query), [`Exec`](/database/sql#DB.Exec),
+and [`QueryRow`](/database/sql#DB.QueryRow).


### PR DESCRIPTION
For #64707.
For #65614.