### PR TITLE
sql: delay calling the Lock function in Register

### DIFF
--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -43,11 +43,11 @@ var nowFunc = time.Now
 // If Register is called twice with the same name or if driver is nil,
 // it panics.
 func Register(name string, driver driver.Driver) {
-	driversMu.Lock()
-	defer driversMu.Unlock()
 	if driver == nil {
 		panic("sql: Register driver is nil")
 	}
+	driversMu.Lock()
+	defer driversMu.Unlock()
 	if _, dup := drivers[name]; dup {
 		panic("sql: Register called twice for driver " + name)
 	}


### PR DESCRIPTION
Calling `Lock` when we need to access `drivers` variable
to avoid meaningless lock.
