### PR TITLE
runtime: add the checkPtraceScope to skip certain tests

### DIFF
--- a/src/runtime/runtime-gdb_test.go
+++ b/src/runtime/runtime-gdb_test.go
@@ -112,6 +112,44 @@ func checkCleanBacktrace(t *testing.T, backtrace string) {
 	// TODO(mundaym): check for unknown frames (e.g. "??").
 }
 
+// checkPtraceScope checks the value of the kernel parameter ptrace_scope,
+// skips the test when gdb cannot attach to the target process via ptrace.
+// See issue 69932
+//
+// 0 - Default attach security permissions.
+// 1 - Restricted attach. Only child processes plus normal permissions.
+// 2 - Admin-only attach. Only executables with CAP_SYS_PTRACE.
+// 3 - No attach. No process may call ptrace at all. Irrevocable.
+func checkPtraceScope(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		return
+	}
+
+	// If the Linux kernel does not have the YAMA module enabled,
+	// there will be no ptrace_scope file, which does not affect the tests.
+	path := "/proc/sys/kernel/yama/ptrace_scope"
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	value, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatalf("failed converting value to int: %v", err)
+	}
+	switch value {
+	case 3:
+		t.Skip("skipping ptrace: Operation not permitted")
+	case 2:
+		if os.Geteuid() != 0 {
+			t.Skip("skipping ptrace: Operation not permitted with non-root user")
+		}
+	}
+}
+
 // NOTE: the maps below are allocated larger than abi.MapBucketCount
 // to ensure that they are not "optimized out".
 
@@ -197,6 +235,7 @@ func testGdbPython(t *testing.T, cgo bool) {
 	t.Parallel()
 	checkGdbVersion(t)
 	checkGdbPython(t)
+	checkPtraceScope(t)
 
 	dir := t.TempDir()
 
@@ -420,6 +459,7 @@ func TestGdbBacktrace(t *testing.T) {
 	checkGdbEnvironment(t)
 	t.Parallel()
 	checkGdbVersion(t)
+	checkPtraceScope(t)
 
 	dir := t.TempDir()
 
@@ -538,6 +578,7 @@ func TestGdbAutotmpTypes(t *testing.T) {
 	checkGdbEnvironment(t)
 	t.Parallel()
 	checkGdbVersion(t)
+	checkPtraceScope(t)
 
 	if runtime.GOOS == "aix" && testing.Short() {
 		t.Skip("TestGdbAutotmpTypes is too slow on aix/ppc64")
@@ -612,6 +653,7 @@ func TestGdbConst(t *testing.T) {
 	checkGdbEnvironment(t)
 	t.Parallel()
 	checkGdbVersion(t)
+	checkPtraceScope(t)
 
 	dir := t.TempDir()
 
@@ -676,6 +718,7 @@ func TestGdbPanic(t *testing.T) {
 	checkGdbEnvironment(t)
 	t.Parallel()
 	checkGdbVersion(t)
+	checkPtraceScope(t)
 
 	if runtime.GOOS == "windows" {
 		t.Skip("no signals on windows")
@@ -755,6 +798,7 @@ func TestGdbInfCallstack(t *testing.T) {
 
 	t.Parallel()
 	checkGdbVersion(t)
+	checkPtraceScope(t)
 
 	dir := t.TempDir()
 


### PR DESCRIPTION
When the kernel parameter ptrace_scope is set to 2 or 3,
certain test cases in runtime-gdb_test.go will fail.
We should skip these tests.

Fixes #69932