### PR TITLE
runtime: add GoID to StackRecord produced by GoroutineProfile()

### DIFF
--- a/src/internal/profilerecord/profilerecord.go
+++ b/src/internal/profilerecord/profilerecord.go
@@ -10,6 +10,7 @@ package profilerecord
 
 type StackRecord struct {
 	Stack []uintptr
+	GoID  uint64
 }
 
 type MemProfileRecord struct {

--- a/src/runtime/runtime_test.go
+++ b/src/runtime/runtime_test.go
@@ -344,23 +344,36 @@ func TestAppendSliceGrowth(t *testing.T) {
 	}
 }
 
-func TestGoroutineProfileTrivial(t *testing.T) {
+func TestGoroutineProfile(t *testing.T) {
 	// Calling GoroutineProfile twice in a row should find the same number of goroutines,
 	// but it's possible there are goroutines just about to exit, so we might end up
 	// with fewer in the second call. Try a few times; it should converge once those
 	// zombies are gone.
+	var records []StackRecord
 	for i := 0; ; i++ {
 		n1, ok := GoroutineProfile(nil) // should fail, there's at least 1 goroutine
 		if n1 < 1 || ok {
 			t.Fatalf("GoroutineProfile(nil) = %d, %v, want >0, false", n1, ok)
 		}
-		n2, ok := GoroutineProfile(make([]StackRecord, n1))
+		records = make([]StackRecord, n1)
+		n2, ok := GoroutineProfile(records)
 		if n2 == n1 && ok {
 			break
 		}
 		t.Logf("GoroutineProfile(%d) = %d, %v, want %d, true", n1, n2, ok, n1)
 		if i >= 10 {
 			t.Fatalf("GoroutineProfile not converging")
+		}
+	}
+	if len(records) < 1 {
+		t.Fatalf("GoroutineProfile hasn't collected any records")
+	}
+	for _, record := range records {
+		if len(record.Stack()) < 1 {
+			t.Fatalf("GoroutineProfile record is missing a stack trace")
+		}
+		if record.GoID() < 1 {
+			t.Fatalf("GoroutineProfile record is missing a GoID")
 		}
 	}
 }


### PR DESCRIPTION
Making this change allows mapping stack traces to goroutines across 
subsequent runs of `GoroutineProfile()`. This is necessary in order to 
use said function as a simple continuous in-process profiler (with sample 
timestamps). The other option, involving `runtime.Stack()` has worse 
performance (in the runtime package) and also produces stack as a string 
which then needs to be parsed back (although, at least it has the goroutine 
ID)

Closes #59663
