### PR TITLE
html: handle single digit decimal numeric entities without semicolon

### DIFF
--- a/src/html/escape.go
+++ b/src/html/escape.go
@@ -104,7 +104,8 @@ func unescapeEntity(b []byte, dst, src int) (dst1, src1 int) {
 			break
 		}
 
-		if i <= 3 { // No characters matched.
+		// We need to have at least "&#." or "&#x.".
+		if (!hex && i < 3) || (hex && i < 4) {
 			b[dst] = b[src]
 			return dst + 1, src + 1
 		}

--- a/src/html/escape_test.go
+++ b/src/html/escape_test.go
@@ -49,11 +49,23 @@ var unescapeTests = []unescapeTest{
 		"Delta = &#916; ",
 		"Delta = Δ ",
 	},
+	// Handle single-digit decimal numeric entities.
+	{
+		"singleDigitDecimalEntity",
+		"Tab = &#9; = &#9 ",
+		"Tab = \t = \t ",
+	},
 	// Handle hexadecimal numeric entities.
 	{
 		"hexadecimalEntity",
 		"Lambda = &#x3bb; = &#X3Bb ",
 		"Lambda = λ = λ ",
+	},
+	// Handle single-digit hexadecimal numeric entities.
+	{
+		"singleDigitHexadecimalEntity",
+		"Tab = &#x9; = &#x9 ",
+		"Tab = \t = \t ",
 	},
 	// Handle numeric early termination.
 	{
@@ -109,6 +121,7 @@ func TestUnescapeEscape(t *testing.T) {
 		`&quot;&lt;&amp;&gt;&quot;`,
 		`3&5==1 && 0<1, "0&lt;1", a+acute=&aacute;`,
 		`The special characters are: <, >, &, ' and "`,
+		`&#9; &#9 &#x9; &#x9`,
 	}
 	for _, s := range ss {
 		if got := UnescapeString(EscapeString(s)); got != s {


### PR DESCRIPTION
Fix handling of "&#9" and add tests for other single-digit cases.

Fixes #66058
Updates #21563
