### PR TITLE
runtime: disable epipe check for wasm platform

### DIFF
--- a/src/runtime/os_wasm.go
+++ b/src/runtime/os_wasm.go
@@ -109,10 +109,10 @@ func newosproc(mp *m) {
 	throw("newosproc: not implemented")
 }
 
+// Do nothing on WASM platform, always return EPIPE to caller.
+//
 //go:linkname os_sigpipe os.sigpipe
-func os_sigpipe() {
-	throw("too many writes on closed pipe")
-}
+func os_sigpipe() {}
 
 //go:linkname syscall_now syscall.now
 func syscall_now() (sec int64, nsec int32) {


### PR DESCRIPTION
Pipe operation seems impossible for wasm build

Fixes #59099 
