### PR TITLE
database/sql: close rows in test

### DIFF
--- a/src/database/sql/sql_test.go
+++ b/src/database/sql/sql_test.go
@@ -267,6 +267,7 @@ func TestQuery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Query: %v", err)
 	}
+	defer rows.Close()
 	type row struct {
 		age  int
 		name string


### PR DESCRIPTION
This change invokes defer rows.Close() in TestQuery to properly close the rows.