### PR TITLE
internal/fmtsort: use cmp.Compare for value comparisons

### DIFF
--- a/src/internal/fmtsort/sort_test.go
+++ b/src/internal/fmtsort/sort_test.go
@@ -67,10 +67,6 @@ func TestCompare(t *testing.T) {
 				switch {
 				case i == j:
 					expect = 0
-					// NaNs are tricky.
-					if typ := v0.Type(); (typ.Kind() == reflect.Float32 || typ.Kind() == reflect.Float64) && math.IsNaN(v0.Float()) {
-						expect = -1
-					}
 				case i < j:
 					expect = -1
 				case i > j:


### PR DESCRIPTION
Refactor compare function to use cmp.Compare for various types.
Remove redundant floatCompare and isNaN functions.