### PR TITLE
crypto/rsa: fix RSA mod overlow timing channel

### DIFF
--- a/src/crypto/ecdsa/ecdsa.go
+++ b/src/crypto/ecdsa/ecdsa.go
@@ -304,7 +304,7 @@ func signNISTEC[Point nistPoint[Point]](c *nistCurve[Point], priv *PrivateKey, c
 	if err != nil {
 		return nil, err
 	}
-	r, err := bigmod.NewNat().SetOverflowingBytes(Rx, c.N)
+	r, _, err := bigmod.NewNat().SetOverflowingBytes(Rx, c.N)
 	if err != nil {
 		return nil, err
 	}
@@ -400,7 +400,7 @@ func hashToNat[Point nistPoint[Point]](c *nistCurve[Point], e *bigmod.Nat, hash 
 			}
 		}
 	}
-	_, err := e.SetOverflowingBytes(hash, c.N)
+	_, _, err := e.SetOverflowingBytes(hash, c.N)
 	if err != nil {
 		panic("ecdsa: internal error: truncated hash is too long")
 	}
@@ -536,7 +536,7 @@ func verifyNISTEC[Point nistPoint[Point]](c *nistCurve[Point], pub *PublicKey, h
 		return false
 	}
 
-	v, err := bigmod.NewNat().SetOverflowingBytes(Rx, c.N)
+	v, _, err := bigmod.NewNat().SetOverflowingBytes(Rx, c.N)
 	if err != nil {
 		return false
 	}

--- a/src/crypto/rsa/pkcs1v15.go
+++ b/src/crypto/rsa/pkcs1v15.go
@@ -352,6 +352,9 @@ func VerifyPKCS1v15(pub *PublicKey, hash crypto.Hash, hashed []byte, sig []byte)
 	}
 
 	em, encErr := encrypt(pub, sig)
+	// Only checking if em == nil to avoid timing attacks, encErr
+	// will be checked at the very end of the function.
+	// Please see https://golang.org/issue/67043
 	if em == nil {
 		return ErrVerification
 	}

--- a/src/crypto/rsa/pkcs1v15.go
+++ b/src/crypto/rsa/pkcs1v15.go
@@ -351,8 +351,8 @@ func VerifyPKCS1v15(pub *PublicKey, hash crypto.Hash, hashed []byte, sig []byte)
 		return ErrVerification
 	}
 
-	em, err := encrypt(pub, sig)
-	if err != nil {
+	em, encErr := encrypt(pub, sig)
+	if em == nil {
 		return ErrVerification
 	}
 	// EM = 0x00 || 0x01 || PS || 0x00 || T
@@ -367,7 +367,7 @@ func VerifyPKCS1v15(pub *PublicKey, hash crypto.Hash, hashed []byte, sig []byte)
 		ok &= subtle.ConstantTimeByteEq(em[i], 0xff)
 	}
 
-	if ok != 1 {
+	if ok != 1 || encErr != nil {
 		return ErrVerification
 	}
 

--- a/src/crypto/rsa/pss.go
+++ b/src/crypto/rsa/pss.go
@@ -362,6 +362,9 @@ func VerifyPSS(pub *PublicKey, hash crypto.Hash, digest []byte, sig []byte, opts
 	emBits := pub.N.BitLen() - 1
 	emLen := (emBits + 7) / 8
 	em, encErr := encrypt(pub, sig)
+	// Only checking if em == nil to avoid timing attacks, encErr
+	// will be checked at the very end of the function.
+	// Please see https://golang.org/issue/67043
 	if em == nil {
 		return ErrVerification
 	}

--- a/src/crypto/rsa/pss.go
+++ b/src/crypto/rsa/pss.go
@@ -368,6 +368,7 @@ func VerifyPSS(pub *PublicKey, hash crypto.Hash, digest []byte, sig []byte, opts
 	if em == nil {
 		return ErrVerification
 	}
+
 	// Like in signPSSWithSalt, deal with mismatches between emLen and the size
 	// of the modulus. The spec would have us wire emLen into the encoding
 	// function, but we'd rather always encode to the size of the modulus and

--- a/src/crypto/rsa/pss.go
+++ b/src/crypto/rsa/pss.go
@@ -361,11 +361,10 @@ func VerifyPSS(pub *PublicKey, hash crypto.Hash, digest []byte, sig []byte, opts
 
 	emBits := pub.N.BitLen() - 1
 	emLen := (emBits + 7) / 8
-	em, err := encrypt(pub, sig)
-	if err != nil {
+	em, encErr := encrypt(pub, sig)
+	if em == nil {
 		return ErrVerification
 	}
-
 	// Like in signPSSWithSalt, deal with mismatches between emLen and the size
 	// of the modulus. The spec would have us wire emLen into the encoding
 	// function, but we'd rather always encode to the size of the modulus and
@@ -378,5 +377,9 @@ func VerifyPSS(pub *PublicKey, hash crypto.Hash, digest []byte, sig []byte, opts
 		em = em[1:]
 	}
 
-	return emsaPSSVerify(digest, em, emBits, opts.saltLength(), hash.New())
+	err := emsaPSSVerify(digest, em, emBits, opts.saltLength(), hash.New())
+	if err != nil || encErr != nil {
+		return ErrVerification
+	}
+	return nil
 }

--- a/src/crypto/rsa/rsa.go
+++ b/src/crypto/rsa/rsa.go
@@ -486,13 +486,11 @@ func encrypt(pub *PublicKey, plaintext []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	m, err := bigmod.NewNat().SetBytes(plaintext, N)
-	if err != nil {
-		return nil, err
-	}
+	m := bigmod.NewNat()
+	_, encErr := m.SetOverflowingBytes(plaintext, N)
 	e := uint(pub.E)
 
-	return bigmod.NewNat().ExpShortVarTime(m, e, N).Bytes(N), nil
+	return bigmod.NewNat().ExpShortVarTime(m, e, N).Bytes(N), encErr
 }
 
 // EncryptOAEP encrypts the given message with RSA-OAEP.


### PR DESCRIPTION
This PR fixes the timing channel in RSA VerifyPKCS1v15 and VerifyPSS.
by not failing early if the RSA signature is larger, 
i.e., if it overflows, the modulus N set by the public key.

Fixes #67043