### PR TITLE
runtime: cleanup crashstack code

### DIFF
--- a/src/runtime/asm.s
+++ b/src/runtime/asm.s
@@ -13,34 +13,3 @@ TEXT ·sigpanic0(SB),NOSPLIT,$0-0
 TEXT ·mapinitnoop<ABIInternal>(SB),NOSPLIT,$0-0
 	RET
 
-#ifndef GOARCH_386
-#ifndef GOARCH_arm
-#ifndef GOARCH_amd64
-#ifndef GOARCH_arm64
-#ifndef GOARCH_loong64
-#ifndef GOARCH_mips
-#ifndef GOARCH_mipsle
-#ifndef GOARCH_mips64
-#ifndef GOARCH_mips64le
-#ifndef GOARCH_ppc64
-#ifndef GOARCH_ppc64le
-#ifndef GOARCH_riscv64
-#ifndef GOARCH_s390x
-#ifndef GOARCH_wasm
-// stub to appease shared build mode.
-TEXT ·switchToCrashStack0<ABIInternal>(SB),NOSPLIT,$0-0
-	UNDEF
-#endif
-#endif
-#endif
-#endif
-#endif
-#endif
-#endif
-#endif
-#endif
-#endif
-#endif
-#endif
-#endif
-#endif

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -578,7 +578,7 @@ func switchToCrashStack(fn func()) {
 // Disable crash stack on Windows for now. Apparently, throwing an exception
 // on a non-system-allocated crash stack causes EXCEPTION_STACK_OVERFLOW and
 // hangs the process (see issue 63938).
-const crashStackImplemented = (GOARCH == "386" || GOARCH == "amd64" || GOARCH == "arm" || GOARCH == "arm64" || GOARCH == "loong64" || GOARCH == "mips" || GOARCH == "mipsle" || GOARCH == "mips64" || GOARCH == "mips64le" || GOARCH == "ppc64" || GOARCH == "ppc64le" || GOARCH == "riscv64" || GOARCH == "s390x" || GOARCH == "wasm") && GOOS != "windows"
+const crashStackImplemented = GOOS != "windows"
 
 //go:noescape
 func switchToCrashStack0(fn func()) // in assembly


### PR DESCRIPTION
This patch removes redundant guards for the crash stack feature, as all
supported Go architectures now have a crash stack implementation.