### PR TITLE
bufio: make Writer.Write and Writer.WriteString behave the same when pass buffer to io.Writer

### DIFF
--- a/src/bufio/bufio.go
+++ b/src/bufio/bufio.go
@@ -676,7 +676,7 @@ func (b *Writer) Write(p []byte) (nn int, err error) {
 		if b.Buffered() == 0 {
 			// Large write, empty buffer.
 			// Write directly from p to avoid copy.
-			n, b.err = b.wr.Write(p)
+			n, b.err = b.wr.Write(p[:min(len(p), len(b.buf))])
 		} else {
 			n = copy(b.buf[b.n:], p)
 			b.n += n


### PR DESCRIPTION
Fixes #69068