### PR TITLE
bytes, strings: optimize Cut for single-byte separators

### DIFF
--- a/src/bytes/bytes.go
+++ b/src/bytes/bytes.go
@@ -1330,6 +1330,12 @@ func Index(s, sep []byte) int {
 //
 // Cut returns slices of the original slice s, not copies.
 func Cut(s, sep []byte) (before, after []byte, found bool) {
+	if len(sep) == 1 {
+		if i := IndexByte(s, sep[0]); i >= 0 {
+			return s[:i], s[i+1:], true
+		}
+		return s, nil, false
+	}
 	if i := Index(s, sep); i >= 0 {
 		return s[:i], s[i+len(sep):], true
 	}

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -2263,3 +2263,31 @@ func TestClone(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkCut(b *testing.B) {
+	b.ReportAllocs()
+
+	for _, skip := range [...]int{2, 4, 8, 16, 32, 64} {
+		s := Repeat(append(append(Repeat([]byte(" "), skip), 'a', 'a'), Repeat([]byte(" "), skip)...), 1<<16/skip)
+		b.Run(fmt.Sprintf("Cut-One/%d", skip), func(b *testing.B) {
+			for range b.N {
+				_, _, _ = Cut(s, []byte{'a'})
+			}
+		})
+		b.Run(fmt.Sprintf("Cut-Two/%d", skip), func(b *testing.B) {
+			for range b.N {
+				_, _, _ = Cut(s, []byte{'a', 'a'})
+			}
+		})
+		b.Run(fmt.Sprintf("Cut-One-Nil/%d", skip), func(b *testing.B) {
+			for range b.N {
+				_, _, _ = Cut(s, []byte{'c'})
+			}
+		})
+		b.Run(fmt.Sprintf("Cut-Two-Nil/%d", skip), func(b *testing.B) {
+			for range b.N {
+				_, _, _ = Cut(s, []byte{'c', 'c'})
+			}
+		})
+	}
+}

--- a/src/internal/stringslite/strings.go
+++ b/src/internal/stringslite/strings.go
@@ -103,6 +103,12 @@ func Index(s, substr string) int {
 }
 
 func Cut(s, sep string) (before, after string, found bool) {
+	if len(sep) == 1 {
+		if i := IndexByte(s, sep[0]); i >= 0 {
+			return s[:i], s[i+1:], true
+		}
+		return s, "", false
+	}
 	if i := Index(s, sep); i >= 0 {
 		return s[:i], s[i+len(sep):], true
 	}

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -2071,3 +2071,31 @@ func BenchmarkReplaceAll(b *testing.B) {
 		stringSink = ReplaceAll("banana", "a", "<>")
 	}
 }
+
+func BenchmarkCut(b *testing.B) {
+	b.ReportAllocs()
+
+	for _, skip := range [...]int{2, 4, 8, 16, 32, 64} {
+		s := Repeat(Repeat(" ", skip)+"aa"+Repeat(" ", skip), 1<<16/skip)
+		b.Run(fmt.Sprintf("Cut-One/%d", skip), func(b *testing.B) {
+			for range b.N {
+				_, _, _ = Cut(s, "a")
+			}
+		})
+		b.Run(fmt.Sprintf("Cut-Two/%d", skip), func(b *testing.B) {
+			for range b.N {
+				_, _, _ = Cut(s, "aa")
+			}
+		})
+		b.Run(fmt.Sprintf("Cut-One-Nil/%d", skip), func(b *testing.B) {
+			for range b.N {
+				_, _, _ = Cut(s, "c")
+			}
+		})
+		b.Run(fmt.Sprintf("Cut-Two-Nil/%d", skip), func(b *testing.B) {
+			for range b.N {
+				_, _, _ = Cut(s, "cc")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Optimize the Cut function in both the bytes and strings packages
to immediately return slices when the separator is a single byte (or
character), avoiding more complex index searching logic. This change
can significantly reduce the execution time for these specific cases,
as benchmark tests added to each package demonstrate improvements.

The optimization checks if the length of the separator is one before
proceeding with the existing search strategy. If so, it uses IndexByte
for a faster lookup of the separator's position.

Additionally, benchmark tests have been added for both packages to
demonstrate the performance benefits of this optimization across
various scenarios.

goos: darwin
goarch: arm64
pkg: strings
cpu: Apple M2 Max
                      │ old-cut.txt │             new-cut.txt             │
                      │   sec/op    │   sec/op     vs base                │
Cut/Cut-One/2-12        4.107n ± 2%   3.431n ± 2%  -16.44% (p=0.000 n=10)
Cut/Cut-Two/2-12        8.123n ± 2%   8.460n ± 1%   +4.15% (p=0.000 n=10)
Cut/Cut-One-Nil/2-12    2.720µ ± 1%   2.751µ ± 0%   +1.14% (p=0.000 n=10)
Cut/Cut-Two-Nil/2-12    2.724µ ± 0%   2.771µ ± 0%   +1.69% (p=0.000 n=10)
Cut/Cut-One/4-12        4.091n ± 1%   3.487n ± 2%  -14.76% (p=0.000 n=10)
Cut/Cut-Two/4-12        8.211n ± 0%   8.593n ± 1%   +4.64% (p=0.000 n=10)
Cut/Cut-One-Nil/4-12    2.289µ ± 1%   2.340µ ± 1%   +2.23% (p=0.000 n=10)
Cut/Cut-Two-Nil/4-12    2.306µ ± 0%   2.333µ ± 0%   +1.15% (p=0.000 n=10)
Cut/Cut-One/8-12        4.090n ± 1%   3.582n ± 3%  -12.41% (p=0.000 n=10)
Cut/Cut-Two/8-12        8.270n ± 1%   8.610n ± 0%   +4.11% (p=0.000 n=10)
Cut/Cut-One-Nil/8-12    2.089µ ± 1%   2.119µ ± 0%   +1.44% (p=0.001 n=10)
Cut/Cut-Two-Nil/8-12    2.101µ ± 1%   2.119µ ± 0%   +0.88% (p=0.019 n=10)
Cut/Cut-One/16-12       4.095n ± 1%   3.481n ± 3%  -14.98% (p=0.000 n=10)
Cut/Cut-Two/16-12       8.193n ± 1%   8.601n ± 0%   +4.98% (p=0.000 n=10)
Cut/Cut-One-Nil/16-12   1.966µ ± 2%   1.999µ ± 0%        ~ (p=0.118 n=10)
Cut/Cut-Two-Nil/16-12   2.001µ ± 1%   2.000µ ± 0%        ~ (p=0.954 n=10)
Cut/Cut-One/32-12       4.449n ± 1%   3.825n ± 2%  -14.03% (p=0.000 n=10)
Cut/Cut-Two/32-12       8.903n ± 1%   9.211n ± 1%   +3.46% (p=0.000 n=10)
Cut/Cut-One-Nil/32-12   1.938µ ± 1%   1.939µ ± 0%        ~ (p=0.926 n=10)
Cut/Cut-Two-Nil/32-12   1.920µ ± 0%   1.943µ ± 0%   +1.17% (p=0.000 n=10)
Cut/Cut-One/64-12       4.712n ± 0%   4.064n ± 1%  -13.75% (p=0.000 n=10)
Cut/Cut-Two/64-12       9.123n ± 0%   9.438n ± 1%   +3.45% (p=0.000 n=10)
Cut/Cut-One-Nil/64-12   1.882µ ± 1%   1.900µ ± 0%   +0.93% (p=0.000 n=10)
Cut/Cut-Two-Nil/64-12   1.886µ ± 0%   1.903µ ± 0%   +0.90% (p=0.000 n=10)
geomean                 113.1n        110.5n        -2.30%

For #67101
