### PR TITLE
debug/gosym: update field count to 1.20+

### DIFF
--- a/src/debug/gosym/pclntab.go
+++ b/src/debug/gosym/pclntab.go
@@ -467,10 +467,10 @@ func (f funcData) pcln() uint32        { return f.field(6) }
 func (f funcData) cuOffset() uint32    { return f.field(8) }
 
 // field returns the nth field of the _func struct.
-// It panics if n == 0 or n > 9; for n == 0, call f.entryPC.
+// It panics if n == 0 or n > 10; for n == 0, call f.entryPC.
 // Most callers should use a named field accessor (just above).
 func (f funcData) field(n uint32) uint32 {
-	if n == 0 || n > 9 {
+	if n == 0 || n > 10 {
 		panic("bad funcdata field")
 	}
 	// In Go 1.18, the first field of _func changed


### PR DESCRIPTION
The _func structure in src/runtime/runtime2.go 
includes a startLine field in versions after 1.20,
which extends the total number of fields to 10