### PR TITLE
fix heap comment

### DIFF
--- a/src/container/heap/heap.go
+++ b/src/container/heap/heap.go
@@ -11,7 +11,8 @@
 // A heap is a common way to implement a priority queue. To build a priority
 // queue, implement the Heap interface with the (negative) priority as the
 // ordering for the Less method, so Push adds items while Pop removes the
-// highest-priority item from the queue. The Examples include such an
+// highest-priority item from the queue. The higher priority items are those
+// that sort earlier. The Examples include such an
 // implementation; the file example_pq_test.go has the complete source.
 package heap
 


### PR DESCRIPTION
The comment of `Pop` says:

> Pop removes and returns the minimum element (according to Less) from the heap.

So it should be `lowest-priority` instead of `highest-priority`.