### PR TITLE
.github: unify style of issue template yaml files, correct small typos

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-bug.yml
+++ b/.github/ISSUE_TEMPLATE/00-bug.yml
@@ -3,7 +3,6 @@
 name: Bugs
 description: The go command, standard library, or anything else
 title: "import/path: issue title"
-
 body:
   - type: markdown
     attributes:
@@ -72,15 +71,15 @@ body:
   - type: textarea
     id: what-did-you-do
     attributes:
-      label: "What did you do?"
-      description: "If possible, provide a recipe for reproducing the error. A complete runnable program is good. A link on [go.dev/play](https://go.dev/play) is best."
+      label: What did you do?
+      description: If possible, provide a recipe for reproducing the error. A complete runnable program is good. A link on [go.dev/play](https://go.dev/play) is best.
     validations:
       required: true
 
   - type: textarea
     id: actual-behavior
     attributes:
-      label: "What did you see happen?"
+      label: What did you see happen?
       description: Command invocations and their associated output, functions with their arguments and return results, full stacktraces for panics (upload a file if it is very long), etc. Prefer copying text output over using screenshots.
     validations:
       required: true
@@ -88,7 +87,7 @@ body:
   - type: textarea
     id: expected-behavior
     attributes:
-      label: "What did you expect to see?"
+      label: What did you expect to see?
       description: Why is the current output incorrect, and any additional context we may need to understand the issue.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/01-pkgsite.yml
+++ b/.github/ISSUE_TEMPLATE/01-pkgsite.yml
@@ -1,47 +1,47 @@
 name: Pkg.go.dev bugs or feature requests
 description: Issues or feature requests for the documentation site
 title: "x/pkgsite: issue title"
-labels: ["pkgsite"]
+labels: [pkgsite]
 body:
   - type: markdown
     attributes:
-      value: "Please answer these questions before submitting your issue. Thanks!"
+      value: Please answer these questions before submitting your issue. Thanks!
   - type: input
     id: url
     attributes:
-      label: "What is the URL of the page with the issue?"
+      label: What is the URL of the page with the issue?
     validations:
       required: true
   - type: input
     id: user-agent
     attributes:
-      label: "What is your user agent?"
+      label: What is your user agent?
       description: "You can find your user agent here: https://www.google.com/search?q=what+is+my+user+agent"
     validations:
       required: true
   - type: textarea
     id: screenshot
     attributes:
-      label: "Screenshot"
-      description: "Please paste a screenshot of the page."
+      label: Screenshot
+      description: Please paste a screenshot of the page.
     validations:
       required: false
   - type: textarea
     id: what-did-you-do
     attributes:
-      label: "What did you do?"
-      description: "If possible, provide a recipe for reproducing the error. Starting with a Private/Incognito tab/window may help rule out problematic browser extensions."
+      label: What did you do?
+      description: If possible, provide a recipe for reproducing the error. Starting with a Private/Incognito tab/window may help rule out problematic browser extensions.
     validations:
       required: true
   - type: textarea
     id: actual-behavior
     attributes:
-      label: "What did you see happen?"
+      label: What did you see happen?
     validations:
       required: true
   - type: textarea
     id: expected-behavior
     attributes:
-      label: "What did you expect to see?"
+      label: What did you expect to see?
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/02-pkgsite-removal.yml
+++ b/.github/ISSUE_TEMPLATE/02-pkgsite-removal.yml
@@ -1,15 +1,15 @@
 name: Pkg.go.dev package removal request
 description: Request a package be removed from the documentation site (pkg.go.dev)
 title: "x/pkgsite: package removal request for [type path here]"
-labels: ["pkgsite/package-removal"]
+labels: [pkgsite/package-removal]
 body:
   - type: markdown
     attributes:
-      value: "Please answer these questions before submitting your issue. Thanks!"
+      value: Please answer these questions before submitting your issue. Thanks!
   - type: input
     id: package-path
     attributes:
-      label: "What is the path of the package that you would like to have removed?"
+      label: What is the path of the package that you would like to have removed?
       description: |
         We can remove packages with a shared path prefix.
         For example, a request for 'github.com/author' would remove all pkg.go.dev pages with that package path prefix.
@@ -18,7 +18,7 @@ body:
   - type: textarea
     id: package-owner
     attributes:
-      label: "Are you the owner of this package?"
+      label: Are you the owner of this package?
       description: |
         Only the package owners can request to have their packages removed from pkg.go.dev.
         If the package path doesn't include your github username, please provide some other form of proof of ownership.
@@ -27,7 +27,7 @@ body:
   - type: textarea
     id: retraction-reason
     attributes:
-      label: "What is the reason that you could not retract this package instead?"
+      label: What is the reason that you could not retract this package instead?
       description: |
         Requesting we remove a module here only hides the generated documentation on pkg.go.dev.
         It does not affect the behaviour of proxy.golang.org or the go command.

--- a/.github/ISSUE_TEMPLATE/03-gopls.yml
+++ b/.github/ISSUE_TEMPLATE/03-gopls.yml
@@ -1,56 +1,56 @@
 name: Gopls bugs or feature requests
 description: Issues or feature requests for the Go language server (gopls)
 title: "x/tools/gopls: issue title"
-labels: ["gopls", "Tools"]
+labels: [gopls, Tools]
 body:
   - type: markdown
     attributes:
-      value: "Please answer these questions before submitting your issue. Thanks!"
+      value: Please answer these questions before submitting your issue. Thanks!
   - type: textarea
     id: gopls-version
     attributes:
-      label: "gopls version"
-      description: "Output of `gopls -v version` on the command line"
+      label: gopls version
+      description: Output of `gopls -v version` on the command line
     validations:
       required: true
   - type: textarea
     id: go-env
     attributes:
-      label: "go env"
-      description: "Output of `go env` on the command line in your workspace directory"
+      label: go env
+      description: Output of `go env` on the command line in your workspace directory
       render: shell
     validations:
       required: true
   - type: textarea
     id: what-did-you-do
     attributes:
-      label: "What did you do?"
-      description: "If possible, provide a recipe for reproducing the error. A complete runnable program is good. A link on [go.dev/play](https://go.dev/play) is better. A failing unit test is the best."
+      label: What did you do?
+      description: If possible, provide a recipe for reproducing the error. A complete runnable program is good. A link on [go.dev/play](https://go.dev/play) is better. A failing unit test is the best.
     validations:
       required: true
   - type: textarea
     id: actual-behavior
     attributes:
-      label: "What did you see happen?"
+      label: What did you see happen?
     validations:
       required: true
   - type: textarea
     id: expected-behavior
     attributes:
-      label: "What did you expect to see?"
+      label: What did you expect to see?
     validations:
       required: true
   - type: textarea
     id: editor-and-settings
     attributes:
-      label: "Editor and settings"
-      description: "Your editor and any settings you have configured (for example, your VSCode settings.json file)"
+      label: Editor and settings
+      description: Your editor and any settings you have configured (for example, your VSCode settings.json file)
     validations:
       required: false
   - type: textarea
     id: logs
     attributes:
-      label: "Logs"
+      label: Logs
       description: "If possible please include gopls logs. Instructions for capturing them can be found here: https://github.com/golang/tools/blob/master/gopls/doc/troubleshooting.md#capture-logs"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/04-vuln.yml
+++ b/.github/ISSUE_TEMPLATE/04-vuln.yml
@@ -1,7 +1,7 @@
 name: Go vulnerability management - bugs and feature requests
 description: Issues or feature requests about Go vulnerability management
 title: "x/vuln: issue title"
-labels: ["vulncheck or vulndb"]
+labels: [vulncheck or vulndb]
 body:
   - type: markdown
     attributes:
@@ -21,7 +21,7 @@ body:
   - type: textarea
     id: reproduce-latest-version
     attributes:
-      label: "Does this issue reproduce at the latest version of golang.org/x/vuln?"
+      label: Does this issue reproduce at the latest version of golang.org/x/vuln?
     validations:
       required: true
   - type: textarea
@@ -34,19 +34,19 @@ body:
   - type: textarea
     id: what-did-you-do
     attributes:
-      label: "What did you do?"
-      description: "If possible, provide a recipe for reproducing the error. A complete runnable program is good. A link on [go.dev/play](https://go.dev/play) is best."
+      label: What did you do?
+      description: If possible, provide a recipe for reproducing the error. A complete runnable program is good. A link on [go.dev/play](https://go.dev/play) is best.
     validations:
       required: true
   - type: textarea
     id: actual-behavior
     attributes:
-      label: "What did you see happen?"
+      label: What did you see happen?
     validations:
       required: true
   - type: textarea
     id: expected-behavior
     attributes:
-      label: "What did you expect to see?"
+      label: What did you expect to see?
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/10-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/10-proposal.yml
@@ -1,7 +1,7 @@
 name: Proposals
 description: New external API or other notable changes
 title: "proposal: import/path: proposal title"
-labels: ["Proposal"]
+labels: [Proposal]
 body:
   - type: markdown
     attributes:
@@ -9,7 +9,7 @@ body:
   - type: textarea
     id: proposal-details
     attributes:
-      label: "Proposal Details"
-      description: "Please provide the details of your proposal here."
+      label: Proposal Details
+      description: Please provide the details of your proposal here.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/11-language-change.yml
+++ b/.github/ISSUE_TEMPLATE/11-language-change.yml
@@ -1,6 +1,6 @@
 name: Language Change Proposals
 description: Changes to the language
-labels: ["Proposal", "LanguageChange", "LanguageChangeReview"]
+labels: [Proposal, LanguageChange, LanguageChangeReview]
 title: "proposal: spec: proposal title"
 
 
@@ -13,32 +13,32 @@ body:
   - type: dropdown
     id: author-go-experience
     attributes:
-      label: "Go Programming Experience"
-      description: "Would you consider yourself a novice, intermediate, or experienced Go programmer?"
+      label: Go Programming Experience
+      description: Would you consider yourself a novice, intermediate, or experienced Go programmer?
       options:
-        - "Novice"
-        - "Intermediate"
-        - "Experienced"
+        - Novice
+        - Intermediate
+        - Experienced
       default: 1
 
   - type: input
     id: author-other-languages-experience
     attributes:
-      label: "Other Languages Experience"
-      description: "What other languages do you have experience with?"
-      placeholder: "Go, Python, JS, Rust"
+      label: Other Languages Experience
+      description: What other languages do you have experience with?
+      placeholder: Go, Python, JS, Rust
     validations:
       required: false
 
   - type: checkboxes
     id: related-idea
     attributes:
-      label: "Related Idea"
+      label: Related Idea
       options:
-        - label: "Has this idea, or one like it, been proposed before?"
-        - label: "Does this affect error handling?"
-        - label: "Is this about generics?"
-        - label: "Is this change backward compatible? Breaking the Go 1 compatibility guarantee is a large cost and requires a large benefit"
+        - label: Has this idea, or one like it, been proposed before?
+        - label: Does this affect error handling?
+        - label: Is this about generics?
+        - label: Is this change backward compatible? Breaking the Go 1 compatibility guarantee is a large cost and requires a large benefit
 
   - type: textarea
     id: related-proposals
@@ -85,24 +85,24 @@ body:
   - type: textarea
     id: proposal
     attributes:
-      label: "Proposal"
-      description: "What is the proposed change? Who does this proposal help, and why? Please describe as precisely as possible the change to the language."
+      label: Proposal
+      description: What is the proposed change? Who does this proposal help, and why? Please describe as precisely as possible the change to the language.
     validations:
       required: true
 
   - type: textarea
     id: language-spec-changes
     attributes:
-      label: "Language Spec Changes"
-      description: "What would change in the language spec?"
+      label: Language Spec Changes
+      description: What would change in the language spec?
     validations:
       required: false
 
   - type: textarea
     id: informal-change
     attributes:
-      label: "Informal Change"
-      description: "Please also describe the change informally, as in a class teaching Go."
+      label: Informal Change
+      description: Please also describe the change informally, as in a class teaching Go.
     validations:
       required: false
 
@@ -124,26 +124,26 @@ body:
     id: orthogonality
     attributes:
       label: "Orthogonality: How does this change interact or overlap with existing features?"
-      description: "Is the goal of this change a performance improvement? If so, what quantifiable improvement should we expect? How would we measure it?"
+      description: Is the goal of this change a performance improvement? If so, what quantifiable improvement should we expect? How would we measure it?
     validations:
       required: false
 
   - type: textarea
     id: learning-curve
     attributes:
-      label: "Would this change make Go easier or harder to learn, and why?"
+      label: Would this change make Go easier or harder to learn, and why?
 
   - type: textarea
     id: cost-description
     attributes:
-      label: "Cost Description"
-      description: "What is the cost of this proposal? (Every language change has a cost)"
+      label: Cost Description
+      description: What is the cost of this proposal? (Every language change has a cost)
 
   - type: input
     id: go-toolchain
     attributes:
       label: Changes to Go ToolChain
-      description: "How many tools (such as vet, gopls, gofmt, goimports, etc.) would be affected? "
+      description: How many tools (such as vet, gopls, gofmt, goimports, etc.) would be affected?
     validations:
       required: false
 
@@ -151,15 +151,14 @@ body:
     id: perf-costs
     attributes:
       label: Performance Costs
-      description: "What is the compile time cost? What is the run time cost? "
+      description: What is the compile time cost? What is the run time cost?
     validations:
       required: false
 
   - type: textarea
     id: prototype
     attributes:
-      label: "Prototype"
-      description: "Can you describe a possible implementation?"
+      label: Prototype
+      description: Can you describe a possible implementation?
     validations:
       required: false
-

--- a/.github/ISSUE_TEMPLATE/11-language-change.yml
+++ b/.github/ISSUE_TEMPLATE/11-language-change.yml
@@ -2,8 +2,6 @@ name: Language Change Proposals
 description: Changes to the language
 labels: [Proposal, LanguageChange, LanguageChangeReview]
 title: "proposal: spec: proposal title"
-
-
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/11-language-change.yml
+++ b/.github/ISSUE_TEMPLATE/11-language-change.yml
@@ -50,7 +50,7 @@ body:
 
        If yes, 
         1. Mention the related proposals 
-        2. then describe how this proposal differs       
+        2. then describe how this proposal differs
     validations:
       required: true
 
@@ -107,7 +107,7 @@ body:
       required: false
 
   - type: textarea
-    id: go-backwards-compatiblity
+    id: go-backwards-compatibility
     attributes:
       label: Is this change backward compatible?
       description: Breaking the Go 1 compatibility guarantee is a large cost and requires a large benefit.

--- a/.github/ISSUE_TEMPLATE/12-telemetry.yml
+++ b/.github/ISSUE_TEMPLATE/12-telemetry.yml
@@ -1,7 +1,7 @@
 name: Go Telemetry Proposals
 description: Changes to the telemetry upload configuration
 title: "x/telemetry/config: proposal title"
-labels: ["Telemetry-Proposal"]
+labels: [Telemetry-Proposal]
 projects: ["golang/29"]
 body:
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Questions
     about: Please use one of the forums for questions or general discussions
-    url:  https://go.dev/wiki/Questions
+    url: https://go.dev/wiki/Questions


### PR DESCRIPTION
Unify style across issue template yaml files:
- Consistent usage of quotes for strings: Roughly half of strings had quotes and the other half didn't so I chose to remove quotes unless necessary (such as due to special characters).
- Removed some extra spaces.
- Fix typo in label: "compatibility" misspelled as "compatiblity"