### PR TITLE
internal/concurrent: introduce noescape wrapper function

### DIFF
--- a/test/fixedbugs/issue68511.go
+++ b/test/fixedbugs/issue68511.go
@@ -1,0 +1,13 @@
+// run -gcflags=all=-d=checkptr
+
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import "unique"
+
+func main() {
+	unique.Make("")
+}


### PR DESCRIPTION
This is similar to CL 598295.

Fixes #68511