### PR TITLE
cmd/go: env changed flag respects $GOROOT/go.env

### DIFF
--- a/src/cmd/go/internal/cfg/cfg.go
+++ b/src/cmd/go/internal/cfg/cfg.go
@@ -422,8 +422,8 @@ var (
 	GORISCV64, goRISCV64Changed = EnvOrAndChanged("GORISCV64", fmt.Sprintf("rva%du64", buildcfg.GORISCV64))
 	GOWASM, goWASMChanged       = EnvOrAndChanged("GOWASM", fmt.Sprint(buildcfg.GOWASM))
 
-	GOPROXY, GOPROXYChanged     = EnvOrAndChanged("GOPROXY", "")
-	GOSUMDB, GOSUMDBChanged     = EnvOrAndChanged("GOSUMDB", "")
+	GOPROXY, GOPROXYChanged     = EnvOrAndChanged("GOPROXY", envCache.m["GOPROXY"])
+	GOSUMDB, GOSUMDBChanged     = EnvOrAndChanged("GOSUMDB", envCache.m["GOSUMDB"])
 	GOPRIVATE                   = Getenv("GOPRIVATE")
 	GONOPROXY, GONOPROXYChanged = EnvOrAndChanged("GONOPROXY", GOPRIVATE)
 	GONOSUMDB, GONOSUMDBChanged = EnvOrAndChanged("GONOSUMDB", GOPRIVATE)

--- a/src/cmd/go/internal/cfg/cfg.go
+++ b/src/cmd/go/internal/cfg/cfg.go
@@ -359,15 +359,13 @@ func readEnvFile(file string, source string) {
 		key, val := line[:i], line[i+1:]
 
 		if source == "GOROOT" {
+			envCache.goroot[string(key)] = string(val)
 			// In the GOROOT/go.env file, do not overwrite fields loaded from the user's go/env file.
 			if _, ok := envCache.m[string(key)]; ok {
 				continue
 			}
 		}
 		envCache.m[string(key)] = string(val)
-		if source == "GOROOT" {
-			envCache.goroot[string(key)] = string(val)
-		}
 	}
 }
 

--- a/src/cmd/go/internal/cfg/cfg.go
+++ b/src/cmd/go/internal/cfg/cfg.go
@@ -445,7 +445,7 @@ func EnvOrAndChanged(name, def string) (v string, changed bool) {
 		} else {
 			changed = val != def
 		}
-		return
+		return v, changed
 	}
 	return def, false
 }

--- a/src/cmd/go/internal/cfg/cfg.go
+++ b/src/cmd/go/internal/cfg/cfg.go
@@ -425,8 +425,8 @@ var (
 	GORISCV64, goRISCV64Changed = EnvOrAndChanged("GORISCV64", fmt.Sprintf("rva%du64", buildcfg.GORISCV64))
 	GOWASM, goWASMChanged       = EnvOrAndChanged("GOWASM", fmt.Sprint(buildcfg.GOWASM))
 
-	GOPROXY, GOPROXYChanged     = EnvOrAndChanged("GOPROXY", envCache.goroot["GOPROXY"])
-	GOSUMDB, GOSUMDBChanged     = EnvOrAndChanged("GOSUMDB", envCache.goroot["GOSUMDB"])
+	GOPROXY, GOPROXYChanged     = EnvOrAndChanged("GOPROXY", "")
+	GOSUMDB, GOSUMDBChanged     = EnvOrAndChanged("GOSUMDB", "")
 	GOPRIVATE                   = Getenv("GOPRIVATE")
 	GONOPROXY, GONOPROXYChanged = EnvOrAndChanged("GONOPROXY", GOPRIVATE)
 	GONOSUMDB, GONOSUMDBChanged = EnvOrAndChanged("GONOSUMDB", GOPRIVATE)
@@ -436,10 +436,16 @@ var (
 
 // EnvOrAndChanged returns the environment variable value
 // and reports whether it differs from the default value.
-func EnvOrAndChanged(name, def string) (string, bool) {
+func EnvOrAndChanged(name, def string) (v string, changed bool) {
 	val := Getenv(name)
 	if val != "" {
-		return val, val != def
+		v = val
+		if g, ok := envCache.goroot[name]; ok {
+			changed = val != g
+		} else {
+			changed = val != def
+		}
+		return
 	}
 	return def, false
 }

--- a/src/cmd/go/internal/cfg/cfg.go
+++ b/src/cmd/go/internal/cfg/cfg.go
@@ -285,8 +285,9 @@ var OrigEnv []string
 var CmdEnv []EnvVar
 
 var envCache struct {
-	once sync.Once
-	m    map[string]string
+	once   sync.Once
+	m      map[string]string
+	goroot map[string]string
 }
 
 // EnvFile returns the name of the Go environment configuration file,
@@ -310,6 +311,7 @@ func EnvFile() (string, bool, error) {
 
 func initEnvCache() {
 	envCache.m = make(map[string]string)
+	envCache.goroot = make(map[string]string)
 	if file, _, _ := EnvFile(); file != "" {
 		readEnvFile(file, "user")
 	}
@@ -363,6 +365,9 @@ func readEnvFile(file string, source string) {
 			}
 		}
 		envCache.m[string(key)] = string(val)
+		if source == "GOROOT" {
+			envCache.goroot[string(key)] = string(val)
+		}
 	}
 }
 
@@ -422,8 +427,8 @@ var (
 	GORISCV64, goRISCV64Changed = EnvOrAndChanged("GORISCV64", fmt.Sprintf("rva%du64", buildcfg.GORISCV64))
 	GOWASM, goWASMChanged       = EnvOrAndChanged("GOWASM", fmt.Sprint(buildcfg.GOWASM))
 
-	GOPROXY, GOPROXYChanged     = EnvOrAndChanged("GOPROXY", envCache.m["GOPROXY"])
-	GOSUMDB, GOSUMDBChanged     = EnvOrAndChanged("GOSUMDB", envCache.m["GOSUMDB"])
+	GOPROXY, GOPROXYChanged     = EnvOrAndChanged("GOPROXY", envCache.goroot["GOPROXY"])
+	GOSUMDB, GOSUMDBChanged     = EnvOrAndChanged("GOSUMDB", envCache.goroot["GOSUMDB"])
 	GOPRIVATE                   = Getenv("GOPRIVATE")
 	GONOPROXY, GONOPROXYChanged = EnvOrAndChanged("GONOPROXY", GOPRIVATE)
 	GONOSUMDB, GONOSUMDBChanged = EnvOrAndChanged("GONOSUMDB", GOPRIVATE)

--- a/src/cmd/go/internal/envcmd/env.go
+++ b/src/cmd/go/internal/envcmd/env.go
@@ -128,7 +128,7 @@ func MkEnv() []cfg.EnvVar {
 		case "GOCACHE":
 			env[i].Value, env[i].Changed = cache.DefaultDir()
 		case "GOTOOLCHAIN":
-			env[i].Value, env[i].Changed = cfg.EnvOrAndChanged("GOTOOLCHAIN", "auto")
+			env[i].Value, env[i].Changed = cfg.EnvOrAndChanged("GOTOOLCHAIN", "")
 		case "GODEBUG":
 			env[i].Changed = env[i].Value != ""
 		}

--- a/src/cmd/go/internal/envcmd/env.go
+++ b/src/cmd/go/internal/envcmd/env.go
@@ -106,7 +106,7 @@ func MkEnv() []cfg.EnvVar {
 		{Name: "GOROOT", Value: cfg.GOROOT},
 		{Name: "GOSUMDB", Value: cfg.GOSUMDB, Changed: cfg.GOSUMDBChanged},
 		{Name: "GOTMPDIR", Value: cfg.Getenv("GOTMPDIR")},
-		{Name: "GOTOOLCHAIN", Value: cfg.Getenv("GOTOOLCHAIN")},
+		{Name: "GOTOOLCHAIN"},
 		{Name: "GOTOOLDIR", Value: build.ToolDir},
 		{Name: "GOVCS", Value: cfg.GOVCS},
 		{Name: "GOVERSION", Value: runtime.Version()},
@@ -128,9 +128,7 @@ func MkEnv() []cfg.EnvVar {
 		case "GOCACHE":
 			env[i].Value, env[i].Changed = cache.DefaultDir()
 		case "GOTOOLCHAIN":
-			if env[i].Value != "auto" {
-				env[i].Changed = true
-			}
+			env[i].Value, env[i].Changed = cfg.EnvOrAndChanged("GOTOOLCHAIN", "auto")
 		case "GODEBUG":
 			env[i].Changed = env[i].Value != ""
 		}

--- a/src/cmd/go/testdata/script/env_changed.txt
+++ b/src/cmd/go/testdata/script/env_changed.txt
@@ -43,3 +43,14 @@ go env -changed -json GOOS
 go env -changed -json GOARCH
 [GOARCH:amd64] stdout '"GOARCH": "arm64"'
 [!GOARCH:amd64] stdout '"GOARCH": "amd64"'
+
+env GOROOT=./a
+env GOPROXY=s
+go env -changed GOPROXY
+! stdout 'GOPROXY'
+env GOPROXY=s2
+go env -changed GOPROXY
+stdout 'GOPROXY=''?s2''?'
+
+--  a/go.env --
+GOPROXY=s


### PR DESCRIPTION
From $GOROOT/go.env file got GOPROXY and GOSUMDB and GOTOOLCHAIN default value.

Fixes #67542