### PR TITLE
cmd/compile: update README to reflect dead code elimination changes

### DIFF
--- a/src/cmd/compile/README.md
+++ b/src/cmd/compile/README.md
@@ -63,7 +63,6 @@ Unified IR is also involved in import/export of packages and inlining.
 
 ### 4. Middle end
 
-* `cmd/compile/internal/deadcode` (dead code elimination)
 * `cmd/compile/internal/inline` (function call inlining)
 * `cmd/compile/internal/devirtualize` (devirtualization of known interface method calls)
 * `cmd/compile/internal/escape` (escape analysis)
@@ -71,6 +70,8 @@ Unified IR is also involved in import/export of packages and inlining.
 Several optimization passes are performed on the IR representation:
 dead code elimination, (early) devirtualization, function call
 inlining, and escape analysis.
+
+The early dead code elimination pass is integrated into the unified IR writer phase.
 
 ### 5. Walk
 


### PR DESCRIPTION
The description of middle-end dead code elimination is inconsistent with the current implementation.

The early dead code elimination pass of IR nodes is no longer located in cmd/compile/internal/deadcode and is no longer called by gc/main.go:Main. It has been moved to the unified IR writer phase. This update modifies the README to reflect this architectural change.