### PR TITLE
encoding/pem: refactor lineBreaker.Write to handle buffer sizes correctly

### DIFF
--- a/src/encoding/pem/pem_test.go
+++ b/src/encoding/pem/pem_test.go
@@ -233,6 +233,34 @@ func TestLineBreaker(t *testing.T) {
 			t.Errorf("#%d: (byte by byte) got:%s want:%s", i, got, test.out)
 		}
 	}
+
+	t.Run("SmallBuffer", func(t *testing.T) {
+		buf := new(strings.Builder)
+		breaker := lineBreaker{out: buf}
+		input := bytes.Repeat([]byte("a"), 10) // Less than pemLineLength
+
+		written, err := breaker.Write(input)
+		if err != nil {
+			t.Fatalf("Write failed: %v", err)
+		}
+		if written != len(input) {
+			t.Errorf("Expected to write %d bytes, wrote %d bytes", len(input), written)
+		}
+	})
+
+	t.Run("LargeBuffer", func(t *testing.T) {
+		buf := new(strings.Builder)
+		breaker := lineBreaker{out: buf}
+		input := bytes.Repeat([]byte("a"), 200) // More than pemLineLength
+
+		written, err := breaker.Write(input)
+		if err != nil {
+			t.Fatalf("Write failed: %v", err)
+		}
+		if written != len(input) {
+			t.Errorf("Expected to write %d bytes, wrote %d bytes", len(input), written)
+		}
+	})
 }
 
 func TestFuzz(t *testing.T) {


### PR DESCRIPTION
Refactor lineBreaker.Write in encoding/pem to correctly handle cases
where the input buffer size is less than, equal to, or greater than
pemLineLength. This change improves the logic for writing data and
handling line breaks, ensuring correct byte counts are returned.
Additionally, new unit tests have been added to verify behavior with
both small and large buffers.
