### PR TITLE
net/http: use sync.OnceFunc, sync.OnceValue

### DIFF
--- a/src/net/http/client.go
+++ b/src/net/http/client.go
@@ -388,15 +388,12 @@ func setRequestCancel(req *Request, rt RoundTripper, deadline time.Time) (stopTi
 	}
 
 	stopTimerCh := make(chan struct{})
-	var once sync.Once
-	stopTimer = func() {
-		once.Do(func() {
-			close(stopTimerCh)
-			if cancelCtx != nil {
-				cancelCtx()
-			}
-		})
-	}
+	stopTimer = sync.OnceFunc(func() {
+		close(stopTimerCh)
+		if cancelCtx != nil {
+			cancelCtx()
+		}
+	})
 
 	timer := time.NewTimer(time.Until(deadline))
 	var timedOut atomic.Bool


### PR DESCRIPTION
Use sync.OnceFunc and sync.OnceValue to simplify the code.