### PR TITLE
internal/testlog: use atomic.Pointer instead of atomic.Value

### DIFF
--- a/src/internal/testlog/log.go
+++ b/src/internal/testlog/log.go
@@ -21,7 +21,7 @@ type Interface interface {
 }
 
 // logger is the current logger Interface.
-// We use an atomic.Value in case test startup
+// We use an atomic.Pointer in case test startup
 // is racing with goroutines started during init.
 // That must not cause a race detector failure,
 // although it will still result in limited visibility


### PR DESCRIPTION
We know the type (*Interface), so we can use the generic atomic.Pointer.
This change also makes sure that concurrent use of SetLogger also 
causes a panic, currently it races (Load, then Store).
