### PR TITLE
index/suffixarray: use built-in clear to simplify code

### DIFF
--- a/src/index/suffixarray/sais.go
+++ b/src/index/suffixarray/sais.go
@@ -219,9 +219,7 @@ func freq_8_32(text []byte, freq, bucket []int32) []int32 {
 	}
 
 	freq = freq[:256] // eliminate bounds check for freq[c] below
-	for i := range freq {
-		freq[i] = 0
-	}
+	clear(freq)
 	for _, c := range text {
 		freq[c]++
 	}
@@ -710,9 +708,7 @@ func recurse_32(sa, oldTmp []int32, numLMS, maxID int) {
 	// sais_32 requires that the caller arrange to clear dst,
 	// because in general the caller may know dst is
 	// freshly-allocated and already cleared. But this one is not.
-	for i := range dst {
-		dst[i] = 0
-	}
+	clear(dst)
 	sais_32(text, maxID, dst, tmp)
 }
 

--- a/src/index/suffixarray/sais2.go
+++ b/src/index/suffixarray/sais2.go
@@ -14,7 +14,7 @@ func text_64(text []byte, sa []int64) {
 }
 
 func sais_8_64(text []byte, textMax int, sa, tmp []int64) {
-	if len(sa) != len(text) || len(tmp) < int(textMax) {
+	if len(sa) != len(text) || len(tmp) < textMax {
 		panic("suffixarray: misuse of sais_8_64")
 	}
 
@@ -76,7 +76,7 @@ func sais_8_64(text []byte, textMax int, sa, tmp []int64) {
 }
 
 func sais_32(text []int32, textMax int, sa, tmp []int32) {
-	if len(sa) != len(text) || len(tmp) < int(textMax) {
+	if len(sa) != len(text) || len(tmp) < textMax {
 		panic("suffixarray: misuse of sais_32")
 	}
 
@@ -138,7 +138,7 @@ func sais_32(text []int32, textMax int, sa, tmp []int32) {
 }
 
 func sais_64(text []int64, textMax int, sa, tmp []int64) {
-	if len(sa) != len(text) || len(tmp) < int(textMax) {
+	if len(sa) != len(text) || len(tmp) < textMax {
 		panic("suffixarray: misuse of sais_64")
 	}
 
@@ -208,9 +208,7 @@ func freq_8_64(text []byte, freq, bucket []int64) []int64 {
 	}
 
 	freq = freq[:256] // eliminate bounds check for freq[c] below
-	for i := range freq {
-		freq[i] = 0
-	}
+	clear(freq)
 	for _, c := range text {
 		freq[c]++
 	}
@@ -225,9 +223,7 @@ func freq_32(text []int32, freq, bucket []int32) []int32 {
 		freq = bucket
 	}
 
-	for i := range freq {
-		freq[i] = 0
-	}
+	clear(freq)
 	for _, c := range text {
 		freq[c]++
 	}
@@ -242,9 +238,7 @@ func freq_64(text []int64, freq, bucket []int64) []int64 {
 		freq = bucket
 	}
 
-	for i := range freq {
-		freq[i] = 0
-	}
+	clear(freq)
 	for _, c := range text {
 		freq[c]++
 	}
@@ -1248,9 +1242,7 @@ func recurse_64(sa, oldTmp []int64, numLMS, maxID int) {
 	// sais_64 requires that the caller arrange to clear dst,
 	// because in general the caller may know dst is
 	// freshly-allocated and already cleared. But this one is not.
-	for i := range dst {
-		dst[i] = 0
-	}
+	clear(dst)
 	sais_64(text, maxID, dst, tmp)
 }
 


### PR DESCRIPTION
"sais2.go" is regenerated by the command "go generate ./...".