### PR TITLE
syscall: skip TestSetuidEtc when root's gid is not 0

### DIFF
--- a/src/syscall/syscall_linux_test.go
+++ b/src/syscall/syscall_linux_test.go
@@ -499,6 +499,9 @@ func TestSetuidEtc(t *testing.T) {
 	if syscall.Getuid() != 0 {
 		t.Skip("skipping root only test")
 	}
+	if syscall.Getgid() != 0 {
+		t.Skip("skipping the test when root's gid is not default value 0")
+	}
 	if testing.Short() && testenv.Builder() != "" && os.Getenv("USER") == "swarming" {
 		// The Go build system's swarming user is known not to be root.
 		// Unfortunately, it sometimes appears as root due the current


### PR DESCRIPTION
When the root user belongs to a special user group
(for example, in a mock environment), TestSetuidEtc will fail.

For example: Setegid(1)
want:"Gid: 0 1 0 1"
got:"Gid: 1001 1 1001 1" 

Fixes #69921
