### PR TITLE
encoding/csv: clarify that Writer uses different line break than RFC 4180 by default

### DIFF
--- a/src/encoding/csv/reader.go
+++ b/src/encoding/csv/reader.go
@@ -4,7 +4,8 @@
 
 // Package csv reads and writes comma-separated values (CSV) files.
 // There are many kinds of CSV files; this package supports the format
-// described in RFC 4180.
+// described in RFC 4180, except that [Writer] uses LF
+// instead of CRLF as newline character by default.
 //
 // A csv file contains zero or more records of one or more fields per record.
 // Each record is separated by the newline character. The final record may


### PR DESCRIPTION
Package documentation of encoding/csv says:

> this package supports the format described in RFC 4180.

According to section 2 of RFC 4180:

> Each record is located on a separate line, delimited by a line break (CRLF).

On the other hand, Writer uses LF (not CRLF) as newline character by default.

> If [Writer.UseCRLF] is true, the Writer ends each output line with \r\n instead of \n.

Strictly speaking, this behavior is different from RFC 4180.
Package documentation would improve if we clarify that point.