### PR TITLE
encoding/json: optimize tag parsing by introducing cutTag helper function

### DIFF
--- a/src/encoding/json/tags.go
+++ b/src/encoding/json/tags.go
@@ -15,8 +15,15 @@ type tagOptions string
 // parseTag splits a struct field's json tag into its name and
 // comma-separated options.
 func parseTag(tag string) (string, tagOptions) {
-	tag, opt, _ := strings.Cut(tag, ",")
+	tag, opt := cutTag(tag)
 	return tag, tagOptions(opt)
+}
+
+func cutTag(tag string) (string, string) {
+	if i := strings.IndexByte(tag, ','); i >= 0 {
+		return tag[:i], tag[i+1:]
+	}
+	return tag, ""
 }
 
 // Contains reports whether a comma-separated list of options
@@ -29,7 +36,7 @@ func (o tagOptions) Contains(optionName string) bool {
 	s := string(o)
 	for s != "" {
 		var name string
-		name, s, _ = strings.Cut(s, ",")
+		name, s = cutTag(s)
 		if name == optionName {
 			return true
 		}


### PR DESCRIPTION
Refactor tag parsing in json encoding to use a new helper function, cutTag,
improving readability and potentially enhancing performance.

goos: darwin
goarch: arm64
pkg: encoding/json
cpu: Apple M2 Max
                      │   old.txt   │               new.txt               │
                      │   sec/op    │   sec/op     vs base                │
CodeEncoder-12          330.4µ ± 5%   342.0µ ± 6%        ~ (p=0.393 n=10)
CodeEncoderError-12     403.9µ ± 8%   342.5µ ± 5%  -15.21% (p=0.000 n=10)
CodeMarshal-12          429.6µ ± 6%   407.3µ ± 7%   -5.17% (p=0.043 n=10)
CodeMarshalError-12     486.5µ ± 5%   481.5µ ± 5%        ~ (p=0.105 n=10)
CodeDecoder-12          1.806m ± 6%   1.783m ± 6%        ~ (p=0.247 n=10)
CodeUnmarshal-12        2.308m ± 1%   2.269m ± 8%        ~ (p=0.315 n=10)
CodeUnmarshalReuse-12   1.805m ± 5%   1.791m ± 6%        ~ (p=0.739 n=10)
geomean                 800.0µ        774.0µ        -3.25%

                      │   old.txt    │               new.txt                │
                      │     B/s      │     B/s       vs base                │
CodeEncoder-12          5.470Gi ± 5%   5.284Gi ± 6%        ~ (p=0.393 n=10)
CodeEncoderError-12     4.475Gi ± 7%   5.277Gi ± 4%  +17.93% (p=0.000 n=10)
CodeMarshal-12          4.207Gi ± 6%   4.437Gi ± 8%   +5.47% (p=0.043 n=10)
CodeMarshalError-12     3.715Gi ± 5%   3.753Gi ± 5%        ~ (p=0.105 n=10)
CodeDecoder-12          1.001Gi ± 5%   1.014Gi ± 5%        ~ (p=0.247 n=10)
CodeUnmarshal-12        801.8Mi ± 1%   815.6Mi ± 8%        ~ (p=0.315 n=10)
CodeUnmarshalReuse-12   1.001Gi ± 5%   1.009Gi ± 5%        ~ (p=0.739 n=10)
geomean                 2.259Gi        2.335Gi        +3.36%

                      │   old.txt    │               new.txt                │
                      │     B/op     │     B/op      vs base                │
CodeEncoder-12            1.000 ±  ?     2.000 ±  ?        ~ (p=0.534 n=10)
CodeEncoderError-12       138.0 ± 1%     137.0 ± 1%        ~ (p=0.440 n=10)
CodeMarshal-12          1.855Mi ± 1%   1.856Mi ± 1%        ~ (p=0.853 n=10)
CodeMarshalError-12     1.889Mi ± 1%   1.893Mi ± 1%        ~ (p=0.631 n=10)
CodeDecoder-12          822.1Ki ± 1%   823.8Ki ± 1%        ~ (p=0.739 n=10)
CodeUnmarshal-12        1.917Mi ± 0%   1.918Mi ± 0%        ~ (p=0.064 n=10)
CodeUnmarshalReuse-12   711.9Ki ± 0%   712.5Ki ± 0%        ~ (p=0.085 n=10)
geomean                 47.63Ki        52.57Ki       +10.38%

                      │    old.txt    │               new.txt                │
                      │   allocs/op   │  allocs/op   vs base                 │
CodeEncoder-12           0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=10) ¹
CodeEncoderError-12      4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=10) ¹
CodeMarshal-12           1.000 ± 0%      1.000 ± 0%       ~ (p=1.000 n=10) ¹
CodeMarshalError-12      6.000 ± 0%      6.000 ± 0%       ~ (p=1.000 n=10) ¹
CodeDecoder-12          25.20k ± 0%     25.20k ± 0%       ~ (p=0.699 n=10)
CodeUnmarshal-12        39.99k ± 0%     39.99k ± 0%       ~ (p=1.000 n=10) ¹
CodeUnmarshalReuse-12   25.21k ± 0%     25.22k ± 0%       ~ (p=0.093 n=10)
geomean                             ²                +0.01%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean