### PR TITLE
cmd/dist: enforce the lowest bootstrap version

### DIFF
--- a/src/cmd/dist/buildtool.go
+++ b/src/cmd/dist/buildtool.go
@@ -123,6 +123,8 @@ var tryDirs = []string{
 	"go1.22.6",
 }
 
+var minBootStrapVersion [3]string = [3]string{"1", "22", "6"}
+
 func bootstrapBuildTools() {
 	goroot_bootstrap := os.Getenv("GOROOT_BOOTSTRAP")
 	if goroot_bootstrap == "" {
@@ -134,6 +136,19 @@ func bootstrapBuildTools() {
 			}
 		}
 	}
+
+	// check bootstrap version.
+	ver := run(pathf("%s/bin", goroot_bootstrap), CheckExit, pathf("%s/bin/go", goroot_bootstrap), "version")
+	_, after, _ := strings.Cut(ver, "go1")
+	if after != "" {
+		v := strings.Split(after, ".")
+		if len(v) > 2 {
+			if v[0] < minBootStrapVersion[1] || v[1] < minBootStrapVersion[2] {
+				fatalf("requires Go 1.%s.%s or later for bootstrap", minBootStrapVersion[1], minBootStrapVersion[2])
+			}
+		}
+	}
+
 	xprintf("Building Go toolchain1 using %s.\n", goroot_bootstrap)
 
 	mkbuildcfg(pathf("%s/src/internal/buildcfg/zbootstrap.go", goroot))

--- a/src/cmd/dist/buildtool.go
+++ b/src/cmd/dist/buildtool.go
@@ -142,7 +142,7 @@ func bootstrapBuildTools() {
 	ver := run(pathf("%s/bin", goroot_bootstrap), CheckExit, pathf("%s/bin/go", goroot_bootstrap), "env", "GOVERSION")
 	// go env GOVERSION output like "go1.22.6\n" or "devel go1.24-ffb3e574 Thu Aug 29 20:16:26 2024 +0000\n".
 	ver = ver[:len(ver)-1]
-	if (strings.Contains(ver, "devel") && version.Compare(version.Lang(minBootstrap), ver) == 1) || version.Compare(ver, minBootstrap) == -1 {
+	if version.Compare(ver, version.Lang(minBootstrap)) == 1 && version.Compare(ver, minBootstrap) == -1 {
 		fatalf("%s does not meet the minimum bootstrap requirement of %s or later", ver, minBootstrap)
 	}
 

--- a/src/cmd/dist/buildtool.go
+++ b/src/cmd/dist/buildtool.go
@@ -142,7 +142,7 @@ func bootstrapBuildTools() {
 	ver := run(pathf("%s/bin", goroot_bootstrap), CheckExit, pathf("%s/bin/go", goroot_bootstrap), "env", "GOVERSION")
 	// go env GOVERSION output like "go1.22.6\n" or "devel go1.24-ffb3e574 Thu Aug 29 20:16:26 2024 +0000\n".
 	ver = ver[:len(ver)-1]
-	if version.Compare(ver, version.Lang(minBootstrap)) == 1 && version.Compare(ver, minBootstrap) == -1 {
+	if version.Compare(ver, version.Lang(minBootstrap)) > 0 && version.Compare(ver, minBootstrap) < 0 {
 		fatalf("%s does not meet the minimum bootstrap requirement of %s or later", ver, minBootstrap)
 	}
 

--- a/src/cmd/dist/buildtool.go
+++ b/src/cmd/dist/buildtool.go
@@ -138,10 +138,13 @@ func bootstrapBuildTools() {
 
 	// check bootstrap version.
 	ver := run(pathf("%s/bin", goroot_bootstrap), CheckExit, pathf("%s/bin/go", goroot_bootstrap), "version")
-	// if go1.22.6,
-	// go version output go version 1.22.6 goos/aoarch,
-	// so split(ver," ")[2].
-	ver = strings.Split(ver, " ")[2]
+	// go version output like go version 1.22.6 goos/aoarch,
+	// or go version devel go1.24-b44ca2cd85.
+	vers := strings.Split(ver, " ")
+	ver = vers[2]
+	if vers[2] == "devel" {
+		ver = vers[3]
+	}
 	if version.Compare(ver, tryDirs[1]) == -1 {
 		fatalf("requires %s or later for bootstrap", tryDirs[1])
 	}

--- a/src/cmd/dist/buildtool.go
+++ b/src/cmd/dist/buildtool.go
@@ -142,8 +142,10 @@ func bootstrapBuildTools() {
 	_, after, _ := strings.Cut(ver, "go1")
 	if after != "" {
 		v := strings.Split(after, ".")
-		if len(v) > 2 {
-			if v[0] < minBootStrapVersion[1] || v[1] < minBootStrapVersion[2] {
+		// if go version output is go1.22.6 goos/goarch
+		// v is ["","22","6 goos/aoarch"].
+		if len(v) == 3 {
+			if v[1] < minBootStrapVersion[1] || strings.Split(v[2], " ")[0] < minBootStrapVersion[2] {
 				fatalf("requires Go 1.%s.%s or later for bootstrap", minBootStrapVersion[1], minBootStrapVersion[2])
 			}
 		}

--- a/src/cmd/dist/buildtool.go
+++ b/src/cmd/dist/buildtool.go
@@ -13,6 +13,7 @@ package main
 
 import (
 	"fmt"
+	"go/version"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -123,8 +124,6 @@ var tryDirs = []string{
 	"go1.22.6",
 }
 
-var minBootStrapVersion [3]string = [3]string{"1", "22", "6"}
-
 func bootstrapBuildTools() {
 	goroot_bootstrap := os.Getenv("GOROOT_BOOTSTRAP")
 	if goroot_bootstrap == "" {
@@ -139,16 +138,12 @@ func bootstrapBuildTools() {
 
 	// check bootstrap version.
 	ver := run(pathf("%s/bin", goroot_bootstrap), CheckExit, pathf("%s/bin/go", goroot_bootstrap), "version")
-	_, after, _ := strings.Cut(ver, "go1")
-	if after != "" {
-		v := strings.Split(after, ".")
-		// if go version output is go1.22.6 goos/goarch
-		// v is ["","22","6 goos/aoarch"].
-		if len(v) == 3 {
-			if v[1] < minBootStrapVersion[1] || strings.Split(v[2], " ")[0] < minBootStrapVersion[2] {
-				fatalf("requires Go 1.%s.%s or later for bootstrap", minBootStrapVersion[1], minBootStrapVersion[2])
-			}
-		}
+	// if go1.22.6,
+	// go version output go version 1.22.6 goos/aoarch,
+	// so split(ver," ")[2].
+	ver = strings.Split(ver, " ")[2]
+	if version.Compare(ver, tryDirs[1]) == -1 {
+		fatalf("requires %s or later for bootstrap", tryDirs[1])
 	}
 
 	xprintf("Building Go toolchain1 using %s.\n", goroot_bootstrap)


### PR DESCRIPTION
The go1.24 release notes say that go1.22.6 is the
minimum bootstraps required,
the go team also use go1.22.6 bootstraps in testing,
so if there's a problem with using an older version,
automated testing won't uncover it.

Now enforce this in dist to avoid
release notes that do not match reality, which can be confusing.

For #64751