### PR TITLE
crypto/x509: include OID in duplicate extension error message

### DIFF
--- a/src/crypto/x509/parser.go
+++ b/src/crypto/x509/parser.go
@@ -964,7 +964,7 @@ func parseCertificate(der []byte) (*Certificate, error) {
 					}
 					oidStr := ext.Id.String()
 					if seenExts[oidStr] {
-						return nil, errors.New("x509: certificate contains duplicate extensions")
+						return nil, errors.New("x509: certificate contains duplicate extension %s", oidStr)
 					}
 					seenExts[oidStr] = true
 					cert.Extensions = append(cert.Extensions, ext)

--- a/src/crypto/x509/parser.go
+++ b/src/crypto/x509/parser.go
@@ -964,7 +964,7 @@ func parseCertificate(der []byte) (*Certificate, error) {
 					}
 					oidStr := ext.Id.String()
 					if seenExts[oidStr] {
-						return nil, errors.New("x509: certificate contains duplicate extension %s", oidStr)
+						return nil, fmt.Errorf("x509: certificate contains duplicate extension with OID %q", oidStr)
 					}
 					seenExts[oidStr] = true
 					cert.Extensions = append(cert.Extensions, ext)


### PR DESCRIPTION
Include the OID in the error message when parsing X.509
certificates. This should ease fixing such issues, because
users can clearly identify the duplicate extension via the
reported error. Previously, this wasn't possible and
required either manually adjusting the standard library or
inspecting the certificate with various debugging tools.

Fixes #66880