### PR TITLE
time: update name of Windows IST timezone

### DIFF
--- a/src/time/zoneinfo_abbrs_windows.go
+++ b/src/time/zoneinfo_abbrs_windows.go
@@ -65,7 +65,7 @@ var abbrs = map[string]abbr{
 	"SE Asia Standard Time":           {"+07", "+07"},     // Asia/Bangkok
 	"Altai Standard Time":             {"+07", "+07"},     // Asia/Barnaul
 	"Middle East Standard Time":       {"EET", "EEST"},    // Asia/Beirut
-	"India Standard Time":             {"IST", "IST"},     // Asia/Calcutta
+	"India Standard Time":             {"IST", "IST"},     // Asia/Kolkata
 	"Transbaikal Standard Time":       {"+09", "+09"},     // Asia/Chita
 	"Sri Lanka Standard Time":         {"+0530", "+0530"}, // Asia/Colombo
 	"Syria Standard Time":             {"+03", "+03"},     // Asia/Damascus


### PR DESCRIPTION
Changes: Calcutta replaced with Kolkata (new)
See References for validations:
- https://www.google.com/search?q=india+kolkata+time+zone
- https://www.timeanddate.com/worldclock/india/kolkata
