### PR TITLE
internal/bytealg: extend memchr result correctly on wasm

### DIFF
--- a/src/bytes/bytes_js_wasm_test.go
+++ b/src/bytes/bytes_js_wasm_test.go
@@ -1,0 +1,21 @@
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build js && wasm
+
+package bytes_test
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestIssue65571(t *testing.T) {
+	b := make([]byte, 1<<31+1)
+	b[1<<31] = 1
+	i := bytes.IndexByte(b, 1)
+	if i != 1<<31 {
+		t.Errorf("IndexByte(b, 1) = %d; want %d", i, 1<<31)
+	}
+}

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -2278,3 +2278,12 @@ func TestClone(t *testing.T) {
 		}
 	}
 }
+
+func TestIssue65571(t *testing.T) {
+	b := make([]byte, 1<<31+1)
+	b[1<<31] = 1
+	i := IndexByte(b, 1)
+	if i != 1<<31 {
+		t.Errorf("IndexByte(b, 1) = %d; want %d", i, 1<<31)
+	}
+}

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -2278,12 +2278,3 @@ func TestClone(t *testing.T) {
 		}
 	}
 }
-
-func TestIssue65571(t *testing.T) {
-	b := make([]byte, 1<<31+1)
-	b[1<<31] = 1
-	i := IndexByte(b, 1)
-	if i != 1<<31 {
-		t.Errorf("IndexByte(b, 1) = %d; want %d", i, 1<<31)
-	}
-}

--- a/src/internal/bytealg/indexbyte_wasm.s
+++ b/src/internal/bytealg/indexbyte_wasm.s
@@ -12,7 +12,7 @@ TEXT ·IndexByte(SB), NOSPLIT, $0-40
 	I64Load b_len+8(FP)
 	I32WrapI64
 	Call memchr<>(SB)
-	I64ExtendI32S
+	I64ExtendI32U
 	Set R0
 
 	Get SP
@@ -35,7 +35,7 @@ TEXT ·IndexByteString(SB), NOSPLIT, $0-32
 	I64Load s_len+8(FP)
 	I32WrapI64
 	Call memchr<>(SB)
-	I64ExtendI32S
+	I64ExtendI32U
 	Set R0
 
 	I64Const $-1


### PR DESCRIPTION
The mem address should be regarded as uint32.

Fixes #65571