### PR TITLE
misc/wasm: remove unused argument

### DIFF
--- a/misc/wasm/wasm_exec.js
+++ b/misc/wasm/wasm_exec.js
@@ -89,7 +89,7 @@
 		throw new Error("globalThis.TextDecoder is not available, polyfill required");
 	}
 
-	const encoder = new TextEncoder("utf-8");
+	const encoder = new TextEncoder();
 	const decoder = new TextDecoder("utf-8");
 
 	globalThis.Go = class {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/TextEncoder 
TextEncoder receives no argument and always works under utf-8

previous https://github.com/golang/go/pull/67778