### PR TITLE
runtime: remove linkname from memhash{32,64} functions

### DIFF
--- a/src/runtime/alg.go
+++ b/src/runtime/alg.go
@@ -56,7 +56,6 @@ var useAeshash bool
 //   - github.com/outcaste-io/ristretto
 //   - github.com/puzpuzpuz/xsync/v2
 //   - github.com/puzpuzpuz/xsync/v3
-//   - github.com/parquet-go/parquet-go
 //   - github.com/authzed/spicedb
 //   - github.com/pingcap/badger
 //
@@ -66,26 +65,8 @@ var useAeshash bool
 //go:linkname memhash
 func memhash(p unsafe.Pointer, h, s uintptr) uintptr
 
-// memhash32 should be an internal detail,
-// but widely used packages access it using linkname.
-// Notable members of the hall of shame include:
-//   - github.com/parquet-go/parquet-go
-//
-// Do not remove or change the type signature.
-// See go.dev/issue/67401.
-//
-//go:linkname memhash32
 func memhash32(p unsafe.Pointer, h uintptr) uintptr
 
-// memhash64 should be an internal detail,
-// but widely used packages access it using linkname.
-// Notable members of the hall of shame include:
-//   - github.com/parquet-go/parquet-go
-//
-// Do not remove or change the type signature.
-// See go.dev/issue/67401.
-//
-//go:linkname memhash64
 func memhash64(p unsafe.Pointer, h uintptr) uintptr
 
 // strhash should be an internal detail,

--- a/src/runtime/alg.go
+++ b/src/runtime/alg.go
@@ -56,7 +56,6 @@ var useAeshash bool
 //   - github.com/outcaste-io/ristretto
 //   - github.com/puzpuzpuz/xsync/v2
 //   - github.com/puzpuzpuz/xsync/v3
-//   - github.com/segmentio/parquet-go
 //   - github.com/parquet-go/parquet-go
 //   - github.com/authzed/spicedb
 //   - github.com/pingcap/badger
@@ -70,7 +69,6 @@ func memhash(p unsafe.Pointer, h, s uintptr) uintptr
 // memhash32 should be an internal detail,
 // but widely used packages access it using linkname.
 // Notable members of the hall of shame include:
-//   - github.com/segmentio/parquet-go
 //   - github.com/parquet-go/parquet-go
 //
 // Do not remove or change the type signature.
@@ -82,7 +80,6 @@ func memhash32(p unsafe.Pointer, h uintptr) uintptr
 // memhash64 should be an internal detail,
 // but widely used packages access it using linkname.
 // Notable members of the hall of shame include:
-//   - github.com/segmentio/parquet-go
 //   - github.com/parquet-go/parquet-go
 //
 // Do not remove or change the type signature.


### PR DESCRIPTION
Remove linkname directives that are no longer necessary given
parquet-go/parquet-go#142 removes the dependency on the `memhash{32,64}`
functions.

This change also removes references to segmentio/parquet-go since that
repository was archived in favor of parquet-go/parquet-go.

Updates #67401 