### PR TITLE
database/sql: allow drivers to override Scan behavior

### DIFF
--- a/api/next/67546.txt
+++ b/api/next/67546.txt
@@ -2,4 +2,4 @@ pkg database/sql/driver, type RowsColumnScanner interface { Close, Columns, Next
 pkg database/sql/driver, type RowsColumnScanner interface, Close() error #67546
 pkg database/sql/driver, type RowsColumnScanner interface, Columns() []string #67546
 pkg database/sql/driver, type RowsColumnScanner interface, Next([]Value) error #67546
-pkg database/sql/driver, type RowsColumnScanner interface, ScanColumn(int, interface{}) error #67546
+pkg database/sql/driver, type RowsColumnScanner interface, ScanColumn(interface{}, int) error #67546

--- a/api/next/67546.txt
+++ b/api/next/67546.txt
@@ -1,0 +1,5 @@
+pkg database/sql/driver, type RowsColumnScanner interface { Close, Columns, Next, ScanColumn } #67546
+pkg database/sql/driver, type RowsColumnScanner interface, Close() error #67546
+pkg database/sql/driver, type RowsColumnScanner interface, Columns() []string #67546
+pkg database/sql/driver, type RowsColumnScanner interface, Next([]Value) error #67546
+pkg database/sql/driver, type RowsColumnScanner interface, ScanColumn(int, interface{}) error #67546

--- a/doc/next/6-stdlib/99-minor/database/sql/driver/67546.md
+++ b/doc/next/6-stdlib/99-minor/database/sql/driver/67546.md
@@ -1,0 +1,1 @@
+A database driver may implement [RowsColumnScanner] to entirely override `Scan` behavior.

--- a/src/database/sql/driver/driver.go
+++ b/src/database/sql/driver/driver.go
@@ -524,7 +524,7 @@ type RowsColumnScanner interface {
 
 	// ScanColumn copies the column in the current row into the value pointed at by
 	// dest. It returns [ErrSkip] to fall back to the normal [database/sql] scanning path.
-	ScanColumn(index int, dest any) error
+	ScanColumn(dest any, index int) error
 }
 
 // Tx is a transaction.

--- a/src/database/sql/driver/driver.go
+++ b/src/database/sql/driver/driver.go
@@ -515,8 +515,10 @@ type RowsColumnTypePrecisionScale interface {
 	ColumnTypePrecisionScale(index int) (precision, scale int64, ok bool)
 }
 
-// RowsColumnScanner may be implemented by [Rows]. It allows the driver to control
-// how values or scanned.
+// RowsColumnScanner may be implemented by [Rows]. It allows the driver to completely
+// take responsibility for how values are scanned and replace the normal [database/sql].
+// scanning path. This allows drivers to directly support types that do not implement
+// [database/sql.Scanner].
 type RowsColumnScanner interface {
 	Rows
 

--- a/src/database/sql/driver/driver.go
+++ b/src/database/sql/driver/driver.go
@@ -516,7 +516,7 @@ type RowsColumnTypePrecisionScale interface {
 }
 
 // RowsColumnScanner may be implemented by [Rows]. It allows the driver to completely
-// take responsibility for how values are scanned and replace the normal [database/sql].
+// take responsibility for how values are scanned and replace the normal [database/sql]
 // scanning path. This allows drivers to directly support types that do not implement
 // [database/sql.Scanner].
 type RowsColumnScanner interface {

--- a/src/database/sql/driver/driver.go
+++ b/src/database/sql/driver/driver.go
@@ -515,6 +515,16 @@ type RowsColumnTypePrecisionScale interface {
 	ColumnTypePrecisionScale(index int) (precision, scale int64, ok bool)
 }
 
+// RowsColumnScanner may be implemented by [Rows]. It allows the driver to control
+// how values or scanned.
+type RowsColumnScanner interface {
+	Rows
+
+	// ScanColumn copies the column in the current row into the value pointed at by
+	// dest. It returns [ErrSkip] to fall back to the normal [database/sql] scanning path.
+	ScanColumn(index int, dest any) error
+}
+
 // Tx is a transaction.
 type Tx interface {
 	Commit() error

--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -3399,8 +3399,8 @@ func (rs *Rows) Scan(dest ...any) error {
 	for i, sv := range rs.lastcols {
 		err := driver.ErrSkip
 
-		if rowsColumnScanner, ok := rs.rowsi.(driver.RowsColumnScanner); ok {
-			err = rowsColumnScanner.ScanColumn(dest[i], i)
+		if rcs, ok := rs.rowsi.(driver.RowsColumnScanner); ok {
+			err = rcs.ScanColumn(dest[i], i)
 		}
 
 		if err == driver.ErrSkip {

--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -3400,7 +3400,7 @@ func (rs *Rows) Scan(dest ...any) error {
 		err := driver.ErrSkip
 
 		if rowsColumnScanner, ok := rs.rowsi.(driver.RowsColumnScanner); ok {
-			err = rowsColumnScanner.ScanColumn(i, dest[i])
+			err = rowsColumnScanner.ScanColumn(dest[i], i)
 		}
 
 		if err == driver.ErrSkip {

--- a/src/database/sql/sql_test.go
+++ b/src/database/sql/sql_test.go
@@ -4271,16 +4271,22 @@ func TestRowsColumnScanner(t *testing.T) {
 	}
 	var (
 		str string
-		n   int64
+		i64 int64
+		i   int
+		f64 float64
+		ui  uint
 	)
-	err = db.QueryRowContext(ctx, "SELECT|t|str,n|").Scan(&str, &n)
+	err = db.QueryRowContext(ctx, "SELECT|t|str,n,n,n,n|").Scan(&str, &i64, &i, &f64, &ui)
 	if err != nil {
 		t.Fatal("select", err)
 	}
 
 	list := []struct{ got, want any }{
 		{str, "foo"},
-		{n, int64(42)},
+		{i64, int64(42)},
+		{i, int(1)},
+		{f64, float64(1)},
+		{ui, uint(1)},
 	}
 
 	for index, item := range list {

--- a/src/database/sql/sql_test.go
+++ b/src/database/sql/sql_test.go
@@ -4241,8 +4241,6 @@ type rcsRows struct {
 
 func (r *rcsRows) ScanColumn(dest any, index int) error {
 	switch d := dest.(type) {
-	// Override int64 to set a specific value. This will prove that
-	// RowsColumnScanner is overriding normal database/sql Scan behavior.
 	case *int64:
 		*d = 42
 		return nil

--- a/src/database/sql/sql_test.go
+++ b/src/database/sql/sql_test.go
@@ -4216,22 +4216,22 @@ type rcsConn struct {
 }
 
 func (c *rcsConn) PrepareContext(ctx context.Context, q string) (driver.Stmt, error) {
-  stmt, err := c.fakeConn.PrepareContext(ctx, q)
-  if err != nil {
-    return stmt, err
-  }
-  return &rcsStmt{stmt.(*fakeStmt)}, nil
+	stmt, err := c.fakeConn.PrepareContext(ctx, q)
+	if err != nil {
+		return stmt, err
+	}
+	return &rcsStmt{stmt.(*fakeStmt)}, nil
 }
 
 type rcsStmt struct {
-  *fakeStmt
+	*fakeStmt
 }
 
 func (s *rcsStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
-  rows, err := s.fakeStmt.QueryContext(ctx, args)
-  if err != nil {
-    return rows, err
-  }
+	rows, err := s.fakeStmt.QueryContext(ctx, args)
+	if err != nil {
+		return rows, err
+	}
 	return &rcsRows{rows.(*rowsCursor)}, nil
 }
 
@@ -4241,8 +4241,8 @@ type rcsRows struct {
 
 func (r *rcsRows) ScanColumn(dest any, index int) error {
 	switch d := dest.(type) {
-  // Override int64 to set a specific value. This will prove that
-  // RowsColumnScanner is overriding normal database/sql Scan behavior.
+	// Override int64 to set a specific value. This will prove that
+	// RowsColumnScanner is overriding normal database/sql Scan behavior.
 	case *int64:
 		*d = 42
 		return nil


### PR DESCRIPTION
Implementing RowsColumnScanner allows the driver
to completely control how values are scanned.

Fixes #67546