### PR TITLE
bytes,strings: optimize Join a bit

### DIFF
--- a/src/bytes/bytes.go
+++ b/src/bytes/bytes.go
@@ -513,10 +513,11 @@ func Join(s [][]byte, sep []byte) []byte {
 
 	var n int
 	if len(sep) > 0 {
-		if len(sep) >= maxInt/(len(s)-1) {
+		hi, lo := bits.Mul(uint(len(sep)), uint(len(s)-1))
+		if hi > 0 || lo >= uint(maxInt) {
 			panic("bytes: Join output length overflow")
 		}
-		n += len(sep) * (len(s) - 1)
+		n += int(lo) // lo = len(sep) * (len(s) - 1)
 	}
 	for _, v := range s {
 		if len(v) > maxInt-n {

--- a/src/strings/strings.go
+++ b/src/strings/strings.go
@@ -436,10 +436,11 @@ func Join(elems []string, sep string) string {
 
 	var n int
 	if len(sep) > 0 {
-		if len(sep) >= maxInt/(len(elems)-1) {
+		hi, lo := bits.Mul(uint(len(sep)), uint(len(elems)-1))
+		if hi > 0 || lo >= uint(maxInt) {
 			panic("strings: Join output length overflow")
 		}
-		n += len(sep) * (len(elems) - 1)
+		n += int(lo) // lo = len(sep) * (len(elems) - 1)
 	}
 	for _, elem := range elems {
 		if len(elem) > maxInt-n {


### PR DESCRIPTION
Use math/bits.Mul to detect overflow in order to avoid a divide
which is slow.

This is a follow-up to CL 602475.