### PR TITLE
text/template/parse: use correct line number in error after comment

### DIFF
--- a/src/text/template/parse/lex.go
+++ b/src/text/template/parse/lex.go
@@ -352,6 +352,7 @@ func lexComment(l *lexer) stateFn {
 	if !delim {
 		return l.errorf("comment ends before closing delimiter")
 	}
+	l.line += strings.Count(l.input[l.start:l.pos], "\n")
 	i := l.thisItem(itemComment)
 	if trimSpace {
 		l.pos += trimMarkerLen

--- a/src/text/template/parse/lex_test.go
+++ b/src/text/template/parse/lex_test.go
@@ -545,7 +545,7 @@ var lexPosTests = []lexTest{
 		{itemRightDelim, 11, "}}", 2},
 		{itemEOF, 13, "", 2},
 	}},
-	{"correctline", "{{/*\n*/}}\n{{undefinedFunction \"test\"}}", []item{
+	{"longcomment", "{{/*\n*/}}\n{{undefinedFunction \"test\"}}", []item{
 		{itemComment, 2, "/*\n*/", 1},
 		{itemText, 9, "\n", 2},
 		{itemLeftDelim, 10, "{{", 3},

--- a/src/text/template/parse/lex_test.go
+++ b/src/text/template/parse/lex_test.go
@@ -545,6 +545,16 @@ var lexPosTests = []lexTest{
 		{itemRightDelim, 11, "}}", 2},
 		{itemEOF, 13, "", 2},
 	}},
+	{"correctline", "{{/*\n*/}}\n{{undefinedFunction \"test\"}}", []item{
+		{itemComment, 2, "/*\n*/", 1},
+		{itemText, 9, "\n", 2},
+		{itemLeftDelim, 10, "{{", 3},
+		{itemIdentifier, 12, "undefinedFunction", 3},
+		{itemSpace, 29, " ", 3},
+		{itemString, 30, "\"test\"", 3},
+		{itemRightDelim, 36, "}}", 3},
+		{itemEOF, 38, "", 3},
+	}},
 }
 
 // The other tests don't check position, to make the test cases easier to construct.


### PR DESCRIPTION
Fixes #69526


