### PR TITLE
net/http: only disable fetch in test

### DIFF
--- a/lib/wasm/wasm_exec_node.js
+++ b/lib/wasm/wasm_exec_node.js
@@ -21,6 +21,16 @@ globalThis.crypto ??= require("crypto");
 
 require("./wasm_exec");
 
+// Disable fetch API in tests so that
+// RoundTrip ends up talking over the same fake
+// network the HTTP servers currently use in
+// various tests and examples.
+// See net/http/roundtrip_js.go.
+// See go.dev/issue/57613.
+if (process.argv[2].endsWith(".test")) {
+	globalThis["JSFetchDisabledInTest"] = true;
+}
+
 const go = new Go();
 go.argv = process.argv.slice(2);
 go.env = Object.assign({ TMPDIR: require("os").tmpdir() }, process.env);

--- a/src/net/http/roundtrip_js.go
+++ b/src/net/http/roundtrip_js.go
@@ -12,8 +12,8 @@ import (
 	"io"
 	"net/http/internal/ascii"
 	"strconv"
-	"strings"
 	"syscall/js"
+	"testing"
 )
 
 var uint8Array = js.Global().Get("Uint8Array")
@@ -53,8 +53,7 @@ var jsFetchMissing = js.Global().Get("fetch").IsUndefined()
 //
 // TODO(go.dev/issue/60810): See if it's viable to test the Fetch API
 // code path.
-var jsFetchDisabled = js.Global().Get("process").Type() == js.TypeObject &&
-	strings.HasPrefix(js.Global().Get("process").Get("argv0").String(), "node")
+var jsFetchDisabled = testing.Testing()
 
 // RoundTrip implements the [RoundTripper] interface using the WHATWG Fetch API.
 func (t *Transport) RoundTrip(req *Request) (*Response, error) {

--- a/src/net/http/roundtrip_js.go
+++ b/src/net/http/roundtrip_js.go
@@ -13,7 +13,6 @@ import (
 	"net/http/internal/ascii"
 	"strconv"
 	"syscall/js"
-	"testing"
 )
 
 var uint8Array = js.Global().Get("Uint8Array")
@@ -47,13 +46,13 @@ const jsFetchRedirect = "js.fetch:redirect"
 var jsFetchMissing = js.Global().Get("fetch").IsUndefined()
 
 // jsFetchDisabled controls whether the use of Fetch API is disabled.
-// It's set to true when we detect we're running in Node.js, so that
+// It's set to true when we detect we're running in test, so that
 // RoundTrip ends up talking over the same fake network the HTTP servers
 // currently use in various tests and examples. See go.dev/issue/57613.
 //
 // TODO(go.dev/issue/60810): See if it's viable to test the Fetch API
 // code path.
-var jsFetchDisabled = testing.Testing()
+var jsFetchDisabled = !js.Global().Get("JSFetchDisabledInTest").IsUndefined()
 
 // RoundTrip implements the [RoundTripper] interface using the WHATWG Fetch API.
 func (t *Transport) RoundTrip(req *Request) (*Response, error) {


### PR DESCRIPTION
This change allows the js/wasm port binary to perform network 
access correctly on Node.js without breaking tests 
that have not yet been migrated.

Updates #57613
Fixes #69106