### PR TITLE
go/types, types2: use slices to simplify the code

### DIFF
--- a/src/cmd/compile/internal/types2/decl.go
+++ b/src/cmd/compile/internal/types2/decl.go
@@ -10,6 +10,7 @@ import (
 	"go/constant"
 	"internal/buildcfg"
 	. "internal/types/errors"
+	"slices"
 )
 
 func (check *Checker) declare(scope *Scope, id *syntax.Name, obj Object, pos syntax.Pos) {
@@ -440,14 +441,7 @@ func (check *Checker) varDecl(obj *Var, lhs []*Var, typ, init syntax.Expr) {
 
 	if debug {
 		// obj must be one of lhs
-		found := false
-		for _, lhs := range lhs {
-			if obj == lhs {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(lhs, obj) {
 			panic("inconsistent lhs")
 		}
 	}

--- a/src/cmd/compile/internal/types2/example_test.go
+++ b/src/cmd/compile/internal/types2/example_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -141,14 +141,14 @@ func fib(x int) int {
 	}
 	var items []string
 	for obj, uses := range usesByObj {
-		sort.Strings(uses)
+		slices.Sort(uses)
 		item := fmt.Sprintf("%s:\n  defined at %s\n  used at %s",
 			types2.ObjectString(obj, types2.RelativeTo(pkg)),
 			obj.Pos(),
 			strings.Join(uses, ", "))
 		items = append(items, item)
 	}
-	sort.Strings(items) // sort by line:col, in effect
+	slices.Sort(items) // sort by line:col, in effect
 	fmt.Println(strings.Join(items, "\n"))
 	fmt.Println()
 
@@ -168,7 +168,7 @@ func fib(x int) int {
 	// 		mode(tv), tvstr)
 	// 	items = append(items, buf.String())
 	// }
-	// sort.Strings(items)
+	// slices.Sort(items)
 	// fmt.Println(strings.Join(items, "\n"))
 
 	// Output:

--- a/src/cmd/compile/internal/types2/issues_test.go
+++ b/src/cmd/compile/internal/types2/issues_test.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"internal/testenv"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 
@@ -164,7 +164,7 @@ L7 uses var z int`
 		fact := fmt.Sprintf("L%d uses %s", id.Pos().Line(), obj)
 		facts = append(facts, fact)
 	}
-	sort.Strings(facts)
+	slices.Sort(facts)
 
 	got := strings.Join(facts, "\n")
 	if got != want {

--- a/src/cmd/compile/internal/types2/labels.go
+++ b/src/cmd/compile/internal/types2/labels.go
@@ -7,6 +7,7 @@ package types2
 import (
 	"cmd/compile/internal/syntax"
 	. "internal/types/errors"
+	"slices"
 )
 
 // labels checks correct label use in body.
@@ -108,14 +109,7 @@ func (check *Checker) blockBranches(all *Scope, parent *block, lstmt *syntax.Lab
 	}
 
 	jumpsOverVarDecl := func(jmp *syntax.BranchStmt) bool {
-		if varDeclPos.IsKnown() {
-			for _, bad := range badJumps {
-				if jmp == bad {
-					return true
-				}
-			}
-		}
-		return false
+		return varDeclPos.IsKnown() && slices.Contains(badJumps, jmp)
 	}
 
 	var stmtBranches func(syntax.Stmt)

--- a/src/cmd/compile/internal/types2/object.go
+++ b/src/cmd/compile/internal/types2/object.go
@@ -193,40 +193,48 @@ func (obj *object) sameId(pkg *Package, name string, foldCase bool) bool {
 	return samePkg(obj.pkg, pkg)
 }
 
-// less reports whether object a is ordered before object b.
+// cmp reports whether object a is ordered before object b.
+// cmp returns:
+//
+//	-1 if a is before b
+//	 0 if a is equivalent to b
+//	+1 if a is behind b
 //
 // Objects are ordered nil before non-nil, exported before
 // non-exported, then by name, and finally (for non-exported
 // functions) by package path.
-func (a *object) less(b *object) bool {
+func (a *object) cmp(b *object) int {
 	if a == b {
-		return false
+		return 0
 	}
 
 	// Nil before non-nil.
 	if a == nil {
-		return true
+		return -1
 	}
 	if b == nil {
-		return false
+		return +1
 	}
 
 	// Exported functions before non-exported.
 	ea := isExported(a.name)
 	eb := isExported(b.name)
 	if ea != eb {
-		return ea
+		if ea {
+			return -1
+		}
+		return +1
 	}
 
 	// Order by name and then (for non-exported names) by package.
 	if a.name != b.name {
-		return a.name < b.name
+		return strings.Compare(a.name, b.name)
 	}
 	if !ea {
-		return a.pkg.path < b.pkg.path
+		return strings.Compare(a.pkg.path, b.pkg.path)
 	}
 
-	return false
+	return 0
 }
 
 // A PkgName represents an imported Go package.

--- a/src/cmd/compile/internal/types2/predicates.go
+++ b/src/cmd/compile/internal/types2/predicates.go
@@ -6,7 +6,10 @@
 
 package types2
 
-import "unicode"
+import (
+	"slices"
+	"unicode"
+)
 
 // isValid reports whether t is a valid type.
 func isValid(t Type) bool { return Unalias(t) != Typ[Invalid] }
@@ -506,14 +509,8 @@ func identicalOrigin(x, y *Named) bool {
 // Instantiations are identical if their origin and type arguments are
 // identical.
 func identicalInstance(xorig Type, xargs []Type, yorig Type, yargs []Type) bool {
-	if len(xargs) != len(yargs) {
+	if !slices.EqualFunc(xargs, yargs, Identical) {
 		return false
-	}
-
-	for i, xa := range xargs {
-		if !Identical(xa, yargs[i]) {
-			return false
-		}
 	}
 
 	return Identical(xorig, yorig)

--- a/src/cmd/compile/internal/types2/resolver.go
+++ b/src/cmd/compile/internal/types2/resolver.go
@@ -6,10 +6,11 @@ package types2
 
 import (
 	"cmd/compile/internal/syntax"
+	"cmp"
 	"fmt"
 	"go/constant"
 	. "internal/types/errors"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -682,7 +683,9 @@ func (check *Checker) packageObjects() {
 		objList[i] = obj
 		i++
 	}
-	sort.Sort(inSourceOrder(objList))
+	slices.SortFunc(objList, func(a, b Object) int {
+		return cmp.Compare(a.order(), b.order())
+	})
 
 	// add new methods to already type-checked types (from a prior Checker.Files call)
 	for _, obj := range objList {
@@ -747,14 +750,6 @@ func (check *Checker) packageObjects() {
 	// methods. We can now safely discard this map.
 	check.methods = nil
 }
-
-// inSourceOrder implements the sort.Sort interface.
-// TODO(gri) replace with slices.SortFunc
-type inSourceOrder []Object
-
-func (a inSourceOrder) Len() int           { return len(a) }
-func (a inSourceOrder) Less(i, j int) bool { return a[i].order() < a[j].order() }
-func (a inSourceOrder) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 
 // unusedImports checks for unused imports.
 func (check *Checker) unusedImports() {

--- a/src/cmd/compile/internal/types2/resolver_test.go
+++ b/src/cmd/compile/internal/types2/resolver_test.go
@@ -8,7 +8,7 @@ import (
 	"cmd/compile/internal/syntax"
 	"fmt"
 	"internal/testenv"
-	"sort"
+	"slices"
 	"testing"
 
 	. "cmd/compile/internal/types2"
@@ -197,7 +197,7 @@ func TestResolveIdents(t *testing.T) {
 	}
 
 	// check the expected set of idents that are simultaneously uses and defs
-	sort.Strings(both)
+	slices.Sort(both)
 	if got, want := fmt.Sprint(both), "[Mutex Stringer error]"; got != want {
 		t.Errorf("simultaneous uses/defs = %s, want %s", got, want)
 	}

--- a/src/cmd/compile/internal/types2/scope.go
+++ b/src/cmd/compile/internal/types2/scope.go
@@ -10,7 +10,7 @@ import (
 	"cmd/compile/internal/syntax"
 	"fmt"
 	"io"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -55,7 +55,7 @@ func (s *Scope) Names() []string {
 		names[i] = name
 		i++
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 	return names
 }
 

--- a/src/cmd/compile/internal/types2/typeset.go
+++ b/src/cmd/compile/internal/types2/typeset.go
@@ -7,7 +7,7 @@ package types2
 import (
 	"cmd/compile/internal/syntax"
 	. "internal/types/errors"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -345,26 +345,22 @@ func intersectTermLists(xterms termlist, xcomp bool, yterms termlist, ycomp bool
 	return terms, comp
 }
 
+func compareFunc(a, b *Func) int {
+	return a.cmp(&b.object)
+}
+
 func sortMethods(list []*Func) {
-	sort.Sort(byUniqueMethodName(list))
+	slices.SortFunc(list, compareFunc)
 }
 
 func assertSortedMethods(list []*Func) {
 	if !debug {
 		panic("assertSortedMethods called outside debug mode")
 	}
-	if !sort.IsSorted(byUniqueMethodName(list)) {
+	if !slices.IsSortedFunc(list, compareFunc) {
 		panic("methods not sorted")
 	}
 }
-
-// byUniqueMethodName method lists can be sorted by their unique method names.
-// todo: replace with slices.SortFunc
-type byUniqueMethodName []*Func
-
-func (a byUniqueMethodName) Len() int           { return len(a) }
-func (a byUniqueMethodName) Less(i, j int) bool { return a[i].less(&a[j].object) }
-func (a byUniqueMethodName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 
 // invalidTypeSet is a singleton type set to signal an invalid type set
 // due to an error. It's also a valid empty type set, so consumers of

--- a/src/cmd/compile/internal/types2/typestring.go
+++ b/src/cmd/compile/internal/types2/typestring.go
@@ -9,7 +9,7 @@ package types2
 import (
 	"bytes"
 	"fmt"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -308,7 +308,7 @@ func (w *typeWriter) typ(typ Type) {
 			w.error("unnamed type parameter")
 			break
 		}
-		if i := tparamIndex(w.tparams.list(), t); i >= 0 {
+		if i := slices.Index(w.tparams.list(), t); i >= 0 {
 			// The names of type parameters that are declared by the type being
 			// hashed are not part of the type identity. Replace them with a
 			// placeholder indicating their index.
@@ -382,7 +382,7 @@ func (w *typeWriter) typeSet(s *_TypeSet) {
 			newTypeHasher(&buf, w.ctxt).typ(term.typ)
 			termHashes = append(termHashes, buf.String())
 		}
-		sort.Strings(termHashes)
+		slices.Sort(termHashes)
 		if !first {
 			w.byte(';')
 		}

--- a/src/go/types/api_test.go
+++ b/src/go/types/api_test.go
@@ -1386,14 +1386,7 @@ func TestScopesInfo(t *testing.T) {
 
 			// look for matching scope description
 			desc := kind + ":" + strings.Join(scope.Names(), " ")
-			found := false
-			for _, d := range test.scopes {
-				if desc == d {
-					found = true
-					break
-				}
-			}
-			if !found {
+			if !slices.Contains(test.scopes, desc) {
 				t.Errorf("package %s: no matching scope found for %s", name, desc)
 			}
 		}
@@ -1942,7 +1935,7 @@ func TestLookupFieldOrMethod(t *testing.T) {
 				t.Errorf("%s: got object = %v; want none", test.src, f)
 			}
 		}
-		if !sameSlice(index, test.index) {
+		if !slices.Equal(index, test.index) {
 			t.Errorf("%s: got index = %v; want %v", test.src, index, test.index)
 		}
 		if indirect != test.indirect {
@@ -1978,18 +1971,6 @@ type Instance = *Tree[int]
 
 	T := pkg.Scope().Lookup("Instance").Type()
 	_, _, _ = LookupFieldOrMethod(T, false, pkg, "M") // verify that LookupFieldOrMethod terminates
-}
-
-func sameSlice(a, b []int) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i, x := range a {
-		if x != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 // newDefined creates a new defined type named T with the given underlying type.

--- a/src/go/types/decl.go
+++ b/src/go/types/decl.go
@@ -11,6 +11,7 @@ import (
 	"go/token"
 	"internal/buildcfg"
 	. "internal/types/errors"
+	"slices"
 )
 
 func (check *Checker) declare(scope *Scope, id *ast.Ident, obj Object, pos token.Pos) {
@@ -515,14 +516,7 @@ func (check *Checker) varDecl(obj *Var, lhs []*Var, typ, init ast.Expr) {
 
 	if debug {
 		// obj must be one of lhs
-		found := false
-		for _, lhs := range lhs {
-			if obj == lhs {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(lhs, obj) {
 			panic("inconsistent lhs")
 		}
 	}

--- a/src/go/types/labels.go
+++ b/src/go/types/labels.go
@@ -8,6 +8,7 @@ import (
 	"go/ast"
 	"go/token"
 	. "internal/types/errors"
+	"slices"
 )
 
 // labels checks correct label use in body.
@@ -109,14 +110,7 @@ func (check *Checker) blockBranches(all *Scope, parent *block, lstmt *ast.Labele
 	}
 
 	jumpsOverVarDecl := func(jmp *ast.BranchStmt) bool {
-		if varDeclPos.IsValid() {
-			for _, bad := range badJumps {
-				if jmp == bad {
-					return true
-				}
-			}
-		}
-		return false
+		return varDeclPos.IsValid() && slices.Contains(badJumps, jmp)
 	}
 
 	blockBranches := func(lstmt *ast.LabeledStmt, list []ast.Stmt) {

--- a/src/go/types/methodset_test.go
+++ b/src/go/types/methodset_test.go
@@ -5,6 +5,7 @@
 package types_test
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -108,7 +109,7 @@ func TestNewMethodSet(t *testing.T) {
 			if got, want := sel.Obj().Name(), m.name; got != want {
 				t.Errorf("%s [method %d]: got name = %q at, want %q", src, i, got, want)
 			}
-			if got, want := sel.Index(), m.index; !sameSlice(got, want) {
+			if got, want := sel.Index(), m.index; !slices.Equal(got, want) {
 				t.Errorf("%s [method %d]: got index = %v, want %v", src, i, got, want)
 			}
 			if got, want := sel.Indirect(), m.indirect; got != want {

--- a/src/go/types/object.go
+++ b/src/go/types/object.go
@@ -196,40 +196,48 @@ func (obj *object) sameId(pkg *Package, name string, foldCase bool) bool {
 	return samePkg(obj.pkg, pkg)
 }
 
-// less reports whether object a is ordered before object b.
+// cmp reports whether object a is ordered before object b.
+// cmp returns:
+//
+//	-1 if a is before b
+//	 0 if a is equivalent to b
+//	+1 if a is behind b
 //
 // Objects are ordered nil before non-nil, exported before
 // non-exported, then by name, and finally (for non-exported
 // functions) by package path.
-func (a *object) less(b *object) bool {
+func (a *object) cmp(b *object) int {
 	if a == b {
-		return false
+		return 0
 	}
 
 	// Nil before non-nil.
 	if a == nil {
-		return true
+		return -1
 	}
 	if b == nil {
-		return false
+		return +1
 	}
 
 	// Exported functions before non-exported.
 	ea := isExported(a.name)
 	eb := isExported(b.name)
 	if ea != eb {
-		return ea
+		if ea {
+			return -1
+		}
+		return +1
 	}
 
 	// Order by name and then (for non-exported names) by package.
 	if a.name != b.name {
-		return a.name < b.name
+		return strings.Compare(a.name, b.name)
 	}
 	if !ea {
-		return a.pkg.path < b.pkg.path
+		return strings.Compare(a.pkg.path, b.pkg.path)
 	}
 
-	return false
+	return 0
 }
 
 // A PkgName represents an imported Go package.

--- a/src/go/types/predicates.go
+++ b/src/go/types/predicates.go
@@ -9,7 +9,10 @@
 
 package types
 
-import "unicode"
+import (
+	"slices"
+	"unicode"
+)
 
 // isValid reports whether t is a valid type.
 func isValid(t Type) bool { return Unalias(t) != Typ[Invalid] }
@@ -509,14 +512,8 @@ func identicalOrigin(x, y *Named) bool {
 // Instantiations are identical if their origin and type arguments are
 // identical.
 func identicalInstance(xorig Type, xargs []Type, yorig Type, yargs []Type) bool {
-	if len(xargs) != len(yargs) {
+	if !slices.EqualFunc(xargs, yargs, Identical) {
 		return false
-	}
-
-	for i, xa := range xargs {
-		if !Identical(xa, yargs[i]) {
-			return false
-		}
 	}
 
 	return Identical(xorig, yorig)

--- a/src/go/types/resolver.go
+++ b/src/go/types/resolver.go
@@ -5,13 +5,14 @@
 package types
 
 import (
+	"cmp"
 	"fmt"
 	"go/ast"
 	"go/constant"
 	"go/internal/typeparams"
 	"go/token"
 	. "internal/types/errors"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -678,7 +679,9 @@ func (check *Checker) packageObjects() {
 		objList[i] = obj
 		i++
 	}
-	sort.Sort(inSourceOrder(objList))
+	slices.SortFunc(objList, func(a, b Object) int {
+		return cmp.Compare(a.order(), b.order())
+	})
 
 	// add new methods to already type-checked types (from a prior Checker.Files call)
 	for _, obj := range objList {
@@ -743,14 +746,6 @@ func (check *Checker) packageObjects() {
 	// methods. We can now safely discard this map.
 	check.methods = nil
 }
-
-// inSourceOrder implements the sort.Sort interface.
-// TODO(gri) replace with slices.SortFunc
-type inSourceOrder []Object
-
-func (a inSourceOrder) Len() int           { return len(a) }
-func (a inSourceOrder) Less(i, j int) bool { return a[i].order() < a[j].order() }
-func (a inSourceOrder) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 
 // unusedImports checks for unused imports.
 func (check *Checker) unusedImports() {

--- a/src/go/types/scope.go
+++ b/src/go/types/scope.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"go/token"
 	"io"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -58,7 +58,7 @@ func (s *Scope) Names() []string {
 		names[i] = name
 		i++
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 	return names
 }
 

--- a/src/go/types/typeset.go
+++ b/src/go/types/typeset.go
@@ -10,7 +10,7 @@ package types
 import (
 	"go/token"
 	. "internal/types/errors"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -348,26 +348,22 @@ func intersectTermLists(xterms termlist, xcomp bool, yterms termlist, ycomp bool
 	return terms, comp
 }
 
+func compareFunc(a, b *Func) int {
+	return a.cmp(&b.object)
+}
+
 func sortMethods(list []*Func) {
-	sort.Sort(byUniqueMethodName(list))
+	slices.SortFunc(list, compareFunc)
 }
 
 func assertSortedMethods(list []*Func) {
 	if !debug {
 		panic("assertSortedMethods called outside debug mode")
 	}
-	if !sort.IsSorted(byUniqueMethodName(list)) {
+	if !slices.IsSortedFunc(list, compareFunc) {
 		panic("methods not sorted")
 	}
 }
-
-// byUniqueMethodName method lists can be sorted by their unique method names.
-// todo: replace with slices.SortFunc
-type byUniqueMethodName []*Func
-
-func (a byUniqueMethodName) Len() int           { return len(a) }
-func (a byUniqueMethodName) Less(i, j int) bool { return a[i].less(&a[j].object) }
-func (a byUniqueMethodName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 
 // invalidTypeSet is a singleton type set to signal an invalid type set
 // due to an error. It's also a valid empty type set, so consumers of

--- a/src/go/types/typestring.go
+++ b/src/go/types/typestring.go
@@ -12,7 +12,7 @@ package types
 import (
 	"bytes"
 	"fmt"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -311,7 +311,7 @@ func (w *typeWriter) typ(typ Type) {
 			w.error("unnamed type parameter")
 			break
 		}
-		if i := tparamIndex(w.tparams.list(), t); i >= 0 {
+		if i := slices.Index(w.tparams.list(), t); i >= 0 {
 			// The names of type parameters that are declared by the type being
 			// hashed are not part of the type identity. Replace them with a
 			// placeholder indicating their index.
@@ -385,7 +385,7 @@ func (w *typeWriter) typeSet(s *_TypeSet) {
 			newTypeHasher(&buf, w.ctxt).typ(term.typ)
 			termHashes = append(termHashes, buf.String())
 		}
-		sort.Strings(termHashes)
+		slices.Sort(termHashes)
 		if !first {
 			w.byte(';')
 		}


### PR DESCRIPTION
Simplify the code and remove some unnecessary helper functions.