### PR TITLE
strings,bytes: improve Repeat panic messages

### DIFF
--- a/src/bytes/bytes.go
+++ b/src/bytes/bytes.go
@@ -583,7 +583,7 @@ func Repeat(b []byte, count int) []byte {
 	if count < 0 {
 		panic("bytes: negative Repeat count")
 	}
-	if len(b) >= maxInt/count {
+	if len(b) > maxInt/count {
 		panic("bytes: Repeat output length overflow")
 	}
 	n := len(b) * count

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -1242,21 +1242,18 @@ func repeat(b []byte, count int) (err error) {
 
 // See Issue golang.org/issue/16237
 func TestRepeatCatchesOverflow(t *testing.T) {
-	const maxInt = int(^uint(0) >> 1)
 	tests := [...]struct {
-		s        string
-		count    int
-		errStr   string
-		contains bool
+		s      string
+		count  int
+		errStr string
 	}{
-		0: {"--", -2147483647, "negative", true},
-		1: {"", int(^uint(0) >> 1), "", true},
-		2: {"-", 10, "", true},
-		3: {"gopher", 0, "", true},
-		4: {"-", -1, "negative", true},
-		5: {"--", -102, "negative", true},
-		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow", true},
-		7: {"-", maxInt, "overflow", false},
+		0: {"--", -2147483647, "negative"},
+		1: {"", int(^uint(0) >> 1), ""},
+		2: {"-", 10, ""},
+		3: {"gopher", 0, ""},
+		4: {"-", -1, "negative"},
+		5: {"--", -102, "negative"},
+		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
 	}
 
 	for i, tt := range tests {
@@ -1268,12 +1265,8 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 			continue
 		}
 
-		if err == nil || tt.contains != strings.Contains(err.Error(), tt.errStr) {
-			if tt.contains {
-				t.Errorf("#%d expected %q got %q", i, tt.errStr, err)
-			} else {
-				t.Errorf("#%d unexpected %q got %q", i, tt.errStr, err)
-			}
+		if err == nil || !strings.Contains(err.Error(), tt.errStr) {
+			t.Errorf("#%d expected %q got %q", i, tt.errStr, err)
 		}
 	}
 }

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -1259,7 +1259,7 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 			}
 
 			if err == nil || !strings.Contains(err.Error(), tt.errStr) {
-				t.Errorf("%s#%d expected %q got %q", prefix, i, tt.errStr, err)
+				t.Errorf("%s#%d got %q want %q", prefix, i, err, tt.errStr)
 			}
 		}
 	}

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -1242,6 +1242,7 @@ func repeat(b []byte, count int) (err error) {
 
 // See Issue golang.org/issue/16237
 func TestRepeatCatchesOverflow(t *testing.T) {
+	const maxInt = int(^uint(0) >> 1)
 	tests := [...]struct {
 		s      string
 		count  int

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -1242,18 +1242,21 @@ func repeat(b []byte, count int) (err error) {
 
 // See Issue golang.org/issue/16237
 func TestRepeatCatchesOverflow(t *testing.T) {
+	const maxInt = int(^uint(0) >> 1)
 	tests := [...]struct {
-		s      string
-		count  int
-		errStr string
+		s        string
+		count    int
+		errStr   string
+		contains bool
 	}{
-		0: {"--", -2147483647, "negative"},
-		1: {"", int(^uint(0) >> 1), ""},
-		2: {"-", 10, ""},
-		3: {"gopher", 0, ""},
-		4: {"-", -1, "negative"},
-		5: {"--", -102, "negative"},
-		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
+		0: {"--", -2147483647, "negative", true},
+		1: {"", int(^uint(0) >> 1), "", true},
+		2: {"-", 10, "", true},
+		3: {"gopher", 0, "", true},
+		4: {"-", -1, "negative", true},
+		5: {"--", -102, "negative", true},
+		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow", true},
+		7: {"-", maxInt, "overflow", false},
 	}
 
 	for i, tt := range tests {
@@ -1265,8 +1268,12 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 			continue
 		}
 
-		if err == nil || !strings.Contains(err.Error(), tt.errStr) {
-			t.Errorf("#%d expected %q got %q", i, tt.errStr, err)
+		if err == nil || tt.contains != strings.Contains(err.Error(), tt.errStr) {
+			if tt.contains {
+				t.Errorf("#%d expected %q got %q", i, tt.errStr, err)
+			} else {
+				t.Errorf("#%d unexpected %q got %q", i, tt.errStr, err)
+			}
 		}
 	}
 }

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -1242,7 +1242,6 @@ func repeat(b []byte, count int) (err error) {
 
 // See Issue golang.org/issue/16237
 func TestRepeatCatchesOverflow(t *testing.T) {
-	const maxInt = int(^uint(0) >> 1)
 	tests := [...]struct {
 		s      string
 		count  int
@@ -1255,7 +1254,6 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 		4: {"-", -1, "negative"},
 		5: {"--", -102, "negative"},
 		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
-		7: {"-", maxInt, " out of "}, // "out of range" or "out of memory", depending on OS
 	}
 
 	for i, tt := range tests {

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -1242,6 +1242,7 @@ func repeat(b []byte, count int) (err error) {
 
 // See Issue golang.org/issue/16237
 func TestRepeatCatchesOverflow(t *testing.T) {
+	const maxInt = int(^uint(0) >> 1)
 	tests := [...]struct {
 		s      string
 		count  int
@@ -1254,9 +1255,20 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 		4: {"-", -1, "negative"},
 		5: {"--", -102, "negative"},
 		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
+		7: {}, // Note: the following cases are only for 64-bit systems.
+		8: {"-", maxInt, "out of range"},
 	}
 
+	const _64bit = 1 << (^uintptr(0) >> 63) / 2
+
 	for i, tt := range tests {
+		if tt.s == "" {
+			if _64bit == 0 {
+				break
+			}
+			continue
+		}
+
 		err := repeat([]byte(tt.s), tt.count)
 		if tt.errStr == "" {
 			if err != nil {

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -1242,49 +1242,48 @@ func repeat(b []byte, count int) (err error) {
 
 // See Issue golang.org/issue/16237
 func TestRepeatCatchesOverflow(t *testing.T) {
-	const maxInt = int(^uint(0) >> 1)
-	tests := [...]struct {
+	type testCase = struct {
 		s      string
 		count  int
 		errStr string
-		_32bit bool // for 32-bit systems
-		_64bit bool // for 64-bit systems
-	}{
-		0: {"--", -2147483647, "negative", true, true},
-		1: {"", maxInt, "", true, true},
-		2: {"-", 10, "", true, true},
-		3: {"gopher", 0, "", true, true},
-		4: {"-", -1, "negative", true, true},
-		5: {"--", -102, "negative", true, true},
-		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow", true, true},
-		7: {"-", maxInt, "out of range", false, true},
 	}
+
+	runTestCases := func(prefix string, tests []testCase) {
+		for i, tt := range tests {
+			err := repeat([]byte(tt.s), tt.count)
+			if tt.errStr == "" {
+				if err != nil {
+					t.Errorf("#%d panicked %v", i, err)
+				}
+				continue
+			}
+
+			if err == nil || !strings.Contains(err.Error(), tt.errStr) {
+				t.Errorf("%s#%d expected %q got %q", prefix, i, tt.errStr, err)
+			}
+		}
+	}
+
+	const maxInt = int(^uint(0) >> 1)
+
+	runTestCases("", []testCase{
+		0: {"--", -2147483647, "negative"},
+		1: {"", maxInt, ""},
+		2: {"-", 10, ""},
+		3: {"gopher", 0, ""},
+		4: {"-", -1, "negative"},
+		5: {"--", -102, "negative"},
+		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
+	})
 
 	const _64bit = 1<<(^uintptr(0)>>63)/2 != 0
-
-	for i, tt := range tests {
-		if _64bit {
-			if !tt._64bit {
-				continue
-			}
-		} else {
-			if !tt._32bit {
-				continue
-			}
-		}
-
-		err := repeat([]byte(tt.s), tt.count)
-		if tt.errStr == "" {
-			if err != nil {
-				t.Errorf("#%d panicked %v", i, err)
-			}
-			continue
-		}
-
-		if err == nil || !strings.Contains(err.Error(), tt.errStr) {
-			t.Errorf("#%d expected %q got %q", i, tt.errStr, err)
-		}
+	if !_64bit {
+		return
 	}
+
+	runTestCases("64-bit", []testCase{
+		0: {"-", maxInt, "out of range"},
+	})
 }
 
 func runesEqual(a, b []rune) bool {

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -1255,7 +1255,7 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 		4: {"-", -1, "negative"},
 		5: {"--", -102, "negative"},
 		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
-		7: {"-", maxInt, "out of"},
+		7: {"-", maxInt, " out of "}, // "out of range" or "out of memory", depending on OS
 	}
 
 	for i, tt := range tests {

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -1276,8 +1276,8 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
 	})
 
-	const _64bit = 1<<(^uintptr(0)>>63)/2 != 0
-	if !_64bit {
+	const is64Bit = 1<<(^uintptr(0)>>63)/2 != 0
+	if !is64Bit {
 		return
 	}
 

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -1254,6 +1254,7 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 		4: {"-", -1, "negative"},
 		5: {"--", -102, "negative"},
 		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
+		7: {"-", maxInt, "out of range"},
 	}
 
 	for i, tt := range tests {

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -1255,7 +1255,7 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 		4: {"-", -1, "negative"},
 		5: {"--", -102, "negative"},
 		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
-		7: {"-", maxInt, "out of range"},
+		7: {"-", maxInt, "out of"},
 	}
 
 	for i, tt := range tests {

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -1242,7 +1242,7 @@ func repeat(b []byte, count int) (err error) {
 
 // See Issue golang.org/issue/16237
 func TestRepeatCatchesOverflow(t *testing.T) {
-	type testCase = struct {
+	type testCase struct {
 		s      string
 		count  int
 		errStr string

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -1247,26 +1247,30 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 		s      string
 		count  int
 		errStr string
+		_32bit bool // for 32-bit systems
+		_64bit bool // for 64-bit systems
 	}{
-		0: {"--", -2147483647, "negative"},
-		1: {"", int(^uint(0) >> 1), ""},
-		2: {"-", 10, ""},
-		3: {"gopher", 0, ""},
-		4: {"-", -1, "negative"},
-		5: {"--", -102, "negative"},
-		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
-		7: {}, // Note: the following cases are only for 64-bit systems.
-		8: {"-", maxInt, "out of range"},
+		0: {"--", -2147483647, "negative", true, true},
+		1: {"", maxInt, "", true, true},
+		2: {"-", 10, "", true, true},
+		3: {"gopher", 0, "", true, true},
+		4: {"-", -1, "negative", true, true},
+		5: {"--", -102, "negative", true, true},
+		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow", true, true},
+		7: {"-", maxInt, "out of range", false, true},
 	}
 
-	const _64bit = 1 << (^uintptr(0) >> 63) / 2
+	const _64bit = 1<<(^uintptr(0)>>63)/2 != 0
 
 	for i, tt := range tests {
-		if tt.s == "" {
-			if _64bit == 0 {
-				break
+		if _64bit {
+			if !tt._64bit {
+				continue
 			}
-			continue
+		} else {
+			if !tt._32bit {
+				continue
+			}
 		}
 
 		err := repeat([]byte(tt.s), tt.count)

--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -569,7 +569,7 @@ func Repeat(s string, count int) string {
 	if count < 0 {
 		panic("strings: negative Repeat count")
 	}
-	if len(s) >= maxInt/count {
+	if len(s) > maxInt/count {
 		panic("strings: Repeat output length overflow")
 	}
 	n := len(s) * count

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -1170,7 +1170,8 @@ func repeat(s string, count int) (err error) {
 
 // See Issue golang.org/issue/16237
 func TestRepeatCatchesOverflow(t *testing.T) {
-	tests := [...]struct {
+	const maxInt = int(^uint(0) >> 1)
+	tests := []struct {
 		s      string
 		count  int
 		errStr string
@@ -1182,6 +1183,12 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 		4: {"-", -1, "negative"},
 		5: {"--", -102, "negative"},
 		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
+		7: {"-", maxInt, "out of range"},
+	}
+
+	const _64bit = 1 << (^uintptr(0) >> 63) / 2
+	if _64bit == 0 {
+		tests = tests[:7]
 	}
 
 	for i, tt := range tests {

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -1183,7 +1183,7 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 		4: {"-", -1, "negative"},
 		5: {"--", -102, "negative"},
 		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
-		7: {"-", maxInt, "out of range"},
+		7: {"-", maxInt, "out of"},
 	}
 
 	for i, tt := range tests {

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -1170,7 +1170,7 @@ func repeat(s string, count int) (err error) {
 
 // See Issue golang.org/issue/16237
 func TestRepeatCatchesOverflow(t *testing.T) {
-	type testCase = struct {
+	type testCase struct {
 		s      string
 		count  int
 		errStr string

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -1204,8 +1204,8 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
 	})
 
-	const _64bit = 1<<(^uintptr(0)>>63)/2 != 0
-	if !_64bit {
+	const is64Bit = 1<<(^uintptr(0)>>63)/2 != 0
+	if !is64Bit {
 		return
 	}
 

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -1187,7 +1187,7 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 			}
 
 			if err == nil || !Contains(err.Error(), tt.errStr) {
-				t.Errorf("%s#%d expected %q got %q", prefix, i, tt.errStr, err)
+				t.Errorf("%s#%d got %q want %q", prefix, i, err, tt.errStr)
 			}
 		}
 	}

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -1170,6 +1170,7 @@ func repeat(s string, count int) (err error) {
 
 // See Issue golang.org/issue/16237
 func TestRepeatCatchesOverflow(t *testing.T) {
+	const maxInt = int(^uint(0) >> 1)
 	tests := [...]struct {
 		s      string
 		count  int

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -1183,7 +1183,7 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 		4: {"-", -1, "negative"},
 		5: {"--", -102, "negative"},
 		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
-		7: {"-", maxInt, "out of"},
+		7: {"-", maxInt, " out of "}, // "out of range" or "out of memory", depending on OS
 	}
 
 	for i, tt := range tests {

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -1182,6 +1182,7 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 		4: {"-", -1, "negative"},
 		5: {"--", -102, "negative"},
 		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
+		7: {"-", maxInt, "out of range"},
 	}
 
 	for i, tt := range tests {

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -1170,7 +1170,6 @@ func repeat(s string, count int) (err error) {
 
 // See Issue golang.org/issue/16237
 func TestRepeatCatchesOverflow(t *testing.T) {
-	const maxInt = int(^uint(0) >> 1)
 	tests := [...]struct {
 		s      string
 		count  int
@@ -1183,7 +1182,6 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 		4: {"-", -1, "negative"},
 		5: {"--", -102, "negative"},
 		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
-		7: {"-", maxInt, " out of "}, // "out of range" or "out of memory", depending on OS
 	}
 
 	for i, tt := range tests {

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -1175,26 +1175,30 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 		s      string
 		count  int
 		errStr string
+		_32bit bool // for 32-bit systems
+		_64bit bool // for 64-bit systems
 	}{
-		0: {"--", -2147483647, "negative"},
-		1: {"", int(^uint(0) >> 1), ""},
-		2: {"-", 10, ""},
-		3: {"gopher", 0, ""},
-		4: {"-", -1, "negative"},
-		5: {"--", -102, "negative"},
-		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
-		7: {}, // Note: the following cases are only for 64-bit systems.
-		8: {"-", maxInt, "out of range"},
+		0: {"--", -2147483647, "negative", true, true},
+		1: {"", maxInt, "", true, true},
+		2: {"-", 10, "", true, true},
+		3: {"gopher", 0, "", true, true},
+		4: {"-", -1, "negative", true, true},
+		5: {"--", -102, "negative", true, true},
+		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow", true, true},
+		7: {"-", maxInt, "out of range", false, true},
 	}
 
-	const _64bit = 1 << (^uintptr(0) >> 63) / 2
+	const _64bit = 1<<(^uintptr(0)>>63)/2 != 0
 
 	for i, tt := range tests {
-		if tt.s == "" {
-			if _64bit == 0 {
-				break
+		if _64bit {
+			if !tt._64bit {
+				continue
 			}
-			continue
+		} else {
+			if !tt._32bit {
+				continue
+			}
 		}
 
 		err := repeat(tt.s, tt.count)

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -1171,7 +1171,7 @@ func repeat(s string, count int) (err error) {
 // See Issue golang.org/issue/16237
 func TestRepeatCatchesOverflow(t *testing.T) {
 	const maxInt = int(^uint(0) >> 1)
-	tests := []struct {
+	tests := [...]struct {
 		s      string
 		count  int
 		errStr string
@@ -1183,17 +1183,20 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 		4: {"-", -1, "negative"},
 		5: {"--", -102, "negative"},
 		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
-
-		// Note: the following cases are only for 64-bit systems.
-		7: {"-", maxInt, "out of range"},
+		7: {}, // Note: the following cases are only for 64-bit systems.
+		8: {"-", maxInt, "out of range"},
 	}
 
 	const _64bit = 1 << (^uintptr(0) >> 63) / 2
-	if _64bit == 0 {
-		tests = tests[:7]
-	}
 
 	for i, tt := range tests {
+		if tt.s == "" {
+			if _64bit == 0 {
+				break
+			}
+			continue
+		}
+
 		err := repeat(tt.s, tt.count)
 		if tt.errStr == "" {
 			if err != nil {

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -1183,6 +1183,8 @@ func TestRepeatCatchesOverflow(t *testing.T) {
 		4: {"-", -1, "negative"},
 		5: {"--", -102, "negative"},
 		6: {string(make([]byte, 255)), int((^uint(0))/255 + 1), "overflow"},
+
+		// Note: the following cases are only for 64-bit systems.
 		7: {"-", maxInt, "out of range"},
 	}
 


### PR DESCRIPTION
The Repeat("-", maxInt) call should produce 

   panic: runtime error: makeslice: len out of range

instead of

   panic: strings: Repeat output length overflow

This PR is only for theory perfection.