### PR TITLE
go/printer: correct cindex meaning in commentInfo comments

### DIFF
--- a/src/go/printer/printer.go
+++ b/src/go/printer/printer.go
@@ -45,9 +45,9 @@ const (
 )
 
 type commentInfo struct {
-	cindex         int               // current comment index
-	comment        *ast.CommentGroup // = printer.comments[cindex]; or nil
-	commentOffset  int               // = printer.posFor(printer.comments[cindex].List[0].Pos()).Offset; or infinity
+	cindex         int               // index of the next comment
+	comment        *ast.CommentGroup // = printer.comments[cindex-1]; or nil
+	commentOffset  int               // = printer.posFor(printer.comments[cindex-1].List[0].Pos()).Offset; or infinity
 	commentNewline bool              // true if the comment group contains newlines
 }
 


### PR DESCRIPTION
(*printer).nextComment increases cindex by one after each call
and it always points to the next element.