### PR TITLE
text/template: simplify unwrapping reflect.Interface value

### DIFF
--- a/src/text/template/exec.go
+++ b/src/text/template/exec.go
@@ -479,7 +479,7 @@ func (s *state) evalPipeline(dot reflect.Value, pipe *parse.PipeNode) (value ref
 		value = s.evalCommand(dot, cmd, value) // previous value is this one's final arg.
 		// If the object has type interface{}, dig down one level to the thing inside.
 		if value.Kind() == reflect.Interface && value.Type().NumMethod() == 0 {
-			value = reflect.ValueOf(value.Interface()) // lovely!
+			value = value.Elem()
 		}
 	}
 	for _, variable := range pipe.Decl {


### PR DESCRIPTION
When text/template is evaluating a pipeline command and encounters an 
`interface{}`, it "digs down one level to the thing inside". Currently it
does this with `value = reflect.ValueOf(value.Interface())`, which is 
unnecessary since it could just use `value = value.Elem()`. This commit
changes it to use the latter.

Why it was written that way is mysterious because the proposed change 
appears to be strictly better, but given the blame date (13 years ago)
it may have been written while reflect was still in development before 
`Elem()` was added.