### PR TITLE
enconding/json: add ValidPos() function

### DIFF
--- a/src/encoding/json/scanner.go
+++ b/src/encoding/json/scanner.go
@@ -25,6 +25,12 @@ func Valid(data []byte) bool {
 	return checkValid(data, scan) == nil
 }
 
+func ValidPos(data []byte) (bool, int64) {
+	scan := newScanner()
+	defer freeScanner(scan)
+	return checkValid(data, scan) == nil, scan.bytes
+}
+
 // checkValid verifies that data is valid JSON-encoded data.
 // scan is passed in for use by checkValid to avoid an allocation.
 // checkValid returns nil or a SyntaxError.

--- a/src/encoding/json/scanner_test.go
+++ b/src/encoding/json/scanner_test.go
@@ -48,6 +48,31 @@ func TestValid(t *testing.T) {
 	}
 }
 
+func TestValidPos(t *testing.T) {
+	tests := []struct {
+		CaseName
+		data string
+		ok   bool
+		pos  int64
+	}{
+		{Name(""), `{"foo":"bar"}`, true, 0},
+		{Name(""), `{"foo":bar"}`, false, 8},
+		{Name(""), `{"bar":foo"}`, false, 9},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			valid, pos := ValidPos([]byte(tt.data))
+			if valid != tt.ok {
+				t.Errorf("%s: ValidPos(`%s`) = %v, want %v", tt.Where, tt.data, valid, tt.ok)
+			}
+			if !tt.ok && tt.pos != pos {
+				t.Errorf("%s: ValidPos(`%s`) returned position %d, want %d",
+					tt.Where, tt.data, pos, tt.pos)
+			}
+		})
+	}
+}
+
 func TestCompactAndIndent(t *testing.T) {
 	tests := []struct {
 		CaseName


### PR DESCRIPTION
Add json.ValidPos() to allow getting the position of where the validation failed
in addition to a boolean to indicate the failure.

Closes #67423