### PR TITLE
slices: return early in Repeat if count is 0

### DIFF
--- a/src/slices/slices.go
+++ b/src/slices/slices.go
@@ -491,6 +491,10 @@ func Concat[S ~[]E, E any](slices ...S) S {
 // Repeat panics if count is negative or if the result of (len(x) * count)
 // overflows.
 func Repeat[S ~[]E, E any](x S, count int) S {
+	if count == 0 {
+		return S{}
+	}
+
 	if count < 0 {
 		panic("cannot be negative")
 	}

--- a/src/slices/slices_test.go
+++ b/src/slices/slices_test.go
@@ -6,6 +6,7 @@ package slices_test
 
 import (
 	"cmp"
+	"fmt"
 	"internal/race"
 	"internal/testenv"
 	"math"
@@ -1447,6 +1448,19 @@ func TestRepeatPanics(t *testing.T) {
 	} {
 		if !panics(func() { _ = Repeat(test.x, test.count) }) {
 			t.Errorf("Repeat %s: got no panic, want panic", test.name)
+		}
+	}
+}
+
+func BenchmarkRepeat(b *testing.B) {
+	s := []byte("0123456789")
+	for _, n := range []int{5, 10} {
+		for _, c := range []int{0, 1, 2, 6} {
+			b.Run(fmt.Sprintf("%dx%d", n, c), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					Repeat(s[:n], c)
+				}
+			})
 		}
 	}
 }


### PR DESCRIPTION
This change matches the implementation of strings/bytes.Repeat and
increases performance:

% benchstat before.out after.out    
goos: darwin
goarch: arm64
pkg: slices
cpu: Apple M1
              │  before.out  │              after.out               │
              │    sec/op    │    sec/op     vs base                │
Repeat/5x0-8    4.1840n ± 1%   0.4691n ± 0%  -88.79% (p=0.000 n=10)
Repeat/5x1-8     10.63n ± 1%    10.97n ± 0%   +3.15% (p=0.000 n=10)
Repeat/5x2-8     14.62n ± 0%    14.86n ± 0%   +1.61% (p=0.000 n=10)
Repeat/5x6-8     24.72n ± 0%    25.32n ± 0%   +2.43% (p=0.000 n=10)
Repeat/10x0-8   4.1915n ± 0%   0.4689n ± 0%  -88.81% (p=0.000 n=10)
Repeat/10x1-8    12.76n ± 0%    12.67n ± 0%   -0.67% (p=0.000 n=10)
Repeat/10x2-8    18.51n ± 0%    19.08n ± 0%   +3.08% (p=0.000 n=10)
Repeat/10x6-8    24.46n ± 0%    25.02n ± 0%   +2.31% (p=0.000 n=10)
geomean          11.85n         6.958n       -41.29%