### PR TITLE
encoding: use slices and maps to clean up tests

### DIFF
--- a/src/encoding/asn1/marshal_test.go
+++ b/src/encoding/asn1/marshal_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"math/big"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -346,7 +347,7 @@ func TestSetEncoder(t *testing.T) {
 	if len(rest) != 0 {
 		t.Error("Unmarshal returned extra garbage")
 	}
-	if !reflect.DeepEqual(expectedOrder, resultStruct.Strings) {
+	if !slices.Equal(expectedOrder, resultStruct.Strings) {
 		t.Errorf("Unexpected SET content. got: %s, want: %s", resultStruct.Strings, expectedOrder)
 	}
 }

--- a/src/encoding/csv/reader_test.go
+++ b/src/encoding/csv/reader_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -470,7 +471,7 @@ func TestRead(t *testing.T) {
 					}
 					break
 				}
-				if got, want := rec, tt.Output[recNum]; !reflect.DeepEqual(got, want) {
+				if got, want := rec, tt.Output[recNum]; !slices.Equal(got, want) {
 					t.Errorf("Read vs ReadAll mismatch;\ngot %q\nwant %q", got, want)
 				}
 				pos := positions[recNum]

--- a/src/encoding/gob/encoder_test.go
+++ b/src/encoding/gob/encoder_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"reflect"
 	"slices"
@@ -74,7 +75,7 @@ func TestEncodeIntSlice(t *testing.T) {
 		res := make([]int8, 9)
 		dec.Decode(&res)
 
-		if !reflect.DeepEqual(s8, res) {
+		if !slices.Equal(s8, res) {
 			t.Fatalf("EncodeIntSlice: expected %v, got %v", s8, res)
 		}
 	})
@@ -88,7 +89,7 @@ func TestEncodeIntSlice(t *testing.T) {
 		res := make([]int16, 9)
 		dec.Decode(&res)
 
-		if !reflect.DeepEqual(s16, res) {
+		if !slices.Equal(s16, res) {
 			t.Fatalf("EncodeIntSlice: expected %v, got %v", s16, res)
 		}
 	})
@@ -102,7 +103,7 @@ func TestEncodeIntSlice(t *testing.T) {
 		res := make([]int32, 9)
 		dec.Decode(&res)
 
-		if !reflect.DeepEqual(s32, res) {
+		if !slices.Equal(s32, res) {
 			t.Fatalf("EncodeIntSlice: expected %v, got %v", s32, res)
 		}
 	})
@@ -116,7 +117,7 @@ func TestEncodeIntSlice(t *testing.T) {
 		res := make([]int64, 9)
 		dec.Decode(&res)
 
-		if !reflect.DeepEqual(s64, res) {
+		if !slices.Equal(s64, res) {
 			t.Fatalf("EncodeIntSlice: expected %v, got %v", s64, res)
 		}
 	})
@@ -689,7 +690,7 @@ func TestMapBug1(t *testing.T) {
 	if err != nil {
 		t.Fatal("decode:", err)
 	}
-	if !reflect.DeepEqual(in, out) {
+	if !maps.Equal(in, out) {
 		t.Errorf("mismatch: %v %v", in, out)
 	}
 }
@@ -763,7 +764,7 @@ func TestSliceReusesMemory(t *testing.T) {
 		if err != nil {
 			t.Fatal("ints: decode:", err)
 		}
-		if !reflect.DeepEqual(x, y) {
+		if !slices.Equal(x, y) {
 			t.Errorf("ints: expected %q got %q\n", x, y)
 		}
 		if addr != &y[0] {
@@ -1199,7 +1200,7 @@ func TestMarshalFloatMap(t *testing.T) {
 
 	got := readMap(out)
 	want := readMap(in)
-	if !reflect.DeepEqual(got, want) {
+	if !slices.Equal(got, want) {
 		t.Fatalf("\nEncode: %v\nDecode: %v", want, got)
 	}
 }

--- a/src/encoding/json/decode_test.go
+++ b/src/encoding/json/decode_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"maps"
 	"math"
 	"math/big"
 	"net"
@@ -1979,7 +1980,7 @@ func TestStringKind(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unmarshal error: %v", err)
 	}
-	if !reflect.DeepEqual(got, want) {
+	if !maps.Equal(got, want) {
 		t.Fatalf("Marshal/Unmarshal mismatch:\n\tgot:  %v\n\twant: %v", got, want)
 	}
 }
@@ -2533,7 +2534,7 @@ func TestUnmarshalRescanLiteralMangledUnquote(t *testing.T) {
 		t.Fatalf("Unmarshal error: %v", err)
 	}
 	want := map[textUnmarshalerString]string{"foo": "", `"`: ""}
-	if !reflect.DeepEqual(got, want) {
+	if !maps.Equal(got, want) {
 		t.Errorf("Marshal/Unmarshal roundtrip:\n\tgot:  %q\n\twant: %q", gotT, wantT)
 	}
 }

--- a/src/encoding/pem/pem_test.go
+++ b/src/encoding/pem/pem_test.go
@@ -163,7 +163,7 @@ func TestCVE202224675(t *testing.T) {
 	// Prior to CVE-2022-24675, this input would cause a stack overflow.
 	input := []byte(strings.Repeat("-----BEGIN \n", 10000000))
 	result, rest := Decode(input)
-	if result != nil || !reflect.DeepEqual(rest, input) {
+	if result != nil || !bytes.Equal(rest, input) {
 		t.Errorf("Encode of %#v decoded as %#v", input, rest)
 	}
 }


### PR DESCRIPTION
Replace reflect.DeepEqual with slices.Equal/maps.Equal, which is
much faster.