### PR TITLE
Bug: Unable to Find ZIP Signature in Large ZIP Files

### DIFF
--- a/src/archive/zip/reader.go
+++ b/src/archive/zip/reader.go
@@ -565,10 +565,10 @@ func readDataDescriptor(r io.Reader, f *File) error {
 }
 
 func readDirectoryEnd(r io.ReaderAt, size int64) (dir *directoryEnd, baseOffset int64, err error) {
-	// look for directoryEndSignature in the last 1k, then in the last 65k
+	// look for directoryEndSignature in the last 1k, then in the last 65k, then in the last 5M
 	var buf []byte
 	var directoryEndOffset int64
-	for i, bLen := range []int64{1024, 65 * 1024} {
+	for i, bLen := range []int64{1024, 65 * 1024,5*1024*1024} {
 		if bLen > size {
 			bLen = size
 		}
@@ -581,7 +581,7 @@ func readDirectoryEnd(r io.ReaderAt, size int64) (dir *directoryEnd, baseOffset 
 			directoryEndOffset = size - bLen + int64(p)
 			break
 		}
-		if i == 1 || bLen == size {
+		if i == 2 || bLen == size {
 			return nil, 0, ErrFormat
 		}
 	}


### PR DESCRIPTION
I am encountering an issue when attempting to read large ZIP files using the Go archive/zip package. The current implementation of the readDirectoryEnd function only searches for the ZIP directory end signature (0x050605) in the last 1KB and 65KB of the file. This approach does not account for cases where the ZIP file might have a larger directory section, especially in ZIP64 files.

Steps to Reproduce:

Create a large ZIP file (greater than 65KB) that contains several entries.
Attempt to read the ZIP file using the archive/zip package.
Observe that the signature for the ZIP directory end cannot be found, resulting in an error indicating that it is not a valid ZIP file.
Expected Behavior:

The readDirectoryEnd function should effectively search for the ZIP directory end signature across a larger range of the file, especially for ZIP64 files, which can have directory entries that exceed the current search limits.

Proposed Solution:

I suggest modifying the readDirectoryEnd function to increase the search range for the directory end signature. For example, consider searching within the last 5M of the file or implementing a more comprehensive search strategy that can handle ZIP64 files more effectively.
Thank you for your attention to this matter. I hope this issue can be addressed in a future release.

