### PR TITLE
cmd/go: let list -m -json include an Origin

### DIFF
--- a/src/cmd/go/internal/modload/build.go
+++ b/src/cmd/go/internal/modload/build.go
@@ -166,8 +166,11 @@ func addUpdate(ctx context.Context, m *modinfo.ModulePublic) {
 // If the two origins conflict including if either is nil,
 // mergeOrigin returns nil.
 func mergeOrigin(m1, m2 *codehost.Origin) *codehost.Origin {
-	if m1 == nil || m2 == nil {
-		return nil
+	if m1 == nil {
+		return m2
+	}
+	if m2 == nil {
+		return m1
 	}
 
 	if m2.VCS != m1.VCS ||

--- a/src/cmd/go/internal/modload/query_test.go
+++ b/src/cmd/go/internal/modload/query_test.go
@@ -197,6 +197,12 @@ func TestQuery(t *testing.T) {
 			if info.Version != tt.vers {
 				t.Errorf("Query(_, %q, %q, %q, %v) = %v, want %v", tt.path, tt.query, tt.current, allow, info.Version, tt.vers)
 			}
+
+			if strings.HasPrefix(tt.query, "v") || tt.query == "latest" {
+				if info.Origin == nil {
+					t.Errorf("Query(_, %q, %q, %q, %v) = %v, info.Origin is nil", tt.path, tt.query, tt.current, allow, info.Version)
+				}
+			}
 		})
 	}
 }

--- a/src/cmd/go/testdata/script/mod_list_issue61423.txt
+++ b/src/cmd/go/testdata/script/mod_list_issue61423.txt
@@ -57,7 +57,7 @@ env GOMODCACHE=$WORK/modcache2
 go list -m -json vcs-test.golang.org/git/issue61415.git@latest
 cp stdout proxy-latest.json
 stdout '"Version": "v0.0.0-20231114180000-08a4fa6bb9c0"'
-! stdout '"Origin":'
+stdout '"Origin":'
 
 # However, if we list a specific, stable version, we should get
 # whatever origin metadata the proxy has for the version.

--- a/src/cmd/go/testdata/script/mod_list_issue67363.txt
+++ b/src/cmd/go/testdata/script/mod_list_issue67363.txt
@@ -1,0 +1,87 @@
+# Test for #67363: fixes let 'go list -m -json' include an Origin
+
+env GOPROXY=https://proxy.golang.org
+
+go list -m -json golang.org/x/arch@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/benchmarks@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/build@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/crypto@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/debug@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/example@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/exp@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/image@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/mobile@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/mod@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/net@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/oauth2@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/perf@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/pkgsite@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/pkgsite-metrics@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/playground@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/review@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/sync@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/sys@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/term@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/text@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/time@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/tools@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/vgo@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/vuln@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/vulndb@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/website@latest
+stdout 'Origin'
+
+go list -m -json golang.org/x/xerrors@latest
+stdout 'Origin'


### PR DESCRIPTION
MergeOrigin will work when m1 or m2 both not nil. But if one of it is nil. It should return other one which is not nil.

Fixes #67363