### PR TITLE
cmd/compile/internal: replace direct calls to Sym.LinksymABI

### DIFF
--- a/src/cmd/compile/internal/ir/func.go
+++ b/src/cmd/compile/internal/ir/func.go
@@ -539,7 +539,7 @@ func FuncPC(pos src.XPos, n Node, wantABI obj.ABI) Node {
 		if abi != wantABI {
 			base.ErrorfAt(pos, 0, "internal/abi.FuncPC%s expects an %v function, %s is defined as %v", wantABI, wantABI, name.Sym().Name, abi)
 		}
-		var e Node = NewLinksymExpr(pos, name.Sym().LinksymABI(abi), types.Types[types.TUINTPTR])
+		var e Node = NewLinksymExpr(pos, name.LinksymABI(abi), types.Types[types.TUINTPTR])
 		e = NewAddrExpr(pos, e)
 		e.SetType(types.Types[types.TUINTPTR].PtrTo())
 		e = NewConvExpr(pos, OCONVNOP, types.Types[types.TUINTPTR], e)


### PR DESCRIPTION
Using (*Sym).LinksymABI(abi) directly is not recommended.

Replace with (*ir.Name).LinksymABI(abi).