### PR TITLE
runtime/atomic: fix TestAnd64 and TestOr64 on 32-bit architectures

### DIFF
--- a/src/internal/runtime/atomic/atomic_andor_test.go
+++ b/src/internal/runtime/atomic/atomic_andor_test.go
@@ -54,6 +54,7 @@ func TestAnd32(t *testing.T) {
 func TestAnd64(t *testing.T) {
 	// Basic sanity check.
 	x := uint64(0xffffffffffffffff)
+	sink = &x
 	for i := uint64(0); i < 64; i++ {
 		old := x
 		v := atomic.And64(&x, ^(1 << i))
@@ -131,6 +132,7 @@ func TestOr32(t *testing.T) {
 func TestOr64(t *testing.T) {
 	// Basic sanity check.
 	x := uint64(0)
+	sink = &x
 	for i := uint64(0); i < 64; i++ {
 		old := x
 		v := atomic.Or64(&x, 1<<i)


### PR DESCRIPTION
On 386, arm and mips the And64, Or64 and Cas64 require 64-bit aligned pointer and at the same time have the go:noescape directive.

This change ensures that in TestAnd64 and TestOr64 the x escapes to the heap so the functions listed above are always happy with &x as their first argument.

