### PR TITLE
cmd/go: avoid when go.env contain GOTOOLCHAIN=local test fail

### DIFF
--- a/src/cmd/go/testdata/script/env_changed.txt
+++ b/src/cmd/go/testdata/script/env_changed.txt
@@ -1,5 +1,6 @@
 # Test query for non-defaults in the env
 
+env GOROOT=./a
 env GOTOOLCHAIN=local
 env GOSUMDB=nodefault
 env GOPROXY=nodefault
@@ -44,7 +45,6 @@ go env -changed -json GOARCH
 [GOARCH:amd64] stdout '"GOARCH": "arm64"'
 [!GOARCH:amd64] stdout '"GOARCH": "amd64"'
 
-env GOROOT=./a
 env GOPROXY=s
 go env -changed GOPROXY
 ! stdout 'GOPROXY'
@@ -52,5 +52,12 @@ env GOPROXY=s2
 go env -changed GOPROXY
 stdout 'GOPROXY=''?s2''?'
 
+env GOROOT=./b
+go env -changed
+! stdout 'GOTOOLCHAIN=''?local''?'
+
 --  a/go.env --
 GOPROXY=s
+
+--  b/go.env --
+GOTOOLCHAIN=local


### PR DESCRIPTION
The test fail when $GOROOT/go.env contain GOTOOLCHAIN=local
because GOTOOLCHAIN=local is assumed to be a non-default value.
This CL fixed the test failure
by using go.env from the test as $GOROOT/go.env throughout the test.
Test have also been added to ensure that
when $GOROOT/go.env contain GOTOOLCHAIN=local,
GOTOOLCHAIN=local is not taken as a non-default value.

Fixes #67793
