### PR TITLE
Refactor message

### DIFF
--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -8521,7 +8521,7 @@ func TestClear(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			if !tc.testFunc(tc.value) {
-				t.Errorf("unexpected result for value.Clear(): %value", tc.value)
+				t.Errorf("unexpected result for value.Clear(): %v value", tc.value)
 			}
 		})
 	}


### PR DESCRIPTION
"/reflect/all_test.go : refactor message."

This PR corrects a syntax error

`%value -> %v value`


