### PR TITLE
math/rand/v2: add Read method to ChaCha8 source

### DIFF
--- a/api/next/67059.txt
+++ b/api/next/67059.txt
@@ -1,1 +1,1 @@
-pkg math/rand/v2, method (*ChaCha8) Read(p []byte) (n int, err error) #67059
+pkg math/rand/v2, method (*ChaCha8) Read([]uint8) (int, error) #67059

--- a/api/next/67059.txt
+++ b/api/next/67059.txt
@@ -1,0 +1,1 @@
+pkg math/rand/v2, method (*ChaCha8) Read(p []byte) (n int, err error) #67059

--- a/doc/next/6-stdlib/99-minor/math/rand/v2/67059.md
+++ b/doc/next/6-stdlib/99-minor/math/rand/v2/67059.md
@@ -1,0 +1,1 @@
+[ChaCha8] source implements the [io.Reader] interface.

--- a/src/internal/chacha8rand/chacha8.go
+++ b/src/internal/chacha8rand/chacha8.go
@@ -181,7 +181,7 @@ func (s *State) FillRand(b []byte) {
 				b = b[n:]
 
 				if len(b) == 0 {
-					break
+					return
 				}
 			}
 			s.Refill()
@@ -194,7 +194,7 @@ func (s *State) FillRand(b []byte) {
 		b = b[n:]
 
 		if len(b) == 0 {
-			break
+			return
 		}
 		s.Refill()
 	}

--- a/src/internal/chacha8rand/rand_test.go
+++ b/src/internal/chacha8rand/rand_test.go
@@ -31,20 +31,35 @@ func TestOutput(t *testing.T) {
 	}
 }
 
-func TestOutputBytes(t *testing.T) {
-	var s State
-	s.Init(seed)
-
+func TestFillRand(t *testing.T) {
 	expect := make([]byte, 0, len(output)*8)
 	for _, v := range output {
 		expect = byteorder.LeAppendUint64(expect, v)
 	}
 
-	got := make([]byte, len(expect))
-	s.FillRand(got)
+	cases := []struct {
+		expect [][]byte
+	}{
+		{[][]byte{expect}},
+		{[][]byte{expect[:1], expect[8:9]}},
+		{[][]byte{expect[:4], expect[8:12]}},
+		{[][]byte{expect[:4], expect[8:12]}},
+		{[][]byte{expect[:8], expect[8:16]}},
+		{[][]byte{expect[:128], expect[128:256]}},
+		{[][]byte{expect[:128], expect[128:]}},
+		{[][]byte{expect[:100], expect[104:]}},
+	}
 
-	if !bytes.Equal(expect, got) {
-		t.Errorf("got = %#x; want = %#x", got, expect)
+	var s State
+	for _, tt := range cases {
+		s.Init(seed)
+		for _, expect := range tt.expect {
+			got := make([]byte, len(expect))
+			s.FillRand(got)
+			if !bytes.Equal(expect, got) {
+				t.Errorf("got = %#x; want = %#x", got, expect)
+			}
+		}
 	}
 }
 

--- a/src/internal/chacha8rand/rand_test.go
+++ b/src/internal/chacha8rand/rand_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"internal/byteorder"
 	. "internal/chacha8rand"
 	"slices"
 	"testing"
@@ -27,6 +28,23 @@ func TestOutput(t *testing.T) {
 			}
 			s.Refill()
 		}
+	}
+}
+
+func TestOutputBytes(t *testing.T) {
+	var s State
+	s.Init(seed)
+
+	expect := make([]byte, 0, len(output)*8)
+	for _, v := range output {
+		expect = byteorder.LeAppendUint64(expect, v)
+	}
+
+	got := make([]byte, len(expect))
+	s.FillRand(got)
+
+	if !bytes.Equal(expect, got) {
+		t.Errorf("got = %#x; want = %#x", got, expect)
 	}
 }
 

--- a/src/math/rand/v2/chacha8.go
+++ b/src/math/rand/v2/chacha8.go
@@ -46,6 +46,7 @@ func (c *ChaCha8) MarshalBinary() ([]byte, error) {
 }
 
 // Read generates len(p) random bytes and writes them into p.
+// It never returns an error.
 func (c *ChaCha8) Read(p []byte) (n int, err error) {
 	c.state.FillRand(p)
 	return len(p), nil

--- a/src/math/rand/v2/chacha8.go
+++ b/src/math/rand/v2/chacha8.go
@@ -44,3 +44,9 @@ func (c *ChaCha8) UnmarshalBinary(data []byte) error {
 func (c *ChaCha8) MarshalBinary() ([]byte, error) {
 	return chacha8rand.Marshal(&c.state), nil
 }
+
+// Read generates len(p) random bytes and writes them into p.
+func (c *ChaCha8) Read(p []byte) (n int, err error) {
+	c.state.FillRand(p)
+	return len(p), nil
+}

--- a/src/math/rand/v2/chacha8_test.go
+++ b/src/math/rand/v2/chacha8_test.go
@@ -6,6 +6,7 @@ package rand_test
 
 import (
 	. "math/rand/v2"
+	"strconv"
 	"testing"
 )
 
@@ -528,4 +529,18 @@ var chacha8marshal = []string{
 	"chacha8:\x00\x00\x00\x00\x00\x00\x00yK3\x9bB!,\x94\x9d\x975\xce'O_t\xee|\xb21\x87\xbb\xbb\xfd)\x8f\xe52\x01\vP\fk",
 	"chacha8:\x00\x00\x00\x00\x00\x00\x00zK3\x9bB!,\x94\x9d\x975\xce'O_t\xee|\xb21\x87\xbb\xbb\xfd)\x8f\xe52\x01\vP\fk",
 	"chacha8:\x00\x00\x00\x00\x00\x00\x00{K3\x9bB!,\x94\x9d\x975\xce'O_t\xee|\xb21\x87\xbb\xbb\xfd)\x8f\xe52\x01\vP\fk",
+}
+
+func BenchmarkRead(b *testing.B) {
+	for _, v := range []int{1, 3, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 1024 * 2, 1024 * 16} {
+		b.Run(strconv.FormatInt(int64(v), 10), func(b *testing.B) {
+			r := NewChaCha8(chacha8seed)
+			buf := make([]byte, v)
+			b.SetBytes(int64(v))
+			b.ResetTimer()
+			for n := b.N; n > 0; n-- {
+				r.Read(buf)
+			}
+		})
+	}
 }

--- a/src/math/rand/v2/chacha8_test.go
+++ b/src/math/rand/v2/chacha8_test.go
@@ -531,8 +531,21 @@ var chacha8marshal = []string{
 	"chacha8:\x00\x00\x00\x00\x00\x00\x00{K3\x9bB!,\x94\x9d\x975\xce'O_t\xee|\xb21\x87\xbb\xbb\xfd)\x8f\xe52\x01\vP\fk",
 }
 
+func TestChaCha8Read(t *testing.T) {
+	c := NewChaCha8(chacha8seed)
+	n, err := c.Read(make([]byte, 128))
+	if n != 128 || err != nil {
+		t.Errorf("(*ChaCha8).Read(buf) = (%v, %v); want = (128, nil)", n, err)
+	}
+
+	n, err = c.Read(make([]byte, 0))
+	if n != 0 || err != nil {
+		t.Errorf("(*ChaCha8).Read(buf) = (%v, %v); want = (0, nil)", n, err)
+	}
+}
+
 func BenchmarkRead(b *testing.B) {
-	for _, v := range []int{1, 3, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 1024 * 2, 1024 * 16} {
+	for _, v := range []int{1, 2, 3, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 1024 * 2, 1024 * 16} {
 		b.Run(strconv.FormatInt(int64(v), 10), func(b *testing.B) {
 			r := NewChaCha8(chacha8seed)
 			buf := make([]byte, v)


### PR DESCRIPTION
Performance on amd64:

              │     B/s      │
Read/1-12       118.7Mi ± 1%
Read/2-12       239.6Mi ± 0%
Read/3-12       353.1Mi ± 1%
Read/4-12       482.8Mi ± 1%
Read/8-12       949.9Mi ± 1%
Read/16-12      1.313Gi ± 1%
Read/32-12      1.795Gi ± 0%
Read/64-12      2.083Gi ± 1%
Read/128-12     2.249Gi ± 2%
Read/256-12     2.314Gi ± 1%
Read/512-12     2.355Gi ± 1%
Read/1024-12    2.384Gi ± 0%
Read/2048-12    2.373Gi ± 3%
Read/16384-12   2.415Gi ± 0%
geomean         1.090Gi

Fixes #67059