### PR TITLE
cmd/internal/obj: don't panic reporting redeclared symbol error message

### DIFF
--- a/src/cmd/internal/obj/plist.go
+++ b/src/cmd/internal/obj/plist.go
@@ -183,16 +183,16 @@ func (ctxt *Link) InitTextSym(s *LSym, flag int, start src.XPos) {
 		return
 	}
 	if s.Func() != nil {
-		ctxt.Diag("%s: symbol %s redeclared\n\t%s: other declaration of symbol %s", ctxt.PosTable.Pos(start), s.Name, ctxt.PosTable.Pos(s.Func().Text.Pos), s.Name)
+		ctxt.Diag("symbol %s redeclared at %s", s.Name, ctxt.PosTable.Pos(start))
 		return
 	}
 	s.NewFuncInfo()
 	if s.OnList() {
-		ctxt.Diag("%s: symbol %s redeclared", ctxt.PosTable.Pos(start), s.Name)
+		ctxt.Diag("symbol %s redeclared at %s", s.Name, ctxt.PosTable.Pos(start))
 		return
 	}
 	if strings.HasPrefix(s.Name, `"".`) {
-		ctxt.Diag("%s: unqualified symbol name: %s", ctxt.PosTable.Pos(start), s.Name)
+		ctxt.Diag("unqualified symbol name %s at %s", s.Name, ctxt.PosTable.Pos(start))
 	}
 
 	// startLine should be the same line number that would be displayed via

--- a/test/fixedbugs/issue68962.go
+++ b/test/fixedbugs/issue68962.go
@@ -1,0 +1,13 @@
+// compile
+
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package main
+
+import _ "unsafe"
+
+//go:linkname a main.c
+func a() {}
+
+func c() {}


### PR DESCRIPTION
Now the linker reports the following error message

/go/test/fixedbugs/issue68962.go:11:6: symbol main.c redeclared at /go/test/fixedbugs/issue68962.go:13:6

Fixes #68962