### PR TITLE
cmd: use omitzero option for time.Time

### DIFF
--- a/src/cmd/go/internal/modinfo/info.go
+++ b/src/cmd/go/internal/modinfo/info.go
@@ -19,7 +19,7 @@ type ModulePublic struct {
 	Query      string           `json:",omitempty"` // version query corresponding to this version
 	Versions   []string         `json:",omitempty"` // available module versions
 	Replace    *ModulePublic    `json:",omitempty"` // replaced by this module
-	Time       *time.Time       `json:",omitempty"` // time version was created
+	Time       time.Time        `json:",omitzero"`  // time version was created
 	Update     *ModulePublic    `json:",omitempty"` // available update (with -u)
 	Main       bool             `json:",omitempty"` // is this the main module?
 	Indirect   bool             `json:",omitempty"` // module is only indirectly needed by main module

--- a/src/cmd/go/internal/modload/build.go
+++ b/src/cmd/go/internal/modload/build.go
@@ -156,7 +156,7 @@ func addUpdate(ctx context.Context, m *modinfo.ModulePublic) {
 		m.Update = &modinfo.ModulePublic{
 			Path:    m.Path,
 			Version: info.Version,
-			Time:    &info.Time,
+			Time:    info.Time,
 		}
 	}
 }
@@ -344,7 +344,7 @@ func moduleInfo(ctx context.Context, rs *Requirements, m module.Version, mode Li
 				m.Error = &modinfo.ModuleError{Err: err.Error()}
 			} else {
 				m.Version = q.Version
-				m.Time = &q.Time
+				m.Time = q.Time
 			}
 		}
 

--- a/src/cmd/go/internal/modload/query.go
+++ b/src/cmd/go/internal/modload/query.go
@@ -234,8 +234,8 @@ func queryProxy(ctx context.Context, proxy, path, query, current string, allowed
 				Version: old.Version,
 				Origin:  old.Origin,
 			}
-			if old.Time != nil {
-				info.Time = *old.Time
+			if !old.Time.IsZero() {
+				info.Time = old.Time
 			}
 			return info, nil
 		}

--- a/src/cmd/go/internal/work/action.go
+++ b/src/cmd/go/internal/work/action.go
@@ -175,9 +175,9 @@ type actionJSON struct {
 	NeedBuild  bool      `json:",omitempty"`
 	ActionID   string    `json:",omitempty"`
 	BuildID    string    `json:",omitempty"`
-	TimeReady  time.Time `json:",omitempty"`
-	TimeStart  time.Time `json:",omitempty"`
-	TimeDone   time.Time `json:",omitempty"`
+	TimeReady  time.Time `json:",omitzero"`
+	TimeStart  time.Time `json:",omitzero"`
+	TimeDone   time.Time `json:",omitzero"`
 
 	Cmd     []string      // `json:",omitempty"`
 	CmdReal time.Duration `json:",omitempty"`

--- a/src/cmd/internal/test2json/test2json.go
+++ b/src/cmd/internal/test2json/test2json.go
@@ -29,7 +29,7 @@ const (
 
 // event is the JSON struct we emit.
 type event struct {
-	Time        *time.Time `json:",omitempty"`
+	Time        time.Time `json:",omitzero"`
 	Action      string
 	Package     string     `json:",omitempty"`
 	Test        string     `json:",omitempty"`
@@ -402,8 +402,7 @@ func (c *Converter) writeOutputEvent(out []byte) {
 func (c *Converter) writeEvent(e *event) {
 	e.Package = c.pkg
 	if c.mode&Timestamp != 0 {
-		t := time.Now()
-		e.Time = &t
+		e.Time = time.Now()
 	}
 	if e.Test == "" {
 		e.Test = c.testName


### PR DESCRIPTION
The doc of time.Time says:
Programs using times should typically store and pass them as values,
not pointers. That is, time variables and struct fields should be of type
time.Time, not *time.Time.

Since CL 615676 added omitzero option to encoding/json package, we can
just replace (*time.Time + omitempty) with (time.Time + omitzero).

For #45669.