### PR TITLE
internal/runtime/atomic: add arm native implementations of And8/Or8

### DIFF
--- a/src/internal/runtime/atomic/atomic_arm.go
+++ b/src/internal/runtime/atomic/atomic_arm.go
@@ -159,8 +159,11 @@ func goStore64(addr *uint64, v uint64) {
 	addrLock(addr).unlock()
 }
 
+//go:noescape
+func Or8(addr *uint8, v uint8)
+
 //go:nosplit
-func Or8(addr *uint8, v uint8) {
+func goOr8(addr *uint8, v uint8) {
 	// Align down to 4 bytes and use 32-bit CAS.
 	uaddr := uintptr(unsafe.Pointer(addr))
 	addr32 := (*uint32)(unsafe.Pointer(uaddr &^ 3))
@@ -173,8 +176,11 @@ func Or8(addr *uint8, v uint8) {
 	}
 }
 
+//go:noescape
+func And8(addr *uint8, v uint8)
+
 //go:nosplit
-func And8(addr *uint8, v uint8) {
+func goAnd8(addr *uint8, v uint8) {
 	// Align down to 4 bytes and use 32-bit CAS.
 	uaddr := uintptr(unsafe.Pointer(addr))
 	addr32 := (*uint32)(unsafe.Pointer(uaddr &^ 3))


### PR DESCRIPTION
With LDREXB/STREXB now available for the arm assembler we can implement these operations natively. The instructions are armv6k+ but for simplicity I only use them on armv7.

Benchmark results for a raspberry Pi 3 model B+:

	goos: linux
	goarch: arm
	pkg: internal/runtime/atomic
	cpu: ARMv7 Processor rev 4 (v7l)
			 │   old.txt    │               new.txt               │
			 │    sec/op    │   sec/op     vs base                │
	And8-4             127.65n ± 0%   68.74n ± 0%  -46.15% (p=0.000 n=10)

Cq-Include-Trybots: luci.golang.try:gotip-linux-arm