### PR TITLE
encoding/json: use slices to simplify the code

### DIFF
--- a/src/encoding/json/decode_test.go
+++ b/src/encoding/json/decode_test.go
@@ -14,6 +14,7 @@ import (
 	"math/big"
 	"net"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -1998,7 +1999,7 @@ func TestByteKind(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unmarshal error: %v", err)
 	}
-	if !reflect.DeepEqual(got, want) {
+	if !slices.Equal(got, want) {
 		t.Fatalf("Marshal/Unmarshal mismatch:\n\tgot:  %v\n\twant: %v", got, want)
 	}
 }
@@ -2017,7 +2018,7 @@ func TestSliceOfCustomByte(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unmarshal error: %v", err)
 	}
-	if !reflect.DeepEqual(got, want) {
+	if !slices.Equal(got, want) {
 		t.Fatalf("Marshal/Unmarshal mismatch:\n\tgot:  %v\n\twant: %v", got, want)
 	}
 }


### PR DESCRIPTION
Use "slices.Equal" instead of "reflect.DeepEqual".

Replace unnecessary helper type "byIndex" with "slices.SortFunc".

No effect on benchmarks.