### PR TITLE
encoding/json: clarify omitempty option for {array,slice,map,string}

### DIFF
--- a/src/encoding/json/encode.go
+++ b/src/encoding/json/encode.go
@@ -72,8 +72,8 @@ import (
 //
 // The "omitempty" option specifies that the field should be omitted
 // from the encoding if the field has an empty value, defined as
-// false, 0, a nil pointer, a nil interface value, and any empty array,
-// slice, map, or string.
+// false, 0, a nil pointer, a nil interface value, and any array,
+// slice, map, or string of length zero.
 //
 // As a special case, if the field tag is "-", the field is always omitted.
 // Note that a field with name "-" can still be generated using the tag "-,".


### PR DESCRIPTION
This CL is inspired by:
https://github.com/golang/go/issues/29310#issuecomment-758768325

When I read omitempty option in encoding/xml package, I find it's
a bit different than encoding/json package.

I think it's more precise to say:
"any array, slice, map, or string of length zero."

Update #29310