### PR TITLE
internal/runtime/atomic: fix uintptr usage in arm And8/Or8

### DIFF
--- a/src/internal/runtime/atomic/atomic_arm.go
+++ b/src/internal/runtime/atomic/atomic_arm.go
@@ -186,9 +186,8 @@ func Or8(addr *uint8, v uint8)
 //go:nosplit
 func goOr8(addr *uint8, v uint8) {
 	// Align down to 4 bytes and use 32-bit CAS.
-	uaddr := uintptr(unsafe.Pointer(addr))
-	addr32 := (*uint32)(unsafe.Pointer(uaddr &^ 3))
-	word := uint32(v) << ((uaddr & 3) * 8) // little endian
+	addr32 := (*uint32)(unsafe.Pointer(uintptr(unsafe.Pointer(addr)) &^ 3))
+	word := uint32(v) << ((uintptr(unsafe.Pointer(addr)) & 3) * 8) // little endian
 	for {
 		old := *addr32
 		if Cas(addr32, old, old|word) {
@@ -203,10 +202,9 @@ func And8(addr *uint8, v uint8)
 //go:nosplit
 func goAnd8(addr *uint8, v uint8) {
 	// Align down to 4 bytes and use 32-bit CAS.
-	uaddr := uintptr(unsafe.Pointer(addr))
-	addr32 := (*uint32)(unsafe.Pointer(uaddr &^ 3))
-	word := uint32(v) << ((uaddr & 3) * 8)    // little endian
-	mask := uint32(0xFF) << ((uaddr & 3) * 8) // little endian
+	addr32 := (*uint32)(unsafe.Pointer(uintptr(unsafe.Pointer(addr)) &^ 3))
+	word := uint32(v) << ((uintptr(unsafe.Pointer(addr)) & 3) * 8)    // little endian
+	mask := uint32(0xFF) << ((uintptr(unsafe.Pointer(addr)) & 3) * 8) // little endian
 	word |= ^mask
 	for {
 		old := *addr32


### PR DESCRIPTION
In CL 622075, I introduced code that violated unsafe.Pointer rules
by casting to uintptr and back across statements. This change corrects it.

Cq-Include-Trybots: luci.golang.try:gotip-linux-arm