### PR TITLE
time: add to format documentation about dangers of using RFC1123{,Z} for parsing

### DIFF
--- a/src/time/format.go
+++ b/src/time/format.go
@@ -32,6 +32,10 @@ import (
 // only to local times. Applying them to UTC times will use "UTC" as the
 // time zone abbreviation, while strictly speaking those RFCs require the
 // use of "GMT" in that case.
+// When using the [RFC1123] or [RFC1123Z] formats for parsing, note that these
+// formats define a leading zero for the day-in-month portion, which is not
+// strictly allowed by RFC 1123. This will result in an error when parsing
+// date strings that occur in the first 9 days of a given month.
 // In general [RFC1123Z] should be used instead of [RFC1123] for servers
 // that insist on that format, and [RFC3339] should be preferred for new protocols.
 // [RFC3339], [RFC822], [RFC822Z], [RFC1123], and [RFC1123Z] are useful for formatting;
@@ -110,8 +114,8 @@ const (
 	RFC822      = "02 Jan 06 15:04 MST"
 	RFC822Z     = "02 Jan 06 15:04 -0700" // RFC822 with numeric zone
 	RFC850      = "Monday, 02-Jan-06 15:04:05 MST"
-	RFC1123     = "Mon, 2 Jan 2006 15:04:05 MST"
-	RFC1123Z    = "Mon, 2 Jan 2006 15:04:05 -0700" // RFC1123 with numeric zone
+	RFC1123     = "Mon, 02 Jan 2006 15:04:05 MST"
+	RFC1123Z    = "Mon, 02 Jan 2006 15:04:05 -0700" // RFC1123 with numeric zone
 	RFC3339     = "2006-01-02T15:04:05Z07:00"
 	RFC3339Nano = "2006-01-02T15:04:05.999999999Z07:00"
 	Kitchen     = "3:04PM"

--- a/src/time/format.go
+++ b/src/time/format.go
@@ -110,8 +110,8 @@ const (
 	RFC822      = "02 Jan 06 15:04 MST"
 	RFC822Z     = "02 Jan 06 15:04 -0700" // RFC822 with numeric zone
 	RFC850      = "Monday, 02-Jan-06 15:04:05 MST"
-	RFC1123     = "Mon, 02 Jan 2006 15:04:05 MST"
-	RFC1123Z    = "Mon, 02 Jan 2006 15:04:05 -0700" // RFC1123 with numeric zone
+	RFC1123     = "Mon, 2 Jan 2006 15:04:05 MST"
+	RFC1123Z    = "Mon, 2 Jan 2006 15:04:05 -0700" // RFC1123 with numeric zone
 	RFC3339     = "2006-01-02T15:04:05Z07:00"
 	RFC3339Nano = "2006-01-02T15:04:05.999999999Z07:00"
 	Kitchen     = "3:04PM"


### PR DESCRIPTION
When using time.RFC1123Z to parse the date header value out of an email,
an error is returned for dates that occur in the first 9 days of a
month. This is because the format strings for RFC 1123 defined in the
time package indicate that the day should be prefixed with a leading 0.

Reading the spec, the line that talks about it seems to indicate that
days can be either 1 or 2 digits:

  `date = 1*2DIGIT month 2*4DIGIT`

So a date header with a day like `7` with no leading zero should be
accepted.

Fixes #67887