### PR TITLE
crypto/cipher: update documentation for aead Open

### DIFF
--- a/src/crypto/cipher/gcm.go
+++ b/src/crypto/cipher/gcm.go
@@ -39,7 +39,7 @@ type AEAD interface {
 	// value passed to Seal.
 	//
 	// To reuse ciphertext's storage for the decrypted output, use ciphertext[:0]
-	// as dst. Otherwise, the remaining capacity of dst must not overlap plaintext.
+	// as dst. Otherwise, the remaining capacity of dst must not overlap ciphertext.
 	//
 	// Even if the function fails, the contents of dst, up to its capacity,
 	// may be overwritten.


### PR DESCRIPTION
The remaining capacity of dst should not overlap ciphertext. 
The previous wording was probably a copy paste mistake from aead Seal.
