### PR TITLE
syscall,misc/wasm: fix path expansion on non-unix platforms

### DIFF
--- a/misc/wasm/wasm_exec.js
+++ b/misc/wasm/wasm_exec.js
@@ -73,6 +73,14 @@
 		}
 	}
 
+	if (!globalThis.path) {
+		globalThis.path = {
+			resolve(...pathSegments) {
+				return pathSegments.join("/");
+			}
+		}
+	}
+
 	if (!globalThis.crypto) {
 		throw new Error("globalThis.crypto is not available, polyfill required (crypto.getRandomValues only)");
 	}

--- a/misc/wasm/wasm_exec_node.js
+++ b/misc/wasm/wasm_exec_node.js
@@ -11,6 +11,7 @@ if (process.argv.length < 3) {
 
 globalThis.require = require;
 globalThis.fs = require("fs");
+globalThis.path = require("path");
 globalThis.TextEncoder = require("util").TextEncoder;
 globalThis.TextDecoder = require("util").TextDecoder;
 

--- a/src/syscall/fs_js.go
+++ b/src/syscall/fs_js.go
@@ -16,6 +16,7 @@ import (
 func now() (sec int64, nsec int32)
 
 var jsProcess = js.Global().Get("process")
+var jsPath = js.Global().Get("path")
 var jsFS = js.Global().Get("fs")
 var constants = jsFS.Get("constants")
 
@@ -101,10 +102,8 @@ func Open(path string, openmode int, perm uint32) (int, error) {
 		}
 	}
 
-	if path[0] != '/' {
-		cwd := jsProcess.Call("cwd").String()
-		path = cwd + "/" + path
-	}
+	path = jsPath.Call("resolve", path).String()
+
 	f := &jsFile{
 		path:    path,
 		entries: entries,


### PR DESCRIPTION
When running a go binary compiled to wasm using node.js on a Windows platform, 
the absolute path passed in is also incorrectly forced to expand.

For example:

E:\Project\CS_Project\gsv\testdata\result.gob.gz

will results to 

open C:\Users\zxilly\AppData\Local\wasm-exec\go1.23rc1\E:\Project\CS_Project\gsv\testdata\result.gob.gz: No such file or directory

C:\Users\zxilly\AppData\Local\wasm-exec\go1.23rc1 is the place of
wasm_exec_node.js

Fixes: #68820 
