### PR TITLE
internal/poll: disable SIO_UDP_NETRESET on Windows

### DIFF
--- a/src/internal/syscall/windows/types_windows.go
+++ b/src/internal/syscall/windows/types_windows.go
@@ -14,6 +14,8 @@ const (
 	TCP_KEEPIDLE  = 0x03
 	TCP_KEEPCNT   = 0x10
 	TCP_KEEPINTVL = 0x11
+
+	SIO_UDP_NETRESET = syscall.IOC_IN | syscall.IOC_VENDOR | 15
 )
 
 const (

--- a/src/net/fd_windows.go
+++ b/src/net/fd_windows.go
@@ -67,6 +67,15 @@ func (fd *netFD) init() error {
 		if err != nil {
 			return wrapSyscallError("wsaioctl", err)
 		}
+		// Disable reporting of NET_UNREACHABLE errors.
+		// See https://go.dev/issue/68614.
+		ret = 0
+		flag = 0
+		size = uint32(unsafe.Sizeof(flag))
+		err = syscall.WSAIoctl(fd.pfd.Sysfd, windows.SIO_UDP_NETRESET, (*byte)(unsafe.Pointer(&flag)), size, nil, 0, &ret, nil, 0)
+		if err != nil {
+			return wrapSyscallError("wsaioctl", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Disable the reception of NET_UNREACHABLE (TTL expired) message reporting
on UDP sockets to match the default behavior of sockets on other
plaforms.

See https://learn.microsoft.com/en-us/windows/win32/winsock/winsock-ioctls#sio_udp_netreset

This is similar to, but a different case from the prior change 3114bd6 /
https://golang.org/issue/5834 that disabled one of the two flags
influencing behavior in response to the reception of related ICMP.

Updates #5834
Updates #68614
