### PR TITLE
cmd/internal/src: use strconv for lico.lineNumber()

### DIFF
--- a/src/cmd/internal/src/pos.go
+++ b/src/cmd/internal/src/pos.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strconv"
 )
 
 // A Pos encodes a source position consisting of a (line, column) number pair
@@ -458,12 +459,12 @@ func (x lico) withStmt(stmt uint) lico {
 }
 
 func (x lico) lineNumber() string {
-	return fmt.Sprintf("%d", x.Line())
+	return strconv.FormatUint(uint64(x.Line()), 10)
 }
 
 func (x lico) lineNumberHTML() string {
 	if x.IsStmt() == PosDefaultStmt {
-		return fmt.Sprintf("%d", x.Line())
+		return x.lineNumber()
 	}
 	style, pfx := "b", "+"
 	if x.IsStmt() == PosNotStmt {


### PR DESCRIPTION
strconv.FormatUint is more efficient than fmt.Sprintf in converting uint to string.

func BenchmarkUintFormatSmall(b *testing.B) {
	benchmark(b, 1)
}

func BenchmarkUintFormatBig(b *testing.B) {
	benchmark(b, math.MaxUint)
}

func benchmark(b *testing.B, i uint64) {
	b.Run("fmt.Sprintf", func(b *testing.B) {
		for n := 0; n < b.N; n++ {
			_ = fmt.Sprintf("%d", i)
		}
	})

	b.Run("strconv.FormatUint", func(b *testing.B) {
		for n := 0; n < b.N; n++ {
			_ = strconv.FormatUint(i, 10)
		}
	})
}

goos: linux
goarch: amd64
pkg: cmd/internal/src
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkUintFormatSmall/fmt.Sprintf-16         	20557179	        61.24 ns/op	       0 B/op	       0 allocs/op
BenchmarkUintFormatSmall/strconv.FormatUint-16  	514643916	         2.066 ns/op	       0 B/op	       0 allocs/op
BenchmarkUintFormatBig/fmt.Sprintf-16           	 5817141	       240.7 ns/op	      32 B/op	       2 allocs/op
BenchmarkUintFormatBig/strconv.FormatUint-16    	 9459267	       111.5 ns/op	      24 B/op	       1 allocs/op
PASS
ok  	cmd/internal/src	5.425s