### PR TITLE
net/url: fix missing handling for opaque value in ResolveReference method

### DIFF
--- a/src/net/url/url.go
+++ b/src/net/url/url.go
@@ -1108,6 +1108,13 @@ func (u *URL) ResolveReference(ref *URL) *URL {
 			url.RawFragment = u.RawFragment
 		}
 	}
+	if ref.Path == "" && u.Opaque != "" {
+		url.Opaque = u.Opaque
+		url.User = nil
+		url.Host = ""
+		url.Path = ""
+		return &url
+	}
 	// The "abs_path" or "rel_path" cases.
 	url.Host = u.Host
 	url.User = u.User

--- a/src/net/url/url_test.go
+++ b/src/net/url/url_test.go
@@ -1248,6 +1248,14 @@ var resolveReferenceTests = []struct {
 
 	// Empty path and query but with ForceQuery (issue 46033).
 	{"https://a/b/c/d;p?q#s", "?", "https://a/b/c/d;p?"},
+
+	// Opaque URLs (issue 66084).
+	{"https://foo.com/bar?a=b", "http:opaque", "http:opaque"},
+	{"http:opaque?x=y#zzz", "https:/foo?a=b#frag", "https:/foo?a=b#frag"},
+	{"http:opaque?x=y#zzz", "https:foo:bar", "https:foo:bar"},
+	{"http:opaque?x=y#zzz", "https:bar/baz?a=b#frag", "https:bar/baz?a=b#frag"},
+	{"http:opaque?x=y#zzz", "https://user@host:1234?a=b#frag", "https://user@host:1234?a=b#frag"},
+	{"http:opaque?x=y#zzz", "?a=b#frag", "http:opaque?a=b#frag"},
 }
 
 func TestResolveReference(t *testing.T) {


### PR DESCRIPTION
The current implementation doesn't resolve as per spec RFC 3986 the case
where the base URL has an opaque value, and the reference doesn't have
either a scheme, authority or path. Currently, this specific case falls
back to the "abs_path" or "rel_path" cases, where the final path results
of the base_path being resolved relatively to the reference's, but since
the opaque value is stored independently, it needs a case of its own.

The algorith for resolving references is defined in RFC 3986 section 5.2.2:
https://www.rfc-editor.org/rfc/rfc3986.html#section-5.2.2

Fixes #66084