### PR TITLE
testing: add Context

### DIFF
--- a/api/next/36532.txt
+++ b/api/next/36532.txt
@@ -1,0 +1,4 @@
+pkg testing, method (*B) Context() context.Context #36532
+pkg testing, method (*F) Context() context.Context #36532
+pkg testing, method (*T) Context() context.Context #36532
+pkg testing, type TB interface, Context() context.Context #36532

--- a/doc/next/6-stdlib/99-minor/testing/36532.md
+++ b/doc/next/6-stdlib/99-minor/testing/36532.md
@@ -1,0 +1,2 @@
+The new [T.Context] and [B.Context] methods return a context that's canceled
+before the end of its associated test or benchmark function.

--- a/doc/next/6-stdlib/99-minor/testing/62516.md
+++ b/doc/next/6-stdlib/99-minor/testing/62516.md
@@ -1,2 +1,2 @@
-The new [T.Chdir] and [B.Chdir] methods can be used to change the working
-directory for the duration of a test or benchmark.
+The new [T.Context] and [B.Context] methods return a context that is canceled
+after the test completes and before test cleanup functions run.


### PR DESCRIPTION
Adds a new Context method to testing.T, that returns a context, that is
canceled before the end of its test function.

Fixes #36532.