### PR TITLE
cmd/api: increase test parallelism

### DIFF
--- a/src/cmd/api/api_test.go
+++ b/src/cmd/api/api_test.go
@@ -293,15 +293,23 @@ func TestIssue64958(t *testing.T) {
 	}()
 
 	testenv.MustHaveGoBuild(t)
+	t.Parallel()
+	var wg sync.WaitGroup
 
 	for _, context := range contexts {
-		w := NewWalker(context, "testdata/src/issue64958")
-		pkg, err := w.importFrom("p", "", 0)
-		if err != nil {
-			t.Errorf("expected no error importing; got %T", err)
-		}
-		w.export(pkg)
+		wg.Add(1)
+		context := context
+		go func() {
+			defer wg.Done()
+			w := NewWalker(context, "testdata/src/issue64958")
+			pkg, err := w.importFrom("p", "", 0)
+			if err != nil {
+				t.Errorf("expected no error importing; got %T", err)
+			}
+			w.export(pkg)
+		}()
 	}
+	wg.Wait()
 }
 
 func TestCheck(t *testing.T) {
@@ -309,5 +317,6 @@ func TestCheck(t *testing.T) {
 		t.Skip("-check not specified")
 	}
 	testenv.MustHaveGoBuild(t)
+	t.Parallel()
 	Check(t)
 }

--- a/src/cmd/api/main_test.go
+++ b/src/cmd/api/main_test.go
@@ -17,7 +17,6 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
-	"internal/singleflight"
 	"internal/testenv"
 	"io"
 	"log"
@@ -386,7 +385,6 @@ func (w *Walker) Features() (fs []string) {
 var parsedFileCache struct {
 	lock sync.RWMutex
 	m    map[string]*ast.File
-	wg   singleflight.Group
 }
 
 func init() {
@@ -411,6 +409,7 @@ func (w *Walker) parseFile(dir, file string) (*ast.File, error) {
 		parsedFileCache.m[filename] = f
 	}
 	parsedFileCache.lock.Unlock()
+
 	return f, nil
 }
 

--- a/src/cmd/api/main_test.go
+++ b/src/cmd/api/main_test.go
@@ -410,6 +410,10 @@ var (
 	pkgTags = map[string][]string{} // map import dir to list of relevant tags
 )
 
+func init() {
+	pkgCache.m = make(map[string]*apiPackage)
+}
+
 // tagKey returns the tag-based key to use in the pkgCache.
 // It is a comma-separated string; the first part is dir, the rest tags.
 // The satisfied tags are derived from context but only those that
@@ -631,8 +635,9 @@ func (w *Walker) importFrom(fromPath, fromDir string, mode types.ImportMode) (*a
 		if tags, ok := pkgTags[dir]; ok {
 			key = tagKey(dir, context, tags)
 			pkgCache.lock.Lock()
-			if pkg := pkgCache[key]; pkg != nil {
-				pkgCache.lock.Unlock()
+			pkg := pkgCache.m[key]
+			pkgCache.lock.Unlock()
+			if pkg != nil {
 				w.imported[name] = pkg
 				return pkg, nil
 			}
@@ -690,7 +695,7 @@ func (w *Walker) importFrom(fromPath, fromDir string, mode types.ImportMode) (*a
 
 	if usePkgCache {
 		pkgCache.lock.Lock()
-		pkgCache[key] = pkg
+		pkgCache.m[key] = pkg
 		pkgCache.lock.Unlock()
 	}
 

--- a/src/cmd/api/main_test.go
+++ b/src/cmd/api/main_test.go
@@ -450,11 +450,7 @@ type listImports struct {
 
 var listCache sync.Map // map[string]listImports, keyed by contextName
 
-// listSem is a semaphore restricting concurrent invocations of 'go list'. 'go
-// list' has its own internal concurrency, so we use a hard-coded constant (to
-// allow the I/O-intensive phases of 'go list' to overlap) instead of scaling
-// all the way up to GOMAXPROCS.
-var listSem = make(chan semToken, 2)
+var listSem = make(chan semToken, runtime.GOMAXPROCS(0))
 
 type semToken struct{}
 


### PR DESCRIPTION
In wsl2,
accessing the Windows file system from WSL is very slow,
and the final test execution can be longer than 10 minutes
if the degree of parallelism is low.
By adding parallelism to make io start faster,
the test time in wsl2 was reduced from 700+s to 280+s.

Fixes #65670