### PR TITLE
runtime/testdata: fix for C23 nullptr keyword

### DIFF
--- a/src/runtime/testdata/testprogcgo/threadprof.go
+++ b/src/runtime/testdata/testprogcgo/threadprof.go
@@ -36,10 +36,10 @@ __attribute__((constructor)) void issue9456() {
 	}
 }
 
-void **nullptr;
+void **nullpointer;
 
 void *crash(void *p) {
-	*nullptr = p;
+	*nullpointer = p;
 	return 0;
 }
 


### PR DESCRIPTION
src/runtime/testdata/testprogcgo/threadprof.go contains C code with a
variable called nullptr.  This conflicts with the nullptr keyword in
the C23 revision of the C standard (showing up as gccgo test build
failures when updating GCC to use C23 by default when building C
code).

Rename that variable to nullpointer to avoid the clash with the
keyword (any other name that's not a keyword would work just as well).
