### PR TITLE
hash: use more internal/byteorder functions to simplify the code

### DIFF
--- a/src/hash/crc32/crc32_generic.go
+++ b/src/hash/crc32/crc32_generic.go
@@ -12,6 +12,8 @@
 
 package crc32
 
+import "internal/byteorder"
+
 // simpleMakeTable allocates and constructs a Table for the specified
 // polynomial. The table is suitable for use with the simple algorithm
 // (simpleUpdate).
@@ -74,7 +76,7 @@ func slicingUpdate(crc uint32, tab *slicing8Table, p []byte) uint32 {
 	if len(p) >= slicing8Cutoff {
 		crc = ^crc
 		for len(p) > 8 {
-			crc ^= uint32(p[0]) | uint32(p[1])<<8 | uint32(p[2])<<16 | uint32(p[3])<<24
+			crc ^= byteorder.LeUint32(p)
 			crc = tab[0][p[7]] ^ tab[1][p[6]] ^ tab[2][p[5]] ^ tab[3][p[4]] ^
 				tab[4][crc>>24] ^ tab[5][(crc>>16)&0xFF] ^
 				tab[6][(crc>>8)&0xFF] ^ tab[7][crc&0xFF]

--- a/src/hash/crc64/crc64.go
+++ b/src/hash/crc64/crc64.go
@@ -153,8 +153,7 @@ func update(crc uint64, tab *Table, p []byte) uint64 {
 		}
 		// Update using slicing-by-8
 		for len(p) > 8 {
-			crc ^= uint64(p[0]) | uint64(p[1])<<8 | uint64(p[2])<<16 | uint64(p[3])<<24 |
-				uint64(p[4])<<32 | uint64(p[5])<<40 | uint64(p[6])<<48 | uint64(p[7])<<56
+			crc ^= byteorder.LeUint64(p)
 			crc = helperTable[7][crc&0xff] ^
 				helperTable[6][(crc>>8)&0xff] ^
 				helperTable[5][(crc>>16)&0xff] ^

--- a/src/hash/fnv/fnv.go
+++ b/src/hash/fnv/fnv.go
@@ -179,36 +179,32 @@ func (s *sum128a) BlockSize() int { return 1 }
 
 func (s *sum32) Sum(in []byte) []byte {
 	v := uint32(*s)
-	return append(in, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+	return byteorder.BeAppendUint32(in, v)
 }
 
 func (s *sum32a) Sum(in []byte) []byte {
 	v := uint32(*s)
-	return append(in, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+	return byteorder.BeAppendUint32(in, v)
 }
 
 func (s *sum64) Sum(in []byte) []byte {
 	v := uint64(*s)
-	return append(in, byte(v>>56), byte(v>>48), byte(v>>40), byte(v>>32), byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+	return byteorder.BeAppendUint64(in, v)
 }
 
 func (s *sum64a) Sum(in []byte) []byte {
 	v := uint64(*s)
-	return append(in, byte(v>>56), byte(v>>48), byte(v>>40), byte(v>>32), byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+	return byteorder.BeAppendUint64(in, v)
 }
 
 func (s *sum128) Sum(in []byte) []byte {
-	return append(in,
-		byte(s[0]>>56), byte(s[0]>>48), byte(s[0]>>40), byte(s[0]>>32), byte(s[0]>>24), byte(s[0]>>16), byte(s[0]>>8), byte(s[0]),
-		byte(s[1]>>56), byte(s[1]>>48), byte(s[1]>>40), byte(s[1]>>32), byte(s[1]>>24), byte(s[1]>>16), byte(s[1]>>8), byte(s[1]),
-	)
+	ret := byteorder.BeAppendUint64(in, s[0])
+	return byteorder.BeAppendUint64(ret, s[1])
 }
 
 func (s *sum128a) Sum(in []byte) []byte {
-	return append(in,
-		byte(s[0]>>56), byte(s[0]>>48), byte(s[0]>>40), byte(s[0]>>32), byte(s[0]>>24), byte(s[0]>>16), byte(s[0]>>8), byte(s[0]),
-		byte(s[1]>>56), byte(s[1]>>48), byte(s[1]>>40), byte(s[1]>>32), byte(s[1]>>24), byte(s[1]>>16), byte(s[1]>>8), byte(s[1]),
-	)
+	ret := byteorder.BeAppendUint64(in, s[0])
+	return byteorder.BeAppendUint64(ret, s[1])
 }
 
 const (


### PR DESCRIPTION
A follow-up for the [CL 585015](https://go.dev/cl/585015).
