### PR TITLE
cmd/go/internal/modget: remove duplicate exit

### DIFF
--- a/src/cmd/go/internal/modget/get.go
+++ b/src/cmd/go/internal/modget/get.go
@@ -1673,7 +1673,6 @@ func (r *resolver) checkPackageProblems(ctx context.Context, pkgPatterns []strin
 			base.Error(err)
 		}
 	}
-	base.ExitIfErrors()
 }
 
 // reportChanges logs version changes to os.Stderr.


### PR DESCRIPTION
base.ExitIfErrors() has been deferred at the begin of the function,
no need to call it again.

