### PR TITLE
crypto/x509: properly pouplate the RevocationList.AuthorityKeyId field

### DIFF
--- a/src/crypto/x509/parser.go
+++ b/src/crypto/x509/parser.go
@@ -416,7 +416,7 @@ func parseSANExtension(der cryptobyte.String) (dnsNames, emailAddresses []string
 }
 
 func parseAuthorityKeyIdentifier(e pkix.Extension) ([]byte, error) {
-	// RFC 5280, 4.2.1.1
+	// RFC 5280, Section 4.2.1.1
 	if e.Critical {
 		// Conforming CAs MUST mark this extension as non-critical
 		return nil, errors.New("x509: authority key identifier incorrectly marked critical")

--- a/src/crypto/x509/x509_test.go
+++ b/src/crypto/x509/x509_test.go
@@ -2909,9 +2909,9 @@ func TestCreateRevocationList(t *testing.T) {
 				t.Fatalf("Generated CRL has wrong Number: got %s, want %s",
 					parsedCRL.Number.String(), tc.template.Number.String())
 			}
-			if !bytes.Equal(parsedCRL.AuthorityKeyId, expectedAKI) {
+			if !bytes.Equal(parsedCRL.AuthorityKeyId, tc.issuer.SubjectKeyId) {
 				t.Fatalf("Generated CRL has wrong Number: got %x, want %x",
-					parsedCRL.AuthorityKeyId, expectedAKI)
+					parsedCRL.AuthorityKeyId, tc.issuer.SubjectKeyId)
 			}
 		})
 	}

--- a/src/crypto/x509/x509_test.go
+++ b/src/crypto/x509/x509_test.go
@@ -2910,7 +2910,7 @@ func TestCreateRevocationList(t *testing.T) {
 					parsedCRL.Number.String(), tc.template.Number.String())
 			}
 			if !bytes.Equal(parsedCRL.AuthorityKeyId, tc.issuer.SubjectKeyId) {
-				t.Fatalf("Generated CRL has wrong Number: got %x, want %x",
+				t.Fatalf("Generated CRL has wrong AuthorityKeyId: got %x, want %x",
 					parsedCRL.AuthorityKeyId, tc.issuer.SubjectKeyId)
 			}
 		})


### PR DESCRIPTION
This looks like a oversight in [CL 416354](https://go.dev/cl/416354).

Fixes #67571
Fixes #57461
