### PR TITLE
cmd/go: make sure the linker for shared doesn't include tempdir path

### DIFF
--- a/src/cmd/go/testdata/script/build_shared_reproducible.txt
+++ b/src/cmd/go/testdata/script/build_shared_reproducible.txt
@@ -1,0 +1,10 @@
+[!buildmode:shared] skip
+[short] skip
+[!cgo] skip '-buildmode=shared requires external linking'
+[!GOOS:linux] skip
+
+env GO111MODULE=off
+env CGO_ENABLED=1
+go install -a -trimpath -buildvcs=false -buildmode=shared -pkgdir=pkgdir1 runtime
+go install -a -trimpath -buildvcs=false -buildmode=shared -pkgdir=pkgdir2 runtime
+[GOOS:linux] cmp -q pkgdir1/libruntime.so pkgdir2/libruntime.so


### PR DESCRIPTION
This is similar to CL 478196 and CL 477296,
but this is for -buildmode=shared.

When using "go install -buildmode=shared std",
because the gold linker is used by default on Linux arm64, 
it will cause temporary paths to be included in libstd.so.

Based on the changes of CL 478196,
I speculate that this may also have issues on other platforms. 
So, this change is for all platform.

Fixes #69464