### PR TITLE
go/ast/internal/tests: add missing copyright header

### DIFF
--- a/src/go/ast/internal/tests/sortimports_test.go
+++ b/src/go/ast/internal/tests/sortimports_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // Tests is a helper package to avoid cyclic dependency between go/ast and go/parser.
 package tests
 


### PR DESCRIPTION
I have forgotten to add it in CL 616340