### PR TITLE
errors: reference Go 1.13 article about errors

### DIFF
--- a/src/errors/errors.go
+++ b/src/errors/errors.go
@@ -26,6 +26,9 @@
 // itself followed by the tree of each of its children in turn
 // (pre-order, depth-first traversal).
 //
+// See https://go.dev/blog/go1.13-errors for a deeper discussion of the
+// philosophy of wrapping and when to wrap.
+//
 // [Is] examines the tree of its first argument looking for an error that
 // matches the second. It reports whether it finds a match. It should be
 // used in preference to simple equality checks:


### PR DESCRIPTION
This commit amends package errors' documentation to include a reference
to the https://go.dev/blog/go1.13-errors blog article. The motivation
is multi-fold, but chiefly the article includes good information about
error philosophy (e.g., when to wrap), and developers who have come to
Go in the intervening five years are likely not have seen this article
at all given the nature of blog publishing and post fanfare. The
material deserves a promotion in visibility.