### PR TITLE
cmd/go: report trimpath erasing ldflags, and allow override

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -234,6 +234,9 @@
 //		Instead of absolute file system paths, the recorded file names
 //		will begin either a module path@version (when using modules),
 //		or a plain import path (when using the standard library, or GOPATH).
+//	-trimldflags
+//		Only meaningful with -trimpath. Controls reporting of ldflags in binary
+//		module information. May affect reproducible builds.
 //	-toolexec 'cmd args'
 //		a program to use to invoke toolchain programs like vet and asm.
 //		For example, instead of running asm, the go command will run

--- a/src/cmd/go/internal/cfg/cfg.go
+++ b/src/cmd/go/internal/cfg/cfg.go
@@ -86,6 +86,7 @@ var (
 	BuildToolexec      []string                // -toolexec flag
 	BuildToolchainName string
 	BuildTrimpath      bool // -trimpath flag
+	BuildTrimldflags   bool // -trimldflags flag
 	BuildV             bool // -v flag
 	BuildWork          bool // -work flag
 	BuildX             bool // -x flag

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -2395,7 +2395,14 @@ func (p *Package) setBuildInfo(ctx context.Context, autoVCS bool) {
 		// determine whether they may refer to system paths. If we do that, we can
 		// redact only those paths from the recorded -ldflags setting and still
 		// record the system-independent parts of the flags.
-		if !cfg.BuildTrimpath {
+		//
+		// For now add a toggle to always allow ldflags reporting, it may make
+		// non-reproducible builds, but it will stop hiding valuable version
+		// information as used by security vulnerability scanners. Although maybe
+		// vcs.describe or vcs.modhash should be added instead.
+		if cfg.BuildTrimpath && cfg.BuildTrimldflags {
+			appendSetting("-trimldflags", "true")
+		} else {
 			appendSetting("-ldflags", ldflags)
 		}
 	}

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -192,6 +192,9 @@ and test commands:
 		Instead of absolute file system paths, the recorded file names
 		will begin either a module path@version (when using modules),
 		or a plain import path (when using the standard library, or GOPATH).
+	-trimldflags
+		Only meaningful with -trimpath. Controls reporting of ldflags in binary
+		module information. May affect reproducible builds.
 	-toolexec 'cmd args'
 		a program to use to invoke toolchain programs like vet and asm.
 		For example, instead of running asm, the go command will run
@@ -338,6 +341,7 @@ func AddBuildFlags(cmd *base.Command, mask BuildFlagMask) {
 	cmd.Flag.Var((*tagsFlag)(&cfg.BuildContext.BuildTags), "tags", "")
 	cmd.Flag.Var((*base.StringsFlag)(&cfg.BuildToolexec), "toolexec", "")
 	cmd.Flag.BoolVar(&cfg.BuildTrimpath, "trimpath", false, "")
+	cmd.Flag.BoolVar(&cfg.BuildTrimldflags, "trimldflags", true, "")
 	cmd.Flag.BoolVar(&cfg.BuildWork, "work", false, "")
 	cmd.Flag.Var((*buildvcsFlag)(&cfg.BuildBuildvcs), "buildvcs", "")
 

--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -283,6 +283,9 @@ func (b *Builder) buildActionID(a *Action) cache.ActionID {
 	fmt.Fprintf(h, "omitdebug %v standard %v local %v prefix %q\n", p.Internal.OmitDebug, p.Standard, p.Internal.Local, p.Internal.LocalPrefix)
 	if cfg.BuildTrimpath {
 		fmt.Fprintln(h, "trimpath")
+		if cfg.BuildTrimldflags {
+			fmt.Fprintln(h, "trimldflags")
+		}
 	}
 	if p.Internal.ForceLibrary {
 		fmt.Fprintf(h, "forcelibrary\n")
@@ -1368,6 +1371,9 @@ func (b *Builder) linkActionID(a *Action) cache.ActionID {
 	fmt.Fprintf(h, "omitdebug %v standard %v local %v prefix %q\n", p.Internal.OmitDebug, p.Standard, p.Internal.Local, p.Internal.LocalPrefix)
 	if cfg.BuildTrimpath {
 		fmt.Fprintln(h, "trimpath")
+		if cfg.BuildTrimldflags {
+			fmt.Fprintln(h, "trimldflags")
+		}
 	}
 
 	// Toolchain-dependent configuration, shared with b.linkSharedActionID.

--- a/src/cmd/go/testdata/counters.txt
+++ b/src/cmd/go/testdata/counters.txt
@@ -77,6 +77,7 @@ go/flag:build-pkgdir
 go/flag:build-race
 go/flag:build-tags
 go/flag:build-toolexec
+go/flag:build-trimldflags
 go/flag:build-trimpath
 go/flag:build-v
 go/flag:build-work
@@ -116,6 +117,7 @@ go/flag:clean-race
 go/flag:clean-tags
 go/flag:clean-testcache
 go/flag:clean-toolexec
+go/flag:clean-trimldflags
 go/flag:clean-trimpath
 go/flag:clean-v
 go/flag:clean-work
@@ -160,6 +162,7 @@ go/flag:fix-pkgdir
 go/flag:fix-race
 go/flag:fix-tags
 go/flag:fix-toolexec
+go/flag:fix-trimldflags
 go/flag:fix-trimpath
 go/flag:fix-v
 go/flag:fix-work
@@ -204,6 +207,7 @@ go/flag:generate-run
 go/flag:generate-skip
 go/flag:generate-tags
 go/flag:generate-toolexec
+go/flag:generate-trimldflags
 go/flag:generate-trimpath
 go/flag:generate-v
 go/flag:generate-work
@@ -242,6 +246,7 @@ go/flag:get-race
 go/flag:get-t
 go/flag:get-tags
 go/flag:get-toolexec
+go/flag:get-trimldflags
 go/flag:get-trimpath
 go/flag:get-u
 go/flag:get-v
@@ -279,6 +284,7 @@ go/flag:install-pkgdir
 go/flag:install-race
 go/flag:install-tags
 go/flag:install-toolexec
+go/flag:install-trimldflags
 go/flag:install-trimpath
 go/flag:install-v
 go/flag:install-work
@@ -326,6 +332,7 @@ go/flag:list-reuse
 go/flag:list-tags
 go/flag:list-test
 go/flag:list-toolexec
+go/flag:list-trimldflags
 go/flag:list-trimpath
 go/flag:list-u
 go/flag:list-v
@@ -499,6 +506,7 @@ go/flag:run-pkgdir
 go/flag:run-race
 go/flag:run-tags
 go/flag:run-toolexec
+go/flag:run-trimldflags
 go/flag:run-trimpath
 go/flag:run-v
 go/flag:run-work
@@ -594,6 +602,7 @@ go/flag:test-test.v
 go/flag:test-timeout
 go/flag:test-toolexec
 go/flag:test-trace
+go/flag:test-trimldflags
 go/flag:test-trimpath
 go/flag:test-v
 go/flag:test-vet
@@ -658,6 +667,7 @@ go/flag:vet-pkgdir
 go/flag:vet-race
 go/flag:vet-tags
 go/flag:vet-toolexec
+go/flag:vet-trimldflags
 go/flag:vet-trimpath
 go/flag:vet-v
 go/flag:vet-vettool


### PR DESCRIPTION
Add a new boolean option -trimldflags. Only meaningful when -trimpath
is true. Defaults to true for backwards compatibility. Otheriwise when
set to false reports ldflags in buildinfo, in spite of -trimpath
setting. Also when ldflags are trimmed from the output, leave a
reproducible marker that it happened.

Building with '-trimpath -ldflags="-X main.Version=234"' will now emit:
	build	-trimldflags=true

Adding -trimldflags=false to the above will emit ldflags:
	build	-ldflags="-X main.Version=234"

Fixes: #63432