### PR TITLE
go/printer: mention that input file is formatted in TestFiles error message

### DIFF
--- a/src/go/printer/printer_test.go
+++ b/src/go/printer/printer_test.go
@@ -125,7 +125,7 @@ func runcheck(t *testing.T, source, golden string, mode checkMode) {
 	}
 
 	// formatted source and golden must be the same
-	if err := checkEqual(source, golden, res, gld); err != nil {
+	if err := checkEqual(fmt.Sprintf("format(%v)", source), golden, res, gld); err != nil {
 		t.Error(err)
 		return
 	}


### PR DESCRIPTION
Currently when one of the tests in TestFiles fail, then the error looks
like this:

--- testdata/generics.input
+++ testdata/generics.golden

which is confusing, with this change it will be:

--- format(testdata/generics.input)
+++ testdata/generics.golden
