### PR TITLE
net,os: use os.LookupEnv instead of syscall.Getenv

### DIFF
--- a/src/net/conf.go
+++ b/src/net/conf.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"runtime"
 	"sync"
-	"syscall"
 )
 
 // The net package's name resolution is rather complicated.
@@ -138,7 +137,7 @@ func initConfVal() {
 	// prefer the cgo resolver.
 	// Note that LOCALDOMAIN can change behavior merely by being
 	// specified with the empty string.
-	_, localDomainDefined := syscall.Getenv("LOCALDOMAIN")
+	_, localDomainDefined := os.LookupEnv("LOCALDOMAIN")
 	if localDomainDefined || os.Getenv("RES_OPTIONS") != "" || os.Getenv("HOSTALIASES") != "" {
 		confVal.preferCgo = true
 		return

--- a/src/os/exec/lp_windows.go
+++ b/src/os/exec/lp_windows.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 )
 
 // ErrNotFound is the error resulting if a path search failed to find an executable file.
@@ -154,7 +153,7 @@ func lookPath(file string, exts []string) (string, error) {
 		dotf   string
 		dotErr error
 	)
-	if _, found := syscall.Getenv("NoDefaultCurrentDirectoryInExePath"); !found {
+	if _, found := os.LookupEnv("NoDefaultCurrentDirectoryInExePath"); !found {
 		if f, err := findExecutable(filepath.Join(".", file), exts); err == nil {
 			if execerrdot.Value() == "0" {
 				execerrdot.IncNonDefault()


### PR DESCRIPTION
The os package already has a function for retrieving an environment
variable with a ok boolean, we don't need to use syscall directly.