### PR TITLE
go/version,internal/gover: treat prerelease patch as valid version

### DIFF
--- a/src/go/version/version.go
+++ b/src/go/version/version.go
@@ -52,8 +52,31 @@ func Lang(x string) string {
 // The versions x and y must begin with a "go" prefix: "go1.21" not "1.21".
 // Invalid versions, including the empty string, compare less than
 // valid versions and equal to each other.
-// The language version "go1.21" compares less than the
-// release candidate and eventual releases "go1.21rc1" and "go1.21.0".
+// After go1.21, the language version is less than specific release versions
+// or other prerelease versions.
+// For example:
+//
+//	Compare("go1.21rc1", "go1.21") = 1
+//	Compare("go1.21rc1", "go1.21.0") = -1
+//	Compare("go1.22rc1", "go1.22") = 1
+//	Compare("go1.22rc1", "go1.22.0") = -1
+//
+// However, When the language version is below go1.21, the situation is quite different,
+// because the initial release version was 1.N, not 1.N.0.
+// For example:
+//
+//	Compare("go1.20rc1", "go1.21") = -1
+//	Compare("go1.19rc1", "go1.19") = -1
+//	Compare("go1.18", "go1.18rc1") = 1
+//	Compare("go1.18", "go1.18rc1") = 1
+//
+// This situation also happens to prerelease for some old patch versions, such as "go1.8.5rc5, "go1.9.2rc2"
+// For example:
+//
+//	Compare("go1.8.5rc4", "go1.8.5rc5") = -1
+//	Compare("go1.8.5rc5", "go1.8.5") = -1
+//	Compare("go1.9.2rc2", "go1.9.2") = -1
+//	Compare("go1.9.2rc2", "go1.9") = 1
 func Compare(x, y string) int {
 	return gover.Compare(stripGo(x), stripGo(y))
 }

--- a/src/go/version/version_test.go
+++ b/src/go/version/version_test.go
@@ -40,6 +40,10 @@ var compareTests = []testCase2[string, string, int]{
 	{"go1.19alpha3", "go1.19beta2", -1},
 	{"go1.19beta2", "go1.19rc1", -1},
 	{"go1.1", "go1.99999999999999998", -1},
+	{"go1.9.2rc2", "go1.9.2", -1},
+	{"go1.9.2rc2", "go1.9.2rc3", -1},
+	{"go1.9.2beta2", "go1.9.2rc3", -1},
+	{"go1.9.2alpha1", "go1.9.2beta2", -1},
 	{"go1.99999999999999998", "go1.99999999999999999", -1},
 }
 
@@ -52,6 +56,7 @@ var langTests = []testCase1[string, string]{
 	{"go1.2", "go1.2"},
 	{"go1", "go1"},
 	{"go222", "go222.0"},
+	{"go1.8.2rc", "go1.8"},
 	{"go1.999testmod", "go1.999"},
 }
 
@@ -73,6 +78,8 @@ var isValidTests = []testCase1[string, bool]{
 	{"go1.19", true},
 	{"go1.3", true},
 	{"go1.2", true},
+	{"go1.9.2rc2", true},
+	{"go1.9.2+rc2", false},
 	{"go1", true},
 }
 

--- a/src/internal/gover/gover_test.go
+++ b/src/internal/gover/gover_test.go
@@ -35,6 +35,10 @@ var compareTests = []testCase2[string, string, int]{
 	{"1.19rc1", "1.19.0", -1},
 	{"1.19alpha3", "1.19beta2", -1},
 	{"1.19beta2", "1.19rc1", -1},
+	{"1.9.2rc2", "1.9.2", -1},
+	{"1.9.2rc2", "1.9.2rc3", -1},
+	{"1.9.2beta2", "1.9.2rc3", -1},
+	{"1.9.2alpha1", "1.9.2beta2", -1},
 	{"1.1", "1.99999999999999998", -1},
 	{"1.99999999999999998", "1.99999999999999999", -1},
 }
@@ -53,6 +57,9 @@ var parseTests = []testCase1[string, Version]{
 	{"1.24", Version{"1", "24", "", "", ""}},
 	{"1.24rc3", Version{"1", "24", "", "rc", "3"}},
 	{"1.24.0", Version{"1", "24", "0", "", ""}},
+	{"1.9.2rc2", Version{"1", "9", "2", "rc", "2"}},
+	{"1.8.5rc4", Version{"1", "8", "5", "rc", "4"}},
+	{"1.8.2beta2", Version{"1", "8", "2", "beta", "2"}},
 	{"1.999testmod", Version{"1", "999", "", "testmod", ""}},
 	{"1.99999999999999999", Version{"1", "99999999999999999", "", "", ""}},
 }
@@ -64,6 +71,8 @@ var langTests = []testCase1[string, string]{
 	{"1.2.3", "1.2"},
 	{"1.2", "1.2"},
 	{"1", "1"},
+	{"1.9.2rc2", "1.9"},
+	{"1.8.5rc4", "1.8"},
 	{"1.999testmod", "1.999"},
 }
 
@@ -72,6 +81,8 @@ func TestIsLang(t *testing.T) { test1(t, isLangTests, "IsLang", IsLang) }
 var isLangTests = []testCase1[string, bool]{
 	{"1.2rc3", false},
 	{"1.2.3", false},
+	{"1.9.2rc2", false},
+	{"1.8.5rc5", false},
 	{"1.999testmod", false},
 	{"1.22", true},
 	{"1.21", true},
@@ -96,6 +107,10 @@ var isValidTests = []testCase1[string, bool]{
 	{"1.20.0", true},
 	{"1.20", true},
 	{"1.19", true},
+	{"1.8.5rc5", true},
+	{"1.9.2rc2", true},
+	{"1.9.2beta1", true},
+	{"1.9.2alpha", true},
 	{"1.3", true},
 	{"1.2", true},
 	{"1", true},


### PR DESCRIPTION
go/version.IsValid do not consider prerelease patch as valid version, but some prerelease patches actually do exist in history versions, such as go1.8.5rc5, go1.8.5rc4, go1.9.2rc2 .The version go1.9.2rc2 even could be found from https://go.dev/dl/?mode=json&include=all, and downloaded from https://dl.google.com/go/go1.9.2rc2.linux-amd64.tar.gz. It's unreasonable to treat an existing version as an invalid version, so it should be fixed.

Fixes #68634
