### PR TITLE
net: enable multipath TCP by default for listeners

### DIFF
--- a/doc/godebug.md
+++ b/doc/godebug.md
@@ -157,6 +157,11 @@ no-op. This setting is controlled by the `randseednop` setting.
 For Go 1.24 it defaults to `randseednop=1`.
 Using `randseednop=0` reverts to the pre-Go 1.24 behavior.
 
+Go 1.24 added new values for the `multipathtcp` setting.
+The values "2" and "3" allow to enable MPTCP only on listeners/
+dialers respectively. It also now enabled MPTCP by default on 
+listeners. Using `multipathtcp=0` reverts to the pre-Go 1.24 behavior.
+
 ### Go 1.23
 
 Go 1.23 changed the channels created by package time to be unbuffered

--- a/doc/godebug.md
+++ b/doc/godebug.md
@@ -159,8 +159,9 @@ Using `randseednop=0` reverts to the pre-Go 1.24 behavior.
 
 Go 1.24 added new values for the `multipathtcp` setting.
 The values "2" and "3" allow to enable MPTCP only on listeners/
-dialers respectively. It also now enabled MPTCP by default on 
-listeners. Using `multipathtcp=0` reverts to the pre-Go 1.24 behavior.
+dialers respectively. For Go 1.24, it now defaults to multipathtcp=2:
+enabled by default on listerners. Using multipathtcp=0 reverts to the
+pre-Go 1.24 behavior.
 
 ### Go 1.23
 

--- a/doc/godebug.md
+++ b/doc/godebug.md
@@ -158,9 +158,14 @@ For Go 1.24 it defaults to `randseednop=1`.
 Using `randseednop=0` reverts to the pre-Go 1.24 behavior.
 
 Go 1.24 added new values for the `multipathtcp` setting.
-The values "2" and "3" allow to enable MPTCP only on listeners/
-dialers respectively. For Go 1.24, it now defaults to multipathtcp=2:
-enabled by default on listerners. Using multipathtcp=0 reverts to the
+The possible values for `multipathtcp` are now:
+- "0": disable MPTCP on dialers and listeners by default
+- "1": enable MPTCP on dialers and listeners by default
+- "2": enable MPTCP on listeners only by default
+- "3": enable MPTCP on dialers only by default
+
+For Go 1.24, it now defaults to multipathtcp="2", thus
+enabled by default on listerners. Using multipathtcp="0" reverts to the
 pre-Go 1.24 behavior.
 
 ### Go 1.23

--- a/doc/next/6-stdlib/99-minor/net/56539.md
+++ b/doc/next/6-stdlib/99-minor/net/56539.md
@@ -1,1 +1,1 @@
-[ListenConfig] uses now MPTCP by default (see #607715).
+[ListenConfig] now uses MPTCP by default.

--- a/doc/next/6-stdlib/99-minor/net/56539.md
+++ b/doc/next/6-stdlib/99-minor/net/56539.md
@@ -1,2 +1,2 @@
 [ListenConfig] now uses MPTCP by default on systems where it is supported
-(Currently on Linux only).
+(currently on Linux only).

--- a/doc/next/6-stdlib/99-minor/net/56539.md
+++ b/doc/next/6-stdlib/99-minor/net/56539.md
@@ -1,0 +1,1 @@
+[ListenConfig] uses now MPTCP by default (see #607715).

--- a/doc/next/6-stdlib/99-minor/net/56539.md
+++ b/doc/next/6-stdlib/99-minor/net/56539.md
@@ -1,1 +1,2 @@
-[ListenConfig] now uses MPTCP by default.
+[ListenConfig] now uses MPTCP by default on systems where it is supported
+(Currently on Linux only).

--- a/src/internal/godebugs/table.go
+++ b/src/internal/godebugs/table.go
@@ -42,7 +42,7 @@ var All = []Info{
 	//{Name: "multipartfiles", Package: "mime/multipart"},
 	{Name: "multipartmaxheaders", Package: "mime/multipart"},
 	{Name: "multipartmaxparts", Package: "mime/multipart"},
-	{Name: "multipathtcp", Package: "net"},
+	{Name: "multipathtcp", Package: "net", Changed: 24, Old: "0"},
 	{Name: "netdns", Package: "net", Opaque: true},
 	{Name: "netedns0", Package: "net", Changed: 19, Old: "0"},
 	{Name: "panicnil", Package: "runtime", Changed: 21, Old: "1"},

--- a/src/net/dial.go
+++ b/src/net/dial.go
@@ -32,6 +32,12 @@ const (
 	defaultMPTCPEnabledDial   = false
 )
 
+// The type of service offered
+//
+//	0 == MPTCP disabled
+//	1 == MPTCP enabled
+//	2 == MPTCP enabled on listeners only
+//	3 == MPTCP enabled on dialers only
 var multipathtcp = godebug.New("multipathtcp")
 
 // mptcpStatusDial is a tristate for Multipath TCP on clients,
@@ -54,7 +60,7 @@ func (m *mptcpStatusDial) get() bool {
 	}
 
 	// If MPTCP is forced via GODEBUG=multipathtcp=1
-	if multipathtcp.Value() == "1" {
+	if multipathtcp.Value() == "1" || multipathtcp.Value() == "3" {
 		multipathtcp.IncNonDefault()
 
 		return true
@@ -90,8 +96,9 @@ func (m *mptcpStatusListen) get() bool {
 		return false
 	}
 
-	// If MPTCP is forced via GODEBUG=multipathtcp=0
-	if multipathtcp.Value() == "0" {
+	// If MPTCP is forced via GODEBUG=multipathtcp=0 or enabled only
+	// on dialers
+	if multipathtcp.Value() == "0" || multipathtcp.Value() == "3" {
 		multipathtcp.IncNonDefault()
 
 		return false

--- a/src/net/dial.go
+++ b/src/net/dial.go
@@ -96,8 +96,8 @@ func (m *mptcpStatusListen) get() bool {
 		return false
 	}
 
-	// If MPTCP is forced via GODEBUG=multipathtcp=0 or enabled only
-	// on dialers
+	// If MPTCP is disabled via GODEBUG=multipathtcp=0 or only
+	// enabled on dialers, but not on listeners.
 	if multipathtcp.Value() == "0" || multipathtcp.Value() == "3" {
 		multipathtcp.IncNonDefault()
 


### PR DESCRIPTION
A previous change [1] was introduced to enable MPTCP by default
for both the clients and servers, based on the discussions [2] in 
golang#56539, where MPTCP would be an opt-in for a release or 
two, and then would become an opt-out.

This change was not accepted at the time because the support for 
a few socket options was missing [3]. Now that this support has been 
added [4] and backported to stable versions not to block MPTCP 
deployment with Go, it sounds like a good time to reconsider the use 
of MPTCP by default.

Instead of enabling MPTCP on both ends by default, as a first step, 
it seems safer to change the default behaviour only for the server 
side (Listeners). On the server side, the impact is minimal: when 
clients don't request to use MPTCP, server applications will create 
"plain" TCP sockets within the kernel when connections are accepted, 
making the performance impact minimal. This should also ease 
experiments where MPTCP is enabled by default on the client side 
(Dialer).

The changes in this patch consist of a duplication of the mptcpStatus 
enumeration to have both a mptcpStatusDial and a mptcpStatusListen, 
where MPTCP is enabled by default in mptcpStatusListen, but disabled 
by default in mptcpStatusDial. It is still possible to turn MPTCP support 
on and off by using GODEBUG=multipathtcp=1.

[1] https://go-review.googlesource.com/c/go/+/563575
[2] https://go.dev/issue/56539#issuecomment-1309294637
[3] https://github.com/multipath-tcp/mptcp_net-next/issues/383
[4] https://github.com/torvalds/linux/commit/bd11dc4fb969ec148e50cd87f88a78246dbc4d0b
[5] https://www.mptcp.dev/faq.html#why--when-should-mptcp-be-enabled-by-default

Updates #56539