### PR TITLE
runtime, internal/syscall/unix: mark getrandom vDSO as non-escaping

### DIFF
--- a/src/internal/syscall/unix/getrandom.go
+++ b/src/internal/syscall/unix/getrandom.go
@@ -13,6 +13,7 @@ import (
 )
 
 //go:linkname vgetrandom runtime.vgetrandom
+//go:noescape
 func vgetrandom(p []byte, flags uint32) (ret int, supported bool)
 
 var getrandomUnsupported atomic.Bool

--- a/src/runtime/vgetrandom_linux.go
+++ b/src/runtime/vgetrandom_linux.go
@@ -11,6 +11,7 @@ import (
 	"unsafe"
 )
 
+//go:noescape
 func vgetrandom1(buf *byte, length uintptr, flags uint32, state uintptr, stateSize uintptr) int
 
 var vgetrandomAlloc struct {


### PR DESCRIPTION
Updates #66779
Updates #69577