### PR TITLE
syscall: add separator for filepath if contains "." in wasip1

### DIFF
--- a/src/syscall/fs_wasip1.go
+++ b/src/syscall/fs_wasip1.go
@@ -409,6 +409,9 @@ func appendCleanPath(buf []byte, path string, lookupParent bool) ([]byte, bool) 
 		case "":
 			continue
 		case ".":
+			if len(buf) > 0 && buf[len(buf)-1] != '/' {
+				buf = append(buf, '/')
+			}
 			continue
 		case "..":
 			if !lookupParent {


### PR DESCRIPTION
Fix cases like "file/."

Updates #69509