### PR TITLE
all: replace simple equality checks with errors.Is()

### DIFF
--- a/src/archive/tar/reader_test.go
+++ b/src/archive/tar/reader_test.go
@@ -684,7 +684,7 @@ func TestReader(t *testing.T) {
 				}
 			}
 
-			if err != v.err {
+			if !errors.Is(err, v.err) {
 				t.Fatalf("unexpected error: got %v, want %v", err, v.err)
 			}
 			f.Close()
@@ -876,7 +876,7 @@ func TestReadTruncation(t *testing.T) {
 					}
 				}
 			}
-			if err != v.err {
+			if !errors.Is(err, v.err) {
 				t.Errorf("test %d, NewReader(%s) with %s discard: got %v, want %v",
 					i, s1, s2, err, v.err)
 			}
@@ -1636,7 +1636,7 @@ func TestInsecurePaths(t *testing.T) {
 
 		tr := NewReader(&buf)
 		h, err := tr.Next()
-		if err != ErrInsecurePath {
+		if !errors.Is(err, ErrInsecurePath) {
 			t.Errorf("tr.Next for file %q: got err %v, want ErrInsecurePath", path, err)
 			continue
 		}

--- a/src/archive/tar/writer.go
+++ b/src/archive/tar/writer.go
@@ -475,7 +475,7 @@ func (tw *Writer) Write(b []byte) (int, error) {
 		return 0, tw.err
 	}
 	n, err := tw.curr.Write(b)
-	if err != nil && err != ErrWriteTooLong {
+	if err != nil && !errors.Is(err, ErrWriteTooLong) {
 		tw.err = err
 	}
 	return n, err
@@ -496,7 +496,7 @@ func (tw *Writer) readFrom(r io.Reader) (int64, error) {
 		return 0, tw.err
 	}
 	n, err := tw.curr.ReadFrom(r)
-	if err != nil && err != ErrWriteTooLong {
+	if err != nil && !errors.Is(err, ErrWriteTooLong) {
 		tw.err = err
 	}
 	return n, err
@@ -506,7 +506,7 @@ func (tw *Writer) readFrom(r io.Reader) (int64, error) {
 // If the current file (from a prior call to [Writer.WriteHeader]) is not fully written,
 // then this returns an error.
 func (tw *Writer) Close() error {
-	if tw.err == ErrWriteAfterClose {
+	if errors.Is(tw.err, ErrWriteAfterClose) {
 		return nil
 	}
 	if tw.err != nil {
@@ -597,7 +597,7 @@ func (sw *sparseFileWriter) Write(b []byte) (n int, err error) {
 
 	n = len(b0) - len(b)
 	switch {
-	case err == ErrWriteTooLong:
+	case errors.Is(err, ErrWriteTooLong):
 		return n, errMissData // Not possible; implies bug in validation logic
 	case err != nil:
 		return n, err
@@ -654,7 +654,7 @@ func (sw *sparseFileWriter) ReadFrom(r io.Reader) (n int64, err error) {
 	switch {
 	case err == io.EOF:
 		return n, io.ErrUnexpectedEOF
-	case err == ErrWriteTooLong:
+	case errors.Is(err, ErrWriteTooLong):
 		return n, errMissData // Not possible; implies bug in validation logic
 	case err != nil:
 		return n, err

--- a/src/archive/tar/writer_test.go
+++ b/src/archive/tar/writer_test.go
@@ -782,7 +782,7 @@ func TestUSTARLongName(t *testing.T) {
 	// Test that we can get a long name back out of the archive.
 	reader := NewReader(&buf)
 	hdr, err = reader.Next()
-	if err != nil && err != ErrInsecurePath {
+	if err != nil && !errors.Is(err, ErrInsecurePath) {
 		t.Fatal(err)
 	}
 	if hdr.Name != longName {
@@ -858,7 +858,7 @@ func TestWriterErrors(t *testing.T) {
 
 	t.Run("BeforeHeader", func(t *testing.T) {
 		tw := NewWriter(new(bytes.Buffer))
-		if _, err := tw.Write([]byte("Kilts")); err != ErrWriteTooLong {
+		if _, err := tw.Write([]byte("Kilts")); !errors.Is(err, ErrWriteTooLong) {
 			t.Fatalf("Write() = %v, want %v", err, ErrWriteTooLong)
 		}
 	})
@@ -872,10 +872,10 @@ func TestWriterErrors(t *testing.T) {
 		if err := tw.Close(); err != nil {
 			t.Fatalf("Close() = %v, want nil", err)
 		}
-		if _, err := tw.Write([]byte("Kilts")); err != ErrWriteAfterClose {
+		if _, err := tw.Write([]byte("Kilts")); !errors.Is(err, ErrWriteAfterClose) {
 			t.Fatalf("Write() = %v, want %v", err, ErrWriteAfterClose)
 		}
-		if err := tw.Flush(); err != ErrWriteAfterClose {
+		if err := tw.Flush(); !errors.Is(err, ErrWriteAfterClose) {
 			t.Fatalf("Flush() = %v, want %v", err, ErrWriteAfterClose)
 		}
 		if err := tw.Close(); err != nil {
@@ -907,7 +907,7 @@ func TestWriterErrors(t *testing.T) {
 
 	t.Run("Persistence", func(t *testing.T) {
 		tw := NewWriter(new(failOnceWriter))
-		if err := tw.WriteHeader(&Header{}); err != io.ErrShortWrite {
+		if err := tw.WriteHeader(&Header{}); !errors.Is(err, io.ErrShortWrite) {
 			t.Fatalf("WriteHeader() = %v, want %v", err, io.ErrShortWrite)
 		}
 		if err := tw.WriteHeader(&Header{Name: "small.txt"}); err == nil {
@@ -997,7 +997,7 @@ func TestIssue12594(t *testing.T) {
 
 		tr := NewReader(&b)
 		hdr, err := tr.Next()
-		if err != nil && err != ErrInsecurePath {
+		if err != nil && !errors.Is(err, ErrInsecurePath) {
 			t.Errorf("test %d, unexpected Next error: %v", i, err)
 		}
 		if hdr.Name != name {
@@ -1027,7 +1027,7 @@ func TestWriteLongHeader(t *testing.T) {
 		h:    &Header{PAXRecords: map[string]string{"GOLANG.x": strings.Repeat("a", maxSpecialFileSize)}},
 	}} {
 		w := NewWriter(io.Discard)
-		if err := w.WriteHeader(test.h); err != ErrFieldTooLong {
+		if err := w.WriteHeader(test.h); !errors.Is(err, ErrFieldTooLong) {
 			t.Errorf("%v: w.WriteHeader() = %v, want ErrFieldTooLong", test.name, err)
 		}
 	}

--- a/src/archive/zip/reader.go
+++ b/src/archive/zip/reader.go
@@ -85,7 +85,7 @@ func OpenReader(name string) (*ReadCloser, error) {
 		return nil, err
 	}
 	r := new(ReadCloser)
-	if err = r.init(f, fi.Size()); err != nil && err != ErrInsecurePath {
+	if err = r.init(f, fi.Size()); err != nil && !errors.Is(err, ErrInsecurePath) {
 		f.Close()
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func NewReader(r io.ReaderAt, size int64) (*Reader, error) {
 	}
 	zr := new(Reader)
 	var err error
-	if err = zr.init(r, size); err != nil && err != ErrInsecurePath {
+	if err = zr.init(r, size); err != nil && !errors.Is(err, ErrInsecurePath) {
 		return nil, err
 	}
 	return zr, err
@@ -145,7 +145,7 @@ func (r *Reader) init(rdr io.ReaderAt, size int64) error {
 	for {
 		f := &File{zip: r, zipr: rdr}
 		err = readDirectoryHeader(f, buf)
-		if err == ErrFormat || err == io.ErrUnexpectedEOF {
+		if errors.Is(err, ErrFormat) || errors.Is(err, io.ErrUnexpectedEOF) {
 			break
 		}
 		if err != nil {

--- a/src/bufio/bufio.go
+++ b/src/bufio/bufio.go
@@ -403,7 +403,7 @@ func (b *Reader) ReadSlice(delim byte) (line []byte, err error) {
 // part of the line returned by ReadLine.
 func (b *Reader) ReadLine() (line []byte, isPrefix bool, err error) {
 	line, err = b.ReadSlice('\n')
-	if err == ErrBufferFull {
+	if errors.Is(err, ErrBufferFull) {
 		// Handle the case where "\r\n" straddles the buffer.
 		if len(line) > 0 && line[len(line)-1] == '\r' {
 			// Put the '\r' back on buf and drop it from line.

--- a/src/bufio/bufio_test.go
+++ b/src/bufio/bufio_test.go
@@ -55,7 +55,7 @@ func readBytes(buf *Reader) string {
 		if err == nil {
 			b[nb] = c
 			nb++
-		} else if err != iotest.ErrTimeout {
+		} else if !errors.Is(err, iotest.ErrTimeout) {
 			panic("Data: " + err.Error())
 		}
 	}
@@ -97,7 +97,7 @@ func readLines(b *Reader) string {
 		if err == io.EOF {
 			break
 		}
-		if err != nil && err != iotest.ErrTimeout {
+		if err != nil && !errors.Is(err, iotest.ErrTimeout) {
 			panic("GetLines: " + err.Error())
 		}
 		s += s1
@@ -193,7 +193,7 @@ func TestZeroReader(t *testing.T) {
 	case err := <-c:
 		if err == nil {
 			t.Error("error expected")
-		} else if err != io.ErrNoProgress {
+		} else if !errors.Is(err, io.ErrNoProgress) {
 			t.Error("unexpected error:", err)
 		}
 	case <-time.After(time.Second):
@@ -827,7 +827,7 @@ func TestBufferFull(t *testing.T) {
 	const longString = "And now, hello, world! It is the time for all good men to come to the aid of their party"
 	buf := NewReaderSize(strings.NewReader(longString), minReadBufferSize)
 	line, err := buf.ReadSlice('!')
-	if string(line) != "And now, hello, " || err != ErrBufferFull {
+	if string(line) != "And now, hello, " || !errors.Is(err, ErrBufferFull) {
 		t.Errorf("first ReadSlice(,) = %q, %v", line, err)
 	}
 	line, err = buf.ReadSlice('!')
@@ -846,10 +846,10 @@ func TestPeek(t *testing.T) {
 	if s, err := buf.Peek(4); string(s) != "abcd" || err != nil {
 		t.Fatalf("want %q got %q, err=%v", "abcd", string(s), err)
 	}
-	if _, err := buf.Peek(-1); err != ErrNegativeCount {
+	if _, err := buf.Peek(-1); !errors.Is(err, ErrNegativeCount) {
 		t.Fatalf("want ErrNegativeCount got %v", err)
 	}
-	if s, err := buf.Peek(32); string(s) != "abcdefghijklmnop" || err != ErrBufferFull {
+	if s, err := buf.Peek(32); string(s) != "abcdefghijklmnop" || !errors.Is(err, ErrBufferFull) {
 		t.Fatalf("want %q, ErrBufFull got %q, err=%v", "abcdefghijklmnop", string(s), err)
 	}
 	if _, err := buf.Read(p[0:3]); string(p[0:3]) != "abc" || err != nil {
@@ -1093,7 +1093,7 @@ func testReadLineNewlines(t *testing.T, input string, expect []readLineResult) {
 			t.Errorf("%q call %d, isPrefix == %v, want %v", input, i, isPrefix, e.isPrefix)
 			return
 		}
-		if err != e.err {
+		if !errors.Is(err, e.err) {
 			t.Errorf("%q call %d, err == %v, want %v", input, i, err, e.err)
 			return
 		}
@@ -1407,7 +1407,7 @@ func TestWriterReadFromErrNoProgress(t *testing.T) {
 	// Use ReadFrom to read in some data.
 	r := &emptyThenNonEmptyReader{r: strings.NewReader("abcd"), n: 100}
 	n2, err := w.ReadFrom(r)
-	if n2 != 0 || err != io.ErrNoProgress {
+	if n2 != 0 || !errors.Is(err, io.ErrNoProgress) {
 		t.Fatalf("buf.Bytes() returned (%v, %v), want (0, io.ErrNoProgress)", n2, err)
 	}
 }

--- a/src/bufio/scan.go
+++ b/src/bufio/scan.go
@@ -149,7 +149,7 @@ func (s *Scanner) Scan() bool {
 		if s.end > s.start || s.err != nil {
 			advance, token, err := s.split(s.buf[s.start:s.end], s.err != nil)
 			if err != nil {
-				if err == ErrFinalToken {
+				if errors.Is(err, ErrFinalToken) {
 					s.token = token
 					s.done = true
 					// When token is not nil, it means the scanning stops

--- a/src/bufio/scan_test.go
+++ b/src/bufio/scan_test.go
@@ -241,7 +241,7 @@ func TestScanLineTooLong(t *testing.T) {
 		}
 	}
 	err := s.Err()
-	if err != ErrTooLong {
+	if !errors.Is(err, ErrTooLong) {
 		t.Fatalf("expected ErrTooLong; got %s", err)
 	}
 }
@@ -378,7 +378,7 @@ func TestNonEOFWithEmptyRead(t *testing.T) {
 		t.Fatal("read should fail")
 	}
 	err := scanner.Err()
-	if err != io.ErrUnexpectedEOF {
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -396,7 +396,7 @@ func TestBadReader(t *testing.T) {
 		t.Fatal("read should fail")
 	}
 	err := scanner.Err()
-	if err != io.ErrNoProgress {
+	if !errors.Is(err, io.ErrNoProgress) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/src/cmd/compile/internal/syntax/printer_test.go
+++ b/src/cmd/compile/internal/syntax/printer_test.go
@@ -5,6 +5,7 @@
 package syntax
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -47,7 +48,7 @@ func TestPrintError(t *testing.T) {
 
 	var buf shortBuffer
 	_, err = Fprint(&buf, ast, 0)
-	if err == nil || err != io.ErrShortBuffer {
+	if err == nil || !errors.Is(err, io.ErrShortBuffer) {
 		t.Errorf("got err = %s, want %s", err, io.ErrShortBuffer)
 	}
 }

--- a/src/cmd/go/internal/cache/cache.go
+++ b/src/cmd/go/internal/cache/cache.go
@@ -209,7 +209,7 @@ func (c *DiskCache) get(id ActionID) (Entry, error) {
 	entry := make([]byte, entrySize+1) // +1 to detect whether f is too long
 	if n, err := io.ReadFull(f, entry); n > entrySize {
 		return missing(errors.New("too long"))
-	} else if err != io.ErrUnexpectedEOF {
+	} else if !errors.Is(err, io.ErrUnexpectedEOF) {
 		if err == io.EOF {
 			return missing(errors.New("file is empty"))
 		}

--- a/src/cmd/go/internal/generate/generate.go
+++ b/src/cmd/go/internal/generate/generate.go
@@ -9,6 +9,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"go/parser"
 	"go/token"
@@ -300,12 +301,12 @@ func (g *Generator) run() (ok bool) {
 		g.lineNum++ // 1-indexed.
 		var buf []byte
 		buf, err = input.ReadSlice('\n')
-		if err == bufio.ErrBufferFull {
+		if errors.Is(err, bufio.ErrBufferFull) {
 			// Line too long - consume and ignore.
 			if isGoGenerate(buf) {
 				g.errorf("directive too long")
 			}
-			for err == bufio.ErrBufferFull {
+			for errors.Is(err, bufio.ErrBufferFull) {
 				_, err = input.ReadSlice('\n')
 			}
 			if err != nil {

--- a/src/cmd/go/internal/modfetch/codehost/codehost.go
+++ b/src/cmd/go/internal/modfetch/codehost/codehost.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -172,7 +173,7 @@ func (e *UnknownRevisionError) Error() string {
 	return "unknown revision " + e.Rev
 }
 func (UnknownRevisionError) Is(err error) bool {
-	return err == fs.ErrNotExist
+	return errors.Is(err, fs.ErrNotExist)
 }
 
 // ErrNoCommits is an error equivalent to fs.ErrNotExist indicating that a given
@@ -185,7 +186,7 @@ func (noCommitsError) Error() string {
 	return "no commits"
 }
 func (noCommitsError) Is(err error) bool {
-	return err == fs.ErrNotExist
+	return errors.Is(err, fs.ErrNotExist)
 }
 
 // AllHex reports whether the revision rev is entirely lower-case hexadecimal digits.

--- a/src/cmd/go/internal/modload/buildlist.go
+++ b/src/cmd/go/internal/modload/buildlist.go
@@ -526,7 +526,7 @@ func (mg *ModuleGraph) BuildList() []module.Version {
 func (mg *ModuleGraph) findError() error {
 	errStack := mg.g.FindPath(func(m module.Version) bool {
 		_, err := mg.loadCache.Get(m)
-		return err != nil && err != par.ErrCacheEntryNotFound
+		return err != nil && !errors.Is(err, par.ErrCacheEntryNotFound)
 	})
 	if len(errStack) > 0 {
 		_, err := mg.loadCache.Get(errStack[len(errStack)-1])

--- a/src/cmd/go/internal/modload/edit.go
+++ b/src/cmd/go/internal/modload/edit.go
@@ -265,7 +265,7 @@ func editRequirements(ctx context.Context, rs *Requirements, tryUpgrade, mustSel
 			}
 
 			summary, err := mg.loadCache.Get(m)
-			if err != nil && err != par.ErrCacheEntryNotFound {
+			if err != nil && !errors.Is(err, par.ErrCacheEntryNotFound) {
 				// We can't determine the requirements of m, so we don't know whether
 				// they would be allowed. This may be a transient error reaching the
 				// repository, rather than a permanent error with the retrieved version.

--- a/src/cmd/go/internal/modload/search.go
+++ b/src/cmd/go/internal/modload/search.go
@@ -133,7 +133,7 @@ func matchPackages(ctx context.Context, m *search.Match, tags map[string]bool, f
 				have[name] = true
 				if isMatch(name) {
 					q.Add(func() {
-						if _, _, err := scanDir(root, pkgDir, tags); err != imports.ErrNoGo {
+						if _, _, err := scanDir(root, pkgDir, tags); !errors.Is(err, imports.ErrNoGo) {
 							addPkg(name)
 						}
 					})
@@ -254,7 +254,7 @@ func walkFromIndex(index *modindex.Module, importPathRoot string, isMatch, treeC
 		if !have[name] {
 			have[name] = true
 			if isMatch(name) {
-				if _, _, err := index.Package(reldir).ScanDir(tags); err != imports.ErrNoGo {
+				if _, _, err := index.Package(reldir).ScanDir(tags); !errors.Is(err, imports.ErrNoGo) {
 					addPkg(name)
 				}
 			}
@@ -293,7 +293,7 @@ func MatchInModule(ctx context.Context, pattern string, m module.Version, tags m
 		return match
 	}
 	if haveGoFiles {
-		if _, _, err := scanDir(root, dir, tags); err != imports.ErrNoGo {
+		if _, _, err := scanDir(root, dir, tags); !errors.Is(err, imports.ErrNoGo) {
 			// ErrNoGo indicates that the directory is not actually a Go package,
 			// perhaps due to the tags in use. Any other non-nil error indicates a
 			// problem with one or more of the Go source files, but such an error does

--- a/src/cmd/go/internal/vcs/vcs.go
+++ b/src/cmd/go/internal/vcs/vcs.go
@@ -907,7 +907,7 @@ func (e *vcsNotFoundError) Error() string {
 }
 
 func (e *vcsNotFoundError) Is(err error) bool {
-	return err == os.ErrNotExist
+	return errors.Is(err, os.ErrNotExist)
 }
 
 // A govcsRule is a single GOVCS rule like private:hg|svn.

--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -995,7 +995,7 @@ func (b *Builder) checkDirectives(a *Action) error {
 	for _, d := range p.Internal.Build.Directives {
 		if strings.HasPrefix(d.Text, "//go:debug") {
 			key, _, err := load.ParseGoDebug(d.Text)
-			if err != nil && err != load.ErrNotGoDebug {
+			if err != nil && !errors.Is(err, load.ErrNotGoDebug) {
 				msg = fmt.Appendf(msg, "%s: invalid //go:debug: %v\n", d.Pos, err)
 				continue
 			}

--- a/src/cmd/internal/archive/archive.go
+++ b/src/cmd/internal/archive/archive.go
@@ -157,7 +157,7 @@ func (r *objReader) peek(n int) ([]byte, error) {
 	}
 	b, err := r.b.Peek(n)
 	if err != nil {
-		if err != bufio.ErrBufferFull {
+		if !errors.Is(err, bufio.ErrBufferFull) {
 			r.error(err)
 		}
 	}

--- a/src/cmd/internal/buildid/buildid.go
+++ b/src/cmd/internal/buildid/buildid.go
@@ -7,6 +7,7 @@ package buildid
 import (
 	"bytes"
 	"debug/elf"
+	"errors"
 	"fmt"
 	"internal/xcoff"
 	"io"
@@ -278,7 +279,7 @@ func readBinary(name string, f *os.File) (id string, err error) {
 	//
 	data := make([]byte, readSize)
 	_, err = io.ReadFull(f, data)
-	if err == io.ErrUnexpectedEOF {
+	if errors.Is(err, io.ErrUnexpectedEOF) {
 		err = nil
 	}
 	if err != nil {

--- a/src/cmd/internal/buildid/rewrite.go
+++ b/src/cmd/internal/buildid/rewrite.go
@@ -9,6 +9,7 @@ import (
 	"cmd/internal/codesign"
 	"crypto/sha256"
 	"debug/macho"
+	"errors"
 	"fmt"
 	"io"
 )
@@ -52,7 +53,7 @@ func FindAndHash(r io.Reader, id string, bufSize int) (matches []int64, hash [32
 		// buf[start:tiny] is left over from previous iteration.
 		// After reading n bytes into buf[tiny:], we process buf[start:tiny+n].
 		n, err := io.ReadFull(r, buf[tiny:])
-		if err != io.ErrUnexpectedEOF && err != io.EOF && err != nil {
+		if !errors.Is(err, io.ErrUnexpectedEOF) && err != io.EOF && err != nil {
 			return nil, [32]byte{}, err
 		}
 

--- a/src/cmd/internal/codesign/codesign.go
+++ b/src/cmd/internal/codesign/codesign.go
@@ -13,6 +13,7 @@ package codesign
 import (
 	"debug/macho"
 	"encoding/binary"
+	"errors"
 	"io"
 
 	"cmd/internal/notsha256"
@@ -258,7 +259,7 @@ func Sign(out []byte, data io.Reader, id string, codeSize, textOff, textSize int
 		if err == io.EOF {
 			break
 		}
-		if err != nil && err != io.ErrUnexpectedEOF {
+		if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
 			panic(err)
 		}
 		if p+n > int(codeSize) {

--- a/src/cmd/link/dwarf_test.go
+++ b/src/cmd/link/dwarf_test.go
@@ -10,6 +10,7 @@ import (
 	"cmd/internal/objfile"
 	"cmd/internal/quoted"
 	"debug/dwarf"
+	"errors"
 	"internal/platform"
 	"internal/testenv"
 	"os"
@@ -175,7 +176,7 @@ func testDWARF(t *testing.T, buildmode string, expectDWARF bool, env ...string) 
 				t.Fatal(err)
 			}
 			var line dwarf.LineEntry
-			if err := lr.SeekPC(addr, &line); err == dwarf.ErrUnknownPC {
+			if err := lr.SeekPC(addr, &line); errors.Is(err, dwarf.ErrUnknownPC) {
 				t.Fatalf("did not find file:line for %#x (main.main)", addr)
 			} else if err != nil {
 				t.Fatal(err)

--- a/src/cmd/link/internal/ld/elf.go
+++ b/src/cmd/link/internal/ld/elf.go
@@ -13,6 +13,7 @@ import (
 	"debug/elf"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"internal/buildcfg"
 	"os"
@@ -832,7 +833,7 @@ func addbuildinfo(val string) {
 
 	b, err := hex.DecodeString(val)
 	if err != nil {
-		if err == hex.ErrLength {
+		if errors.Is(err, hex.ErrLength) {
 			Exitf("-B argument must have even number of digits: %s", ov)
 		}
 		if inv, ok := err.(hex.InvalidByteError); ok {

--- a/src/cmd/vendor/golang.org/x/text/internal/language/parse.go
+++ b/src/cmd/vendor/golang.org/x/text/internal/language/parse.go
@@ -121,7 +121,7 @@ func (s *scanner) toLower(start, end int) {
 }
 
 func (s *scanner) setError(e error) {
-	if s.err == nil || (e == ErrSyntax && s.err != ErrSyntax) {
+	if s.err == nil || (errors.Is(e, ErrSyntax) && !errors.Is(s.err, ErrSyntax)) {
 		s.err = e
 	}
 }

--- a/src/compress/flate/flate_test.go
+++ b/src/compress/flate/flate_test.go
@@ -11,6 +11,7 @@ package flate
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -266,7 +267,7 @@ func TestTruncatedStreams(t *testing.T) {
 	for i := 0; i < len(data)-1; i++ {
 		r := NewReader(strings.NewReader(data[:i]))
 		_, err := io.Copy(io.Discard, r)
-		if err != io.ErrUnexpectedEOF {
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
 			t.Errorf("io.Copy(%d) on truncated stream: got %v, want %v", i, err, io.ErrUnexpectedEOF)
 		}
 	}

--- a/src/compress/flate/inflate_test.go
+++ b/src/compress/flate/inflate_test.go
@@ -7,6 +7,7 @@ package flate
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -58,7 +59,7 @@ func TestReaderTruncated(t *testing.T) {
 		r := strings.NewReader(v.input)
 		zr := NewReader(r)
 		b, err := io.ReadAll(zr)
-		if err != io.ErrUnexpectedEOF {
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
 			t.Errorf("test %d, error mismatch: got %v, want io.ErrUnexpectedEOF", i, err)
 		}
 		if string(b) != v.output {

--- a/src/compress/gzip/example_test.go
+++ b/src/compress/gzip/example_test.go
@@ -7,6 +7,7 @@ package gzip_test
 import (
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -182,13 +183,13 @@ func Example_compressingReader() {
 
 		// Copy our data to gzipWriter, which compresses it to
 		// gzipWriter, which feeds it to bodyReader.
-		if _, err := io.Copy(gzipWriter, dataReader); err != nil && err != io.ErrClosedPipe {
+		if _, err := io.Copy(gzipWriter, dataReader); err != nil && !errors.Is(err, io.ErrClosedPipe) {
 			sendErr(err)
 		}
-		if err := gzipWriter.Close(); err != nil && err != io.ErrClosedPipe {
+		if err := gzipWriter.Close(); err != nil && !errors.Is(err, io.ErrClosedPipe) {
 			sendErr(err)
 		}
-		if err := httpWriter.Close(); err != nil && err != io.ErrClosedPipe {
+		if err := httpWriter.Close(); err != nil && !errors.Is(err, io.ErrClosedPipe) {
 			sendErr(err)
 		}
 	}()

--- a/src/compress/gzip/gunzip_test.go
+++ b/src/compress/gzip/gunzip_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"compress/flate"
 	"encoding/base64"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -554,7 +555,7 @@ func TestTruncatedStreams(t *testing.T) {
 		for i := 1; i < len(tc.data); i++ {
 			r, err := NewReader(strings.NewReader(string(tc.data[:i])))
 			if err != nil {
-				if err != io.ErrUnexpectedEOF {
+				if !errors.Is(err, io.ErrUnexpectedEOF) {
 					t.Errorf("NewReader(%s-%d) on truncated stream: got %v, want %v", tc.name, i, err, io.ErrUnexpectedEOF)
 				}
 				continue
@@ -563,7 +564,7 @@ func TestTruncatedStreams(t *testing.T) {
 			if ferr, ok := err.(*flate.ReadError); ok {
 				err = ferr.Err
 			}
-			if err != io.ErrUnexpectedEOF {
+			if !errors.Is(err, io.ErrUnexpectedEOF) {
 				t.Errorf("io.Copy(%s-%d) on truncated stream: got %v, want %v", tc.name, i, err, io.ErrUnexpectedEOF)
 			}
 		}

--- a/src/compress/lzw/reader_test.go
+++ b/src/compress/lzw/reader_test.go
@@ -6,6 +6,7 @@ package lzw
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -105,7 +106,7 @@ func TestReader(t *testing.T) {
 			if err != tt.err {
 				t.Errorf("%s: io.Copy: %v want %v", tt.desc, err, tt.err)
 			}
-			if err == io.ErrUnexpectedEOF {
+			if errors.Is(err, io.ErrUnexpectedEOF) {
 				// Even if the input is truncated, we should still return the
 				// partial decoded result.
 				if n == 0 || !strings.HasPrefix(tt.raw, s) {
@@ -143,7 +144,7 @@ func TestReaderReset(t *testing.T) {
 			if err != tt.err {
 				t.Errorf("%s: io.Copy: %v want %v", tt.desc, err, tt.err)
 			}
-			if err == io.ErrUnexpectedEOF {
+			if errors.Is(err, io.ErrUnexpectedEOF) {
 				// Even if the input is truncated, we should still return the
 				// partial decoded result.
 				if n == 0 || !strings.HasPrefix(tt.raw, b.String()) {

--- a/src/crypto/rsa/rsa_test.go
+++ b/src/crypto/rsa/rsa_test.go
@@ -15,6 +15,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"flag"
 	"fmt"
 	"internal/testenv"
@@ -190,7 +191,7 @@ func testEverything(t *testing.T, priv *PrivateKey) {
 
 	msg := []byte("test")
 	enc, err := EncryptPKCS1v15(rand.Reader, &priv.PublicKey, msg)
-	if err == ErrMessageTooLong {
+	if errors.Is(err, ErrMessageTooLong) {
 		t.Log("key too small for EncryptPKCS1v15")
 	} else if err != nil {
 		t.Errorf("EncryptPKCS1v15: %v", err)
@@ -211,7 +212,7 @@ func testEverything(t *testing.T, priv *PrivateKey) {
 
 	label := []byte("label")
 	enc, err = EncryptOAEP(sha256.New(), rand.Reader, &priv.PublicKey, msg, label)
-	if err == ErrMessageTooLong {
+	if errors.Is(err, ErrMessageTooLong) {
 		t.Log("key too small for EncryptOAEP")
 	} else if err != nil {
 		t.Errorf("EncryptOAEP: %v", err)
@@ -228,7 +229,7 @@ func testEverything(t *testing.T, priv *PrivateKey) {
 
 	hash := sha256.Sum256(msg)
 	sig, err := SignPKCS1v15(nil, priv, crypto.SHA256, hash[:])
-	if err == ErrMessageTooLong {
+	if errors.Is(err, ErrMessageTooLong) {
 		t.Log("key too small for SignPKCS1v15")
 	} else if err != nil {
 		t.Errorf("SignPKCS1v15: %v", err)
@@ -254,7 +255,7 @@ func testEverything(t *testing.T, priv *PrivateKey) {
 
 	opts := &PSSOptions{SaltLength: PSSSaltLengthAuto}
 	sig, err = SignPSS(rand.Reader, priv, crypto.SHA256, hash[:], opts)
-	if err == ErrMessageTooLong {
+	if errors.Is(err, ErrMessageTooLong) {
 		t.Log("key too small for SignPSS with PSSSaltLengthAuto")
 	} else if err != nil {
 		t.Errorf("SignPSS: %v", err)
@@ -280,7 +281,7 @@ func testEverything(t *testing.T, priv *PrivateKey) {
 
 	opts.SaltLength = PSSSaltLengthEqualsHash
 	sig, err = SignPSS(rand.Reader, priv, crypto.SHA256, hash[:], opts)
-	if err == ErrMessageTooLong {
+	if errors.Is(err, ErrMessageTooLong) {
 		t.Log("key too small for SignPSS with PSSSaltLengthEqualsHash")
 	} else if err != nil {
 		t.Errorf("SignPSS: %v", err)

--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -630,7 +630,7 @@ func (c *Conn) readRecordOrCCS(expectChangeCipherSpec bool) error {
 		// RFC 8446, Section 6.1 suggests that EOF without an alertCloseNotify
 		// is an error, but popular web sites seem to do this, so we accept it
 		// if and only if at the record boundary.
-		if err == io.ErrUnexpectedEOF && c.rawInput.Len() == 0 {
+		if errors.Is(err, io.ErrUnexpectedEOF) && c.rawInput.Len() == 0 {
 			err = io.EOF
 		}
 		if e, ok := err.(net.Error); !ok || !e.Temporary() {

--- a/src/crypto/tls/tls_test.go
+++ b/src/crypto/tls/tls_test.go
@@ -606,7 +606,7 @@ func TestConnCloseBreakingWrite(t *testing.T) {
 	}
 
 	<-closeReturned
-	if err := tconn.Close(); err != net.ErrClosed {
+	if err := tconn.Close(); !errors.Is(err, net.ErrClosed) {
 		t.Errorf("Close error = %v; want net.ErrClosed", err)
 	}
 }

--- a/src/crypto/x509/x509_test.go
+++ b/src/crypto/x509/x509_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/gob"
 	"encoding/hex"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"internal/testenv"
 	"io"
@@ -3666,7 +3667,7 @@ func TestDisableSHA1ForCertOnly(t *testing.T) {
 	}
 
 	err = cert.CheckSignature(SHA1WithRSA, ocspTBS, nil)
-	if err != rsa.ErrVerification {
+	if !errors.Is(err, rsa.ErrVerification) {
 		t.Errorf("unexpected error: %s", err)
 	}
 }

--- a/src/database/sql/example_service_test.go
+++ b/src/database/sql/example_service_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -76,7 +77,7 @@ where
 			sql.Named("org", org),
 		).Scan(&name)
 		if err != nil {
-			if err == sql.ErrNoRows {
+			if errors.Is(err, sql.ErrNoRows) {
 				http.Error(w, "not found", http.StatusNotFound)
 				return
 			}

--- a/src/database/sql/example_test.go
+++ b/src/database/sql/example_test.go
@@ -7,6 +7,7 @@ package sql_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -57,7 +58,7 @@ func ExampleDB_QueryRowContext() {
 	var created time.Time
 	err := db.QueryRowContext(ctx, "SELECT username, created_at FROM users WHERE id=?", id).Scan(&username, &created)
 	switch {
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 		log.Printf("no user with id %d\n", id)
 	case err != nil:
 		log.Fatalf("query error: %v\n", err)
@@ -314,7 +315,7 @@ func ExampleStmt() {
 	var username string
 	err = stmt.QueryRowContext(ctx, id).Scan(&username)
 	switch {
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 		log.Fatalf("no user with id %d", id)
 	case err != nil:
 		log.Fatal(err)
@@ -336,7 +337,7 @@ func ExampleStmt_QueryRowContext() {
 	var username string
 	err = stmt.QueryRowContext(ctx, id).Scan(&username)
 	switch {
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 		log.Fatalf("no user with id %d", id)
 	case err != nil:
 		log.Fatal(err)

--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -1704,7 +1704,7 @@ func (db *DB) execDC(ctx context.Context, dc *driverConn, release func(error), q
 			}
 			resi, err = ctxDriverExec(ctx, execerCtx, execer, query, nvdargs)
 		})
-		if err != driver.ErrSkip {
+		if !errors.Is(err, driver.ErrSkip) {
 			if err != nil {
 				return nil, err
 			}
@@ -1777,7 +1777,7 @@ func (db *DB) queryDC(ctx, txctx context.Context, dc *driverConn, releaseConn fu
 			}
 			rowsi, err = ctxDriverQuery(ctx, queryerCtx, queryer, query, nvdargs)
 		})
-		if err != driver.ErrSkip {
+		if !errors.Is(err, driver.ErrSkip) {
 			if err != nil {
 				releaseConn(err)
 				return nil, err

--- a/src/database/sql/sql_test.go
+++ b/src/database/sql/sql_test.go
@@ -856,7 +856,7 @@ func TestTxRollbackCommitErr(t *testing.T) {
 		t.Errorf("expected nil error from Rollback; got %v", err)
 	}
 	err = tx.Commit()
-	if err != ErrTxDone {
+	if !errors.Is(err, ErrTxDone) {
 		t.Errorf("expected %q from Commit; got %q", ErrTxDone, err)
 	}
 
@@ -869,7 +869,7 @@ func TestTxRollbackCommitErr(t *testing.T) {
 		t.Errorf("expected nil error from Commit; got %v", err)
 	}
 	err = tx.Rollback()
-	if err != ErrTxDone {
+	if !errors.Is(err, ErrTxDone) {
 		t.Errorf("expected %q from Rollback; got %q", ErrTxDone, err)
 	}
 }
@@ -2094,7 +2094,7 @@ func TestMaxOpenConns(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				var op string
-				if err := stmt.QueryRow("sleep", sleepMillis).Scan(&op); err != nil && err != ErrNoRows {
+				if err := stmt.QueryRow("sleep", sleepMillis).Scan(&op); err != nil && !errors.Is(err, ErrNoRows) {
 					t.Error(err)
 				}
 			}()
@@ -2472,7 +2472,7 @@ func TestStmtCloseDeps(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				var op string
-				if err := stmt.QueryRow("sleep", sleepMillis).Scan(&op); err != nil && err != ErrNoRows {
+				if err := stmt.QueryRow("sleep", sleepMillis).Scan(&op); err != nil && !errors.Is(err, ErrNoRows) {
 					t.Error(err)
 				}
 			}()

--- a/src/debug/dwarf/entry_test.go
+++ b/src/debug/dwarf/entry_test.go
@@ -7,6 +7,7 @@ package dwarf_test
 import (
 	. "debug/dwarf"
 	"encoding/binary"
+	"errors"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -112,7 +113,7 @@ func testRanges(t *testing.T, name string, want []wantRange) {
 			if w.ranges != nil {
 				t.Errorf("%s: missing Entry for %#x", name, w.pc)
 			}
-			if err != ErrUnknownPC {
+			if !errors.Is(err, ErrUnknownPC) {
 				t.Errorf("%s: expected ErrUnknownPC for %#x, got %v", name, w.pc, err)
 			}
 			continue

--- a/src/debug/dwarf/line_test.go
+++ b/src/debug/dwarf/line_test.go
@@ -6,6 +6,7 @@ package dwarf_test
 
 import (
 	. "debug/dwarf"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -232,12 +233,12 @@ func TestLineSeek(t *testing.T) {
 	}
 
 	// Check that seeking to a PC returns the right line.
-	if err := lr.SeekPC(table[0].Address-1, &line); err != ErrUnknownPC {
+	if err := lr.SeekPC(table[0].Address-1, &line); !errors.Is(err, ErrUnknownPC) {
 		t.Fatalf("lr.SeekPC to %#x returned %v instead of ErrUnknownPC", table[0].Address-1, err)
 	}
 	for i, testLine := range table {
 		if testLine.EndSequence {
-			if err := lr.SeekPC(testLine.Address, &line); err != ErrUnknownPC {
+			if err := lr.SeekPC(testLine.Address, &line); !errors.Is(err, ErrUnknownPC) {
 				t.Fatalf("lr.SeekPC to %#x returned %v instead of ErrUnknownPC", testLine.Address, err)
 			}
 			continue

--- a/src/debug/elf/symbols_test.go
+++ b/src/debug/elf/symbols_test.go
@@ -5,6 +5,7 @@
 package elf
 
 import (
+	"errors"
 	"io"
 	"path"
 	"reflect"
@@ -30,10 +31,10 @@ func TestSymbols(t *testing.T) {
 		}
 		defer f.Close()
 		fs, err := getfunc(f)
-		if err != nil && err != ErrNoSymbols {
+		if err != nil && !errors.Is(err, ErrNoSymbols) {
 			t.Error(err)
 			return
-		} else if err == ErrNoSymbols {
+		} else if errors.Is(err, ErrNoSymbols) {
 			fs = []Symbol{}
 		}
 		if !reflect.DeepEqual(ts, fs) {

--- a/src/debug/macho/file_test.go
+++ b/src/debug/macho/file_test.go
@@ -6,6 +6,7 @@ package macho
 
 import (
 	"bytes"
+	"errors"
 	"internal/obscuretestdata"
 	"io"
 	"reflect"
@@ -391,7 +392,7 @@ func TestOpenFatFailure(t *testing.T) {
 
 	filename = "testdata/gcc-386-darwin-exec.base64" // not a fat Mach-O
 	ff, err := openFatObscured(filename)
-	if err != ErrNotFat {
+	if !errors.Is(err, ErrNotFat) {
 		t.Errorf("OpenFat %s: got %v, want ErrNotFat", filename, err)
 	}
 	if ff != nil {

--- a/src/encoding/csv/reader.go
+++ b/src/encoding/csv/reader.go
@@ -254,9 +254,9 @@ func (r *Reader) ReadAll() (records [][]string, err error) {
 // The result is only valid until the next call to readLine.
 func (r *Reader) readLine() ([]byte, error) {
 	line, err := r.r.ReadSlice('\n')
-	if err == bufio.ErrBufferFull {
+	if errors.Is(err, bufio.ErrBufferFull) {
 		r.rawBuffer = append(r.rawBuffer[:0], line...)
-		for err == bufio.ErrBufferFull {
+		for errors.Is(err, bufio.ErrBufferFull) {
 			line, err = r.r.ReadSlice('\n')
 			r.rawBuffer = append(r.rawBuffer, line...)
 		}

--- a/src/encoding/csv/writer_test.go
+++ b/src/encoding/csv/writer_test.go
@@ -58,7 +58,7 @@ func TestWrite(t *testing.T) {
 			f.Comma = tt.Comma
 		}
 		err := f.WriteAll(tt.Input)
-		if err != tt.Error {
+		if !errors.Is(err, tt.Error) {
 			t.Errorf("Unexpected error:\ngot  %v\nwant %v", err, tt.Error)
 		}
 		out := b.String()

--- a/src/encoding/gob/encoder_test.go
+++ b/src/encoding/gob/encoder_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"cmp"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -1260,7 +1261,7 @@ func TestDecodePartial(t *testing.T) {
 			// The decoder used to erroneously return io.EOF in some cases here,
 			// such as if the input was cut off right after some type specs,
 			// but before any value was actually transmitted.
-			if err != io.ErrUnexpectedEOF {
+			if !errors.Is(err, io.ErrUnexpectedEOF) {
 				t.Errorf("%d/%d: expected io.ErrUnexpectedEOF: %v", i, len(data), err)
 			}
 		}

--- a/src/flag/flag.go
+++ b/src/flag/flag.go
@@ -1165,7 +1165,7 @@ func (f *FlagSet) Parse(arguments []string) error {
 		case ContinueOnError:
 			return err
 		case ExitOnError:
-			if err == ErrHelp {
+			if errors.Is(err, ErrHelp) {
 				os.Exit(0)
 			}
 			os.Exit(2)

--- a/src/flag/flag_test.go
+++ b/src/flag/flag_test.go
@@ -6,6 +6,7 @@ package flag_test
 
 import (
 	"bytes"
+	"errors"
 	. "flag"
 	"fmt"
 	"internal/testenv"
@@ -443,7 +444,7 @@ func TestHelp(t *testing.T) {
 	if err == nil {
 		t.Fatal("error expected")
 	}
-	if err != ErrHelp {
+	if !errors.Is(err, ErrHelp) {
 		t.Fatal("expected ErrHelp; got ", err)
 	}
 	if !helpCalled {

--- a/src/fmt/scan_test.go
+++ b/src/fmt/scan_test.go
@@ -947,7 +947,7 @@ func TestMultiLine(t *testing.T) {
 	}
 	if err == nil {
 		t.Error("Sscanln: expected error; got none")
-	} else if err != io.ErrUnexpectedEOF {
+	} else if !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Errorf("Sscanln: expected io.ErrUnexpectedEOF (ha!); got %s", err)
 	}
 }
@@ -1018,7 +1018,7 @@ func (r *RecursiveInt) Scan(state ScanState, verb rune) (err error) {
 	next := new(RecursiveInt)
 	_, err = Fscanf(state, ".%v", next)
 	if err != nil {
-		if err == io.ErrUnexpectedEOF {
+		if errors.Is(err, io.ErrUnexpectedEOF) {
 			err = nil
 		}
 		return

--- a/src/image/gif/reader.go
+++ b/src/image/gif/reader.go
@@ -425,7 +425,7 @@ func (d *decoder) readImageDescriptor(keepAllFrames bool) error {
 	lzwr := lzw.NewReader(br, lzw.LSB, int(litWidth))
 	defer lzwr.Close()
 	if err = readFull(lzwr, m.Pix); err != nil {
-		if err != io.ErrUnexpectedEOF {
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
 			return fmt.Errorf("gif: reading image data: %v", err)
 		}
 		return errNotEnough
@@ -441,7 +441,7 @@ func (d *decoder) readImageDescriptor(keepAllFrames bool) error {
 	// before the LZW decoder saw an explicit end code), provided that
 	// the io.ReadFull call above successfully read len(m.Pix) bytes.
 	// See https://golang.org/issue/9856 for an example GIF.
-	if n, err := lzwr.Read(d.tmp[256:257]); n != 0 || (err != io.EOF && err != io.ErrUnexpectedEOF) {
+	if n, err := lzwr.Read(d.tmp[256:257]); n != 0 || (err != && !errors.Is(err, io.ErrUnexpectedEOF)) {
 		if err != nil {
 			return fmt.Errorf("gif: reading image data: %v", err)
 		}

--- a/src/image/jpeg/huffman.go
+++ b/src/image/jpeg/huffman.go
@@ -5,6 +5,7 @@
 package jpeg
 
 import (
+	"errors"
 	"io"
 )
 
@@ -49,7 +50,7 @@ func (d *decoder) ensureNBits(n int32) error {
 	for {
 		c, err := d.readByteStuffedByte()
 		if err != nil {
-			if err == io.ErrUnexpectedEOF {
+			if errors.Is(err, io.ErrUnexpectedEOF) {
 				return errShortHuffmanData
 			}
 			return err

--- a/src/image/jpeg/reader_test.go
+++ b/src/image/jpeg/reader_test.go
@@ -7,6 +7,7 @@ package jpeg
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -499,7 +500,7 @@ func TestIssue56724(t *testing.T) {
 	b = b[:24] // truncate image data
 
 	_, err = Decode(bytes.NewReader(b))
-	if err != io.ErrUnexpectedEOF {
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Errorf("got: %v, want: %v", err, io.ErrUnexpectedEOF)
 	}
 }

--- a/src/image/png/reader.go
+++ b/src/image/png/reader.go
@@ -10,6 +10,7 @@ package png
 import (
 	"compress/zlib"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash"
 	"hash/crc32"
@@ -510,7 +511,7 @@ func (d *decoder) readImagePass(r io.Reader, pass int, allocateOnly bool) (image
 		// Read the decompressed bytes.
 		_, err := io.ReadFull(r, cr)
 		if err != nil {
-			if err == io.EOF || err == io.ErrUnexpectedEOF {
+			if err == io.EOF || errors.Is(err, io.ErrUnexpectedEOF) {
 				return nil, FormatError("not enough pixel data")
 			}
 			return nil, err

--- a/src/internal/fuzz/worker.go
+++ b/src/internal/fuzz/worker.go
@@ -656,7 +656,7 @@ func (ws *workerServer) serve(ctx context.Context) error {
 	for {
 		var c call
 		if err := dec.Decode(&c); err != nil {
-			if err == io.EOF || err == ctx.Err() {
+			if err == io.EOF || errors.Is(err, ctx.Err()) {
 				return nil
 			} else {
 				return err

--- a/src/internal/fuzz/worker_test.go
+++ b/src/internal/fuzz/worker_test.go
@@ -154,7 +154,7 @@ func runBenchmarkWorker() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 	fn := func(CorpusEntry) error { return nil }
-	if err := RunFuzzWorker(ctx, fn); err != nil && err != ctx.Err() {
+	if err := RunFuzzWorker(ctx, fn); err != nil && !errors.Is(err, ctx.Err()) {
 		panic(err)
 	}
 }

--- a/src/internal/saferio/io_test.go
+++ b/src/internal/saferio/io_test.go
@@ -6,6 +6,7 @@ package saferio
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"testing"
 )
@@ -54,7 +55,7 @@ func TestReadData(t *testing.T) {
 
 	t.Run("large-UnexpectedEOF", func(t *testing.T) {
 		_, err := ReadData(bytes.NewReader(make([]byte, chunk)), chunk+1)
-		if err != io.ErrUnexpectedEOF {
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
 			t.Errorf("ReadData = %v, want io.ErrUnexpectedEOF", err)
 		}
 	})

--- a/src/internal/syscall/windows/registry/registry_test.go
+++ b/src/internal/syscall/windows/registry/registry_test.go
@@ -9,6 +9,7 @@ package registry_test
 import (
 	"bytes"
 	"crypto/rand"
+	"errors"
 	"os"
 	"syscall"
 	"testing"
@@ -95,7 +96,7 @@ func TestCreateOpenDeleteKey(t *testing.T) {
 		defer testKOpenedAgain.Close()
 		t.Fatalf("key %q should already been deleted", testKName)
 	}
-	if err != registry.ErrNotExist {
+	if !errors.Is(err, registry.ErrNotExist) {
 		t.Fatalf(`unexpected error ("not exist" expected): %v`, err)
 	}
 }
@@ -222,7 +223,7 @@ func testErrNotExist(t *testing.T, name string, err error) {
 		t.Errorf("%s value should not exist", name)
 		return
 	}
-	if err != registry.ErrNotExist {
+	if !errors.Is(err, registry.ErrNotExist) {
 		t.Errorf("reading %s value should return 'not exist' error, but got: %s", name, err)
 		return
 	}
@@ -233,7 +234,7 @@ func testErrUnexpectedType(t *testing.T, test ValueTest, gottype uint32, err err
 		t.Errorf("GetXValue(%q) should not succeed", test.Name)
 		return
 	}
-	if err != registry.ErrUnexpectedType {
+	if !errors.Is(err, registry.ErrUnexpectedType) {
 		t.Errorf("reading %s value should return 'unexpected key value type' error, but got: %s", test.Name, err)
 		return
 	}
@@ -338,7 +339,7 @@ func testGetValue(t *testing.T, k registry.Key, test ValueTest, size int) {
 		t.Errorf("GetValue(%s, [%d]byte) should fail, but succeeded", test.Name, size-1)
 		return
 	}
-	if err != registry.ErrShortBuffer {
+	if !errors.Is(err, registry.ErrShortBuffer) {
 		t.Errorf("reading %s value should return 'short buffer' error, but got: %s", test.Name, err)
 		return
 	}
@@ -370,7 +371,7 @@ func testGetValue(t *testing.T, k registry.Key, test ValueTest, size int) {
 		t.Errorf("GetValue(%q) should not succeed", test.Name)
 		return
 	}
-	if err != registry.ErrNotExist {
+	if !errors.Is(err, registry.ErrNotExist) {
 		t.Errorf("GetValue(%q) should return 'not exist' error, but got: %s", test.Name, err)
 		return
 	}

--- a/src/internal/sysinfo/cpuinfo_linux.go
+++ b/src/internal/sysinfo/cpuinfo_linux.go
@@ -7,6 +7,7 @@ package sysinfo
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -20,7 +21,7 @@ func readLinuxProcCPUInfo(buf []byte) error {
 	defer f.Close()
 
 	_, err = io.ReadFull(f, buf)
-	if err != nil && err != io.ErrUnexpectedEOF {
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
 		return err
 	}
 

--- a/src/internal/trace/internal/oldtrace/parser_test.go
+++ b/src/internal/trace/internal/oldtrace/parser_test.go
@@ -6,6 +6,7 @@ package oldtrace
 
 import (
 	"bytes"
+	"errors"
 	"internal/trace/version"
 	"os"
 	"path/filepath"
@@ -64,7 +65,7 @@ func TestParseCanned(t *testing.T) {
 			}
 			checkTrace(t, int(v), trace)
 		case strings.HasSuffix(f.Name(), "_unordered"):
-			if err != ErrTimeOrder {
+			if !errors.Is(err, ErrTimeOrder) {
 				t.Errorf("unordered trace is not detected %v: %v", f.Name(), err)
 			}
 		default:

--- a/src/io/fs/glob_test.go
+++ b/src/io/fs/glob_test.go
@@ -5,6 +5,7 @@
 package fs_test
 
 import (
+	"errors"
 	. "io/fs"
 	"os"
 	"path"
@@ -51,7 +52,7 @@ func TestGlobError(t *testing.T) {
 	bad := []string{`[]`, `nonexist/[]`}
 	for _, pattern := range bad {
 		_, err := Glob(os.DirFS("."), pattern)
-		if err != path.ErrBadPattern {
+		if !errors.Is(err, path.ErrBadPattern) {
 			t.Errorf("Glob(fs, %#q) returned err=%v, want path.ErrBadPattern", pattern, err)
 		}
 	}
@@ -61,7 +62,7 @@ func TestCVE202230630(t *testing.T) {
 	// Prior to CVE-2022-30630, a stack exhaustion would occur given a large
 	// number of separators. There is now a limit of 10,000.
 	_, err := Glob(os.DirFS("."), "/*"+strings.Repeat("/", 10001))
-	if err != path.ErrBadPattern {
+	if !errors.Is(err, path.ErrBadPattern) {
 		t.Fatalf("Glob returned err=%v, want %v", err, path.ErrBadPattern)
 	}
 }

--- a/src/io/io_test.go
+++ b/src/io/io_test.go
@@ -292,7 +292,7 @@ func testReadAtLeast(t *testing.T, rb ReadWriter) {
 		t.Errorf("expected to have read 2 bytes, got %v", n)
 	}
 	n, err = ReadAtLeast(rb, buf, 4)
-	if err != ErrShortBuffer {
+	if !errors.Is(err, ErrShortBuffer) {
 		t.Errorf("expected ErrShortBuffer got %v", err)
 	}
 	if n != 0 {
@@ -348,7 +348,7 @@ func TestTeeReader(t *testing.T) {
 	pr, pw := Pipe()
 	pr.Close()
 	r = TeeReader(rb, pw)
-	if n, err := ReadFull(r, dst); n != 0 || err != ErrClosedPipe {
+	if n, err := ReadFull(r, dst); n != 0 || !errors.Is(err, ErrClosedPipe) {
 		t.Errorf("closed tee: ReadFull(r, dst) = %d, %v; want 0, EPIPE", n, err)
 	}
 }

--- a/src/io/multi_test.go
+++ b/src/io/multi_test.go
@@ -210,7 +210,7 @@ func TestMultiWriterError(t *testing.T) {
 	})
 	w := MultiWriter(f1, f2)
 	n, err := w.Write(make([]byte, 100))
-	if n != 50 || err != ErrShortWrite {
+	if n != 50 || !errors.Is(err, ErrShortWrite) {
 		t.Errorf("Write = %d, %v, want 50, ErrShortWrite", n, err)
 	}
 }

--- a/src/io/pipe_test.go
+++ b/src/io/pipe_test.go
@@ -6,6 +6,7 @@ package io_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	. "io"
 	"slices"
@@ -216,7 +217,7 @@ func TestPipeReadClose2(t *testing.T) {
 	go delayClose(t, r, c, pipeTest{})
 	n, err := r.Read(make([]byte, 64))
 	<-c
-	if n != 0 || err != ErrClosedPipe {
+	if n != 0 || !errors.Is(err, ErrClosedPipe) {
 		t.Errorf("read from closed pipe: %v, %v want %v, %v", n, err, 0, ErrClosedPipe)
 	}
 }
@@ -257,7 +258,7 @@ func TestPipeWriteClose2(t *testing.T) {
 	go delayClose(t, w, c, pipeTest{})
 	n, err := w.Write(make([]byte, 64))
 	<-c
-	if n != 0 || err != ErrClosedPipe {
+	if n != 0 || !errors.Is(err, ErrClosedPipe) {
 		t.Errorf("write to closed pipe: %v, %v want %v, %v", n, err, 0, ErrClosedPipe)
 	}
 }
@@ -302,7 +303,7 @@ func TestWriteAfterWriterClose(t *testing.T) {
 	buf := make([]byte, 100)
 	var result string
 	n, err := ReadFull(r, buf)
-	if err != nil && err != ErrUnexpectedEOF {
+	if err != nil && !errors.Is(err, ErrUnexpectedEOF) {
 		t.Fatalf("got: %q; want: %q", err, ErrUnexpectedEOF)
 	}
 	result = string(buf[0:n])
@@ -311,7 +312,7 @@ func TestWriteAfterWriterClose(t *testing.T) {
 	if result != "hello" {
 		t.Errorf("got: %q; want: %q", result, "hello")
 	}
-	if writeErr != ErrClosedPipe {
+	if !errors.Is(writeErr, ErrClosedPipe) {
 		t.Errorf("got: %q; want: %q", writeErr, ErrClosedPipe)
 	}
 }

--- a/src/math/big/floatmarsh_test.go
+++ b/src/math/big/floatmarsh_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"encoding/json"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -96,7 +97,7 @@ func TestFloatCorruptGob(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := gob.NewDecoder(bytes.NewReader(b[:10])).Decode(&rx); err != io.ErrUnexpectedEOF {
+	if err := gob.NewDecoder(bytes.NewReader(b[:10])).Decode(&rx); !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Errorf("got %v want EOF", err)
 	}
 

--- a/src/math/big/natconv_test.go
+++ b/src/math/big/natconv_test.go
@@ -6,6 +6,7 @@ package big
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math/bits"
@@ -227,7 +228,7 @@ func TestScanBase(t *testing.T) {
 	for _, a := range natScanTests {
 		r := strings.NewReader(a.s)
 		x, b, count, err := nat(nil).scan(r, a.base, a.frac)
-		if err != a.err {
+		if errors.Is(err, a.err) {
 			t.Errorf("scan%+v\n\tgot error = %v; want %v", a, err, a.err)
 		}
 		if x.cmp(a.x) != 0 {

--- a/src/math/big/ratconv_test.go
+++ b/src/math/big/ratconv_test.go
@@ -6,6 +6,7 @@ package big
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -66,7 +67,7 @@ func TestScanExponent(t *testing.T) {
 	for _, a := range exponentTests {
 		r := strings.NewReader(a.s)
 		x, b, err := scanExponent(r, a.base2ok, a.sepOk)
-		if err != a.err {
+		if errors.Is(err, a.err) {
 			t.Errorf("scanExponent%+v\n\tgot error = %v; want %v", a, err, a.err)
 		}
 		if x != a.x {

--- a/src/mime/mediatype_test.go
+++ b/src/mime/mediatype_test.go
@@ -5,6 +5,7 @@
 package mime
 
 import (
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -477,10 +478,10 @@ func TestParseMediaTypeBogus(t *testing.T) {
 		if params != nil {
 			t.Errorf("ParseMediaType(%q): got non-nil params on error", tt.in)
 		}
-		if err != ErrInvalidMediaParameter && mt != "" {
+		if !errors.Is(err, ErrInvalidMediaParameter) && mt != "" {
 			t.Errorf("ParseMediaType(%q): got unexpected non-empty media type string", tt.in)
 		}
-		if err == ErrInvalidMediaParameter && mt != tt.mt {
+		if errors.Is(err, ErrInvalidMediaParameter) && mt != tt.mt {
 			t.Errorf("ParseMediaType(%q): in case of invalid parameters: expected type %q, got %q", tt.in, tt.mt, mt)
 		}
 	}

--- a/src/mime/multipart/formdata_test.go
+++ b/src/mime/multipart/formdata_test.go
@@ -6,6 +6,7 @@ package multipart
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -299,7 +300,7 @@ func TestReadForm_MetadataTooLarge(t *testing.T) {
 			}
 			fr := NewReader(&buf, fw.Boundary())
 			_, err := fr.ReadForm(0)
-			if err != ErrMessageTooLarge {
+			if !errors.Is(err, ErrMessageTooLarge) {
 				t.Errorf("fr.ReadForm() = %v, want ErrMessageTooLarge", err)
 			}
 		})
@@ -478,7 +479,7 @@ func TestReadFormEndlessHeaderLine(t *testing.T) {
 			)
 			r := NewReader(fr, "boundary")
 			_, err := r.ReadForm(1 << 20)
-			if err != ErrMessageTooLarge {
+			if !errors.Is(err, ErrMessageTooLarge) {
 				t.Fatalf("ReadForm(1 << 20): %v, want ErrMessageTooLarge", err)
 			}
 		})

--- a/src/mime/multipart/multipart_test.go
+++ b/src/mime/multipart/multipart_test.go
@@ -7,6 +7,7 @@ package multipart
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/textproto"
@@ -316,7 +317,7 @@ Oh no, premature EOF!
 			t.Fatalf("didn't get a part")
 		}
 		_, err = io.Copy(io.Discard, part)
-		if err != io.ErrUnexpectedEOF {
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
 			t.Fatalf("expected error io.ErrUnexpectedEOF; got %v", err)
 		}
 	}

--- a/src/net/http/client.go
+++ b/src/net/http/client.go
@@ -693,7 +693,7 @@ func (c *Client) do(req *Request) (retres *Response, reterr error) {
 			// Sentinel error to let users select the
 			// previous response, without closing its
 			// body. See Issue 10069.
-			if err == ErrUseLastResponse {
+			if errors.Is(err, ErrUseLastResponse) {
 				return resp, nil
 			}
 

--- a/src/net/http/client_test.go
+++ b/src/net/http/client_test.go
@@ -1328,7 +1328,7 @@ func testClientTimeoutCancel(t *testing.T, mode testMode) {
 	}
 	cancel()
 	_, err = io.Copy(io.Discard, res.Body)
-	if err != ExportErrRequestCanceled {
+	if !errors.Is(err, ExportErrRequestCanceled) {
 		t.Fatalf("error = %v; want errRequestCanceled", err)
 	}
 }

--- a/src/net/http/clientserver_test.go
+++ b/src/net/http/clientserver_test.go
@@ -13,6 +13,7 @@ import (
 	"crypto/rand"
 	"crypto/sha1"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -494,7 +495,7 @@ func TestH12_HandlerWritesTooLittle(t *testing.T) {
 				t.Errorf("%s body is %T; want slurpResult", proto, res.Body)
 				return
 			}
-			if sr.err != io.ErrUnexpectedEOF {
+			if !errors.Is(sr.err, io.ErrUnexpectedEOF) {
 				t.Errorf("%s read error = %v; want io.ErrUnexpectedEOF", proto, sr.err)
 			}
 			if string(sr.body) != "12" {
@@ -579,7 +580,7 @@ func test304Responses(t *testing.T, mode testMode) {
 	cst := newClientServerTest(t, mode, HandlerFunc(func(w ResponseWriter, r *Request) {
 		w.WriteHeader(StatusNotModified)
 		_, err := w.Write([]byte("illegal body"))
-		if err != ErrBodyNotAllowed {
+		if !errors.Is(err, ErrBodyNotAllowed) {
 			t.Errorf("on Write, expected ErrBodyNotAllowed, got %v", err)
 		}
 	}))
@@ -680,7 +681,7 @@ func testCancelRequestMidBody(t *testing.T, mode testMode) {
 	if all != "Hello" {
 		t.Errorf("Read %q (%q + %q); want Hello", all, firstRead, rest)
 	}
-	if err != ExportErrRequestCanceled {
+	if !errors.Is(err, ExportErrRequestCanceled) {
 		t.Errorf("ReadAll error = %v; want %v", err, ExportErrRequestCanceled)
 	}
 }

--- a/src/net/http/example_test.go
+++ b/src/net/http/example_test.go
@@ -6,6 +6,7 @@ package http_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -132,7 +133,7 @@ func ExampleServer_Shutdown() {
 		close(idleConnsClosed)
 	}()
 
-	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+	if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
 		// Error starting or closing listener:
 		log.Fatalf("HTTP server ListenAndServe: %v", err)
 	}

--- a/src/net/http/httputil/persist.go
+++ b/src/net/http/httputil/persist.go
@@ -141,7 +141,7 @@ func (sc *ServerConn) Read() (*http.Request, error) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 	if err != nil {
-		if err == io.ErrUnexpectedEOF {
+		if errors.Is(err, io.ErrUnexpectedEOF) {
 			// A close from the opposing client is treated as a
 			// graceful close, even if there was some unparse-able
 			// data before the close.

--- a/src/net/http/internal/chunked.go
+++ b/src/net/http/internal/chunked.go
@@ -159,7 +159,7 @@ func readChunkLine(b *bufio.Reader) ([]byte, error) {
 		// If the caller asked for a line, there should be a line.
 		if err == io.EOF {
 			err = io.ErrUnexpectedEOF
-		} else if err == bufio.ErrBufferFull {
+		} else if errors.Is(err, bufio.ErrBufferFull) {
 			err = ErrLineTooLong
 		}
 		return nil, err

--- a/src/net/http/internal/chunked_test.go
+++ b/src/net/http/internal/chunked_test.go
@@ -7,6 +7,7 @@ package internal
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -129,7 +130,7 @@ func TestChunkReaderAllocs(t *testing.T) {
 		if n != len(readBuf)-1 {
 			t.Fatalf("read %d bytes; want %d", n, len(readBuf)-1)
 		}
-		if err != io.ErrUnexpectedEOF {
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
 			t.Fatalf("read error = %v; want ErrUnexpectedEOF", err)
 		}
 	})
@@ -221,7 +222,7 @@ func TestIncompleteChunk(t *testing.T) {
 	for i := 0; i < len(valid); i++ {
 		incomplete := valid[:i]
 		r := NewChunkedReader(strings.NewReader(incomplete))
-		if _, err := io.ReadAll(r); err != io.ErrUnexpectedEOF {
+		if _, err := io.ReadAll(r); !errors.Is(err, io.ErrUnexpectedEOF) {
 			t.Errorf("expected io.ErrUnexpectedEOF for %q, got %v", incomplete, err)
 		}
 	}

--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -51,7 +51,7 @@ func (pe *ProtocolError) Error() string { return pe.ErrorString }
 
 // Is lets http.ErrNotSupported match errors.ErrUnsupported.
 func (pe *ProtocolError) Is(err error) bool {
-	return pe == ErrNotSupported && err == errors.ErrUnsupported
+	return errors.Is(pe, ErrNotSupported) && errors.Is(err, errors.ErrUnsupported)
 }
 
 var (

--- a/src/net/http/request_test.go
+++ b/src/net/http/request_test.go
@@ -260,7 +260,7 @@ func TestParseMultipartForm(t *testing.T) {
 
 	req.Header = Header{"Content-Type": {"text/plain"}}
 	err = req.ParseMultipartForm(25)
-	if err != ErrNotMultipart {
+	if !errors.Is(err, ErrNotMultipart) {
 		t.Error("expected ErrNotMultipart for text/plain")
 	}
 }
@@ -1149,7 +1149,7 @@ func testMissingFile(t *testing.T, req *Request) {
 	if fh != nil {
 		t.Errorf("FormFile file header = %v, want nil", fh)
 	}
-	if err != ErrMissingFile {
+	if !errors.Is(err, ErrMissingFile) {
 		t.Errorf("FormFile err = %q, want ErrMissingFile", err)
 	}
 }

--- a/src/net/http/response_test.go
+++ b/src/net/http/response_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"go/token"
 	"io"
@@ -838,7 +839,7 @@ func TestResponseContentLengthShortBody(t *testing.T) {
 	if buf.String() != shortBody {
 		t.Errorf("Read body %q; want %q", buf.String(), shortBody)
 	}
-	if err != io.ErrUnexpectedEOF {
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Errorf("io.Copy error = %#v; want io.ErrUnexpectedEOF", err)
 	}
 }

--- a/src/net/http/serve_test.go
+++ b/src/net/http/serve_test.go
@@ -1176,7 +1176,7 @@ func testIdentityResponse(t *testing.T, mode testMode) {
 		switch {
 		case req.FormValue("overwrite") == "1":
 			_, err := rw.Write([]byte("foo TOO LONG"))
-			if err != ErrContentLength {
+			if !errors.Is(err, ErrContentLength) {
 				t.Errorf("expected ErrContentLength; got %v", err)
 			}
 		case req.FormValue("underwrite") == "1":
@@ -2991,7 +2991,7 @@ func testServerWriteHijackZeroBytes(t *testing.T, mode testMode) {
 		}
 		defer conn.Close()
 		_, err = w.Write(nil)
-		if err != ErrHijacked {
+		if !errors.Is(err, ErrHijacked) {
 			t.Errorf("Write error = %v; want ErrHijacked", err)
 		}
 	}), func(ts *httptest.Server) {

--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -560,7 +560,7 @@ func (t *Transport) roundTrip(req *Request) (_ *Response, err error) {
 	req = setupRewindBody(req)
 
 	if altRT := t.alternateRoundTripper(req); altRT != nil {
-		if resp, err := altRT.RoundTrip(req); err != ErrSkipAltProtocol {
+		if resp, err := altRT.RoundTrip(req); !errors.Is(err, ErrSkipAltProtocol) {
 			return resp, err
 		}
 		var err error

--- a/src/net/http/transport_test.go
+++ b/src/net/http/transport_test.go
@@ -1874,7 +1874,7 @@ func testTransportGzipShort(t *testing.T, mode testMode) {
 	if err == nil {
 		t.Fatal("Expect an error from reading a body.")
 	}
-	if err != io.ErrUnexpectedEOF {
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Errorf("ReadAll error = %v; want io.ErrUnexpectedEOF", err)
 	}
 }

--- a/src/net/lookup.go
+++ b/src/net/lookup.go
@@ -714,7 +714,7 @@ func (r *Resolver) goLookupSRV(ctx context.Context, service, proto, name string)
 	var cname dnsmessage.Name
 	for {
 		h, err := p.AnswerHeader()
-		if err == dnsmessage.ErrSectionDone {
+		if errors.Is(err, dnsmessage.ErrSectionDone) {
 			break
 		}
 		if err != nil {
@@ -760,7 +760,7 @@ func (r *Resolver) goLookupMX(ctx context.Context, name string) ([]*MX, error) {
 	var mxs []*MX
 	for {
 		h, err := p.AnswerHeader()
-		if err == dnsmessage.ErrSectionDone {
+		if errors.Is(err, dnsmessage.ErrSectionDone) {
 			break
 		}
 		if err != nil {
@@ -804,7 +804,7 @@ func (r *Resolver) goLookupNS(ctx context.Context, name string) ([]*NS, error) {
 	var nss []*NS
 	for {
 		h, err := p.AnswerHeader()
-		if err == dnsmessage.ErrSectionDone {
+		if errors.Is(err, dnsmessage.ErrSectionDone) {
 			break
 		}
 		if err != nil {
@@ -846,7 +846,7 @@ func (r *Resolver) goLookupTXT(ctx context.Context, name string) ([]string, erro
 	var txts []string
 	for {
 		h, err := p.AnswerHeader()
-		if err == dnsmessage.ErrSectionDone {
+		if errors.Is(err, dnsmessage.ErrSectionDone) {
 			break
 		}
 		if err != nil {

--- a/src/net/parse.go
+++ b/src/net/parse.go
@@ -8,6 +8,7 @@
 package net
 
 import (
+	"errors"
 	"internal/bytealg"
 	"io"
 	"os"
@@ -56,7 +57,7 @@ func (f *file) readLine() (s string, ok bool) {
 		if n >= 0 {
 			f.data = f.data[0 : ln+n]
 		}
-		if err == io.EOF || err == io.ErrUnexpectedEOF {
+		if err == io.EOF || errors.Is(err, io.ErrUnexpectedEOF) {
 			f.atEOF = true
 		}
 	}

--- a/src/net/pipe.go
+++ b/src/net/pipe.go
@@ -5,6 +5,7 @@
 package net
 
 import (
+	"errors"
 	"io"
 	"os"
 	"sync"
@@ -140,7 +141,7 @@ func (*pipe) RemoteAddr() Addr { return pipeAddr{} }
 
 func (p *pipe) Read(b []byte) (int, error) {
 	n, err := p.read(b)
-	if err != nil && err != io.EOF && err != io.ErrClosedPipe {
+	if err != nil && err != io.EOF && !errors.Is(err, io.ErrClosedPipe) {
 		err = &OpError{Op: "read", Net: "pipe", Err: err}
 	}
 	return n, err
@@ -172,7 +173,7 @@ func (p *pipe) read(b []byte) (n int, err error) {
 
 func (p *pipe) Write(b []byte) (int, error) {
 	n, err := p.write(b)
-	if err != nil && err != io.ErrClosedPipe {
+	if err != nil && !errors.Is(err, io.ErrClosedPipe) {
 		err = &OpError{Op: "write", Net: "pipe", Err: err}
 	}
 	return n, err

--- a/src/net/pipe_test.go
+++ b/src/net/pipe_test.go
@@ -5,6 +5,7 @@
 package net_test
 
 import (
+	"errors"
 	"io"
 	"net"
 	"testing"
@@ -28,22 +29,22 @@ func TestPipeCloseError(t *testing.T) {
 	c1, c2 := net.Pipe()
 	c1.Close()
 
-	if _, err := c1.Read(nil); err != io.ErrClosedPipe {
+	if _, err := c1.Read(nil); !errors.Is(err, io.ErrClosedPipe) {
 		t.Errorf("c1.Read() = %v, want io.ErrClosedPipe", err)
 	}
-	if _, err := c1.Write(nil); err != io.ErrClosedPipe {
+	if _, err := c1.Write(nil); !errors.Is(err, io.ErrClosedPipe) {
 		t.Errorf("c1.Write() = %v, want io.ErrClosedPipe", err)
 	}
-	if err := c1.SetDeadline(time.Time{}); err != io.ErrClosedPipe {
+	if err := c1.SetDeadline(time.Time{}); !errors.Is(err, io.ErrClosedPipe) {
 		t.Errorf("c1.SetDeadline() = %v, want io.ErrClosedPipe", err)
 	}
-	if _, err := c2.Read(nil); err != io.EOF {
+	if _, err := c2.Read(nil); !errors.Is(err, io.EOF) {
 		t.Errorf("c2.Read() = %v, want io.EOF", err)
 	}
-	if _, err := c2.Write(nil); err != io.ErrClosedPipe {
+	if _, err := c2.Write(nil); !errors.Is(err, io.ErrClosedPipe) {
 		t.Errorf("c2.Write() = %v, want io.ErrClosedPipe", err)
 	}
-	if err := c2.SetDeadline(time.Time{}); err != io.ErrClosedPipe {
+	if err := c2.SetDeadline(time.Time{}); !errors.Is(err, io.ErrClosedPipe) {
 		t.Errorf("c2.SetDeadline() = %v, want io.ErrClosedPipe", err)
 	}
 }

--- a/src/net/resolverdialfunc_test.go
+++ b/src/net/resolverdialfunc_test.go
@@ -253,7 +253,7 @@ func (a *resolverFuncConn) Write(packet []byte) (n int, err error) {
 	if err == nil && a.h.Question != nil {
 		a.h.Question(h, q)
 	}
-	if err != nil && err != dnsmessage.ErrSectionDone {
+	if err != nil && !errors.Is(err, dnsmessage.ErrSectionDone) {
 		return 0, err
 	}
 

--- a/src/net/rpc/server.go
+++ b/src/net/rpc/server.go
@@ -587,7 +587,7 @@ func (server *Server) readRequestHeader(codec ServerCodec) (svc *service, mtype 
 	err = codec.ReadRequestHeader(req)
 	if err != nil {
 		req = nil
-		if err == io.EOF || err == io.ErrUnexpectedEOF {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 			return
 		}
 		err = errors.New("rpc: server cannot decode request: " + err.Error())

--- a/src/net/rpc/server_test.go
+++ b/src/net/rpc/server_test.go
@@ -680,7 +680,7 @@ func TestErrorAfterClientClose(t *testing.T) {
 		t.Fatal("close error:", err)
 	}
 	err = client.Call("Arith.Add", &Args{7, 9}, new(Reply))
-	if err != ErrShutdown {
+	if !errors.Is(err, ErrShutdown) {
 		t.Errorf("Forever: expected ErrShutdown got %v", err)
 	}
 }

--- a/src/net/tcpsock_test.go
+++ b/src/net/tcpsock_test.go
@@ -694,7 +694,7 @@ func TestCopyPipeIntoTCP(t *testing.T) {
 
 		buf := make([]byte, 100)
 		n, err := io.ReadFull(c, buf)
-		if err != io.ErrUnexpectedEOF || n != 2 {
+		if !errors.Is(err, io.ErrUnexpectedEOF) || n != 2 {
 			errc <- fmt.Errorf("got err=%q n=%v; want err=%q n=2", err, n, io.ErrUnexpectedEOF)
 			return
 		}

--- a/src/net/textproto/reader_test.go
+++ b/src/net/textproto/reader_test.go
@@ -7,6 +7,7 @@ package textproto
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io"
 	"net"
 	"reflect"
@@ -101,7 +102,7 @@ func TestReadDotLines(t *testing.T) {
 
 	s, err = r.ReadDotLines()
 	want = []string{"another"}
-	if !reflect.DeepEqual(s, want) || err != io.ErrUnexpectedEOF {
+	if !reflect.DeepEqual(s, want) || !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Fatalf("ReadDotLines2: %v, %v", s, err)
 	}
 }
@@ -116,7 +117,7 @@ func TestReadDotBytes(t *testing.T) {
 
 	b, err = r.ReadDotBytes()
 	want = []byte("anot.her\n")
-	if !reflect.DeepEqual(b, want) || err != io.ErrUnexpectedEOF {
+	if !reflect.DeepEqual(b, want) || !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Fatalf("ReadDotBytes2: %q, %v", b, err)
 	}
 }

--- a/src/os/exec_unix.go
+++ b/src/os/exec_unix.go
@@ -152,7 +152,7 @@ func (p *Process) release() error {
 
 func findProcess(pid int) (p *Process, err error) {
 	h, err := pidfdFind(pid)
-	if err == ErrProcessDone {
+	if errors.Is(err, ErrProcessDone) {
 		// We can't return an error here since users are not expecting
 		// it. Instead, return a process with a "done" state already
 		// and let a subsequent Signal or Wait call catch that.

--- a/src/os/file.go
+++ b/src/os/file.go
@@ -440,7 +440,7 @@ func (f *File) wrapErr(op string, err error) error {
 	if err == nil || err == io.EOF {
 		return err
 	}
-	if err == poll.ErrFileClosing {
+	if errors.Is(err, poll.ErrFileClosing) {
 		err = ErrClosed
 	} else if checkWrapErr && errors.Is(err, poll.ErrFileClosing) {
 		panic("unexpected error wrapping poll.ErrFileClosing: " + err.Error())

--- a/src/os/os_test.go
+++ b/src/os/os_test.go
@@ -2123,7 +2123,7 @@ func TestWriteAtInAppendMode(t *testing.T) {
 	defer f.Close()
 
 	_, err = f.WriteAt([]byte(""), 1)
-	if err != ErrWriteAtInAppendMode {
+	if !errors.Is(err, ErrWriteAtInAppendMode) {
 		t.Fatalf("f.WriteAt returned %v, expected %v", err, ErrWriteAtInAppendMode)
 	}
 }

--- a/src/os/pidfd_linux_test.go
+++ b/src/os/pidfd_linux_test.go
@@ -43,10 +43,10 @@ func TestFindProcessViaPidfd(t *testing.T) {
 
 	// Check that all Process' public methods work as expected with
 	// "done" Process.
-	if err := proc.Kill(); err != os.ErrProcessDone {
+	if err := proc.Kill(); !errors.Is(err, os.ErrProcessDone) {
 		t.Errorf("Kill: got %v, want %v", err, os.ErrProcessDone)
 	}
-	if err := proc.Signal(os.Kill); err != os.ErrProcessDone {
+	if err := proc.Signal(os.Kill); !errors.Is(err, os.ErrProcessDone) {
 		t.Errorf("Signal: got %v, want %v", err, os.ErrProcessDone)
 	}
 	if _, err := proc.Wait(); !errors.Is(err, syscall.ECHILD) {

--- a/src/os/pipe_test.go
+++ b/src/os/pipe_test.go
@@ -11,6 +11,7 @@ package os_test
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"internal/testenv"
 	"io"
@@ -218,7 +219,7 @@ func testClosedPipeRace(t *testing.T, read bool) {
 		t.Error("I/O on closed pipe unexpectedly succeeded")
 	} else if pe, ok := err.(*fs.PathError); !ok {
 		t.Errorf("I/O on closed pipe returned unexpected error type %T; expected fs.PathError", pe)
-	} else if pe.Err != fs.ErrClosed {
+	} else if !errors.Is(pe.Err, fs.ErrClosed) {
 		t.Errorf("got error %q but expected %q", pe.Err, fs.ErrClosed)
 	} else {
 		t.Logf("I/O returned expected error %q", err)
@@ -314,7 +315,7 @@ func testCloseWithBlockingRead(t *testing.T, r, w *os.File) {
 		if pe, ok := err.(*fs.PathError); ok {
 			err = pe.Err
 		}
-		if err != io.EOF && err != fs.ErrClosed {
+		if err != io.EOF && !errors.Is(err, fs.ErrClosed) {
 			t.Errorf("got %v, expected EOF or closed", err)
 		}
 		close(done)

--- a/src/os/readfrom_linux_test.go
+++ b/src/os/readfrom_linux_test.go
@@ -237,23 +237,23 @@ func TestCopyFileRange(t *testing.T) {
 		defer Remove(anyFile.Name())
 		defer anyFile.Close()
 
-		if _, err := io.Copy(nilFile, nilFile); err != ErrInvalid {
+		if _, err := io.Copy(nilFile, nilFile); !errors.Is(err, ErrInvalid) {
 			t.Errorf("io.Copy(nilFile, nilFile) = %v, want %v", err, ErrInvalid)
 		}
-		if _, err := io.Copy(anyFile, nilFile); err != ErrInvalid {
+		if _, err := io.Copy(anyFile, nilFile); !errors.Is(err, ErrInvalid) {
 			t.Errorf("io.Copy(anyFile, nilFile) = %v, want %v", err, ErrInvalid)
 		}
-		if _, err := io.Copy(nilFile, anyFile); err != ErrInvalid {
+		if _, err := io.Copy(nilFile, anyFile); !errors.Is(err, ErrInvalid) {
 			t.Errorf("io.Copy(nilFile, anyFile) = %v, want %v", err, ErrInvalid)
 		}
 
-		if _, err := nilFile.ReadFrom(nilFile); err != ErrInvalid {
+		if _, err := nilFile.ReadFrom(nilFile); !errors.Is(err, ErrInvalid) {
 			t.Errorf("nilFile.ReadFrom(nilFile) = %v, want %v", err, ErrInvalid)
 		}
-		if _, err := anyFile.ReadFrom(nilFile); err != ErrInvalid {
+		if _, err := anyFile.ReadFrom(nilFile); !errors.Is(err, ErrInvalid) {
 			t.Errorf("anyFile.ReadFrom(nilFile) = %v, want %v", err, ErrInvalid)
 		}
-		if _, err := nilFile.ReadFrom(anyFile); err != ErrInvalid {
+		if _, err := nilFile.ReadFrom(anyFile); !errors.Is(err, ErrInvalid) {
 			t.Errorf("nilFile.ReadFrom(anyFile) = %v, want %v", err, ErrInvalid)
 		}
 	})

--- a/src/os/timeout_test.go
+++ b/src/os/timeout_test.go
@@ -7,6 +7,7 @@
 package os_test
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -34,13 +35,13 @@ func TestNonpollableDeadline(t *testing.T) {
 	defer os.Remove(f.Name())
 	defer f.Close()
 	deadline := time.Now().Add(10 * time.Second)
-	if err := f.SetDeadline(deadline); err != os.ErrNoDeadline {
+	if err := f.SetDeadline(deadline); !errors.Is(err, os.ErrNoDeadline) {
 		t.Errorf("SetDeadline on file returned %v, wanted %v", err, os.ErrNoDeadline)
 	}
-	if err := f.SetReadDeadline(deadline); err != os.ErrNoDeadline {
+	if err := f.SetReadDeadline(deadline); !errors.Is(err, os.ErrNoDeadline) {
 		t.Errorf("SetReadDeadline on file returned %v, wanted %v", err, os.ErrNoDeadline)
 	}
-	if err := f.SetWriteDeadline(deadline); err != os.ErrNoDeadline {
+	if err := f.SetWriteDeadline(deadline); !errors.Is(err, os.ErrNoDeadline) {
 		t.Errorf("SetWriteDeadline on file returned %v, wanted %v", err, os.ErrNoDeadline)
 	}
 }

--- a/src/path/filepath/match_test.go
+++ b/src/path/filepath/match_test.go
@@ -5,6 +5,7 @@
 package filepath_test
 
 import (
+	"errors"
 	"fmt"
 	"internal/testenv"
 	"os"
@@ -150,7 +151,7 @@ func TestCVE202230632(t *testing.T) {
 	// large number of separators (more than 4,000,000). There is now a limit
 	// of 10,000.
 	_, err := Glob("/*" + strings.Repeat("/", 10001))
-	if err != ErrBadPattern {
+	if !errors.Is(err, ErrBadPattern) {
 		t.Fatalf("Glob returned err=%v, want ErrBadPattern", err)
 	}
 }
@@ -158,7 +159,7 @@ func TestCVE202230632(t *testing.T) {
 func TestGlobError(t *testing.T) {
 	bad := []string{`[]`, `nonexist/[]`}
 	for _, pattern := range bad {
-		if _, err := Glob(pattern); err != ErrBadPattern {
+		if _, err := Glob(pattern); !errors.Is(err, ErrBadPattern) {
 			t.Errorf("Glob(%#q) returned err=%v, want ErrBadPattern", pattern, err)
 		}
 	}

--- a/src/testing/internal/testdeps/deps.go
+++ b/src/testing/internal/testdeps/deps.go
@@ -13,6 +13,7 @@ package testdeps
 import (
 	"bufio"
 	"context"
+	"errors"
 	"internal/fuzz"
 	"internal/testlog"
 	"io"
@@ -163,7 +164,7 @@ func (TestDeps) CoordinateFuzzing(
 		CorpusDir:       corpusDir,
 		CacheDir:        cacheDir,
 	})
-	if err == ctx.Err() {
+	if errors.Is(err, ctx.Err()) {
 		return nil
 	}
 	return err
@@ -179,7 +180,7 @@ func (TestDeps) RunFuzzWorker(fn func(fuzz.CorpusEntry) error) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 	err := fuzz.RunFuzzWorker(ctx, fn)
-	if err == ctx.Err() {
+	if errors.Is(err, ctx.Err()) {
 		return nil
 	}
 	return err

--- a/src/time/zoneinfo_test.go
+++ b/src/time/zoneinfo_test.go
@@ -60,7 +60,7 @@ func TestLoadLocationValidatesNames(t *testing.T) {
 	}
 	for _, v := range bad {
 		_, err := time.LoadLocation(v)
-		if err != time.ErrLocation {
+		if !errors.Is(err, time.ErrLocation) {
 			t.Errorf("LoadLocation(%q) error = %v; want ErrLocation", v, err)
 		}
 	}


### PR DESCRIPTION
This was grep command was used to find occurrences:

  grep -rnP 'err (?:!|=)= ([a-z]{2,}\.)?E[a-z]+'

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.
