### PR TITLE
go/ast: note that in BasicLit CHARs and STRINGs are quoted

### DIFF
--- a/src/go/ast/ast.go
+++ b/src/go/ast/ast.go
@@ -303,7 +303,7 @@ type (
 	// Note that for the CHAR and STRING kinds, the literal is stored
 	// with its quotes. For example, for a double-quoted STRING, the
 	// first and the last rune in the Value field will be ". The
-	// Unquote and UnquoteChar functions in the strconv package can be
+	// [strconv.Unquote] and [strconv.UnquoteChar] functions can be
 	// used to unquote STRING and CHAR values, respectively.
 	BasicLit struct {
 		ValuePos token.Pos   // literal position

--- a/src/go/ast/ast.go
+++ b/src/go/ast/ast.go
@@ -299,6 +299,12 @@ type (
 	}
 
 	// A BasicLit node represents a literal of basic type.
+	//
+	// Note that for the CHAR and STRING kinds, the literal is stored
+	// with its quotes. For example, for a double-quoted STRING, the
+	// first and the last rune in the Value field will be ". The
+	// Unquote and UnquoteChar functions in the strconv package can be
+	// used to unquote STRING and CHAR values, respectively.
 	BasicLit struct {
 		ValuePos token.Pos   // literal position
 		Kind     token.Token // token.INT, token.FLOAT, token.IMAG, token.CHAR, or token.STRING


### PR DESCRIPTION
This reapplies CL 244960, for some reason CL 264181 removed this comment.

Updates #39590 