### PR TITLE
go/ast: don't MergeLine in SortImports when last import on the same line as RParen

### DIFF
--- a/src/go/ast/import.go
+++ b/src/go/ast/import.go
@@ -207,6 +207,8 @@ func sortSpecs(fset *token.FileSet, f *File, d *GenDecl, specs []Spec) []Spec {
 			deduped = append(deduped, s)
 		} else {
 			p := s.Pos()
+			// This function is exited early when len(specs) <= 1,
+			// so d.Rparen must be populated (d.Rparen.IsValid() == true).
 			if l := lineAt(fset, p); l != lineAt(fset, d.Rparen) {
 				fset.File(p).MergeLine(l)
 			}

--- a/src/go/ast/import.go
+++ b/src/go/ast/import.go
@@ -207,8 +207,8 @@ func sortSpecs(fset *token.FileSet, f *File, d *GenDecl, specs []Spec) []Spec {
 			deduped = append(deduped, s)
 		} else {
 			p := s.Pos()
-			if endLine != lineAt(fset, d.Rparen) {
-				fset.File(p).MergeLine(lineAt(fset, p))
+			if l := lineAt(fset, p); l != lineAt(fset, d.Rparen) {
+				fset.File(p).MergeLine(l)
 			}
 		}
 	}

--- a/src/go/ast/import.go
+++ b/src/go/ast/import.go
@@ -33,11 +33,11 @@ func SortImports(fset *token.FileSet, f *File) {
 		for j, s := range d.Specs {
 			if j > i && lineAt(fset, s.Pos()) > 1+lineAt(fset, d.Specs[j-1].End()) {
 				// j begins a new run. End this one.
-				specs = append(specs, sortSpecs(fset, f, d.Specs[i:j])...)
+				specs = append(specs, sortSpecs(fset, f, d, d.Specs[i:j])...)
 				i = j
 			}
 		}
-		specs = append(specs, sortSpecs(fset, f, d.Specs[i:])...)
+		specs = append(specs, sortSpecs(fset, f, d, d.Specs[i:])...)
 		d.Specs = specs
 
 		// Deduping can leave a blank line before the rparen; clean that up.
@@ -109,7 +109,7 @@ type cgPos struct {
 	cg   *CommentGroup
 }
 
-func sortSpecs(fset *token.FileSet, f *File, specs []Spec) []Spec {
+func sortSpecs(fset *token.FileSet, f *File, d *GenDecl, specs []Spec) []Spec {
 	// Can't short-circuit here even if specs are already sorted,
 	// since they might yet need deduplication.
 	// A lone import, however, may be safely ignored.
@@ -207,7 +207,9 @@ func sortSpecs(fset *token.FileSet, f *File, specs []Spec) []Spec {
 			deduped = append(deduped, s)
 		} else {
 			p := s.Pos()
-			fset.File(p).MergeLine(lineAt(fset, p))
+			if endLine != lineAt(fset, d.Rparen) {
+				fset.File(p).MergeLine(lineAt(fset, p))
+			}
 		}
 	}
 	specs = deduped

--- a/src/go/ast/import_test.go
+++ b/src/go/ast/import_test.go
@@ -79,3 +79,42 @@ import (
 		}
 	})
 }
+
+func TestIssue69183(t *testing.T) {
+	const src = `package A
+import (
+"a"//a
+"a")
+`
+	fs := token.NewFileSet()
+	f, err := parser.ParseFile(fs, "test.go", src, parser.ParseComments|parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ast.SortImports(fs, f) // should not panic
+}
+
+func TestSortImportsSameLastLine(t *testing.T) {
+	const src = `package A
+import (
+"a"//a
+"a")
+func a() {}
+`
+
+	fs := token.NewFileSet()
+	f, err := parser.ParseFile(fs, "test.go", src, parser.ParseComments|parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ast.SortImports(fs, f)
+	ast.Print(fs, f)
+	fd := f.Decls[1].(*ast.FuncDecl)
+	fdPos := fs.Position(fd.Pos())
+	if fdPos.Column != 1 || fdPos.Line != 5 {
+		t.Errorf("invalid fdPod.Column = %v; want = 1", fdPos.Column)
+	}
+	if fdPos.Line != 5 {
+		t.Errorf("invalid fdPod.Line = %v; want = 5", fdPos.Line)
+	}
+}

--- a/src/go/ast/import_test.go
+++ b/src/go/ast/import_test.go
@@ -111,10 +111,10 @@ func a() {}
 	ast.Print(fs, f)
 	fd := f.Decls[1].(*ast.FuncDecl)
 	fdPos := fs.Position(fd.Pos())
-	if fdPos.Column != 1 || fdPos.Line != 5 {
-		t.Errorf("invalid fdPod.Column = %v; want = 1", fdPos.Column)
+	if fdPos.Column != 1 {
+		t.Errorf("invalid fdPos.Column = %v; want = 1", fdPos.Column)
 	}
 	if fdPos.Line != 5 {
-		t.Errorf("invalid fdPod.Line = %v; want = 5", fdPos.Line)
+		t.Errorf("invalid fdPos.Line = %v; want = 5", fdPos.Line)
 	}
 }

--- a/src/go/ast/import_test.go
+++ b/src/go/ast/import_test.go
@@ -86,12 +86,12 @@ import (
 "a"//a
 "a")
 `
-	fs := token.NewFileSet()
-	f, err := parser.ParseFile(fs, "test.go", src, parser.ParseComments|parser.SkipObjectResolution)
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments|parser.SkipObjectResolution)
 	if err != nil {
 		t.Fatal(err)
 	}
-	ast.SortImports(fs, f) // should not panic
+	ast.SortImports(fset, f) // should not panic
 }
 
 func TestSortImportsSameLastLine(t *testing.T) {
@@ -102,14 +102,17 @@ import (
 func a() {}
 `
 
-	fs := token.NewFileSet()
-	f, err := parser.ParseFile(fs, "test.go", src, parser.ParseComments|parser.SkipObjectResolution)
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments|parser.SkipObjectResolution)
 	if err != nil {
 		t.Fatal(err)
 	}
-	ast.SortImports(fs, f)
+	ast.SortImports(fset, f)
 	fd := f.Decls[1].(*ast.FuncDecl)
-	fdPos := fs.Position(fd.Pos())
+	fdPos := fset.Position(fd.Pos())
+	// After SortImports, the Position of the func, should still be at Column == 1.
+	// This is related to the issue: https://go.dev/issue/69183, we were merging lines
+	// incorrectly, which caused the position to be Column = 6, Line = 4.
 	if fdPos.Column != 1 {
 		t.Errorf("invalid fdPos.Column = %v; want = 1", fdPos.Column)
 	}

--- a/src/go/ast/import_test.go
+++ b/src/go/ast/import_test.go
@@ -108,7 +108,6 @@ func a() {}
 		t.Fatal(err)
 	}
 	ast.SortImports(fs, f)
-	ast.Print(fs, f)
 	fd := f.Decls[1].(*ast.FuncDecl)
 	fdPos := fs.Position(fd.Pos())
 	if fdPos.Column != 1 {


### PR DESCRIPTION
Fixes #69183