### PR TITLE
io: fix typo inside copyBuffer

### DIFF
--- a/src/io/io.go
+++ b/src/io/io.go
@@ -411,8 +411,8 @@ func copyBuffer(dst Writer, src Reader, buf []byte) (written int64, err error) {
 		return wt.WriteTo(dst)
 	}
 	// Similarly, if the writer has a ReadFrom method, use it to do the copy.
-	if rt, ok := dst.(ReaderFrom); ok {
-		return rt.ReadFrom(src)
+	if rf, ok := dst.(ReaderFrom); ok {
+		return rf.ReadFrom(src)
 	}
 	if buf == nil {
 		size := 32 * 1024


### PR DESCRIPTION
The "rt" seems to be caused after copy-pasting the previous "wt" block
which make sense as WriterTo, but for ReaderFrom it makes more sense 
thinking of rf instead of rt.