### PR TITLE
encoding/json: optimize tagOptions.Contains

### DIFF
--- a/src/encoding/json/tags.go
+++ b/src/encoding/json/tags.go
@@ -27,12 +27,12 @@ func (o tagOptions) Contains(optionName string) bool {
 		return false
 	}
 	s := string(o)
-	for s != "" {
-		var name string
-		name, s, _ = strings.Cut(s, ",")
-		if name == optionName {
+	for idx := strings.Index(s, ","); idx != -1; {
+		if optionName == s[:idx] {
 			return true
 		}
+		s = s[idx+1:]
+		idx = strings.Index(s, ",")
 	}
-	return false
+	return optionName == s
 }

--- a/src/encoding/json/tags_test.go
+++ b/src/encoding/json/tags_test.go
@@ -26,3 +26,10 @@ func TestTagParsing(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkTagOptionsContains(b *testing.B) {
+	_, opts := parseTag("field,foobar,foo")
+	for range b.N {
+		opts.Contains("foo")
+	}
+}


### PR DESCRIPTION
The new code is about 18% faster.

Here is the benchmark highlights:

goos: windows
goarch: amd64
pkg: encoding/json
cpu: Intel(R) Core(TM) i5-10200H CPU @ 2.40GHz
                     │  old.bench  │              new.bench              │
                     │   sec/op    │   sec/op     vs base                │
TagOptionsContains-8   17.07n ± 1%   13.87n ± 3%  -18.78% (p=0.000 n=10)