### PR TITLE
time: implement the encoding.(Binary|Text)Appender for Time

### DIFF
--- a/api/next/62384.txt
+++ b/api/next/62384.txt
@@ -9,3 +9,5 @@ pkg math/big, method (*Float) AppendText([]uint8) ([]uint8, error) #62384
 pkg math/big, method (*Int) AppendText([]uint8) ([]uint8, error) #62384
 pkg math/big, method (*Rat) AppendText([]uint8) ([]uint8, error) #62384
 pkg regexp, method (*Regexp) AppendText([]uint8) ([]uint8, error) #62384
+pkg time, method (Time) AppendBinary([]uint8) ([]uint8, error) #62384
+pkg time, method (Time) AppendText([]uint8) ([]uint8, error) #62384

--- a/doc/next/6-stdlib/99-minor/time/62384.md
+++ b/doc/next/6-stdlib/99-minor/time/62384.md
@@ -1,0 +1,1 @@
+[Time] now implements the [encoding.BinaryAppender] and [encoding.TextAppender] interfaces.

--- a/src/time/time_test.go
+++ b/src/time/time_test.go
@@ -1403,6 +1403,13 @@ var defaultLocTests = []struct {
 	{"UnixMilli", func(t1, t2 Time) bool { return t1.UnixMilli() == t2.UnixMilli() }},
 	{"UnixMicro", func(t1, t2 Time) bool { return t1.UnixMicro() == t2.UnixMicro() }},
 
+	{"AppendBinary", func(t1, t2 Time) bool {
+		buf1 := make([]byte, 4, 32)
+		buf2 := make([]byte, 4, 32)
+		a1, b1 := t1.AppendBinary(buf1)
+		a2, b2 := t2.AppendBinary(buf2)
+		return bytes.Equal(a1[4:], a2[4:]) && b1 == b2
+	}},
 	{"MarshalBinary", func(t1, t2 Time) bool {
 		a1, b1 := t1.MarshalBinary()
 		a2, b2 := t2.MarshalBinary()
@@ -1417,6 +1424,14 @@ var defaultLocTests = []struct {
 		a1, b1 := t1.MarshalJSON()
 		a2, b2 := t2.MarshalJSON()
 		return bytes.Equal(a1, a2) && b1 == b2
+	}},
+	{"AppendText", func(t1, t2 Time) bool {
+		maxCap := len(RFC3339Nano) + 4
+		buf1 := make([]byte, 4, maxCap)
+		buf2 := make([]byte, 4, maxCap)
+		a1, b1 := t1.AppendText(buf1)
+		a2, b2 := t2.AppendText(buf2)
+		return bytes.Equal(a1[4:], a2[4:]) && b1 == b2
 	}},
 	{"MarshalText", func(t1, t2 Time) bool {
 		a1, b1 := t1.MarshalText()
@@ -1507,6 +1522,13 @@ func BenchmarkMarshalText(b *testing.B) {
 	t := Now()
 	for i := 0; i < b.N; i++ {
 		t.MarshalText()
+	}
+}
+
+func BenchmarkMarshalBinary(b *testing.B) {
+	t := Now()
+	for i := 0; i < b.N; i++ {
+		t.MarshalBinary()
 	}
 }
 


### PR DESCRIPTION
"Time.Marshal(Binary|Text)" could also gain some performance
improvements. Here is the benchmark highlight:

                │     old      │                 new                 │
                │    sec/op    │   sec/op     vs base                │
MarshalText-8     104.00n ± 3%   67.27n ± 2%  -35.32% (p=0.000 n=10)
MarshalBinary-8    31.77n ± 2%   12.13n ± 1%  -61.82% (p=0.000 n=10)
geomean            57.48n        28.57n       -50.30%

                │    old     │                  new                   │
                │    B/op    │   B/op     vs base                     │
MarshalText-8     48.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)
MarshalBinary-8   16.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)

                │    old     │                   new                   │
                │ allocs/op  │ allocs/op   vs base                     │
MarshalText-8     1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
MarshalBinary-8   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)

For #62384