### PR TITLE
os: use filepathlite.Base

### DIFF
--- a/src/os/path_unix.go
+++ b/src/os/path_unix.go
@@ -16,24 +16,6 @@ func IsPathSeparator(c uint8) bool {
 	return PathSeparator == c
 }
 
-// basename removes trailing slashes and the leading directory name from path name.
-func basename(name string) string {
-	i := len(name) - 1
-	// Remove trailing slashes
-	for ; i > 0 && name[i] == '/'; i-- {
-		name = name[:i]
-	}
-	// Remove leading directory name
-	for i--; i >= 0; i-- {
-		if name[i] == '/' {
-			name = name[i+1:]
-			break
-		}
-	}
-
-	return name
-}
-
 // splitPath returns the base name and parent directory.
 func splitPath(path string) (string, string) {
 	// if no better parent is found, the path is relative from "here"

--- a/src/os/path_windows.go
+++ b/src/os/path_windows.go
@@ -21,30 +21,6 @@ func IsPathSeparator(c uint8) bool {
 	return c == '\\' || c == '/'
 }
 
-// basename removes trailing slashes and the leading
-// directory name and drive letter from path name.
-func basename(name string) string {
-	// Remove drive letter
-	if len(name) == 2 && name[1] == ':' {
-		name = "."
-	} else if len(name) > 2 && name[1] == ':' {
-		name = name[2:]
-	}
-	i := len(name) - 1
-	// Remove trailing slashes
-	for ; i > 0 && (name[i] == '/' || name[i] == '\\'); i-- {
-		name = name[:i]
-	}
-	// Remove leading directory name
-	for i--; i >= 0; i-- {
-		if name[i] == '/' || name[i] == '\\' {
-			name = name[i+1:]
-			break
-		}
-	}
-	return name
-}
-
 func dirname(path string) string {
 	vol := filepathlite.VolumeName(path)
 	i := len(path) - 1

--- a/src/os/stat_aix.go
+++ b/src/os/stat_aix.go
@@ -5,12 +5,13 @@
 package os
 
 import (
+	"internal/filepathlite"
 	"syscall"
 	"time"
 )
 
 func fillFileStatFromSys(fs *fileStat, name string) {
-	fs.name = basename(name)
+	fs.name = filepathlite.Base(name)
 	fs.size = int64(fs.sys.Size)
 	fs.modTime = stTimespecToTime(fs.sys.Mtim)
 	fs.mode = FileMode(fs.sys.Mode & 0777)

--- a/src/os/stat_darwin.go
+++ b/src/os/stat_darwin.go
@@ -5,12 +5,13 @@
 package os
 
 import (
+	"internal/filepathlite"
 	"syscall"
 	"time"
 )
 
 func fillFileStatFromSys(fs *fileStat, name string) {
-	fs.name = basename(name)
+	fs.name = filepathlite.Base(name)
 	fs.size = fs.sys.Size
 	fs.modTime = time.Unix(fs.sys.Mtimespec.Unix())
 	fs.mode = FileMode(fs.sys.Mode & 0777)

--- a/src/os/stat_dragonfly.go
+++ b/src/os/stat_dragonfly.go
@@ -5,12 +5,13 @@
 package os
 
 import (
+	"internal/filepathlite"
 	"syscall"
 	"time"
 )
 
 func fillFileStatFromSys(fs *fileStat, name string) {
-	fs.name = basename(name)
+	fs.name = filepathlite.Base(name)
 	fs.size = fs.sys.Size
 	fs.modTime = time.Unix(fs.sys.Mtim.Unix())
 	fs.mode = FileMode(fs.sys.Mode & 0777)

--- a/src/os/stat_freebsd.go
+++ b/src/os/stat_freebsd.go
@@ -5,12 +5,13 @@
 package os
 
 import (
+	"internal/filepathlite"
 	"syscall"
 	"time"
 )
 
 func fillFileStatFromSys(fs *fileStat, name string) {
-	fs.name = basename(name)
+	fs.name = filepathlite.Base(name)
 	fs.size = fs.sys.Size
 	fs.modTime = time.Unix(fs.sys.Mtimespec.Unix())
 	fs.mode = FileMode(fs.sys.Mode & 0777)

--- a/src/os/stat_js.go
+++ b/src/os/stat_js.go
@@ -7,12 +7,13 @@
 package os
 
 import (
+	"internal/filepathlite"
 	"syscall"
 	"time"
 )
 
 func fillFileStatFromSys(fs *fileStat, name string) {
-	fs.name = basename(name)
+	fs.name = filepathlite.Base(name)
 	fs.size = fs.sys.Size
 	fs.modTime = time.Unix(fs.sys.Mtime, fs.sys.MtimeNsec)
 	fs.mode = FileMode(fs.sys.Mode & 0777)

--- a/src/os/stat_linux.go
+++ b/src/os/stat_linux.go
@@ -5,12 +5,13 @@
 package os
 
 import (
+	"internal/filepathlite"
 	"syscall"
 	"time"
 )
 
 func fillFileStatFromSys(fs *fileStat, name string) {
-	fs.name = basename(name)
+	fs.name = filepathlite.Base(name)
 	fs.size = fs.sys.Size
 	fs.modTime = time.Unix(fs.sys.Mtim.Unix())
 	fs.mode = FileMode(fs.sys.Mode & 0777)

--- a/src/os/stat_netbsd.go
+++ b/src/os/stat_netbsd.go
@@ -5,12 +5,13 @@
 package os
 
 import (
+	"internal/filepathlite"
 	"syscall"
 	"time"
 )
 
 func fillFileStatFromSys(fs *fileStat, name string) {
-	fs.name = basename(name)
+	fs.name = filepathlite.Base(name)
 	fs.size = fs.sys.Size
 	fs.modTime = time.Unix(fs.sys.Mtimespec.Unix())
 	fs.mode = FileMode(fs.sys.Mode & 0777)

--- a/src/os/stat_openbsd.go
+++ b/src/os/stat_openbsd.go
@@ -5,12 +5,13 @@
 package os
 
 import (
+	"internal/filepathlite"
 	"syscall"
 	"time"
 )
 
 func fillFileStatFromSys(fs *fileStat, name string) {
-	fs.name = basename(name)
+	fs.name = filepathlite.Base(name)
 	fs.size = fs.sys.Size
 	fs.modTime = time.Unix(fs.sys.Mtim.Unix())
 	fs.mode = FileMode(fs.sys.Mode & 0777)

--- a/src/os/stat_solaris.go
+++ b/src/os/stat_solaris.go
@@ -5,6 +5,7 @@
 package os
 
 import (
+	"internal/filepathlite"
 	"syscall"
 	"time"
 )
@@ -18,7 +19,7 @@ const (
 )
 
 func fillFileStatFromSys(fs *fileStat, name string) {
-	fs.name = basename(name)
+	fs.name = filepathlite.Base(name)
 	fs.size = fs.sys.Size
 	fs.modTime = time.Unix(fs.sys.Mtim.Unix())
 	fs.mode = FileMode(fs.sys.Mode & 0777)

--- a/src/os/stat_wasip1.go
+++ b/src/os/stat_wasip1.go
@@ -7,12 +7,13 @@
 package os
 
 import (
+	"internal/filepathlite"
 	"syscall"
 	"time"
 )
 
 func fillFileStatFromSys(fs *fileStat, name string) {
-	fs.name = basename(name)
+	fs.name = filepathlite.Base(name)
 	fs.size = int64(fs.sys.Size)
 	fs.mode = FileMode(fs.sys.Mode)
 	fs.modTime = time.Unix(0, int64(fs.sys.Mtime))

--- a/src/os/stat_windows.go
+++ b/src/os/stat_windows.go
@@ -5,6 +5,7 @@
 package os
 
 import (
+	"internal/filepathlite"
 	"internal/syscall/windows"
 	"syscall"
 	"unsafe"
@@ -107,7 +108,7 @@ func statHandle(name string, h syscall.Handle) (FileInfo, error) {
 	}
 	switch ft {
 	case syscall.FILE_TYPE_PIPE, syscall.FILE_TYPE_CHAR:
-		return &fileStat{name: basename(name), filetype: ft}, nil
+		return &fileStat{name: filepathlite.Base(name), filetype: ft}, nil
 	}
 	fs, err := newFileStatFromGetFileInformationByHandle(name, h)
 	if err != nil {

--- a/src/os/types_windows.go
+++ b/src/os/types_windows.go
@@ -61,7 +61,7 @@ func newFileStatFromGetFileInformationByHandle(path string, h syscall.Handle) (f
 	}
 
 	return &fileStat{
-		name:           basename(path),
+		name:           filepathlite.Base(path),
 		FileAttributes: d.FileAttributes,
 		CreationTime:   d.CreationTime,
 		LastAccessTime: d.LastAccessTime,
@@ -346,7 +346,7 @@ func (fs *fileStat) saveInfoFromPath(path string) error {
 			return &PathError{Op: "FullPath", Path: path, Err: err}
 		}
 	}
-	fs.name = basename(path)
+	fs.name = filepathlite.Base(path)
 	return nil
 }
 


### PR DESCRIPTION
Replace custom basename implementations with filepathlite.Base across
all relevant os/stat files to unify path processing across platforms.
