### PR TITLE
math/big: fix comment typo in natdiv.go

### DIFF
--- a/src/math/big/natdiv.go
+++ b/src/math/big/natdiv.go
@@ -392,7 +392,7 @@ Proof that q ≤ q̂:
 	      ≥ (1/y)·((x₁ - y₁ + 1)·S - x)    [above: q̂·y₁ ≥ x₁ - y₁ + 1]
 	      = (1/y)·(x₁·S - y₁·S + S - x)    [distribute S]
 	      = (1/y)·(S - x₀ - y₁·S)          [-x = -x₁·S - x₀]
-	      > -y₁·S / y                      [x₀ < S, so S - x₀ < 0; drop it]
+	      > -y₁·S / y                      [x₀ < S, so S - x₀ > 0; drop it]
 	      ≥ -1                             [y₁·S ≤ y]
 
 	So q̂ - q > -1.


### PR DESCRIPTION
Comment in line 395:
[x₀ < S, so S - x₀ < 0; drop it]
Should be:
[x₀ < S, so S - x₀ > 0; drop it]

The proof is based on S - x₀ > 0, thus it's a typo of comment.

Fixes #68466