### PR TITLE
plugin: include a warning about race detector compatability in docs

### DIFF
--- a/src/plugin/plugin.go
+++ b/src/plugin/plugin.go
@@ -30,8 +30,8 @@
 //     portable.
 //
 //   - Plugins are poorly supported by the Go race detector. Even simple
-//     race conditions may not be automatically detected. See 
-//     [this issue](https://github.com/golang/go/issues/24245) for more information.
+//     race conditions may not be automatically detected. See
+//     https://go.dev/issue/24245 for more information.
 //
 //   - Applications that use plugins may require careful configuration
 //     to ensure that the various parts of the program be made available

--- a/src/plugin/plugin.go
+++ b/src/plugin/plugin.go
@@ -29,6 +29,10 @@
 //     macOS, making them unsuitable for applications intended to be
 //     portable.
 //
+//   - Plugins are poorly supported by the Go race detector. Even simple
+//     race conditions may not be automatically detected. See 
+//     [this issue](https://github.com/golang/go/issues/24245) for more information.
+//
 //   - Applications that use plugins may require careful configuration
 //     to ensure that the various parts of the program be made available
 //     in the correct location in the file system (or container image).


### PR DESCRIPTION
As described in #24245, the race detector isn't able to find some race conditions in plugins.
This commit adds a warning about this to the plugins documentation.

Updates #24245
