### PR TITLE
fmt: replace sort with slices to reduce dependency tree

### DIFF
--- a/src/fmt/errors.go
+++ b/src/fmt/errors.go
@@ -6,7 +6,7 @@ package fmt
 
 import (
 	"errors"
-	"sort"
+	"slices"
 )
 
 // Errorf formats according to a format specifier and returns the string as a
@@ -34,7 +34,7 @@ func Errorf(format string, a ...any) error {
 		err = w
 	default:
 		if p.reordered {
-			sort.Ints(p.wrappedErrs)
+			slices.Sort(p.wrappedErrs)
 		}
 		var errs []error
 		for i, argNum := range p.wrappedErrs {


### PR DESCRIPTION
This CL replaces the usage of sort with slices in fmt package, reducing
the dependency tree. The fmt package previously depended on sort, which
in turn depended on slices and other packages. This change simplifies
the dependencies.
