### PR TITLE
internal/filepathlite: use host node.js function to parse path in wasm

### DIFF
--- a/misc/wasm/wasm_exec.js
+++ b/misc/wasm/wasm_exec.js
@@ -73,13 +73,25 @@
 		}
 	}
 
-	if (!globalThis.path) {
-		globalThis.path = {
-			resolve(...pathSegments) {
-				return pathSegments.join("/");
-			}
-		}
-	}
+    if (!globalThis.path) {
+        globalThis.path = {
+            resolve(...pathSegments) {
+                return pathSegments.join("/");
+            },
+            isAbsolute(path) {
+                return path[0] === "/";
+            },
+            parse(path) {
+                return {
+                    root: "/"
+                }
+            },
+            normalize(path) {
+                return path;
+            },
+			sep: "/",
+        }
+    }
 
 	if (!globalThis.crypto) {
 		throw new Error("globalThis.crypto is not available, polyfill required (crypto.getRandomValues only)");

--- a/misc/wasm/wasm_exec.js
+++ b/misc/wasm/wasm_exec.js
@@ -73,25 +73,25 @@
 		}
 	}
 
-    if (!globalThis.path) {
-        globalThis.path = {
-            resolve(...pathSegments) {
-                return pathSegments.join("/");
-            },
-            isAbsolute(path) {
-                return path[0] === "/";
-            },
-            parse(path) {
-                return {
-                    root: "/"
-                }
-            },
-            normalize(path) {
-                return path;
-            },
+	if (!globalThis.path) {
+		globalThis.path = {
+			resolve(...pathSegments) {
+				return pathSegments.join("/");
+			},
+			isAbsolute(path) {
+				return path[0] === "/";
+			},
+			parse(path) {
+				return {
+					root: "/"
+				}
+			},
+			normalize(path) {
+				return path;
+			},
 			sep: "/",
-        }
-    }
+		}
+	}
 
 	if (!globalThis.crypto) {
 		throw new Error("globalThis.crypto is not available, polyfill required (crypto.getRandomValues only)");

--- a/src/internal/filepathlite/path_js_wasm.go
+++ b/src/internal/filepathlite/path_js_wasm.go
@@ -1,0 +1,36 @@
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build js && wasm
+
+package filepathlite
+
+import "syscall/js"
+
+func IsPathSeparator(c uint8) bool {
+	return c == '\\' || c == '/'
+}
+
+var jsPath = js.Global().Get("path")
+
+var (
+	Separator = jsPath.Get("sep").String()[0]
+)
+
+func isLocal(path string) bool {
+	return !jsPath.Call("isAbsolute", path).Bool()
+}
+
+func localize(path string) (string, error) {
+	return jsPath.Call("normalize", path).String(), nil
+}
+
+func IsAbs(path string) bool {
+	return jsPath.Call("isAbsolute", path).Bool()
+}
+
+func volumeNameLen(path string) int {
+	length := jsPath.Call("parse", path).Get("root").Get("length").Int()
+	return max(0, length-1)
+}

--- a/src/internal/filepathlite/path_unix.go
+++ b/src/internal/filepathlite/path_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build unix || (js && wasm) || wasip1
+//go:build unix || wasip1
 
 package filepathlite
 


### PR DESCRIPTION
wasm works on a number of different host platforms, 
so specific implementations of path operations should be provided by the host platform.

Fixes #43768
