### PR TITLE
go/printer: do not panic on *ast.ParenExpr in combinesWithName

### DIFF
--- a/src/go/printer/nodes.go
+++ b/src/go/printer/nodes.go
@@ -411,9 +411,7 @@ func combinesWithName(x ast.Expr) bool {
 	case *ast.BinaryExpr:
 		return combinesWithName(x.X) && !isTypeElem(x.Y)
 	case *ast.ParenExpr:
-		// name(x) combines but we are making sure at
-		// the call site that x is never parenthesized.
-		panic("unexpected parenthesized expression")
+		return combinesWithName(x.X)
 	}
 	return false
 }

--- a/src/go/printer/testdata/generics.golden
+++ b/src/go/printer/testdata/generics.golden
@@ -45,6 +45,8 @@ type _[P T | T] struct{}
 type _[P T | T | T | T] struct{}
 type _[P *T, _ any] struct{}
 type _[P *T,] struct{}
+type _[P *T,] struct{}
+type _[P ~int] struct{}
 type _[P *T, _ any] struct{}
 type _[P T] struct{}
 type _[P T, _ any] struct{}

--- a/src/go/printer/testdata/generics.input
+++ b/src/go/printer/testdata/generics.input
@@ -42,6 +42,8 @@ type _[P T | T] struct{}
 type _[P T | T | T | T] struct{}
 type _[P *T, _ any] struct{}
 type _[P (*T),] struct{}
+type _[P ((*T)),] struct{}
+type _[P ((~int)),] struct{}
 type _[P (*T), _ any] struct{}
 type _[P (T),] struct{}
 type _[P (T), _ any] struct{}


### PR DESCRIPTION
Fixes #69206