### PR TITLE
expvar: add the missing deletion step for keys

### DIFF
--- a/src/expvar/expvar.go
+++ b/src/expvar/expvar.go
@@ -249,6 +249,7 @@ func (v *Map) Delete(key string) {
 	i, found := slices.BinarySearch(v.keys, key)
 	if found {
 		v.keys = slices.Delete(v.keys, i, i+1)
+		v.m.Delete(key)
 	}
 }
 

--- a/src/expvar/expvar_test.go
+++ b/src/expvar/expvar_test.go
@@ -199,6 +199,9 @@ func TestMapDelete(t *testing.T) {
 	}
 
 	colors.Delete("red")
+	if v := colors.Get("red"); v != nil {
+		t.Errorf("removed red, Get should return nil; got %v", v)
+	}
 	n = 0
 	colors.Do(func(KeyValue) { n++ })
 	if n != 1 {
@@ -214,6 +217,9 @@ func TestMapDelete(t *testing.T) {
 
 	colors.Delete("blue")
 	colors.Delete("blue")
+	if v := colors.Get("blue"); v != nil {
+		t.Errorf("removed blue, Get should return nil; got %v", v)
+	}
 	n = 0
 	colors.Do(func(KeyValue) { n++ })
 	if n != 0 {


### PR DESCRIPTION
In CL575777 I forgot to remove the key from the "sync.Map".
This did not cause the test to fail due to the lack of an associated
testcase. Now delete the key correctly and add the testcase.