### PR TITLE
crypto,hash: add t.Helper calls to test helpers

### DIFF
--- a/src/crypto/dsa/dsa_test.go
+++ b/src/crypto/dsa/dsa_test.go
@@ -24,6 +24,7 @@ func testSignAndVerify(t *testing.T, i int, priv *PrivateKey) {
 }
 
 func testParameterGeneration(t *testing.T, sizes ParameterSizes, L, N int) {
+	t.Helper()
 	var priv PrivateKey
 	params := &priv.Parameters
 

--- a/src/crypto/internal/hpke/hpke_test.go
+++ b/src/crypto/internal/hpke/hpke_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func mustDecodeHex(t *testing.T, in string) []byte {
+	t.Helper()
 	b, err := hex.DecodeString(in)
 	if err != nil {
 		t.Fatal(err)

--- a/src/crypto/tls/tls_test.go
+++ b/src/crypto/tls/tls_test.go
@@ -163,6 +163,7 @@ func TestX509MixedKeyPair(t *testing.T) {
 }
 
 func newLocalListener(t testing.TB) net.Listener {
+	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		ln, err = net.Listen("tcp6", "[::1]:0")

--- a/src/crypto/x509/boring_test.go
+++ b/src/crypto/x509/boring_test.go
@@ -27,6 +27,7 @@ const (
 )
 
 func boringRSAKey(t *testing.T, size int) *rsa.PrivateKey {
+	t.Helper()
 	k, err := rsa.GenerateKey(rand.Reader, size)
 	if err != nil {
 		t.Fatal(err)
@@ -35,6 +36,7 @@ func boringRSAKey(t *testing.T, size int) *rsa.PrivateKey {
 }
 
 func boringECDSAKey(t *testing.T, curve elliptic.Curve) *ecdsa.PrivateKey {
+	t.Helper()
 	k, err := ecdsa.GenerateKey(curve, rand.Reader)
 	if err != nil {
 		t.Fatal(err)

--- a/src/crypto/x509/oid_test.go
+++ b/src/crypto/x509/oid_test.go
@@ -320,6 +320,7 @@ func BenchmarkOIDMarshalUnmarshalText(b *testing.B) {
 }
 
 func mustNewOIDFromInts(t testing.TB, ints []uint64) OID {
+	t.Helper()
 	oid, err := OIDFromInts(ints)
 	if err != nil {
 		t.Fatalf("OIDFromInts(%v) unexpected error: %v", ints, err)

--- a/src/crypto/x509/x509_test.go
+++ b/src/crypto/x509/x509_test.go
@@ -1472,6 +1472,7 @@ func TestCreateCertificateRequest(t *testing.T) {
 }
 
 func marshalAndParseCSR(t *testing.T, template *CertificateRequest) *CertificateRequest {
+	t.Helper()
 	derBytes, err := CreateCertificateRequest(rand.Reader, template, testPrivateKey)
 	if err != nil {
 		t.Fatal(err)
@@ -1636,6 +1637,7 @@ func TestCriticalFlagInCSRRequestedExtensions(t *testing.T) {
 // serialiseAndParse generates a self-signed certificate from template and
 // returns a parsed version of it.
 func serialiseAndParse(t *testing.T, template *Certificate) *Certificate {
+	t.Helper()
 	derBytes, err := CreateCertificate(rand.Reader, template, template, &testPrivateKey.PublicKey, testPrivateKey)
 	if err != nil {
 		t.Fatalf("failed to create certificate: %s", err)

--- a/src/hash/maphash/smhasher_test.go
+++ b/src/hash/maphash/smhasher_test.go
@@ -96,6 +96,7 @@ func (s *hashSet) addS_seed(x string, seed Seed) {
 	s.add(h.Sum64())
 }
 func (s *hashSet) check(t *testing.T) {
+	t.Helper()
 	list := s.list
 	slices.Sort(list)
 
@@ -259,6 +260,7 @@ func TestSmhasherSparse(t *testing.T) {
 	sparse(t, h, 2048, 2)
 }
 func sparse(t *testing.T, h *hashSet, n int, k int) {
+	t.Helper()
 	b := make([]byte, n/8)
 	setbits(h, b, 0, k)
 	h.check(t)
@@ -295,6 +297,7 @@ func TestSmhasherPermutation(t *testing.T) {
 	permutation(t, h, []uint32{0, 1, 2, 3, 4, 5, 6, 7, 1 << 29, 2 << 29, 3 << 29, 4 << 29, 5 << 29, 6 << 29, 7 << 29}, 6)
 }
 func permutation(t *testing.T, h *hashSet, s []uint32, n int) {
+	t.Helper()
 	b := make([]byte, n*4)
 	genPerm(h, b, s, 0)
 	h.check(t)
@@ -362,6 +365,7 @@ func TestSmhasherAvalanche(t *testing.T) {
 	avalancheTest1(t, &bytesKey{make([]byte, 200)})
 }
 func avalancheTest1(t *testing.T, k key) {
+	t.Helper()
 	const REP = 100000
 	r := rand.New(rand.NewSource(1234))
 	n := k.bits()
@@ -456,6 +460,7 @@ func TestSmhasherText(t *testing.T) {
 	text(t, h, "", "FooBar")
 }
 func text(t *testing.T, h *hashSet, prefix, suffix string) {
+	t.Helper()
 	const N = 4
 	const S = "ABCDEFGHIJKLMNOPQRSTabcdefghijklmnopqrst0123456789"
 	const L = len(S)


### PR DESCRIPTION
Use t.Helper to make the reported failure lines more helpful.