### PR TITLE
net,net/netip: implement the encoding.(Binary|Text)Appender

### DIFF
--- a/api/next/62384.txt
+++ b/api/next/62384.txt
@@ -15,3 +15,10 @@ pkg math/rand/v2, method (*ChaCha8) AppendBinary([]uint8) ([]uint8, error) #6238
 pkg math/rand/v2, method (*PCG) AppendBinary([]uint8) ([]uint8, error) #62384
 pkg crypto/x509, method (OID) AppendBinary([]uint8) ([]uint8, error) #62384
 pkg crypto/x509, method (OID) AppendText([]uint8) ([]uint8, error) #62384
+pkg net, method (IP) AppendText([]uint8) ([]uint8, error) #62384
+pkg net/netip, method (Addr) AppendBinary([]uint8) ([]uint8, error) #62384
+pkg net/netip, method (Addr) AppendText([]uint8) ([]uint8, error) #62384
+pkg net/netip, method (AddrPort) AppendBinary([]uint8) ([]uint8, error) #62384
+pkg net/netip, method (AddrPort) AppendText([]uint8) ([]uint8, error) #62384
+pkg net/netip, method (Prefix) AppendBinary([]uint8) ([]uint8, error) #62384
+pkg net/netip, method (Prefix) AppendText([]uint8) ([]uint8, error) #62384

--- a/doc/next/6-stdlib/99-minor/net/62384.md
+++ b/doc/next/6-stdlib/99-minor/net/62384.md
@@ -1,0 +1,1 @@
+[IP] now implements the [encoding.TextAppender] interface.

--- a/doc/next/6-stdlib/99-minor/net/netip/62384.md
+++ b/doc/next/6-stdlib/99-minor/net/netip/62384.md
@@ -1,0 +1,2 @@
+[Addr], [AddrPort] and [Prefix] now implement the [encoding.BinaryAppender] and
+[encoding.TextAppender] interfaces.

--- a/src/net/ip.go
+++ b/src/net/ip.go
@@ -301,11 +301,18 @@ func (ip IP) String() string {
 	if len(ip) != IPv4len && len(ip) != IPv6len {
 		return "?" + hexString(ip)
 	}
-	// If IPv4, use dotted notation.
-	if p4 := ip.To4(); len(p4) == IPv4len {
-		return netip.AddrFrom4([4]byte(p4)).String()
+
+	var buf []byte
+	switch len(ip) {
+	case IPv4len:
+		const maxCap = len("255.255.255.255")
+		buf = make([]byte, 0, maxCap)
+	case IPv6len:
+		const maxCap = len("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+		buf = make([]byte, 0, maxCap)
 	}
-	return netip.AddrFrom16([16]byte(ip)).String()
+	buf = ip.appendTo(buf)
+	return string(buf)
 }
 
 func hexString(b []byte) string {
@@ -325,17 +332,41 @@ func ipEmptyString(ip IP) string {
 	return ip.String()
 }
 
+// appendTo appends the string representation of ip to b and returns the expanded b
+// If len(ip) != IPv4len or IPv6len, it appends nothing.
+func (ip IP) appendTo(b []byte) []byte {
+	// If IPv4, use dotted notation.
+	if p4 := ip.To4(); len(p4) == IPv4len {
+		ip = p4
+	}
+	addr, _ := netip.AddrFromSlice(ip)
+	return addr.AppendTo(b)
+}
+
+// AppendText implements the [encoding.TextAppender] interface.
+// The encoding is the same as returned by [IP.String], with one exception:
+// When len(ip) is zero, it appends nothing.
+func (ip IP) AppendText(b []byte) ([]byte, error) {
+	if len(ip) == 0 {
+		return b, nil
+	}
+	if len(ip) != IPv4len && len(ip) != IPv6len {
+		return b, &AddrError{Err: "invalid IP address", Addr: hexString(ip)}
+	}
+
+	return ip.appendTo(b), nil
+}
+
 // MarshalText implements the [encoding.TextMarshaler] interface.
 // The encoding is the same as returned by [IP.String], with one exception:
 // When len(ip) is zero, it returns an empty slice.
 func (ip IP) MarshalText() ([]byte, error) {
-	if len(ip) == 0 {
-		return []byte(""), nil
+	// 24 is satisfied with all IPv4 addresses and short IPv6 addresses
+	b, err := ip.AppendText(make([]byte, 0, 24))
+	if err != nil {
+		return nil, err
 	}
-	if len(ip) != IPv4len && len(ip) != IPv6len {
-		return nil, &AddrError{Err: "invalid IP address", Addr: hexString(ip)}
-	}
-	return []byte(ip.String()), nil
+	return b, nil
 }
 
 // UnmarshalText implements the [encoding.TextUnmarshaler] interface.

--- a/src/net/netip/netip_test.go
+++ b/src/net/netip/netip_test.go
@@ -351,6 +351,32 @@ func TestIPv4Constructors(t *testing.T) {
 	}
 }
 
+func TestAddrAppendText(t *testing.T) {
+	tests := []struct {
+		ip   Addr
+		want string
+	}{
+		{Addr{}, ""}, // zero IP
+		{mustIP("1.2.3.4"), "1.2.3.4"},
+		{mustIP("fd7a:115c:a1e0:ab12:4843:cd96:626b:430b"), "fd7a:115c:a1e0:ab12:4843:cd96:626b:430b"},
+		{mustIP("::ffff:192.168.140.255"), "::ffff:192.168.140.255"},
+		{mustIP("::ffff:192.168.140.255%en0"), "::ffff:192.168.140.255%en0"},
+	}
+	for i, tc := range tests {
+		ip := tc.ip
+
+		mtAppend := make([]byte, 4, 32)
+		mtAppend, err := ip.AppendText(mtAppend)
+		mtAppend = mtAppend[4:]
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(mtAppend) != tc.want {
+			t.Errorf("%d. for (%v) AppendText = %q; want %q", i, ip, mtAppend, tc.want)
+		}
+	}
+}
+
 func TestAddrMarshalUnmarshalBinary(t *testing.T) {
 	tests := []struct {
 		ip       string
@@ -380,6 +406,23 @@ func TestAddrMarshalUnmarshalBinary(t *testing.T) {
 		}
 		if ip != ip2 {
 			t.Fatalf("got %v; want %v", ip2, ip)
+		}
+
+		bAppend := make([]byte, 4, 32)
+		bAppend, err = ip.AppendBinary(bAppend)
+		bAppend = bAppend[4:]
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(bAppend) != tc.wantSize {
+			t.Fatalf("%q encoded to size %d; want %d", tc.ip, len(bAppend), tc.wantSize)
+		}
+		var ip3 Addr
+		if err := ip3.UnmarshalBinary(bAppend); err != nil {
+			t.Fatal(err)
+		}
+		if ip != ip3 {
+			t.Fatalf("got %v; want %v", ip3, ip)
 		}
 	}
 
@@ -416,6 +459,17 @@ func TestAddrPortMarshalTextString(t *testing.T) {
 		if string(mt) != tt.want {
 			t.Errorf("%d. for (%v, %v) MarshalText = %q; want %q", i, tt.in.Addr(), tt.in.Port(), mt, tt.want)
 		}
+
+		mtAppend := make([]byte, 4, 32)
+		mtAppend, err = tt.in.AppendText(mtAppend)
+		mtAppend = mtAppend[4:]
+		if err != nil {
+			t.Errorf("%d. for (%v, %v) AppendText error: %v", i, tt.in.Addr(), tt.in.Port(), err)
+			continue
+		}
+		if string(mtAppend) != tt.want {
+			t.Errorf("%d. for (%v, %v) AppendText = %q; want %q", i, tt.in.Addr(), tt.in.Port(), mtAppend, tt.want)
+		}
 	}
 }
 
@@ -447,6 +501,23 @@ func TestAddrPortMarshalUnmarshalBinary(t *testing.T) {
 		}
 		if ipport != ipport2 {
 			t.Fatalf("got %v; want %v", ipport2, ipport)
+		}
+
+		bAppend := make([]byte, 4, 32)
+		bAppend, err = ipport.AppendBinary(bAppend)
+		bAppend = bAppend[4:]
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(bAppend) != tc.wantSize {
+			t.Fatalf("%q encoded to size %d; want %d", tc.ipport, len(bAppend), tc.wantSize)
+		}
+		var ipport3 AddrPort
+		if err := ipport3.UnmarshalBinary(bAppend); err != nil {
+			t.Fatal(err)
+		}
+		if ipport != ipport3 {
+			t.Fatalf("got %v; want %v", ipport3, ipport)
 		}
 	}
 
@@ -482,6 +553,17 @@ func TestPrefixMarshalTextString(t *testing.T) {
 		if string(mt) != tt.want {
 			t.Errorf("%d. for %v MarshalText = %q; want %q", i, tt.in, mt, tt.want)
 		}
+
+		mtAppend := make([]byte, 4, 64)
+		mtAppend, err = tt.in.AppendText(mtAppend)
+		mtAppend = mtAppend[4:]
+		if err != nil {
+			t.Errorf("%d. for %v AppendText error: %v", i, tt.in, err)
+			continue
+		}
+		if string(mtAppend) != tt.want {
+			t.Errorf("%d. for %v AppendText = %q; want %q", i, tt.in, mtAppend, tt.want)
+		}
 	}
 }
 
@@ -514,6 +596,23 @@ func TestPrefixMarshalUnmarshalBinary(t *testing.T) {
 		}
 		if prefix != prefix2 {
 			t.Fatalf("got %v; want %v", prefix2, prefix)
+		}
+
+		bAppend := make([]byte, 4, 32)
+		bAppend, err = prefix.AppendBinary(bAppend)
+		bAppend = bAppend[4:]
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(bAppend) != tc.wantSize {
+			t.Fatalf("%q encoded to size %d; want %d", tc.prefix, len(bAppend), tc.wantSize)
+		}
+		var prefix3 Prefix
+		if err := prefix3.UnmarshalBinary(bAppend); err != nil {
+			t.Fatal(err)
+		}
+		if prefix != prefix3 {
+			t.Fatalf("got %v; want %v", prefix3, prefix)
 		}
 	}
 


### PR DESCRIPTION
Implement the encoding.TextAppender interface for "net.IP".

Implement the encoding.(Binary|Text)Appender interfaces for
"netip.Addr", "netip.AddrPort" and "netip.Prefix".

"net.IP.MarshalText" also gets some performance improvements:

                          │     old      │                 new                 │
                          │    sec/op    │   sec/op     vs base                │
IPMarshalText/IPv4-8         66.06n ± 1%   14.55n ± 1%  -77.97% (p=0.000 n=10)
IPMarshalText/IPv6-8        117.00n ± 1%   63.18n ± 1%  -46.00% (p=0.000 n=10)
IPMarshalText/IPv6_long-8    137.8n ± 1%   111.3n ± 1%  -19.27% (p=0.000 n=10)
geomean                      102.1n        46.77n       -54.21%

                          │    old     │                   new                   │
                          │    B/op    │    B/op     vs base                     │
IPMarshalText/IPv4-8        32.00 ± 0%    0.00 ± 0%  -100.00% (p=0.000 n=10)
IPMarshalText/IPv6-8        48.00 ± 0%    0.00 ± 0%  -100.00% (p=0.000 n=10)
IPMarshalText/IPv6_long-8   96.00 ± 0%   48.00 ± 0%   -50.00% (p=0.000 n=10)

                          │    old     │                   new                   │
                          │ allocs/op  │ allocs/op   vs base                     │
IPMarshalText/IPv4-8        2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
IPMarshalText/IPv6-8        2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
IPMarshalText/IPv6_long-8   2.000 ± 0%   1.000 ± 0%   -50.00% (p=0.000 n=10)

All exported types in the standard library that implement the
"encoding.(Binary|Text)Marshaler" now also implement the
"encoding.(Binary|Text)Appender".

Fixes #62384