### PR TITLE
go/parser: convert *ast.CallExpr into *ast.ParenExpr in extractName

### DIFF
--- a/src/go/parser/parser.go
+++ b/src/go/parser/parser.go
@@ -2695,6 +2695,9 @@ func extractName(x ast.Expr, force bool) (*ast.Ident, ast.Expr) {
 	case *ast.CallExpr:
 		if name, _ := x.Fun.(*ast.Ident); name != nil {
 			if len(x.Args) == 1 && x.Ellipsis == token.NoPos && (force || isTypeElem(x.Args[0])) {
+				// x = name (x.Args[0])
+				// (Note that the cmd/compile/internal/syntax parser does not care
+				// about syntax tree fidelity and does not preserve parentheses here.)
 				return name, &ast.ParenExpr{
 					Lparen: x.Lparen,
 					X:      x.Args[0],

--- a/src/go/parser/parser.go
+++ b/src/go/parser/parser.go
@@ -2667,8 +2667,8 @@ func (p *parser) parseTypeSpec(doc *ast.CommentGroup, _ token.Token, _ int) ast.
 //	P*[]int     T/F      P       *[]int
 //	P*E         T        P       *E
 //	P*E         F        nil     P*E
-//	P([]int)    T/F      P       []int
-//	P(E)        T        P       E
+//	P([]int)    T/F      P       ([]int)
+//	P(E)        T        P       (E)
 //	P(E)        F        nil     P(E)
 //	P*E|F|~G    T/F      P       *E|F|~G
 //	P*E|F|G     T        P       *E|F|G
@@ -2695,8 +2695,11 @@ func extractName(x ast.Expr, force bool) (*ast.Ident, ast.Expr) {
 	case *ast.CallExpr:
 		if name, _ := x.Fun.(*ast.Ident); name != nil {
 			if len(x.Args) == 1 && x.Ellipsis == token.NoPos && (force || isTypeElem(x.Args[0])) {
-				// x = name "(" x.ArgList[0] ")"
-				return name, x.Args[0]
+				return name, &ast.ParenExpr{
+					Lparen: x.Lparen,
+					X:      x.Args[0],
+					Rparen: x.Rparen,
+				}
 			}
 		}
 	}

--- a/src/go/parser/parser_test.go
+++ b/src/go/parser/parser_test.go
@@ -823,7 +823,7 @@ func TestIssue57490(t *testing.T) {
 }
 
 func TestParseTypeParamsAsParenExpr(t *testing.T) {
-	const src = "package p;type X[A (B),] struct{}"
+	const src = "package p; type X[A (B),] struct{}"
 
 	fset := token.NewFileSet()
 	f, err := ParseFile(fset, "test.go", src, ParseComments|SkipObjectResolution)

--- a/src/go/parser/parser_test.go
+++ b/src/go/parser/parser_test.go
@@ -823,13 +823,14 @@ func TestIssue57490(t *testing.T) {
 }
 
 func TestParseTypeParamsAsParenExpr(t *testing.T) {
-	const src = "package p\ntype X[A (B),] struct{}"
+	const src = "package p;type X[A (B),] struct{}"
 
-	fs := token.NewFileSet()
-	f, err := ParseFile(fs, "test.go", src, ParseComments|SkipObjectResolution)
+	fset := token.NewFileSet()
+	f, err := ParseFile(fset, "test.go", src, ParseComments|SkipObjectResolution)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	typeParam := f.Decls[0].(*ast.GenDecl).Specs[0].(*ast.TypeSpec).TypeParams.List[0].Type
 	_, ok := typeParam.(*ast.ParenExpr)
 	if !ok {

--- a/src/go/parser/parser_test.go
+++ b/src/go/parser/parser_test.go
@@ -821,3 +821,18 @@ func TestIssue57490(t *testing.T) {
 		t.Fatalf("offset = %d, want %d", offset, tokFile.Size())
 	}
 }
+
+func TestParseTypeParamsAsParenExpr(t *testing.T) {
+	const src = "package p\ntype X[A (B),] struct{}"
+
+	fs := token.NewFileSet()
+	f, err := ParseFile(fs, "test.go", src, ParseComments|SkipObjectResolution)
+	if err != nil {
+		t.Fatal(err)
+	}
+	typeParam := f.Decls[0].(*ast.GenDecl).Specs[0].(*ast.TypeSpec).TypeParams.List[0].Type
+	_, ok := typeParam.(*ast.ParenExpr)
+	if !ok {
+		t.Fatalf("typeParam is a %T; want: *ast.ParenExpr", typeParam)
+	}
+}


### PR DESCRIPTION
We are loosing a bit of the AST information, i believe we should
convert *ast.CallExpr into *ast.ParenExpr.

See https://github.com/golang/go/issues/69206#issuecomment-2324592744