### PR TITLE
regexp/syntax: optimize OpCharClass fold case in calcFlags

### DIFF
--- a/src/regexp/syntax/regexp.go
+++ b/src/regexp/syntax/regexp.go
@@ -210,6 +210,8 @@ func calcFlags(re *Regexp, flags *map[*Regexp]printFlags) (must, cant printFlags
 	}
 }
 
+// calcFlagsI determines if the case-folding flag (?i) is required for character classes.
+// It checks whether to look inside or outside character ranges for case folding, depending on which range is smaller, to minimize unnecessary checks.
 func calcFlagsI(re *Regexp) (must, cant printFlags) {
 	if len(re.Rune) < 2 {
 		return 0, 0

--- a/src/regexp/syntax/regexp_test.go
+++ b/src/regexp/syntax/regexp_test.go
@@ -1,0 +1,30 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package syntax
+
+import "testing"
+
+var benchmarkTests = []string{
+	`^(.*);$|^;(.*)`,
+	`(foo|bar$)x*`,
+	`[^=,]`,
+	`([^=,]+)=([^=,]+)`,
+	`([^=,]+)=([^=,]+),.*`,
+}
+
+func BenchmarkString(b *testing.B) {
+	for _, tt := range benchmarkTests {
+		re, err := Parse(tt, Perl|DotNL)
+		if err != nil {
+			b.Fatalf("Parse(%#q) = error %v", tt, err)
+		}
+
+		b.Run(tt, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = re.String()
+			}
+		})
+	}
+}

--- a/src/regexp/syntax/regexp_test.go
+++ b/src/regexp/syntax/regexp_test.go
@@ -1,4 +1,4 @@
-// Copyright 2011 The Go Authors. All rights reserved.
+// Copyright 2024 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/src/regexp/syntax/simplify_test.go
+++ b/src/regexp/syntax/simplify_test.go
@@ -114,6 +114,7 @@ var simplifyTests = []struct {
 	{`(?i)[a-z]`, "[A-Za-z\u017F\u212A]"},
 	{`(?i)[\x00-\x{FFFD}]`, "[\\x00-\uFFFD]"},
 	{`(?i)[\x00-\x{10FFFF}]`, `(?s:.)`},
+	{`[xX][O-u]`, `(?i:X)[O-u]`},
 
 	// Empty string as a regular expression.
 	// The empty string must be preserved inside parens in order


### PR DESCRIPTION
Fixes #69303 