### PR TITLE
all: remove use of reflect.DeepEqual for testing errors

### DIFF
--- a/src/cmd/dist/buildtag_test.go
+++ b/src/cmd/dist/buildtag_test.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 )
 
@@ -36,8 +35,18 @@ var buildParserTests = []struct {
 func TestBuildParser(t *testing.T) {
 	for _, tt := range buildParserTests {
 		matched, err := matchexpr(tt.x)
-		if matched != tt.matched || !reflect.DeepEqual(err, tt.err) {
+		if matched != tt.matched || !equalError(err, tt.err) {
 			t.Errorf("matchexpr(%q) = %v, %v; want %v, %v", tt.x, matched, err, tt.matched, tt.err)
 		}
 	}
+}
+
+func equalError(a, b error) bool {
+	if a == nil {
+		return b == nil
+	}
+	if b == nil {
+		return a == nil
+	}
+	return a.Error() == b.Error()
 }

--- a/src/encoding/csv/reader_test.go
+++ b/src/encoding/csv/reader_test.go
@@ -404,6 +404,16 @@ field"`,
 	Errors:  []error{errInvalidDelim},
 }}
 
+func equalError(a, b error) bool {
+	if a == nil {
+		return b == nil
+	}
+	if b == nil {
+		return a == nil
+	}
+	return a.Error() == b.Error()
+}
+
 func TestRead(t *testing.T) {
 	newReader := func(tt readTest) (*Reader, [][][2]int, map[int][2]int, string) {
 		positions, errPositions, input := makePositions(tt.Input)
@@ -429,7 +439,7 @@ func TestRead(t *testing.T) {
 			r, positions, errPositions, input := newReader(tt)
 			out, err := r.ReadAll()
 			if wantErr := firstError(tt.Errors, positions, errPositions); wantErr != nil {
-				if !reflect.DeepEqual(err, wantErr) {
+				if !equalError(err, wantErr) {
 					t.Fatalf("ReadAll() error mismatch:\ngot  %v (%#v)\nwant %v (%#v)", err, err, wantErr, wantErr)
 				}
 				if out != nil {
@@ -461,7 +471,7 @@ func TestRead(t *testing.T) {
 				} else if recNum >= len(tt.Output) {
 					wantErr = io.EOF
 				}
-				if !reflect.DeepEqual(err, wantErr) {
+				if !equalError(err, wantErr) {
 					t.Fatalf("Read() error at record %d:\ngot %v (%#v)\nwant %v (%#v)", recNum, err, err, wantErr, wantErr)
 				}
 				// ErrFieldCount is explicitly non-fatal.

--- a/src/encoding/json/decode_test.go
+++ b/src/encoding/json/decode_test.go
@@ -2470,7 +2470,7 @@ func TestUnmarshalErrorAfterMultipleJSON(t *testing.T) {
 				var v any
 				err = dec.Decode(&v)
 			}
-			if !reflect.DeepEqual(err, tt.err) {
+			if !equalError(err, tt.err) {
 				t.Errorf("%s: Decode error:\n\tgot:  %v\n\twant: %v", tt.Where, err, tt.err)
 			}
 		})

--- a/src/encoding/json/scanner_test.go
+++ b/src/encoding/json/scanner_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"math"
 	"math/rand"
-	"reflect"
 	"strings"
 	"testing"
 )
@@ -198,7 +197,7 @@ func TestIndentErrors(t *testing.T) {
 			slice := make([]uint8, 0)
 			buf := bytes.NewBuffer(slice)
 			if err := Indent(buf, []uint8(tt.in), "", ""); err != nil {
-				if !reflect.DeepEqual(err, tt.err) {
+				if !equalError(err, tt.err) {
 					t.Fatalf("%s: Indent error:\n\tgot:  %v\n\twant: %v", tt.Where, err, tt.err)
 				}
 			}

--- a/src/encoding/json/stream_test.go
+++ b/src/encoding/json/stream_test.go
@@ -472,7 +472,7 @@ func TestDecodeInStream(t *testing.T) {
 					got, err = dec.Token()
 				}
 				if errWant, ok := want.(error); ok {
-					if err == nil || !reflect.DeepEqual(err, errWant) {
+					if err == nil || !equalError(err, errWant) {
 						t.Fatalf("%s:\n\tinput: %s\n\tgot error:  %v\n\twant error: %v", tt.Where, tt.json, err, errWant)
 					}
 					break

--- a/src/encoding/xml/read_test.go
+++ b/src/encoding/xml/read_test.go
@@ -324,7 +324,8 @@ type BadPathEmbeddedB struct {
 }
 
 var badPathTests = []struct {
-	v, e any
+	v any
+	e error
 }{
 	{&BadPathTestA{}, &TagPathError{reflect.TypeFor[BadPathTestA](), "First", "items>item1", "Second", "items"}},
 	{&BadPathTestB{}, &TagPathError{reflect.TypeFor[BadPathTestB](), "First", "items>item1", "Second", "items>item1>value"}},
@@ -332,10 +333,20 @@ var badPathTests = []struct {
 	{&BadPathTestD{}, &TagPathError{reflect.TypeFor[BadPathTestD](), "First", "", "Second", "First"}},
 }
 
+func equalError(a, b error) bool {
+	if a == nil {
+		return b == nil
+	}
+	if b == nil {
+		return a == nil
+	}
+	return a.Error() == b.Error()
+}
+
 func TestUnmarshalBadPaths(t *testing.T) {
 	for _, tt := range badPathTests {
 		err := Unmarshal([]byte(pathTestString), tt.v)
-		if !reflect.DeepEqual(err, tt.e) {
+		if !equalError(err, tt.e) {
 			t.Fatalf("Unmarshal with %#v didn't fail properly:\nhave %#v,\nwant %#v", tt.v, err, tt.e)
 		}
 	}

--- a/src/go/build/constraint/expr_test.go
+++ b/src/go/build/constraint/expr_test.go
@@ -7,7 +7,6 @@ package constraint
 import (
 	"fmt"
 	"maps"
-	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -160,11 +159,21 @@ func TestParseError(t *testing.T) {
 			if err == nil {
 				t.Fatalf("parseExpr(%q) = %v, want error", tt.in, x)
 			}
-			if !reflect.DeepEqual(err, tt.err) {
+			if !equalError(err, tt.err) {
 				t.Fatalf("parseExpr(%q): wrong error:\nhave %#v\nwant %#v", tt.in, err, tt.err)
 			}
 		})
 	}
+}
+
+func equalError(a, b error) bool {
+	if a == nil {
+		return b == nil
+	}
+	if b == nil {
+		return a == nil
+	}
+	return a.Error() == b.Error()
 }
 
 var exprEvalTests = []struct {

--- a/src/net/dnsclient_unix_test.go
+++ b/src/net/dnsclient_unix_test.go
@@ -1420,7 +1420,7 @@ func TestStrictErrorsLookupIP(t *testing.T) {
 			} else {
 				wantErr = tt.wantLaxErr
 			}
-			if !reflect.DeepEqual(err, wantErr) {
+			if !equalError(err, wantErr) {
 				t.Errorf("#%d (%s) strict=%v: got err %#v; want %#v", i, tt.desc, strict, err, wantErr)
 			}
 
@@ -1439,6 +1439,16 @@ func TestStrictErrorsLookupIP(t *testing.T) {
 			}
 		}
 	}
+}
+
+func equalError(a, b error) bool {
+	if a == nil {
+		return b == nil
+	}
+	if b == nil {
+		return a == nil
+	}
+	return a.Error() == b.Error()
 }
 
 // Issue 17448. With StrictErrors enabled, temporary errors should make
@@ -1495,7 +1505,7 @@ func TestStrictErrorsLookupTXT(t *testing.T) {
 		} else {
 			wantRRs = 1
 		}
-		if !reflect.DeepEqual(err, wantErr) {
+		if !equalError(err, wantErr) {
 			t.Errorf("strict=%v: got err %#v; want %#v", strict, err, wantErr)
 		}
 		a, err := p.AllAnswers()

--- a/src/net/http/request_test.go
+++ b/src/net/http/request_test.go
@@ -888,6 +888,16 @@ func TestIssue10884_MaxBytesEOF(t *testing.T) {
 	}
 }
 
+func equalError(a, b error) bool {
+	if a == nil {
+		return b == nil
+	}
+	if b == nil {
+		return a == nil
+	}
+	return a.Error() == b.Error()
+}
+
 // Issue 14981: MaxBytesReader's return error wasn't sticky. It
 // doesn't technically need to be, but people expected it to be.
 func TestMaxBytesReaderStickyError(t *testing.T) {
@@ -905,7 +915,7 @@ func TestMaxBytesReaderStickyError(t *testing.T) {
 				firstErr = err
 				continue
 			}
-			if !reflect.DeepEqual(err, firstErr) {
+			if !equalError(err, firstErr) {
 				return fmt.Errorf("non-sticky error. got log:\n%s", log.Bytes())
 			}
 			t.Logf("Got log: %s", log.Bytes())

--- a/src/net/http/transfer_test.go
+++ b/src/net/http/transfer_test.go
@@ -326,10 +326,20 @@ func TestParseTransferEncoding(t *testing.T) {
 			ProtoMinor: 1,
 		}
 		gotErr := tr.parseTransferEncoding()
-		if !reflect.DeepEqual(gotErr, tt.wantErr) {
+		if !equalError(gotErr, tt.wantErr) {
 			t.Errorf("%d.\ngot error:\n%v\nwant error:\n%v\n\n", i, gotErr, tt.wantErr)
 		}
 	}
+}
+
+func equalError(a, b error) bool {
+	if a == nil {
+		return b == nil
+	}
+	if b == nil {
+		return a == nil
+	}
+	return a.Error() == b.Error()
 }
 
 // issue 39017 - disallow Content-Length values such as "+3"
@@ -366,7 +376,7 @@ func TestParseContentLength(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if _, gotErr := parseContentLength([]string{tt.cl}); !reflect.DeepEqual(gotErr, tt.wantErr) {
+		if _, gotErr := parseContentLength([]string{tt.cl}); !equalError(gotErr, tt.wantErr) {
 			t.Errorf("%q:\n\tgot=%v\n\twant=%v", tt.cl, gotErr, tt.wantErr)
 		}
 	}

--- a/src/net/ip_test.go
+++ b/src/net/ip_test.go
@@ -272,11 +272,11 @@ func TestIPString(t *testing.T) {
 		if out := tt.in.String(); out != tt.str {
 			t.Errorf("IP.String(%v) = %q, want %q", tt.in, out, tt.str)
 		}
-		if out, err := tt.in.MarshalText(); !bytes.Equal(out, tt.byt) || !reflect.DeepEqual(err, tt.error) {
+		if out, err := tt.in.MarshalText(); !bytes.Equal(out, tt.byt) || !equalError(err, tt.error) {
 			t.Errorf("IP.MarshalText(%v) = %v, %v, want %v, %v", tt.in, out, err, tt.byt, tt.error)
 		}
 		buf := make([]byte, 4, 32)
-		if out, err := tt.in.AppendText(buf); !bytes.Equal(out[4:], tt.byt) || !reflect.DeepEqual(err, tt.error) {
+		if out, err := tt.in.AppendText(buf); !bytes.Equal(out[4:], tt.byt) || !equalError(err, tt.error) {
 			t.Errorf("IP.AppendText(%v) = %v, %v, want %v, %v", tt.in, out[4:], err, tt.byt, tt.error)
 		}
 	}
@@ -438,7 +438,7 @@ var parseCIDRTests = []struct {
 func TestParseCIDR(t *testing.T) {
 	for _, tt := range parseCIDRTests {
 		ip, net, err := ParseCIDR(tt.in)
-		if !reflect.DeepEqual(err, tt.err) {
+		if !equalError(err, tt.err) {
 			t.Errorf("ParseCIDR(%q) = %v, %v; want %v, %v", tt.in, ip, net, tt.ip, tt.net)
 		}
 		if err == nil && (!tt.ip.Equal(ip) || !tt.net.IP.Equal(net.IP) || !reflect.DeepEqual(net.Mask, tt.net.Mask)) {

--- a/src/net/iprawsock_test.go
+++ b/src/net/iprawsock_test.go
@@ -64,7 +64,7 @@ func TestResolveIPAddr(t *testing.T) {
 
 	for _, tt := range resolveIPAddrTests {
 		addr, err := ResolveIPAddr(tt.network, tt.litAddrOrName)
-		if !reflect.DeepEqual(addr, tt.addr) || !reflect.DeepEqual(err, tt.err) {
+		if !reflect.DeepEqual(addr, tt.addr) || !equalError(err, tt.err) {
 			t.Errorf("ResolveIPAddr(%q, %q) = %#v, %v, want %#v, %v", tt.network, tt.litAddrOrName, addr, err, tt.addr, tt.err)
 			continue
 		}

--- a/src/net/ipsock_test.go
+++ b/src/net/ipsock_test.go
@@ -221,7 +221,7 @@ func TestAddrList(t *testing.T) {
 
 	for i, tt := range addrListTests {
 		addrs, err := filterAddrList(tt.filter, tt.ips, tt.inetaddr, "ADDR")
-		if !reflect.DeepEqual(err, tt.err) {
+		if !equalError(err, tt.err) {
 			t.Errorf("#%v: got %v; want %v", i, err, tt.err)
 		}
 		if tt.err != nil {

--- a/src/net/tcpsock_test.go
+++ b/src/net/tcpsock_test.go
@@ -334,7 +334,7 @@ func TestResolveTCPAddr(t *testing.T) {
 
 	for _, tt := range resolveTCPAddrTests {
 		addr, err := ResolveTCPAddr(tt.network, tt.litAddrOrName)
-		if !reflect.DeepEqual(addr, tt.addr) || !reflect.DeepEqual(err, tt.err) {
+		if !reflect.DeepEqual(addr, tt.addr) || !equalError(err, tt.err) {
 			t.Errorf("ResolveTCPAddr(%q, %q) = %#v, %v, want %#v, %v", tt.network, tt.litAddrOrName, addr, err, tt.addr, tt.err)
 			continue
 		}

--- a/src/net/udpsock_test.go
+++ b/src/net/udpsock_test.go
@@ -96,7 +96,7 @@ func TestResolveUDPAddr(t *testing.T) {
 
 	for _, tt := range resolveUDPAddrTests {
 		addr, err := ResolveUDPAddr(tt.network, tt.litAddrOrName)
-		if !reflect.DeepEqual(addr, tt.addr) || !reflect.DeepEqual(err, tt.err) {
+		if !reflect.DeepEqual(addr, tt.addr) || !equalError(err, tt.err) {
 			t.Errorf("ResolveUDPAddr(%q, %q) = %#v, %v, want %#v, %v", tt.network, tt.litAddrOrName, addr, err, tt.addr, tt.err)
 			continue
 		}

--- a/src/strconv/atoc_test.go
+++ b/src/strconv/atoc_test.go
@@ -7,7 +7,6 @@ package strconv_test
 import (
 	"math"
 	"math/cmplx"
-	"reflect"
 	. "strconv"
 	"testing"
 )
@@ -192,7 +191,7 @@ func TestParseComplex(t *testing.T) {
 			test.err = &NumError{Func: "ParseComplex", Num: test.in, Err: test.err}
 		}
 		got, err := ParseComplex(test.in, 128)
-		if !reflect.DeepEqual(err, test.err) {
+		if !equalError(err, test.err) {
 			t.Fatalf("ParseComplex(%q, 128) = %v, %v; want %v, %v", test.in, got, err, test.out, test.err)
 		}
 		if !(cmplx.IsNaN(test.out) && cmplx.IsNaN(got)) && got != test.out {
@@ -201,7 +200,7 @@ func TestParseComplex(t *testing.T) {
 
 		if complex128(complex64(test.out)) == test.out {
 			got, err := ParseComplex(test.in, 64)
-			if !reflect.DeepEqual(err, test.err) {
+			if !equalError(err, test.err) {
 				t.Fatalf("ParseComplex(%q, 64) = %v, %v; want %v, %v", test.in, got, err, test.out, test.err)
 			}
 			got64 := complex64(got)

--- a/src/strconv/atof_test.go
+++ b/src/strconv/atof_test.go
@@ -7,7 +7,6 @@ package strconv_test
 import (
 	"math"
 	"math/rand"
-	"reflect"
 	. "strconv"
 	"strings"
 	"sync"
@@ -515,7 +514,7 @@ func testAtof(t *testing.T, opt bool) {
 		test := &atoftests[i]
 		out, err := ParseFloat(test.in, 64)
 		outs := FormatFloat(out, 'g', -1, 64)
-		if outs != test.out || !reflect.DeepEqual(err, test.err) {
+		if outs != test.out || !equalError(err, test.err) {
 			t.Errorf("ParseFloat(%v, 64) = %v, %v want %v, %v",
 				test.in, out, err, test.out, test.err)
 		}
@@ -528,7 +527,7 @@ func testAtof(t *testing.T, opt bool) {
 				continue
 			}
 			outs := FormatFloat(float64(out32), 'g', -1, 32)
-			if outs != test.out || !reflect.DeepEqual(err, test.err) {
+			if outs != test.out || !equalError(err, test.err) {
 				t.Errorf("ParseFloat(%v, 32) = %v, %v want %v, %v  # %v",
 					test.in, out32, err, test.out, test.err, out)
 			}
@@ -542,7 +541,7 @@ func testAtof(t *testing.T, opt bool) {
 			continue
 		}
 		outs := FormatFloat(float64(out32), 'g', -1, 32)
-		if outs != test.out || !reflect.DeepEqual(err, test.err) {
+		if outs != test.out || !equalError(err, test.err) {
 			t.Errorf("ParseFloat(%v, 32) = %v, %v want %v, %v  # %v",
 				test.in, out32, err, test.out, test.err, out)
 		}

--- a/src/strconv/atoi_test.go
+++ b/src/strconv/atoi_test.go
@@ -479,7 +479,7 @@ func TestAtoi(t *testing.T) {
 			if test.err != nil {
 				testErr = &NumError{"Atoi", test.in, test.err.(*NumError).Err}
 			}
-			if int(test.out) != out || !reflect.DeepEqual(testErr, err) {
+			if int(test.out) != out || !equalError(testErr, err) {
 				t.Errorf("Atoi(%q) = %v, %v want %v, %v",
 					test.in, out, err, test.out, testErr)
 			}
@@ -492,7 +492,7 @@ func TestAtoi(t *testing.T) {
 			if test.err != nil {
 				testErr = &NumError{"Atoi", test.in, test.err.(*NumError).Err}
 			}
-			if test.out != int64(out) || !reflect.DeepEqual(testErr, err) {
+			if test.out != int64(out) || !equalError(testErr, err) {
 				t.Errorf("Atoi(%q) = %v, %v want %v, %v",
 					test.in, out, err, test.out, testErr)
 			}


### PR DESCRIPTION
See the following link:
https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/deepequalerrors

This CL tries to avoid using reflect.DeepEqual with errors.

This is a follow-up to b9596aea50a0703f89c6f11c206cfd2c7dd189fa.
The original commit message:

"Comparing errors using DeepEqual breaks if frame information
is added as proposed in Issue #29934.

Updates #29934."