### PR TITLE
os/exec: on Windows look for extensions in Run if not already done

### DIFF
--- a/src/os/exec/exec.go
+++ b/src/os/exec/exec.go
@@ -440,7 +440,7 @@ func Command(name string, arg ...string) *Cmd {
 		// cmd.Dir may be set after we return from this function and that may cause
 		// the command to resolve to a different extension.
 		lp, err := lookExtensions(name, "")
-		cmd.cacheLookExtensions = lp
+		cmd.cachedLookExtensions = lp
 		if err != nil {
 			cmd.Err = err
 		}
@@ -642,10 +642,10 @@ func (c *Cmd) Start() error {
 		return c.Err
 	}
 	lp := c.Path
-	if c.cacheLookExtensions != "" {
-		lp = c.cacheLookExtensions
+	if c.cachedLookExtensions != "" {
+		lp = c.cachedLookExtensions
 	}
-	if runtime.GOOS == "windows" && c.cacheLookExtensions == "" {
+	if runtime.GOOS == "windows" && c.cachedLookExtensions == "" {
 		// If c.Path is relative, we had to wait until now
 		// to resolve it in case c.Dir was changed.
 		// (If it is absolute, we already resolved its extension in Command

--- a/src/os/exec/exec.go
+++ b/src/os/exec/exec.go
@@ -644,7 +644,7 @@ func (c *Cmd) Start() error {
 	}
 	lp := c.Path
 	if runtime.GOOS == "windows" {
-		if lp == "" {
+		if c.cacheLookExtensions == "" {
 			// If c.Path is relative, we had to wait until now
 			// to resolve it in case c.Dir was changed.
 			// (If it is absolute, we already resolved its extension in Command
@@ -665,7 +665,7 @@ func (c *Cmd) Start() error {
 			if err != nil {
 				return err
 			}
-		} else if c.cacheLookExtensions != "" {
+		} else {
 			lp = c.cacheLookExtensions
 		}
 	}

--- a/src/os/exec/exec.go
+++ b/src/os/exec/exec.go
@@ -334,7 +334,7 @@ type Cmd struct {
 	lookPathErr error
 
 	// cacheLookExtensions cache the result of calling lookExtensions,
-	// use it only on windows.
+	// set it only on windows.
 	cacheLookExtensions string
 }
 

--- a/src/os/exec/exec.go
+++ b/src/os/exec/exec.go
@@ -333,9 +333,9 @@ type Cmd struct {
 	// and https://go.dev/issue/43724 for more context.
 	lookPathErr error
 
-	// calledLookExtensions indicates whether
-	// lookExtensions has been called in Cmd.Command.
-	calledLookExtensions bool
+	// cacheLookExtensions cache the result of calling lookExtensions,
+	// use it only on windows.
+	cacheLookExtensions string
 }
 
 // A ctxResult reports the result of watching the Context associated with a
@@ -440,11 +440,8 @@ func Command(name string, arg ...string) *Cmd {
 		// Note that we cannot add an extension here for relative paths, because
 		// cmd.Dir may be set after we return from this function and that may cause
 		// the command to resolve to a different extension.
-		cmd.calledLookExtensions = true
 		lp, err := lookExtensions(name, "")
-		if lp != "" {
-			cmd.Path = lp
-		}
+		cmd.cacheLookExtensions = lp
 		if err != nil {
 			cmd.Err = err
 		}
@@ -646,7 +643,10 @@ func (c *Cmd) Start() error {
 		return c.Err
 	}
 	lp := c.Path
-	if runtime.GOOS == "windows" && !c.calledLookExtensions {
+	if c.cacheLookExtensions == "" {
+		lp = c.cacheLookExtensions
+	}
+	if runtime.GOOS == "windows" && c.cacheLookExtensions == "" {
 		// If c.Path is relative, we had to wait until now
 		// to resolve it in case c.Dir was changed.
 		// (If it is absolute, we already resolved its extension in Command

--- a/src/os/exec/exec.go
+++ b/src/os/exec/exec.go
@@ -333,9 +333,9 @@ type Cmd struct {
 	// and https://go.dev/issue/43724 for more context.
 	lookPathErr error
 
-	// cacheLookExtensions cache the result of calling lookExtensions,
-	// set it only on windows.
-	cacheLookExtensions string
+	// cachedLookExtensions caches the result of calling lookExtensions.
+	// This is only used on Windows.
+	cachedLookExtensions string
 }
 
 // A ctxResult reports the result of watching the Context associated with a
@@ -434,8 +434,7 @@ func Command(name string, arg ...string) *Cmd {
 		// We may need to add a filename extension from PATHEXT
 		// or verify an extension that is already present.
 		// Since the path is absolute, its extension should be unambiguous
-		// and independent of cmd.Dir, and we can go ahead and update cmd.Path to
-		// reflect it.
+		// and independent of cmd.Dir, and we can go ahead and cache the lookup now.
 		//
 		// Note that we cannot add an extension here for relative paths, because
 		// cmd.Dir may be set after we return from this function and that may cause

--- a/src/os/exec/exec.go
+++ b/src/os/exec/exec.go
@@ -332,6 +332,10 @@ type Cmd struct {
 	// See https://go.dev/blog/path-security
 	// and https://go.dev/issue/43724 for more context.
 	lookPathErr error
+
+	// cacheLookExtensions cache the result of calling lookExtensions,
+	// use it only on windows.
+	cacheLookExtensions string
 }
 
 // A ctxResult reports the result of watching the Context associated with a
@@ -437,9 +441,7 @@ func Command(name string, arg ...string) *Cmd {
 		// cmd.Dir may be set after we return from this function and that may cause
 		// the command to resolve to a different extension.
 		lp, err := lookExtensions(name, "")
-		if lp != "" {
-			cmd.Path = lp
-		}
+		cmd.cacheLookExtensions = lp
 		if err != nil {
 			cmd.Err = err
 		}
@@ -640,8 +642,8 @@ func (c *Cmd) Start() error {
 		}
 		return c.Err
 	}
-	lp := c.Path
-	if runtime.GOOS == "windows" && !filepath.IsAbs(c.Path) {
+	lp := c.cacheLookExtensions
+	if lp == "" && runtime.GOOS == "windows" {
 		// If c.Path is relative, we had to wait until now
 		// to resolve it in case c.Dir was changed.
 		// (If it is absolute, we already resolved its extension in Command

--- a/src/os/exec/exec.go
+++ b/src/os/exec/exec.go
@@ -643,7 +643,7 @@ func (c *Cmd) Start() error {
 		return c.Err
 	}
 	lp := c.Path
-	if c.cacheLookExtensions == "" {
+	if c.cacheLookExtensions != "" {
 		lp = c.cacheLookExtensions
 	}
 	if runtime.GOOS == "windows" && c.cacheLookExtensions == "" {

--- a/src/os/exec/exec.go
+++ b/src/os/exec/exec.go
@@ -333,9 +333,9 @@ type Cmd struct {
 	// and https://go.dev/issue/43724 for more context.
 	lookPathErr error
 
-	// callLookExtensions indicate whether
+	// calledLookExtensions indicates whether
 	// lookExtensions has been called in Cmd.Command.
-	callLookExtensions bool
+	calledLookExtensions bool
 }
 
 // A ctxResult reports the result of watching the Context associated with a
@@ -440,7 +440,7 @@ func Command(name string, arg ...string) *Cmd {
 		// Note that we cannot add an extension here for relative paths, because
 		// cmd.Dir may be set after we return from this function and that may cause
 		// the command to resolve to a different extension.
-		cmd.callLookExtensions = true
+		cmd.calledLookExtensions = true
 		lp, err := lookExtensions(name, "")
 		if lp != "" {
 			cmd.Path = lp
@@ -646,7 +646,7 @@ func (c *Cmd) Start() error {
 		return c.Err
 	}
 	lp := c.Path
-	if runtime.GOOS == "windows" && !c.callLookExtensions {
+	if runtime.GOOS == "windows" && !c.calledLookExtensions {
 		// If c.Path is relative, we had to wait until now
 		// to resolve it in case c.Dir was changed.
 		// (If it is absolute, we already resolved its extension in Command

--- a/src/os/exec/exec.go
+++ b/src/os/exec/exec.go
@@ -665,7 +665,7 @@ func (c *Cmd) Start() error {
 			if err != nil {
 				return err
 			}
-		} else {
+		} else if c.cacheLookExtensions != "" {
 			lp = c.cacheLookExtensions
 		}
 	}

--- a/src/os/exec/exec_windows_test.go
+++ b/src/os/exec/exec_windows_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -105,5 +106,18 @@ func TestChildCriticalEnv(t *testing.T) {
 	}
 	if strings.TrimSpace(string(out)) == "" {
 		t.Error("no SYSTEMROOT found")
+	}
+}
+
+func TestIssue66586(t *testing.T) {
+	testenv.MustHaveGoBuild(t)
+	path := filepath.Join(testenv.GOROOT(t), "bin", "go")
+	cmd := exec.Command(path, "version")
+	err := cmd.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != cmd.Path {
+		t.Fatalf("unexpected path: %s", cmd.Path)
 	}
 }

--- a/src/os/exec/exec_windows_test.go
+++ b/src/os/exec/exec_windows_test.go
@@ -112,7 +112,7 @@ func TestChildCriticalEnv(t *testing.T) {
 func TestIssue66586(t *testing.T) {
 	testenv.MustHaveGoBuild(t)
 	path := filepath.Join(testenv.GOROOT(t), "bin", "go")
-	cmd := exec.Command(path, "version")
+	cmd := exec.Cmd{Path: path, Args: []string{path, "version"}}
 	err := cmd.Run()
 	if err != nil {
 		t.Fatal(err)

--- a/src/os/exec/exec_windows_test.go
+++ b/src/os/exec/exec_windows_test.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -106,18 +105,5 @@ func TestChildCriticalEnv(t *testing.T) {
 	}
 	if strings.TrimSpace(string(out)) == "" {
 		t.Error("no SYSTEMROOT found")
-	}
-}
-
-func TestIssue66586(t *testing.T) {
-	testenv.MustHaveGoBuild(t)
-	path := filepath.Join(testenv.GOROOT(t), "bin", "go")
-	cmd := exec.Cmd{Path: path, Args: []string{path, "version"}}
-	err := cmd.Run()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if path != cmd.Path {
-		t.Fatalf("unexpected path: %s", cmd.Path)
 	}
 }


### PR DESCRIPTION
[CL 512155](https://go.dev/cl/512155) fixed #36768, but introduced #62596.
[CL 527820](https://go.dev/cl/527820) fixed #62596, but meant that the code failed to look up
file extensions on Windows for a relative path.
This CL fixes that problem by recording whether it has already
looked up file extensions.
This does mean that if Path is set manually then we do not update
it with file extensions, as doing that would be racy.

Fixes #66586
