### PR TITLE
crypto/tls: disable 3DES by default

### DIFF
--- a/src/crypto/tls/cipher_suites.go
+++ b/src/crypto/tls/cipher_suites.go
@@ -328,6 +328,10 @@ var disabledCipherSuites = map[uint16]bool{
 	TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256:   true,
 	TLS_RSA_WITH_AES_128_CBC_SHA256:         true,
 
+	// 3DES
+	TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA: true,
+	TLS_RSA_WITH_3DES_EDE_CBC_SHA:       true,
+
 	// RC4
 	TLS_ECDHE_ECDSA_WITH_RC4_128_SHA: true,
 	TLS_ECDHE_RSA_WITH_RC4_128_SHA:   true,

--- a/src/net/http/client_test.go
+++ b/src/net/http/client_test.go
@@ -946,7 +946,7 @@ func testResponseSetsTLSConnectionState(t *testing.T, mode testMode) {
 
 	c := ts.Client()
 	tr := c.Transport.(*Transport)
-	tr.TLSClientConfig.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA}
+	tr.TLSClientConfig.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA}//{tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA}
 	tr.TLSClientConfig.MaxVersion = tls.VersionTLS12 // to get to pick the cipher suite
 	tr.Dial = func(netw, addr string) (net.Conn, error) {
 		return net.Dial(netw, ts.Listener.Addr().String())
@@ -959,7 +959,7 @@ func testResponseSetsTLSConnectionState(t *testing.T, mode testMode) {
 	if res.TLS == nil {
 		t.Fatal("Response didn't set TLS Connection State.")
 	}
-	if got, want := res.TLS.CipherSuite, tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA; got != want {
+	if got, want := res.TLS.CipherSuite, tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA; got != want {
 		t.Errorf("TLS Cipher Suite = %d; want %d", got, want)
 	}
 }


### PR DESCRIPTION
Fixes #66214 should the proposal be accepted. This moves 3DES to optional and fixes a related test to use a more modern cipher to guarantee it's functional for some time to come.