### PR TITLE
net/mail: parse ipv6 in addresses according to RFC 5321.

### DIFF
--- a/src/net/mail/message.go
+++ b/src/net/mail/message.go
@@ -751,13 +751,13 @@ func (p *addrParser) consumeDomainLiteral() (string, error) {
 		return "", errors.New("mail: unclosed domain-literal")
 	}
 
+	// Check if the domain literal is an IP address
 	if addr, ok := strings.CutPrefix(dtext, "IPv6:"); ok {
 		if len(net.ParseIP(addr)) != net.IPv6len {
 			return "", fmt.Errorf("mail: invalid IPv6 address in domain-literal: %q", dtext)
 		}
 
 	} else if net.ParseIP(dtext).To4() != nil {
-		// Check if the domain literal is an IP address
 		return "", fmt.Errorf("mail: invalid IP address in domain-literal: %q", dtext)
 	}
 

--- a/src/net/mail/message.go
+++ b/src/net/mail/message.go
@@ -751,8 +751,13 @@ func (p *addrParser) consumeDomainLiteral() (string, error) {
 		return "", errors.New("mail: unclosed domain-literal")
 	}
 
-	// Check if the domain literal is an IP address
-	if net.ParseIP(dtext) == nil {
+	if addr, ok := strings.CutPrefix(dtext, "IPv6:"); ok {
+		if len(net.ParseIP(addr)) != net.IPv6len {
+			return "", fmt.Errorf("mail: invalid IPv6 address in domain-literal: %q", dtext)
+		}
+
+	} else if len(net.ParseIP(dtext).To4()) != net.IPv4len {
+		// Check if the domain literal is an IP address
 		return "", fmt.Errorf("mail: invalid IP address in domain-literal: %q", dtext)
 	}
 

--- a/src/net/mail/message.go
+++ b/src/net/mail/message.go
@@ -757,7 +757,7 @@ func (p *addrParser) consumeDomainLiteral() (string, error) {
 			return "", fmt.Errorf("mail: invalid IPv6 address in domain-literal: %q", dtext)
 		}
 
-	} else if net.ParseIP(dtext).To4() != nil {
+	} else if net.ParseIP(dtext).To4() == nil {
 		return "", fmt.Errorf("mail: invalid IP address in domain-literal: %q", dtext)
 	}
 

--- a/src/net/mail/message.go
+++ b/src/net/mail/message.go
@@ -756,7 +756,7 @@ func (p *addrParser) consumeDomainLiteral() (string, error) {
 			return "", fmt.Errorf("mail: invalid IPv6 address in domain-literal: %q", dtext)
 		}
 
-	} else if len(net.ParseIP(dtext).To4()) != net.IPv4len {
+	} else if net.ParseIP(dtext).To4() != nil {
 		// Check if the domain literal is an IP address
 		return "", fmt.Errorf("mail: invalid IP address in domain-literal: %q", dtext)
 	}

--- a/src/net/mail/message.go
+++ b/src/net/mail/message.go
@@ -763,8 +763,13 @@ func (p *addrParser) consumeDomainLiteral() (string, error) {
 		return "", errors.New("mail: unclosed domain-literal")
 	}
 
-	// Check if the domain literal is an IP address
-	if net.ParseIP(dtext) == nil {
+	if addr, ok := strings.CutPrefix(dtext, "IPv6:"); ok {
+		if len(net.ParseIP(addr)) != net.IPv6len {
+			return "", fmt.Errorf("mail: invalid IPv6 address in domain-literal: %q", dtext)
+		}
+
+	} else if len(net.ParseIP(dtext).To4()) != net.IPv4len {
+		// Check if the domain literal is an IP address
 		return "", fmt.Errorf("mail: invalid IP address in domain-literal: %q", dtext)
 	}
 

--- a/src/net/mail/message.go
+++ b/src/net/mail/message.go
@@ -769,7 +769,7 @@ func (p *addrParser) consumeDomainLiteral() (string, error) {
 			return "", fmt.Errorf("mail: invalid IPv6 address in domain-literal: %q", dtext)
 		}
 
-	} else if net.ParseIP(dtext).To4() != nil {
+	} else if net.ParseIP(dtext).To4() == nil {
 		return "", fmt.Errorf("mail: invalid IP address in domain-literal: %q", dtext)
 	}
 

--- a/src/net/mail/message.go
+++ b/src/net/mail/message.go
@@ -768,7 +768,7 @@ func (p *addrParser) consumeDomainLiteral() (string, error) {
 			return "", fmt.Errorf("mail: invalid IPv6 address in domain-literal: %q", dtext)
 		}
 
-	} else if len(net.ParseIP(dtext).To4()) != net.IPv4len {
+	} else if net.ParseIP(dtext).To4() != nil {
 		// Check if the domain literal is an IP address
 		return "", fmt.Errorf("mail: invalid IP address in domain-literal: %q", dtext)
 	}

--- a/src/net/mail/message.go
+++ b/src/net/mail/message.go
@@ -763,13 +763,13 @@ func (p *addrParser) consumeDomainLiteral() (string, error) {
 		return "", errors.New("mail: unclosed domain-literal")
 	}
 
+	// Check if the domain literal is an IP address
 	if addr, ok := strings.CutPrefix(dtext, "IPv6:"); ok {
 		if len(net.ParseIP(addr)) != net.IPv6len {
 			return "", fmt.Errorf("mail: invalid IPv6 address in domain-literal: %q", dtext)
 		}
 
 	} else if net.ParseIP(dtext).To4() != nil {
-		// Check if the domain literal is an IP address
 		return "", fmt.Errorf("mail: invalid IP address in domain-literal: %q", dtext)
 	}
 

--- a/src/net/mail/message_test.go
+++ b/src/net/mail/message_test.go
@@ -395,6 +395,7 @@ func TestAddressParsingError(t *testing.T) {
 		22: {"<jdoe@[[192.168.0.1]>", "bad character in domain-literal"},
 		23: {"<jdoe@[192.168.0.1>", "unclosed domain-literal"},
 		24: {"<jdoe@[256.0.0.1]>", "invalid IP address in domain-literal"},
+		25: {"<jdoe@[fd42::de:ad:be:ef]>", "invalid IP address in domain-literal"},
 	}
 
 	for i, tc := range mustErrTestCases {
@@ -825,6 +826,20 @@ func TestAddressParsing(t *testing.T) {
 				Address: "jdoe@[192.168.0.1]",
 			}},
 		},
+		// IPv6 Domain-literal
+		{
+			`jdoe@[IPv6:fd42::dead:beef:1234]`,
+			[]*Address{{
+				Address: "jdoe@[IPv6:fd42::dead:beef:1234]",
+			}},
+		},
+		{
+			`John Doe <jdoe@[IPv6:fd42::dead:beef:1234]>`,
+			[]*Address{{
+				Name:    "John Doe",
+				Address: "jdoe@[IPv6:fd42::dead:beef:1234]",
+			}},
+		},
 	}
 	for _, test := range tests {
 		if len(test.exp) == 1 {
@@ -989,6 +1004,20 @@ func TestAddressParser(t *testing.T) {
 				Address: "jdoe@[192.168.0.1]",
 			}},
 		},
+		// IPv6 Domain-literal
+		{
+			`jdoe@[IPv6:fd42::dead:beef:1234]`,
+			[]*Address{{
+				Address: "jdoe@[IPv6:fd42::dead:beef:1234]",
+			}},
+		},
+		{
+			`John Doe <jdoe@[IPv6:fd42::dead:beef:1234]>`,
+			[]*Address{{
+				Name:    "John Doe",
+				Address: "jdoe@[IPv6:fd42::dead:beef:1234]",
+			}},
+		},
 	}
 
 	ap := AddressParser{WordDecoder: &mime.WordDecoder{
@@ -1103,6 +1132,15 @@ func TestAddressString(t *testing.T) {
 		{
 			&Address{Name: "Bob", Address: "bob@[192.168.0.1]"},
 			`"Bob" <bob@[192.168.0.1]>`,
+		},
+		// IPv6 Domain-literal
+		{
+			&Address{Address: "bob@[IPv6:fd42::dead:beef:1234]"},
+			"<bob@[IPv6:fd42::dead:beef:1234]>",
+		},
+		{
+			&Address{Name: "Bob", Address: "bob@[IPv6:fd42::dead:beef:1234]"},
+			`"Bob" <bob@[IPv6:fd42::dead:beef:1234]>`,
 		},
 	}
 	for _, test := range tests {

--- a/src/net/mail/message_test.go
+++ b/src/net/mail/message_test.go
@@ -396,6 +396,7 @@ func TestAddressParsingError(t *testing.T) {
 		22: {"<jdoe@[[192.168.0.1]>", "bad character in domain-literal"},
 		23: {"<jdoe@[192.168.0.1>", "unclosed domain-literal"},
 		24: {"<jdoe@[256.0.0.1]>", "invalid IP address in domain-literal"},
+		25: {"<jdoe@[fd42::de:ad:be:ef]>", "invalid IP address in domain-literal"},
 	}
 
 	for i, tc := range mustErrTestCases {
@@ -826,6 +827,20 @@ func TestAddressParsing(t *testing.T) {
 				Address: "jdoe@[192.168.0.1]",
 			}},
 		},
+		// IPv6 Domain-literal
+		{
+			`jdoe@[IPv6:fd42::dead:beef:1234]`,
+			[]*Address{{
+				Address: "jdoe@[IPv6:fd42::dead:beef:1234]",
+			}},
+		},
+		{
+			`John Doe <jdoe@[IPv6:fd42::dead:beef:1234]>`,
+			[]*Address{{
+				Name:    "John Doe",
+				Address: "jdoe@[IPv6:fd42::dead:beef:1234]",
+			}},
+		},
 	}
 	for _, test := range tests {
 		if len(test.exp) == 1 {
@@ -990,6 +1005,20 @@ func TestAddressParser(t *testing.T) {
 				Address: "jdoe@[192.168.0.1]",
 			}},
 		},
+		// IPv6 Domain-literal
+		{
+			`jdoe@[IPv6:fd42::dead:beef:1234]`,
+			[]*Address{{
+				Address: "jdoe@[IPv6:fd42::dead:beef:1234]",
+			}},
+		},
+		{
+			`John Doe <jdoe@[IPv6:fd42::dead:beef:1234]>`,
+			[]*Address{{
+				Name:    "John Doe",
+				Address: "jdoe@[IPv6:fd42::dead:beef:1234]",
+			}},
+		},
 	}
 
 	ap := AddressParser{WordDecoder: &mime.WordDecoder{
@@ -1104,6 +1133,15 @@ func TestAddressString(t *testing.T) {
 		{
 			&Address{Name: "Bob", Address: "bob@[192.168.0.1]"},
 			`"Bob" <bob@[192.168.0.1]>`,
+		},
+		// IPv6 Domain-literal
+		{
+			&Address{Address: "bob@[IPv6:fd42::dead:beef:1234]"},
+			"<bob@[IPv6:fd42::dead:beef:1234]>",
+		},
+		{
+			&Address{Name: "Bob", Address: "bob@[IPv6:fd42::dead:beef:1234]"},
+			`"Bob" <bob@[IPv6:fd42::dead:beef:1234]>`,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
The new domain-literal support missed that IPv6 addresses need to be
prefixed with "IPv6:".

The IPv6-address-literal Specification, defined in RFC 5321 Section 4.1.3,
outlines the format for IPv6 address literals:
https://datatracker.ietf.org/doc/html/rfc5321#section-4.1.3

Good news, the IANA has registered no other Address Literal Tags.

Updates #60206 