### PR TITLE
os/file: return a fs.ReadFileFS instead of a fs.FS for os.DirFS

### DIFF
--- a/src/os/file.go
+++ b/src/os/file.go
@@ -680,7 +680,7 @@ func (f *File) SyscallConn() (syscall.RawConn, error) {
 //
 // The result implements [io/fs.StatFS], [io/fs.ReadFileFS] and
 // [io/fs.ReadDirFS].
-func DirFS(dir string) fs.ReadDirFile {
+func DirFS(dir string) fs.ReadFileFS {
 	return dirFS(dir)
 }
 

--- a/src/os/file.go
+++ b/src/os/file.go
@@ -680,7 +680,7 @@ func (f *File) SyscallConn() (syscall.RawConn, error) {
 //
 // The result implements [io/fs.StatFS], [io/fs.ReadFileFS] and
 // [io/fs.ReadDirFS].
-func DirFS(dir string) fs.ReadFileFS {
+func DirFS(dir string) fs.ReadDirFile {
 	return dirFS(dir)
 }
 

--- a/src/os/file.go
+++ b/src/os/file.go
@@ -680,7 +680,7 @@ func (f *File) SyscallConn() (syscall.RawConn, error) {
 //
 // The result implements [io/fs.StatFS], [io/fs.ReadFileFS] and
 // [io/fs.ReadDirFS].
-func DirFS(dir string) fs.FS {
+func DirFS(dir string) fs.ReadDirFS {
 	return dirFS(dir)
 }
 

--- a/src/os/file.go
+++ b/src/os/file.go
@@ -680,7 +680,7 @@ func (f *File) SyscallConn() (syscall.RawConn, error) {
 //
 // The result implements [io/fs.StatFS], [io/fs.ReadFileFS] and
 // [io/fs.ReadDirFS].
-func DirFS(dir string) fs.ReadDirFS {
+func DirFS(dir string) fs.ReadFileFS {
 	return dirFS(dir)
 }
 


### PR DESCRIPTION
`func DirFS(dir string) fs.FS` return a `fs.FS` but implements `ReadFile`. returning `fs.ReadFileFS` instead will allow `ReadFile` to be called on the returned instance.