### PR TITLE
net/http: initialize Value with File length in cloneMultipartForm

### DIFF
--- a/src/net/http/clone.go
+++ b/src/net/http/clone.go
@@ -68,7 +68,7 @@ func cloneMultipartForm(f *multipart.Form) *multipart.Form {
 		Value: (map[string][]string)(Header(f.Value).Clone()),
 	}
 	if f.File != nil {
-		m := make(map[string][]*multipart.FileHeader)
+		m := make(map[string][]*multipart.FileHeader, len(f.File))
 		for k, vv := range f.File {
 			vv2 := make([]*multipart.FileHeader, len(vv))
 			for i, v := range vv {


### PR DESCRIPTION
Improve the initialization of the Value map in cloneMultipartForm by
utilizing the length of the File map to optimize memory allocation.