### PR TITLE
compress/flate: use built-in clear to simplify the code

### DIFF
--- a/src/compress/flate/deflate.go
+++ b/src/compress/flate/deflate.go
@@ -612,12 +612,8 @@ func (d *compressor) reset(w io.Writer) {
 		d.bestSpeed.reset()
 	default:
 		d.chainHead = -1
-		for i := range d.hashHead {
-			d.hashHead[i] = 0
-		}
-		for i := range d.hashPrev {
-			d.hashPrev[i] = 0
-		}
+		clear(d.hashHead[:])
+		clear(d.hashPrev[:])
 		d.hashOffset = 1
 		d.index, d.windowEnd = 0, 0
 		d.blockStart, d.byteAvailable = 0, false

--- a/src/compress/flate/deflatefast.go
+++ b/src/compress/flate/deflatefast.go
@@ -286,9 +286,7 @@ func (e *deflateFast) reset() {
 func (e *deflateFast) shiftOffsets() {
 	if len(e.prev) == 0 {
 		// We have no history; just clear the table.
-		for i := range e.table[:] {
-			e.table[i] = tableEntry{}
-		}
+		clear(e.table[:])
 		e.cur = maxMatchOffset + 1
 		return
 	}

--- a/src/compress/flate/huffman_bit_writer.go
+++ b/src/compress/flate/huffman_bit_writer.go
@@ -198,9 +198,7 @@ func (w *huffmanBitWriter) writeBytes(bytes []byte) {
 //	numOffsets       The number of offsets in offsetEncoding
 //	litenc, offenc   The literal and offset encoder to use
 func (w *huffmanBitWriter) generateCodegen(numLiterals int, numOffsets int, litEnc, offEnc *huffmanEncoder) {
-	for i := range w.codegenFreq {
-		w.codegenFreq[i] = 0
-	}
+	clear(w.codegenFreq[:])
 	// Note that we are using codegen both as a temporary variable for holding
 	// a copy of the frequencies, and as the place where we put the result.
 	// This is fine because the output is always shorter than the input used
@@ -530,12 +528,8 @@ func (w *huffmanBitWriter) writeBlockDynamic(tokens []token, eof bool, input []b
 // and offsetEncoding.
 // The number of literal and offset tokens is returned.
 func (w *huffmanBitWriter) indexTokens(tokens []token) (numLiterals, numOffsets int) {
-	for i := range w.literalFreq {
-		w.literalFreq[i] = 0
-	}
-	for i := range w.offsetFreq {
-		w.offsetFreq[i] = 0
-	}
+	clear(w.literalFreq)
+	clear(w.offsetFreq)
 
 	for _, t := range tokens {
 		if t < matchType {
@@ -621,9 +615,7 @@ func (w *huffmanBitWriter) writeBlockHuff(eof bool, input []byte) {
 	}
 
 	// Clear histogram
-	for i := range w.literalFreq {
-		w.literalFreq[i] = 0
-	}
+	clear(w.literalFreq)
 
 	// Add everything as literals
 	histogram(input, w.literalFreq)


### PR DESCRIPTION
The new bootstrap toolchain allows us to use the built-in clear.

Updates #64751