### PR TITLE
make.bash: preserve GOROOT_BOOTSTRAP

### DIFF
--- a/src/make.bash
+++ b/src/make.bash
@@ -166,8 +166,10 @@ bootstrapenv() {
 export GOROOT="$(cd .. && pwd)"
 IFS=$'\n'; for go_exe in $(type -ap go); do
 	if [[ ! -x "$GOROOT_BOOTSTRAP/bin/go" ]]; then
+		goroot_bootstrap=$GOROOT_BOOTSTRAP
 		GOROOT_BOOTSTRAP=""
 		goroot=$(bootstrapenv "$go_exe" env GOROOT)
+		GOROOT_BOOTSTRAP=$goroot_bootstrap
 		if [[ "$goroot" != "$GOROOT" ]]; then
 			if [[ "$goroot_bootstrap_set" == "true" ]]; then
 				printf 'WARNING: %s does not exist, found %s from env\n' "$GOROOT_BOOTSTRAP/bin/go" "$go_exe" >&2

--- a/src/make.rc
+++ b/src/make.rc
@@ -60,9 +60,11 @@ if(! ~ $#GOROOT_BOOTSTRAP 1){
 }
 for(p in $path){
 	if(! test -x $GOROOT_BOOTSTRAP/bin/go){
-		GOROOT_BOOTSTRAP = ()
 		if(go_exe = `{path=$p whatis go}){
+			goroot_bootstrap = $GOROOT_BOOTSTRAP
+			GOROOT_BOOTSTRAP = ()
 			goroot = `{bootstrapenv $go_exe env GOROOT}
+			GOROOT_BOOTSTRAP = $goroot_bootstrap
 			if(! ~ $goroot $GOROOT){
 				if(~ $goroot_bootstrap_set 'true'){
 					echo 'WARNING: '$GOROOT_BOOTSTRAP'/bin/go does not exist, found '$go_exe' from env' >[1=2]


### PR DESCRIPTION
[CL 582076](https://go.dev/cl/582076) made the GOROOT_BOOTSTRAP set to "", which in turn
causes the next iteration to return true. "$GOROOT_BOOTSTRAP/bin/go"
becomes "/bin/go", which always exists.

Fixes #67654
