### PR TITLE
net/url: make the URL not escape to the heap when parsing

### DIFF
--- a/src/net/url/url_test.go
+++ b/src/net/url/url_test.go
@@ -2209,3 +2209,12 @@ func TestJoinPath(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkParse(b *testing.B) {
+	for range b.N {
+		_, err := Parse("https://test.go.dev/test/url/path?query=1&param2=test#section")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
         │  beforeurl  │              afterurl               │
         │   sec/op    │   sec/op     vs base                │
Parse-12   324.9n ± 1%   253.0n ± 0%  -22.15% (p=0.000 n=20)

         │ beforeurl  │             afterurl              │
         │    B/op    │   B/op    vs base                 │
Parse-12   144.0 ± 0%   0.0 ± 0%  -100.00% (p=0.000 n=20)

         │ beforeurl  │              afterurl               │
         │ allocs/op  │ allocs/op   vs base                 │
Parse-12   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=20)