### PR TITLE
net/http/httptest: This change modifies Go to not block on Server.Start if serveFlag is set

### DIFF
--- a/src/net/http/httptest/server.go
+++ b/src/net/http/httptest/server.go
@@ -134,7 +134,6 @@ func (s *Server) Start() {
 	s.goServe()
 	if serveFlag != "" {
 		fmt.Fprintln(os.Stderr, "httptest: serving on", s.URL)
-		select {}
 	}
 }
 


### PR DESCRIPTION
The presence of the `httptest.serve=<addr>` flag seems to switch the expectation of how the `httptest.Server.Start()` works since it is currently blocking after printing the url.

Unless I am missing something, we don't really need that blocking `select {}` after the print.
This change makes the behaviour consistent irrespective of whether tests are invoked with a `httptest.serve` flag (eg: `go test  -httptest.serve=127.0.0.1:8081`) or without it.