### PR TITLE
syscall/js: auto recycle Func

### DIFF
--- a/lib/wasm/wasm_exec.js
+++ b/lib/wasm/wasm_exec.js
@@ -115,6 +115,12 @@
 			this._pendingEvent = null;
 			this._scheduledTimeouts = new Map();
 			this._nextCallbackTimeoutID = 1;
+			this._cleanup = null;
+			this._registry = new FinalizationRegistry((func, id) => {
+				if (this._cleanup) {
+					this._cleanup(id);
+				}
+			})
 
 			const setInt64 = (addr, v) => {
 				this.mem.setUint32(addr + 0, v, true);
@@ -563,12 +569,17 @@
 
 		_makeFuncWrapper(id) {
 			const go = this;
-			return function () {
+			const f = function () {
 				const event = { id: id, this: this, args: arguments };
 				go._pendingEvent = event;
 				go._resume();
 				return event.result;
 			};
+			// Should never remove the cleanup function
+			if (id !== 1) {
+				this._registry.register(f, id);
+			}
+			return f;
 		}
 	}
 })();


### PR DESCRIPTION
This patch allows js to clear function references 
on the go wasm side accordingly after running garbage collection

Updates #57435 