### PR TITLE
cmd/go: exit non-zero if version -m is used with a non-Go file

### DIFF
--- a/src/cmd/go/internal/version/version.go
+++ b/src/cmd/go/internal/version/version.go
@@ -135,7 +135,8 @@ func isGoBinaryCandidate(file string, info fs.FileInfo) bool {
 // If mustPrint is true, scanFile will report any error reading file.
 // Otherwise (mustPrint is false, because scanFile is being called
 // by scanDir) scanFile prints nothing for non-Go binaries.
-func scanFile(file string, info fs.FileInfo, mustPrint bool) (ok bool) {
+// scanFile reports whether the file is a Go binary.
+func scanFile(file string, info fs.FileInfo, mustPrint bool) bool {
 	if info.Mode()&fs.ModeSymlink != 0 {
 		// Accept file symlinks only.
 		i, err := os.Stat(file)

--- a/src/cmd/go/internal/version/version.go
+++ b/src/cmd/go/internal/version/version.go
@@ -93,7 +93,7 @@ func runVersion(ctx context.Context, cmd *base.Command, args []string) {
 			scanDir(arg)
 		} else {
 			ok := scanFile(arg, info, true)
-			if !ok {
+			if !ok && *versionM {
 				base.SetExitStatus(1)
 			}
 		}


### PR DESCRIPTION
Fixes #66426