### PR TITLE
runtime/debug: add the options parameter to SetCrashOutput

### DIFF
--- a/src/runtime/debug/example_monitor_test.go
+++ b/src/runtime/debug/example_monitor_test.go
@@ -91,7 +91,7 @@ func monitor() {
 	if err != nil {
 		log.Fatalf("StdinPipe: %v", err)
 	}
-	debug.SetCrashOutput(pipe.(*os.File)) // (this conversion is safe)
+	debug.SetCrashOutput(pipe.(*os.File), debug.CrashOptions{}) // (this conversion is safe)
 	if err := cmd.Start(); err != nil {
 		log.Fatalf("can't start monitor: %v", err)
 	}

--- a/src/runtime/debug/stack.go
+++ b/src/runtime/debug/stack.go
@@ -43,7 +43,7 @@ type CrashOptions struct{}
 // To disable this additional crash output, call SetCrashOutput(nil).
 // If called concurrently with a crash, some in-progress output may be written
 // to the old file even after an overriding SetCrashOutput returns.
-func SetCrashOutput(f *os.File, opts CrashOptions) error {
+func SetCrashOutput(f *os.File, opts ...CrashOptions) error {
 	fd := ^uintptr(0)
 	if f != nil {
 		// The runtime will write to this file descriptor from

--- a/src/runtime/debug/stack.go
+++ b/src/runtime/debug/stack.go
@@ -31,6 +31,9 @@ func Stack() []byte {
 	}
 }
 
+// CrashOptions is a placeholder type for future options to SetCrashOutput.
+type CrashOptions struct{}
+
 // SetCrashOutput configures a single additional file where unhandled
 // panics and other fatal errors are printed, in addition to standard error.
 // There is only one additional file: calling SetCrashOutput again overrides
@@ -40,7 +43,7 @@ func Stack() []byte {
 // To disable this additional crash output, call SetCrashOutput(nil).
 // If called concurrently with a crash, some in-progress output may be written
 // to the old file even after an overriding SetCrashOutput returns.
-func SetCrashOutput(f *os.File) error {
+func SetCrashOutput(f *os.File, opts CrashOptions) error {
 	fd := ^uintptr(0)
 	if f != nil {
 		// The runtime will write to this file descriptor from

--- a/src/runtime/debug/stack_test.go
+++ b/src/runtime/debug/stack_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		if err := SetCrashOutput(f); err != nil {
+		if err := SetCrashOutput(f, CrashOptions{}); err != nil {
 			log.Fatal(err) // e.g. EMFILE
 		}
 		println("hello")

--- a/src/runtime/traceback_system_test.go
+++ b/src/runtime/traceback_system_test.go
@@ -28,7 +28,7 @@ func crash() {
 	// Ensure that we get pc=0x%x values in the traceback.
 	debug.SetTraceback("system")
 	writeSentinel(os.Stdout)
-	debug.SetCrashOutput(os.Stdout)
+	debug.SetCrashOutput(os.Stdout, debug.CrashOptions{})
 
 	go func() {
 		// This call is typically inlined.


### PR DESCRIPTION
This PR adds the CrashOptions as a parameter to the SetCrashOutput function. 

Updates #67182