### PR TITLE
cmd/go: support both .netrc and _netrc under windows

### DIFF
--- a/src/cmd/go/internal/auth/netrc.go
+++ b/src/cmd/go/internal/auth/netrc.go
@@ -84,11 +84,17 @@ func netrcPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	base := ".netrc"
+	path := filepath.Join(dir, ".netrc")
 	if runtime.GOOS == "windows" {
-		base = "_netrc"
+		if _, err := os.Stat(path); err != nil {
+			if !os.IsNotExist(err) {
+				return "", err
+			}
+			path = filepath.Join(dir, "_netrc")
+		}
 	}
-	return filepath.Join(dir, base), nil
+
+	return path, nil
 }
 
 func readNetrc() {


### PR DESCRIPTION
Fixes: #66832