### PR TITLE
database/sql: rewrite Null[T].Value method, update doc for Null[T]

### DIFF
--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -433,7 +433,7 @@ func (n Null[T]) Value() (driver.Value, error) {
 	v := any(n.V)
 	// See issue 69728.
 	if valuer, ok := v.(driver.Valuer); ok {
-		val, err := valuer.Value()
+		val, err := callValuerValue(valuer)
 		if err != nil {
 			return val, err
 		}

--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -435,7 +435,7 @@ func (n Null[T]) Value() (driver.Value, error) {
 	if valuer, ok := v.(driver.Valuer); ok {
 		val, err := valuer.Value()
 		if err != nil {
-			return nil, err
+			return val, err
 		}
 		v = val
 	}

--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -410,6 +410,8 @@ func (n NullTime) Value() (driver.Value, error) {
 //	} else {
 //	   // NULL value
 //	}
+//
+// T should be one of the types accepted by [driver.Value].
 type Null[T any] struct {
 	V     T
 	Valid bool
@@ -428,7 +430,17 @@ func (n Null[T]) Value() (driver.Value, error) {
 	if !n.Valid {
 		return nil, nil
 	}
-	return n.V, nil
+	v := any(n.V)
+	// See issue 69728.
+	if valuer, ok := v.(driver.Valuer); ok {
+		val, err := valuer.Value()
+		if err != nil {
+			return nil, err
+		}
+		v = val
+	}
+	// See issue 69837.
+	return driver.DefaultParameterConverter.ConvertValue(v)
 }
 
 // Scanner is an interface used by [Rows.Scan].


### PR DESCRIPTION
Update doc for Null[T] to clarify that T should be one of the types
accepted by driver.Value.

Modify the Value() method of Null[T]:
1) recognize T implementing driver.Valuer interface and invoke it.
2) use the DefaultParameterConverter to convert native types that
are not directly supported as driver.Value types.

Fixes #69728
Fixes #69837