### PR TITLE
crypto/ecdh: remove 8 byte pointer overhead for non-boringcrypto builds

### DIFF
--- a/src/crypto/ecdh/ecdh.go
+++ b/src/crypto/ecdh/ecdh.go
@@ -66,9 +66,10 @@ type Curve interface {
 // with [crypto/x509.MarshalPKIXPublicKey]. For NIST curves, they then need to
 // be converted with [crypto/ecdsa.PublicKey.ECDH] after parsing.
 type PublicKey struct {
+	boring boring.PublicKeyECDH
+
 	curve     Curve
 	publicKey []byte
-	boring    *boring.PublicKeyECDH
 }
 
 // Bytes returns a copy of the encoding of the public key.
@@ -105,9 +106,10 @@ func (k *PublicKey) Curve() Curve {
 // with [crypto/x509.MarshalPKCS8PrivateKey]. For NIST curves, they then need to
 // be converted with [crypto/ecdsa.PrivateKey.ECDH] after parsing.
 type PrivateKey struct {
+	boring boring.PrivateKeyECDH
+
 	curve      Curve
 	privateKey []byte
-	boring     *boring.PrivateKeyECDH
 	// publicKey is set under publicKeyOnce, to allow loading private keys with
 	// NewPrivateKey without having to perform a scalar multiplication.
 	publicKey     *PublicKey
@@ -160,7 +162,7 @@ func (k *PrivateKey) Curve() Curve {
 
 func (k *PrivateKey) PublicKey() *PublicKey {
 	k.publicKeyOnce.Do(func() {
-		if k.boring != nil {
+		if boring.Enabled && k.boring.Valid() {
 			// Because we already checked in NewPrivateKey that the key is valid,
 			// there should not be any possible errors from BoringCrypto,
 			// so we turn the error into a panic.

--- a/src/crypto/ecdh/nist.go
+++ b/src/crypto/ecdh/nist.go
@@ -93,7 +93,7 @@ func (c *nistCurve[Point]) NewPrivateKey(key []byte) (*PrivateKey, error) {
 	return k, nil
 }
 
-func newBoringPrivateKey(c Curve, bk *boring.PrivateKeyECDH, privateKey []byte) (*PrivateKey, error) {
+func newBoringPrivateKey(c Curve, bk boring.PrivateKeyECDH, privateKey []byte) (*PrivateKey, error) {
 	k := &PrivateKey{
 		curve:      c,
 		boring:     bk,

--- a/src/crypto/internal/boring/notboring.go
+++ b/src/crypto/internal/boring/notboring.go
@@ -115,9 +115,10 @@ func VerifyRSAPSS(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte, saltLen 
 type PublicKeyECDH struct{}
 type PrivateKeyECDH struct{}
 
-func ECDH(*PrivateKeyECDH, *PublicKeyECDH) ([]byte, error)      { panic("boringcrypto: not available") }
-func GenerateKeyECDH(string) (*PrivateKeyECDH, []byte, error)   { panic("boringcrypto: not available") }
-func NewPrivateKeyECDH(string, []byte) (*PrivateKeyECDH, error) { panic("boringcrypto: not available") }
-func NewPublicKeyECDH(string, []byte) (*PublicKeyECDH, error)   { panic("boringcrypto: not available") }
-func (*PublicKeyECDH) Bytes() []byte                            { panic("boringcrypto: not available") }
-func (*PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error)      { panic("boringcrypto: not available") }
+func ECDH(PrivateKeyECDH, PublicKeyECDH) ([]byte, error)       { panic("boringcrypto: not available") }
+func GenerateKeyECDH(string) (PrivateKeyECDH, []byte, error)   { panic("boringcrypto: not available") }
+func NewPrivateKeyECDH(string, []byte) (PrivateKeyECDH, error) { panic("boringcrypto: not available") }
+func NewPublicKeyECDH(string, []byte) (PublicKeyECDH, error)   { panic("boringcrypto: not available") }
+func (*PublicKeyECDH) Bytes() []byte                           { panic("boringcrypto: not available") }
+func (*PrivateKeyECDH) PublicKey() (PublicKeyECDH, error)      { panic("boringcrypto: not available") }
+func (*PrivateKeyECDH) Valid() bool                            { panic("boringcrypto: not available") }


### PR DESCRIPTION
This change makes the PublicKey and PrivateKey structs 8 bytes smaller,
by removing a pointer field from non-boringcrypto builds.