### PR TITLE
strings: move TrimPrefix and TrimSuffix to stringslite

### DIFF
--- a/src/internal/stringslite/strings.go
+++ b/src/internal/stringslite/strings.go
@@ -122,3 +122,17 @@ func CutSuffix(s, suffix string) (before string, found bool) {
 	}
 	return s[:len(s)-len(suffix)], true
 }
+
+func TrimPrefix(s, prefix string) string {
+	if HasPrefix(s, prefix) {
+		return s[len(prefix):]
+	}
+	return s
+}
+
+func TrimSuffix(s, suffix string) string {
+	if HasSuffix(s, suffix) {
+		return s[:len(s)-len(suffix)]
+	}
+	return s
+}

--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -1075,19 +1075,13 @@ func TrimSpace(s string) string {
 // TrimPrefix returns s without the provided leading prefix string.
 // If s doesn't start with prefix, s is returned unchanged.
 func TrimPrefix(s, prefix string) string {
-	if HasPrefix(s, prefix) {
-		return s[len(prefix):]
-	}
-	return s
+	return stringslite.TrimPrefix(s, prefix)
 }
 
 // TrimSuffix returns s without the provided trailing suffix string.
 // If s doesn't end with suffix, s is returned unchanged.
 func TrimSuffix(s, suffix string) string {
-	if HasSuffix(s, suffix) {
-		return s[:len(s)-len(suffix)]
-	}
-	return s
+	return stringslite.TrimSuffix(s, suffix)
 }
 
 // Replace returns a copy of the string s with the first n


### PR DESCRIPTION
To help packages use these functions like "os" which using
the copied function "stringsTrimSuffix".