### PR TITLE
compress/bzip2: optimize bit shifting in ReadBits64

### DIFF
--- a/src/compress/bzip2/bit_reader.go
+++ b/src/compress/bzip2/bit_reader.go
@@ -62,8 +62,8 @@ func (br *bitReader) ReadBits64(bits uint) (n uint64) {
 	//
 	// The next line right shifts the desired bits into the
 	// least-significant places and masks off anything above.
-	n = (br.n >> (br.bits - bits)) & ((1 << bits) - 1)
 	br.bits -= bits
+	n = (br.n >> br.bits) & ((1 << bits) - 1)
 	return
 }
 


### PR DESCRIPTION
Optimize the calculation of 'n' by adjusting the order of operations
in ReadBits64. This change ensures that bit shifting is performed after
updating 'br.bits', which aligns with the intended logic and may also
offer slight performance improvements.
