### PR TITLE
crypto/rsa: documents timing leaks in rsa package

### DIFF
--- a/src/crypto/rsa/pkcs1v15.go
+++ b/src/crypto/rsa/pkcs1v15.go
@@ -321,6 +321,13 @@ func SignPKCS1v15(random io.Reader, priv *PrivateKey, hash crypto.Hash, hashed [
 // function and sig is the signature. A valid signature is indicated by
 // returning a nil error. If hash is zero then hashed is used directly. This
 // isn't advisable except for interoperability.
+//
+// Note: VerifyPKCS1v15 has a timing channel that can leak bits of the
+// signature or public key. This timing channel is not possible if the
+// signature would verify under the public key (it only leaks invalid
+// signatures). As neither the signature nor the public key are viewed
+// as secret; this function does not provide confidentiality guarantees
+// on the signature or public key. See https://golang.org/issue/67043
 func VerifyPKCS1v15(pub *PublicKey, hash crypto.Hash, hashed []byte, sig []byte) error {
 	if boring.Enabled {
 		bkey, err := boringPublicKey(pub)

--- a/src/crypto/rsa/pss.go
+++ b/src/crypto/rsa/pss.go
@@ -338,6 +338,11 @@ func SignPSS(rand io.Reader, priv *PrivateKey, hash crypto.Hash, digest []byte, 
 // result of hashing the input message using the given hash function. The opts
 // argument may be nil, in which case sensible defaults are used. opts.Hash is
 // ignored.
+//
+// Note: As neither the signature nor the public key is viewed as secret;
+// VerifyPSS does not provide confidentiality guarantees on the public key or
+// signature and does not attempt to prevent timing channels which leak the
+// these values. See https://golang.org/issue/67043
 func VerifyPSS(pub *PublicKey, hash crypto.Hash, digest []byte, sig []byte, opts *PSSOptions) error {
 	if boring.Enabled {
 		bkey, err := boringPublicKey(pub)

--- a/src/crypto/rsa/rsa.go
+++ b/src/crypto/rsa/rsa.go
@@ -20,9 +20,9 @@
 // Decrypter and Signer interfaces from the crypto package.
 //
 // Operations in this package are implemented using constant-time algorithms,
-// except for [GenerateKey], [PrivateKey.Precompute], and [PrivateKey.Validate].
-// Every other operation only leaks the bit size of the involved values, which
-// all depend on the selected key size.
+// except for encrypt, [GenerateKey], [PrivateKey.Precompute],
+// and [PrivateKey.Validate]. Every other operation only leaks the bit size of
+// the involved values, which all depend on the selected key size.
 package rsa
 
 import (
@@ -479,6 +479,9 @@ func mgf1XOR(out []byte, hash hash.Hash, seed []byte) {
 // be returned if the size of the salt is too large.
 var ErrMessageTooLong = errors.New("crypto/rsa: message too long for RSA key size")
 
+// WARNING: encrypt contains a timing channel that reveals if the signature
+// is numerically larger than the modulus N, potentially leaking a bit of
+// the public key or the plaintext. See https://golang.org/issue/67043
 func encrypt(pub *PublicKey, plaintext []byte) ([]byte, error) {
 	boring.Unreachable()
 


### PR DESCRIPTION
This PR documents the timing channel in RSA VerifyPKCS1v15 and VerifyPSS.
by not failing early if the RSA signature is larger,
i.e., if it overflows, the modulus N set by the public key.

Fixes #67043
