### PR TITLE
go/printer: do not treat comments inside a ast.Decl as godoc

### DIFF
--- a/src/go/printer/nodes.go
+++ b/src/go/printer/nodes.go
@@ -1739,6 +1739,9 @@ func (p *printer) genDecl(d *ast.GenDecl) {
 	p.setPos(d.Pos())
 	p.print(d.Tok, blank)
 
+	p.inDecl = true
+	defer func() { p.inDecl = false }()
+
 	if d.Lparen.IsValid() || len(d.Specs) != 1 {
 		// group of parenthesized declarations
 		p.setPos(d.Lparen)
@@ -1923,6 +1926,10 @@ func (p *printer) funcDecl(d *ast.FuncDecl) {
 	p.setComment(d.Doc)
 	p.setPos(d.Pos())
 	p.print(token.FUNC, blank)
+
+	p.inDecl = true
+	defer func() { p.inDecl = false }()
+
 	// We have to save startCol only after emitting FUNC; otherwise it can be on a
 	// different line (all whitespace preceding the FUNC is emitted only when the
 	// FUNC is emitted).

--- a/src/go/printer/nodes.go
+++ b/src/go/printer/nodes.go
@@ -1739,8 +1739,8 @@ func (p *printer) genDecl(d *ast.GenDecl) {
 	p.setPos(d.Pos())
 	p.print(d.Tok, blank)
 
+	defer func(d bool) { p.inDecl = d }(p.inDecl)
 	p.inDecl = true
-	defer func() { p.inDecl = false }()
 
 	if d.Lparen.IsValid() || len(d.Specs) != 1 {
 		// group of parenthesized declarations
@@ -1927,8 +1927,8 @@ func (p *printer) funcDecl(d *ast.FuncDecl) {
 	p.setPos(d.Pos())
 	p.print(token.FUNC, blank)
 
+	defer func(d bool) { p.inDecl = d }(p.inDecl)
 	p.inDecl = true
-	defer func() { p.inDecl = false }()
 
 	// We have to save startCol only after emitting FUNC; otherwise it can be on a
 	// different line (all whitespace preceding the FUNC is emitted only when the

--- a/src/go/printer/printer.go
+++ b/src/go/printer/printer.go
@@ -63,15 +63,12 @@ type printer struct {
 	mode         pmode        // current printer mode
 	endAlignment bool         // if set, terminate alignment immediately
 	impliedSemi  bool         // if set, a linebreak implies a semicolon
+	inDecl       bool         // if set, printer is inside declaration (after first token)
 	lastTok      token.Token  // last token printed (token.ILLEGAL if it's whitespace)
 	prevOpen     token.Token  // previous non-brace "open" token (, [, or token.ILLEGAL
 	wsbuf        []whiteSpace // delayed white space
 	goBuild      []int        // start index of all //go:build comments in output
 	plusBuild    []int        // start index of all // +build comments in output
-
-	// inDecl is set to true when inside of an ast.Decl,
-	// after printing the first token of that declaration.
-	inDecl bool
 
 	// Positions
 	// The out position differs from the pos position when the result

--- a/src/go/printer/printer.go
+++ b/src/go/printer/printer.go
@@ -745,7 +745,7 @@ func (p *printer) intersperseComments(next token.Position, tok token.Token) (wro
 		changed := false
 		if !p.inDecl &&
 			p.lastTok != token.IMPORT && // do not rewrite cgo's import "C" comments
-			p.posFor(p.comment.Pos()).Column == 1 &&
+			p.posFor(p.comment.Pos()).Line != p.last.Line &&
 			p.posFor(p.comment.End()+1) == next {
 			// Unindented comment abutting next token position:
 			// a top-level doc comment.

--- a/src/go/printer/printer.go
+++ b/src/go/printer/printer.go
@@ -69,6 +69,10 @@ type printer struct {
 	goBuild      []int        // start index of all //go:build comments in output
 	plusBuild    []int        // start index of all // +build comments in output
 
+	// inDecl is set to true when inside of an ast.Decl,
+	// after printing the first token of that declaration.
+	inDecl bool
+
 	// Positions
 	// The out position differs from the pos position when the result
 	// formatting differs from the source formatting (in the amount of
@@ -739,8 +743,8 @@ func (p *printer) intersperseComments(next token.Position, tok token.Token) (wro
 	for p.commentBefore(next) {
 		list := p.comment.List
 		changed := false
-		if p.lastTok != token.IMPORT && // do not rewrite cgo's import "C" comments
-			p.posFor(p.comment.Pos()).Column == 1 &&
+		if !p.inDecl &&
+			p.lastTok != token.IMPORT && // do not rewrite cgo's import "C" comments
 			p.posFor(p.comment.End()+1) == next {
 			// Unindented comment abutting next token position:
 			// a top-level doc comment.

--- a/src/go/printer/printer.go
+++ b/src/go/printer/printer.go
@@ -745,6 +745,7 @@ func (p *printer) intersperseComments(next token.Position, tok token.Token) (wro
 		changed := false
 		if !p.inDecl &&
 			p.lastTok != token.IMPORT && // do not rewrite cgo's import "C" comments
+			p.posFor(p.comment.Pos()).Column == 1 &&
 			p.posFor(p.comment.End()+1) == next {
 			// Unindented comment abutting next token position:
 			// a top-level doc comment.

--- a/src/go/printer/printer_test.go
+++ b/src/go/printer/printer_test.go
@@ -893,15 +893,15 @@ func main() {
 		{
 			in: `package main
 
-func main() {
-//line a:15:1
+func a() {
+//line a:5:1
 	//
 }
 `,
 			fmt: `package main
 
-func main() {
-//line a:15:1
+func a() {
+//line a:5:1
 	//
 }
 `,

--- a/src/go/printer/printer_test.go
+++ b/src/go/printer/printer_test.go
@@ -897,6 +897,10 @@ func main() {
 	//go:directive
 	// test
 	type a struct{}
+
+//go:directive
+// test
+test()
 }
 `,
 			fmt: `package main
@@ -905,6 +909,10 @@ func main() {
 	//go:directive
 	// test
 	type a struct{}
+
+	//go:directive
+	// test
+	test()
 }
 `,
 		},

--- a/src/go/printer/printer_test.go
+++ b/src/go/printer/printer_test.go
@@ -867,11 +867,11 @@ func TestEmptyDecl(t *testing.T) { // issue 63566
 
 func TestDocFormat(t *testing.T) {
 	cases := []struct {
-		in  string
-		fmt string
+		src  string
+		want string
 	}{
 		{
-			in: `package main
+			src: `package main
 
 func main() {
 //
@@ -880,7 +880,7 @@ func main() {
 //
 }
 `,
-			fmt: `package main
+			want: `package main
 
 func main() {
 	//
@@ -891,7 +891,7 @@ func main() {
 `,
 		},
 		{
-			in: `package main
+			src: `package main
 
 func main() {
 	//go:directive
@@ -903,7 +903,7 @@ func main() {
 test()
 }
 `,
-			fmt: `package main
+			want: `package main
 
 func main() {
 	//go:directive
@@ -917,7 +917,7 @@ func main() {
 `,
 		},
 		{
-			in: `package main
+			src: `package main
 
 func main() {
 //go:directive
@@ -925,7 +925,7 @@ func main() {
 type a struct{}
 }
 `,
-			fmt: `package main
+			want: `package main
 
 func main() {
 	//go:directive
@@ -935,14 +935,14 @@ func main() {
 `,
 		},
 		{
-			in: `package main
+			src: `package main
 
 func a() {
 //line a:5:1
 	//
 }
 `,
-			fmt: `package main
+			want: `package main
 
 func a() {
 //line a:5:1
@@ -952,7 +952,7 @@ func a() {
 		},
 
 		{
-			in: `package main
+			src: `package main
 
 // test comment
 //go:directive2
@@ -960,7 +960,7 @@ func a() {
 func main() {
 }
 `,
-			fmt: `package main
+			want: `package main
 
 // test comment
 // test comment
@@ -971,7 +971,7 @@ func main() {
 `,
 		},
 		{
-			in: `package main
+			src: `package main
 
 	// test comment
 	//go:directive2
@@ -979,7 +979,7 @@ func main() {
 func main() {
 }
 `,
-			fmt: `package main
+			want: `package main
 
 // test comment
 // test comment
@@ -990,7 +990,7 @@ func main() {
 `,
 		},
 		{
-			in: `package main
+			src: `package main
 
 /* test
  */ // test comment
@@ -999,7 +999,7 @@ func main() {
 func main() {
 }
 `,
-			fmt: `package main
+			want: `package main
 
 /* test
  */ // test comment
@@ -1011,12 +1011,12 @@ func main() {
 		},
 
 		{
-			in: `package main  //comment
+			src: `package main  //comment
 var a int = 4 //comment
 func a() {
 }
 `,
-			fmt: `package main  //comment
+			want: `package main  //comment
 var a int = 4 //comment
 func a() {
 }
@@ -1025,31 +1025,31 @@ func a() {
 
 		// Edge case found by a fuzzer, not a real-world example.
 		{
-			in:  "package A\n\nimport(\"\f\"\n//\n\"\")",
-			fmt: "package A\n\nimport (\n\t\"\f\" //\n\t\"\"\n)\n",
+			src:  "package A\n\nimport(\"\f\"\n//\n\"\")",
+			want: "package A\n\nimport (\n\t\"\f\" //\n\t\"\"\n)\n",
 		},
 		{
-			in:  "package A\n\nimport(`\f`\n//\n\"\")",
-			fmt: "package A\n\nimport (\n\t`\f` //\n\t\"\"\n)\n",
+			src:  "package A\n\nimport(`\f`\n//\n\"\")",
+			want: "package A\n\nimport (\n\t`\f` //\n\t\"\"\n)\n",
 		},
 	}
 
 	for _, tt := range cases {
-		fs := token.NewFileSet()
-		f, err := parser.ParseFile(fs, "test.go", tt.in, parser.ParseComments|parser.SkipObjectResolution)
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, "test.go", tt.src, parser.ParseComments|parser.SkipObjectResolution)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		var s strings.Builder
+		var buf strings.Builder
 		cfg := Config{Tabwidth: 8, Mode: UseSpaces | TabIndent}
-		if err := cfg.Fprint(&s, fs, f); err != nil {
+		if err := cfg.Fprint(&buf, fset, f); err != nil {
 			t.Fatal(err)
 		}
 
-		out := s.String()
-		if out != tt.fmt {
-			t.Errorf("source\n%v\nformatted as:\n%v\nwant formatted as:\n%v", tt.in, out, tt.fmt)
+		got := buf.String()
+		if got != tt.want {
+			t.Errorf("source\n%v\nformatted as:\n%v\nwant formatted as:\n%v", tt.src, got, tt.want)
 		}
 	}
 }

--- a/src/go/printer/printer_test.go
+++ b/src/go/printer/printer_test.go
@@ -893,6 +893,42 @@ func main() {
 		{
 			in: `package main
 
+func main() {
+	//go:directive
+	// test
+	type a struct{}
+}
+`,
+			fmt: `package main
+
+func main() {
+	//go:directive
+	// test
+	type a struct{}
+}
+`,
+		},
+		{
+			in: `package main
+
+func main() {
+//go:directive
+// test
+type a struct{}
+}
+`,
+			fmt: `package main
+
+func main() {
+	//go:directive
+	// test
+	type a struct{}
+}
+`,
+		},
+		{
+			in: `package main
+
 func a() {
 //line a:5:1
 	//
@@ -906,9 +942,15 @@ func a() {
 }
 `,
 		},
+
+		// Edge case found by a fuzzer, not a real-world example.
 		{
 			in:  "package A\n\nimport(\"\f\"\n//\n\"\")",
 			fmt: "package A\n\nimport (\n\t\"\f\" //\n\t\"\"\n)\n",
+		},
+		{
+			in:  "package A\n\nimport(`\f`\n//\n\"\")",
+			fmt: "package A\n\nimport (\n\t`\f` //\n\t\"\"\n)\n",
 		},
 	}
 

--- a/src/go/printer/printer_test.go
+++ b/src/go/printer/printer_test.go
@@ -906,6 +906,10 @@ func a() {
 }
 `,
 		},
+		{
+			in:  "package A\n\nimport(\"\f\"\n//\n\"\")",
+			fmt: "package A\n\nimport (\n\t\"\f\" //\n\t\"\"\n)\n",
+		},
 	}
 
 	for _, tt := range cases {

--- a/src/go/printer/printer_test.go
+++ b/src/go/printer/printer_test.go
@@ -1008,6 +1008,25 @@ func main() {
 		{
 			src: `package main
 
+	// test comment
+	//go:directive2
+	// test comment
+func main() {
+}
+`,
+			fmt: `package main
+
+// test comment
+// test comment
+//
+//go:directive2
+func main() {
+}
+`,
+		},
+		{
+			src: `package main
+
 /* test
  */ // test comment
 //go:directive2


### PR DESCRIPTION
This change makes sure that we do not format comments 
as doc comments inside of a declaration and makes the 
go doc formatter idempotent:

Previously:

	// test comment
	//go:directive2
	// test comment
func main() {
}

was formatted to:

// test comment
//go:directive2
// test comment
func main() {
}

after another formatting, it got formatted with doc rules into:

// test comment
// test comment
//
//go:directive2
func main() {
}

With this change it gets directly to the correct form (last one).