### PR TITLE
regexp: fix compiling alternate patterns of different fold case literals

### DIFF
--- a/src/regexp/find_test.go
+++ b/src/regexp/find_test.go
@@ -98,6 +98,8 @@ var findTests = []FindTest{
 	{`\B`, "x y", nil},
 	{`\B`, "xx yy", build(2, 1, 1, 4, 4)},
 	{`(|a)*`, "aa", build(3, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2)},
+	{`0A|0[aA]`, "0a", build(1, 0, 2)},
+	{`0[aA]|0A`, "0a", build(1, 0, 2)},
 
 	// RE2 tests
 	{`[^\S\s]`, "abcd", nil},

--- a/src/regexp/syntax/regexp.go
+++ b/src/regexp/syntax/regexp.go
@@ -76,7 +76,7 @@ func (x *Regexp) Equal(y *Regexp) bool {
 		}
 
 	case OpLiteral, OpCharClass:
-		return slices.Equal(x.Rune, y.Rune)
+		return x.Flags&FoldCase == y.Flags&FoldCase && slices.Equal(x.Rune, y.Rune)
 
 	case OpAlternate, OpConcat:
 		return slices.EqualFunc(x.Sub, y.Sub, (*Regexp).Equal)


### PR DESCRIPTION
Fixing Equal method in regexp/syntax package fixes compilation of
some alternate patterns like "0A|0[aA]".

Fixes #59007