### PR TITLE
net/http: disable 100 continue status after handler finished

### DIFF
--- a/src/net/http/transport_test.go
+++ b/src/net/http/transport_test.go
@@ -6918,16 +6918,28 @@ func testHandlerAbortRacesBodyRead(t *testing.T, mode testMode) {
 		panic(ErrAbortHandler)
 	})).ts
 
+	newRequest := func() *Request {
+		const reqLen = 6 * 1024 * 1024
+		req, _ := NewRequest("POST", ts.URL, &io.LimitedReader{R: neverEnding('x'), N: reqLen})
+		req.ContentLength = reqLen
+		return req
+	}
+
 	var wg sync.WaitGroup
 	for i := 0; i < 2; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 10; j++ {
-				const reqLen = 6 * 1024 * 1024
-				req, _ := NewRequest("POST", ts.URL, &io.LimitedReader{R: neverEnding('x'), N: reqLen})
-				req.ContentLength = reqLen
+				req := newRequest()
 				resp, _ := ts.Client().Transport.RoundTrip(req)
+				if resp != nil {
+					resp.Body.Close()
+				}
+
+				req = newRequest()
+				req.Header.Set("Expect", "100-continue")
+				resp, _ = ts.Client().Transport.RoundTrip(req)
 				if resp != nil {
 					resp.Body.Close()
 				}


### PR DESCRIPTION
When client supplies "Expect: 100-continue" header,
server wraps request body into expectContinueReader
that writes 100 Continue status on the first body read.

When handler acts as a reverse proxy and passes incoming
request (or body) to the client (or transport) it may happen
that request body is read after handler exists which may
cause nil pointer panic on connection write if server
already closed the connection.

This change disables write of 100 Continue status by expectContinueReader
after handler finished and before connection is closed.

It also fixes racy access to w.wroteContinue.

Fixes #53808
Updates #46866