### PR TITLE
cmd/compile: teach dse about equivalent LocalAddrs

### DIFF
--- a/src/cmd/compile/internal/ssa/deadstore.go
+++ b/src/cmd/compile/internal/ssa/deadstore.go
@@ -27,7 +27,6 @@ func dse(f *Func) {
 		// Find all the stores in this block. Categorize their uses:
 		//  loadUse contains stores which are used by a subsequent load.
 		//  storeUse contains stores which are used by a subsequent store.
-		//  localAddrs contains indexes into b.Values for each unique LocalAddr.
 		loadUse.clear()
 		storeUse.clear()
 		// TODO(deparker): use the 'clear' builtin once compiler bootstrap minimum version is raised to 1.21.


### PR DESCRIPTION
This patch teaches DSE that two LocalAddrs of the same variable 
are equal, even if they are from different memory states. This avoids 
dependance on a store into the same LocalAddr being added to 
loadUse even though the store is unnecessary and is in fact 
shadowed. 

Fixes #59021