### PR TITLE
crypto/md5: improve ARM64 MD5 performance by optimizing ROUND3 function

### DIFF
--- a/src/crypto/md5/md5block_arm64.s
+++ b/src/crypto/md5/md5block_arm64.s
@@ -95,18 +95,28 @@ loop:
 	MOVW	(5*4)(R1), R8
 	MOVW	R6, R9
 
+#define ROUND3FIRST(a, b, c, d, index, const, shift) \
+	MOVW	d, R9; \
+	EORW	c, R9; \
+	EORW	b, R9; \
+	ADDW	$const, a; \
+	ADDW	R8, a; \
+	MOVW	(index*4)(R1),R8; \
+	ADDW	R9, a; \
+	RORW	$(32-shift), a; \
+	ADDW	b, a
+
 #define ROUND3(a, b, c, d, index, const, shift) \
+	EORW	a, R9; \
+	EORW	b, R9; \
 	ADDW	$const, a; \
 	ADDW	R8, a; \
 	MOVW	(index*4)(R1), R8; \
-	EORW	d, R9; \
-	EORW	b, R9; \
 	ADDW	R9, a; \
 	RORW	$(32-shift), a; \
-	MOVW	b, R9; \
 	ADDW	b, a
 
-	ROUND3(R4,R5,R6,R7, 8,0xfffa3942, 4);
+	ROUND3FIRST(R4,R5,R6,R7, 8,0xfffa3942, 4);
 	ROUND3(R7,R4,R5,R6,11,0x8771f681,11);
 	ROUND3(R6,R7,R4,R5,14,0x6d9d6122,16);
 	ROUND3(R5,R6,R7,R4, 1,0xfde5380c,23);


### PR DESCRIPTION
This commit enhances the performance of the MD5 functionality on ARM64 architecture by optimizing the ROUND3 function in the `md5block_arm64.s` assembly file.

- Refactored the `ROUND3` macro to improve the computation order, introducing a new `ROUND3FIRST` macro to handle the initial calculation more efficiently.
- Optimized the XOR operations in the `ROUND3` macro to reduce unnecessary instructions and improve parallelism within the ARM64 architecture.

Performance testing was conducted on an ARM64 Linux machine using Go's benchmark tool. TThe benchmarks were run 10 times each to ensure statistical significance and with a single CPU core. The following results were observed:
    goos: linux
    goarch: arm64
    pkg: md5
    cpu: HUAWEI,Kunpeng 920
    
                    │ baseline.txt │              new.txt               │
                    │    sec/op    │   sec/op     vs base               │
    Hash8Bytes 163.3n ± 0% 162.8n ± 0% -0.34% (p=0.000 n=10)
    Hash64 280.1n ± 2% 279.8n ± 0% -0.09% (p=0.001 n=10)
    Hash128 398.4n ± 0% 397.6n ± 0% -0.21% (p=0.017 n=10)
    Hash256 634.6n ± 1% 633.3n ± 0% -0.21% (p=0.000 n=10)
    Hash512 1.106µ ± 0% 1.105µ ± 0% -0.09% (p=0.000 n=10)
    Hash1K 2.053µ ± 0% 2.052µ ± 0% -0.05% (p=0.001 n=10)
    Hash8K 15.27µ ± 1% 15.27µ ± 0% -0.04% (p=0.000 n=10)
    Hash1M 1.942m ± 0% 1.936m ± 0% -0.31% (p=0.002 n=10)
    Hash8M 15.61m ± 0% 15.62m ± 0% ~ (p=1.000 n=10)
    Hash8BytesUnaligned 162.6n ± 0% 162.6n ± 0% ~ (p=0.555 n=10)
    Hash1KUnaligned 2.068µ ± 0% 2.066µ ± 0% -0.10% (p=0.000 n=10)
    Hash8KUnaligned 15.36µ ± 0% 15.36µ ± 0% ~ (p=0.168 n=10)
    geomean 4.465µ 4.460µ -0.12%
    
                    │ baseline.txt │               new.txt               │
                    │     B/s      │     B/s       vs base               │
    Hash8Bytes 46.72Mi ± 0% 46.88Mi ± 0% +0.36% (p=0.000 n=10)
    Hash64 217.9Mi ± 2% 218.1Mi ± 0% +0.09% (p=0.000 n=10)
    Hash128 306.4Mi ± 0% 307.0Mi ± 0% +0.23% (p=0.017 n=10)
    Hash256 384.7Mi ± 1% 385.5Mi ± 0% +0.21% (p=0.000 n=10)
    Hash512 441.6Mi ± 0% 441.9Mi ± 0% +0.07% (p=0.000 n=10)
    Hash1K 475.6Mi ± 0% 475.8Mi ± 0% +0.05% (p=0.000 n=10)
    Hash8K 511.5Mi ± 1% 511.7Mi ± 0% +0.04% (p=0.000 n=10)
    Hash1M 515.0Mi ± 0% 516.6Mi ± 0% +0.32% (p=0.001 n=10)
    Hash8M 512.3Mi ± 0% 512.3Mi ± 0% ~ (p=1.000 n=10)
    Hash8BytesUnaligned 46.94Mi ± 0% 46.93Mi ± 0% ~ (p=0.754 n=10)
    Hash1KUnaligned 472.2Mi ± 0% 472.7Mi ± 0% +0.11% (p=0.000 n=10)
    Hash8KUnaligned 508.7Mi ± 0% 508.7Mi ± 0% ~ (p=0.158 n=10)
    geomean 291.9Mi 292.3Mi +0.12%

When testing with large files (e.g., a 3GB file), the runtime was reduced from 8.65 seconds to 7.39 seconds, resulting in an approximate 9% reduction in execution time. This demonstrates a more significant performance gain when handling larger datasets.

Overall, these optimizations provide modest improvements for small input sizes and more noticeable performance benefits when processing larger files, especially in memory-intensive workloads like file hashing.