### PR TITLE
runtime: always acquire M when acquiring locks by rank

### DIFF
--- a/src/runtime/lockrank_off.go
+++ b/src/runtime/lockrank_off.go
@@ -27,7 +27,8 @@ func lockWithRank(l *mutex, rank lockRank) {
 // This function may be called in nosplit context and thus must be nosplit.
 //
 //go:nosplit
-func acquireLockRank(rank lockRank) {
+func acquireLockRankAndM(rank lockRank) {
+	acquirem()
 }
 
 func unlockWithRank(l *mutex) {
@@ -37,7 +38,8 @@ func unlockWithRank(l *mutex) {
 // This function may be called in nosplit context and thus must be nosplit.
 //
 //go:nosplit
-func releaseLockRank(rank lockRank) {
+func releaseLockRankAndM(rank lockRank) {
+	releasem(getg().m)
 }
 
 func lockWithRankMayAcquire(l *mutex, rank lockRank) {

--- a/src/runtime/lockrank_on.go
+++ b/src/runtime/lockrank_on.go
@@ -104,12 +104,16 @@ func printHeldLocks(gp *g) {
 	}
 }
 
-// acquireLockRank acquires a rank which is not associated with a mutex lock
+// acquireLockRankAndM acquires a rank which is not associated with a mutex
+// lock. To maintain the invariant that an M with m.locks==0 does not hold any
+// lock-like resources, it also acquires the M.
 //
 // This function may be called in nosplit context and thus must be nosplit.
 //
 //go:nosplit
-func acquireLockRank(rank lockRank) {
+func acquireLockRankAndM(rank lockRank) {
+	acquirem()
+
 	gp := getg()
 	// Log the new class. See comment on lockWithRank.
 	systemstack(func() {
@@ -189,12 +193,14 @@ func unlockWithRank(l *mutex) {
 	})
 }
 
-// releaseLockRank releases a rank which is not associated with a mutex lock
+// releaseLockRankAndM releases a rank which is not associated with a mutex
+// lock. To maintain the invariant that an M with m.locks==0 does not hold any
+// lock-like resources, it also releases the M.
 //
 // This function may be called in nosplit context and thus must be nosplit.
 //
 //go:nosplit
-func releaseLockRank(rank lockRank) {
+func releaseLockRankAndM(rank lockRank) {
 	gp := getg()
 	systemstack(func() {
 		found := false
@@ -211,6 +217,8 @@ func releaseLockRank(rank lockRank) {
 			throw("lockRank release without matching lockRank acquire")
 		}
 	})
+
+	releasem(getg().m)
 }
 
 // nosplit because it may be called from nosplit contexts.

--- a/src/runtime/rwmutex.go
+++ b/src/runtime/rwmutex.go
@@ -72,9 +72,7 @@ func (rw *rwmutex) rlock() {
 	// things blocking on the lock may consume all of the Ps and
 	// deadlock (issue #20903). Alternatively, we could drop the P
 	// while sleeping.
-	acquirem()
-
-	acquireLockRank(rw.readRank)
+	acquireLockRankAndM(rw.readRank)
 	lockWithRankMayAcquire(&rw.rLock, getLockRank(&rw.rLock))
 
 	if rw.readerCount.Add(1) < 0 {
@@ -116,8 +114,7 @@ func (rw *rwmutex) runlock() {
 			unlock(&rw.rLock)
 		}
 	}
-	releaseLockRank(rw.readRank)
-	releasem(getg().m)
+	releaseLockRankAndM(rw.readRank)
 }
 
 // lock locks rw for writing.


### PR DESCRIPTION
Profiling of runtime-internal locks checks gp.m.locks to see if it's
safe to add a new record to the profile, but direct use of
acquireLockRank can change the list of the M's active lock ranks without
updating gp.m.locks to match. The runtime's internal rwmutex
implementation makes a point of calling acquirem/releasem when
manipulating the lock rank list, but the other user of acquireLockRank
(the GC's Gscan bit) relied on the GC's invariants to avoid deadlocks.

Codify the rwmutex approach by renaming acquireLockRank to
acquireLockRankAndM and having it include a call to aquirem. Do the same
for release.

Fixes #64706
Fixes #66004