### PR TITLE
src/buildall.bash: use grep -E instead of egrep

### DIFF
--- a/src/buildall.bash
+++ b/src/buildall.bash
@@ -41,7 +41,7 @@ GOROOT="$(cd .. && pwd)"
 
 gettargets() {
 	../bin/go tool dist list | sed -e 's|/|-|' |
-		egrep -v '^(android|ios)' # need C toolchain even for cross-compiling
+		grep -E -v '^(android|ios)' # need C toolchain even for cross-compiling
 	echo linux-arm-arm5
 }
 


### PR DESCRIPTION
according to https://www.phoronix.com/news/GNU-Grep-3.8-Stop-egrep-fgrep egrep and fgrep should not be used anymore. thats why using buildall.bash throws the following warning: egrep: warning: egrep is obsolescent; using grep -E