### PR TITLE
testing: skip TestChdir/relative when on Windows when GOROOT and TMPDIR are on different drives

### DIFF
--- a/src/testing/testing_test.go
+++ b/src/testing/testing_test.go
@@ -300,10 +300,7 @@ func TestChdir(t *testing.T) {
 	}
 	rel, err := filepath.Rel(oldDir, tmp)
 	if err != nil {
-		// when GOROOT is git clone dir,
-		// there will happen error here,
-		// skip this test to avoid false test failures.
-		t.Skip(err)
+		rel = "skip"
 	}
 
 	for _, tc := range []struct {
@@ -334,6 +331,9 @@ func TestChdir(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.dir == "skip" {
+				return
+			}
 			if !filepath.IsAbs(tc.pwd) {
 				t.Fatalf("Bad tc.pwd: %q (must be absolute)", tc.pwd)
 			}

--- a/src/testing/testing_test.go
+++ b/src/testing/testing_test.go
@@ -300,6 +300,8 @@ func TestChdir(t *testing.T) {
 	}
 	rel, err := filepath.Rel(oldDir, tmp)
 	if err != nil {
+		// If GOROOT is on C: volume and tmp is on the D: volume, there
+		// is no relative path between them, so skip that test case.
 		rel = "skip"
 	}
 

--- a/src/testing/testing_test.go
+++ b/src/testing/testing_test.go
@@ -300,7 +300,10 @@ func TestChdir(t *testing.T) {
 	}
 	rel, err := filepath.Rel(oldDir, tmp)
 	if err != nil {
-		t.Fatal(err)
+		// when GOROOT is git clone dir,
+		// there will happen error here,
+		// skip this test to avoid false test failures.
+		t.Skip(err)
 	}
 
 	for _, tc := range []struct {

--- a/src/testing/testing_test.go
+++ b/src/testing/testing_test.go
@@ -334,7 +334,7 @@ func TestChdir(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.dir == "skip" {
-				return
+				t.Skipf("skipping test because there is no relative path between %s and %s", oldDir, tmp)
 			}
 			if !filepath.IsAbs(tc.pwd) {
 				t.Fatalf("Bad tc.pwd: %q (must be absolute)", tc.pwd)


### PR DESCRIPTION
Fixes #69159