### PR TITLE
sys/cpu: add Int8 matrix multiplication instructions CPU feature flag for ARM64

### DIFF
--- a/src/vendor/golang.org/x/sys/cpu/cpu.go
+++ b/src/vendor/golang.org/x/sys/cpu/cpu.go
@@ -105,6 +105,7 @@ var ARM64 struct {
 	HasSVE      bool // Scalable Vector Extensions
 	HasSVE2     bool // Scalable Vector Extensions 2
 	HasASIMDFHM bool // Advanced SIMD multiplication FP16 to FP32
+	HasI8MM     bool // Advanced SIMD Int8 matrix multiplication instructions
 	_           CacheLinePad
 }
 

--- a/src/vendor/golang.org/x/sys/cpu/cpu_arm64.go
+++ b/src/vendor/golang.org/x/sys/cpu/cpu_arm64.go
@@ -38,6 +38,7 @@ func initOptions() {
 		{Name: "dcpop", Feature: &ARM64.HasDCPOP},
 		{Name: "asimddp", Feature: &ARM64.HasASIMDDP},
 		{Name: "asimdfhm", Feature: &ARM64.HasASIMDFHM},
+		{Name: "i8mm", Feature: &ARM64.HasI8MM},
 	}
 }
 
@@ -143,6 +144,11 @@ func parseARM64SystemRegisters(isar0, isar1, pfr0 uint64) {
 	switch extractBits(isar1, 20, 23) {
 	case 1:
 		ARM64.HasLRCPC = true
+	}
+
+	switch extractBits(isar1, 55, 52) {
+	case 1:
+		ARM64.HasI8MM = true
 	}
 
 	// ID_AA64PFR0_EL1

--- a/src/vendor/golang.org/x/sys/cpu/cpu_linux_arm64.go
+++ b/src/vendor/golang.org/x/sys/cpu/cpu_linux_arm64.go
@@ -37,6 +37,7 @@ const (
 	hwcap_ASIMDFHM = 1 << 23
 
 	hwcap2_SVE2 = 1 << 1
+	hwcap2_I8MM = 1 << 13
 )
 
 // linuxKernelCanEmulateCPUID reports whether we're running
@@ -109,6 +110,7 @@ func doinit() {
 
 	// HWCAP2 feature bits
 	ARM64.HasSVE2 = isSet(hwCap2, hwcap2_SVE2)
+	ARM64.HasI8MM = isSet(hwCap2, hwcap2_I8MM)
 }
 
 func isSet(hwc uint, value uint) bool {


### PR DESCRIPTION
References:
- https://github.com/torvalds/linux/blob/5bbd9b249880dba032bffa002dd9cd12cd5af09c/arch/arm64/include/uapi/asm/hwcap.h#L75C9-L75C31
- https://developer.arm.com/documentation/ddi0601/2024-03/AArch64-Registers/ID-AA64ISAR1-EL1--AArch64-Instruction-Set-Attribute-Register-1