### PR TITLE
cmd/compile,cmd/link: export string global consts to DWARF

### DIFF
--- a/doc/next/3-tools.md
+++ b/doc/next/3-tools.md
@@ -20,3 +20,8 @@ non-existent identifiers. Some of these mistakes may cause tests not
 to run.
 
 This analyzer is among the subset of analyzers that are run by `go test`.
+
+### Compiler Toolchain {#compiler}
+
+The DWARF debug information recorded in binaries has contained string constants
+now.

--- a/src/cmd/internal/dwarf/dwarf.go
+++ b/src/cmd/internal/dwarf/dwarf.go
@@ -334,6 +334,7 @@ const (
 	DW_ABRV_INLINED_SUBROUTINE_RANGES
 	DW_ABRV_VARIABLE
 	DW_ABRV_INT_CONSTANT
+	DW_ABRV_STRING_CONSTANT
 	DW_ABRV_LEXICAL_BLOCK_RANGES
 	DW_ABRV_LEXICAL_BLOCK_SIMPLE
 	DW_ABRV_STRUCTFIELD
@@ -547,6 +548,16 @@ var abbrevs = []dwAbbrev{
 			{DW_AT_name, DW_FORM_string},
 			{DW_AT_type, DW_FORM_ref_addr},
 			{DW_AT_const_value, DW_FORM_sdata},
+		},
+	},
+
+	/* STRING CONSTANT */
+	{
+		DW_TAG_constant,
+		DW_CHILDREN_no,
+		[]dwAttrForm{
+			{DW_AT_name, DW_FORM_string},
+			{DW_AT_const_value, DW_FORM_string},
 		},
 	},
 
@@ -988,6 +999,13 @@ func PutIntConst(ctxt Context, info, typ Sym, name string, val int64) {
 	putattr(ctxt, info, DW_ABRV_INT_CONSTANT, DW_FORM_string, DW_CLS_STRING, int64(len(name)), name)
 	putattr(ctxt, info, DW_ABRV_INT_CONSTANT, DW_FORM_ref_addr, DW_CLS_REFERENCE, 0, typ)
 	putattr(ctxt, info, DW_ABRV_INT_CONSTANT, DW_FORM_sdata, DW_CLS_CONSTANT, val, nil)
+}
+
+// PutStringConst writes a DIE for a string constant
+func PutStringConst(ctxt Context, info Sym, name string, val string) {
+	Uleb128put(ctxt, info, DW_ABRV_STRING_CONSTANT)
+	putattr(ctxt, info, DW_ABRV_STRING_CONSTANT, DW_FORM_string, DW_CLS_STRING, int64(len(name)), name)
+	putattr(ctxt, info, DW_ABRV_STRING_CONSTANT, DW_FORM_string, DW_CLS_STRING, int64(len(val)), val)
 }
 
 // PutGlobal writes a DIE for a global variable.

--- a/src/cmd/internal/obj/dwarf.go
+++ b/src/cmd/internal/obj/dwarf.go
@@ -395,6 +395,21 @@ func (ctxt *Link) DwarfIntConst(name, typename string, val int64) {
 	dwarf.PutIntConst(dwCtxt{ctxt}, s, ctxt.Lookup(dwarf.InfoPrefix+typename), myimportpath+"."+name, val)
 }
 
+// DwarfStringConst creates a link symbol for a string constant with the
+// given name, type and value.
+func (ctxt *Link) DwarfStringConst(name string, val string) {
+	myimportpath := ctxt.Pkgpath
+	if myimportpath == "" {
+		return
+	}
+	s := ctxt.LookupInit(dwarf.ConstInfoPrefix+myimportpath, func(s *LSym) {
+		s.Type = objabi.SDWARFCONST
+		ctxt.Data = append(ctxt.Data, s)
+	})
+
+	dwarf.PutStringConst(dwCtxt{ctxt}, s, myimportpath+"."+name, val)
+}
+
 // DwarfGlobal creates a link symbol containing a DWARF entry for
 // a global variable.
 func (ctxt *Link) DwarfGlobal(typename string, varSym *LSym) {

--- a/src/runtime/runtime-gdb_test.go
+++ b/src/runtime/runtime-gdb_test.go
@@ -594,6 +594,7 @@ package main
 const aConstant int = 42
 const largeConstant uint64 = ^uint64(0)
 const minusOne int64 = -1
+const stringConstant string = "hello"
 
 func main() {
 	println("hello world")
@@ -631,6 +632,7 @@ func TestGdbConst(t *testing.T) {
 		"-ex", "print main.minusOne",
 		"-ex", "print 'runtime.mSpanInUse'",
 		"-ex", "print 'runtime._PageSize'",
+		"-ex", "print main.stringConstant",
 		filepath.Join(dir, "a.exe"),
 	}
 	gdbArgsFixup(args)
@@ -642,7 +644,16 @@ func TestGdbConst(t *testing.T) {
 
 	sgot := strings.ReplaceAll(string(got), "\r\n", "\n")
 
-	if !strings.Contains(sgot, "\n$1 = 42\n$2 = 18446744073709551615\n$3 = -1\n$4 = 1 '\\001'\n$5 = 8192") {
+	const match = `
+$1 = 42
+$2 = 18446744073709551615
+$3 = -1
+$4 = 1 '\\001'
+$5 = 8192
+$6 = 'hello'
+`
+
+	if !strings.Contains(sgot, match) {
 		t.Fatalf("output mismatch")
 	}
 }


### PR DESCRIPTION
Updates #14517
Fixes #67744 