### PR TITLE
net/http/httptest: ensure that a superfluous WriteHeader call panics in httptest

### DIFF
--- a/src/net/http/httptest/recorder.go
+++ b/src/net/http/httptest/recorder.go
@@ -142,6 +142,7 @@ func checkWriteHeaderCode(code int) {
 // WriteHeader implements [http.ResponseWriter].
 func (rw *ResponseRecorder) WriteHeader(code int) {
 	if rw.wroteHeader {
+		panic(fmt.Sprintf("superfluous response.WriteHeader call"))
 		return
 	}
 


### PR DESCRIPTION
In net/http, using WriteHeader() twice creates a log entry, since the second one is superfluous:
https://cs.opensource.google/go/go/+/refs/tags/go1.23.1:src/net/http/server.go;l=1201

In net/http/httptest though, while a check is made, there is no way to detect the superfluous usage.
That makes superfluous calls reasy to reach production runtimes.
To help prevent that, this change proposes rejecting any superfluous WriteHeader calls in the httptest package.