### PR TITLE
doc: fix two instances of "the the" in godebug.md

### DIFF
--- a/doc/godebug.md
+++ b/doc/godebug.md
@@ -186,12 +186,12 @@ X25519Kyber768Draft00 by default. The default can be reverted using the
 Go 1.23 changed the behavior of
 [crypto/x509.ParseCertificate](/pkg/crypto/x509/#ParseCertificate) to reject
 serial numbers that are negative. This change can be reverted with
-the the [`x509negativeserial` setting](/pkg/crypto/x509/#ParseCertificate).
+the [`x509negativeserial` setting](/pkg/crypto/x509/#ParseCertificate).
 
 Go 1.23 changed the behavior of
 [crypto/x509.ParseCertificate](/pkg/crypto/x509/#ParseCertificate) to reject
 serial numbers that are longer than 20 octets. This change can be reverted with
-the the [`x509seriallength` setting](/pkg/crypto/x509/#ParseCertificate).
+the [`x509seriallength` setting](/pkg/crypto/x509/#ParseCertificate).
 
 Go 1.23 re-enabled support in html/template for ECMAScript 6 template literals by default.
 The [`jstmpllitinterp` setting](/pkg/html/template#hdr-Security_Model) no longer has


### PR DESCRIPTION
Remove two instances of "the the" introduced recently
in [CL 562343](https://go.dev/cl/562343) and [CL 562975](https://go.dev/cl/562975).
