### PR TITLE
net/internal/cgotest: don't try to use cgo with netgo build tag

### DIFF
--- a/src/net/internal/cgotest/resstate.go
+++ b/src/net/internal/cgotest/resstate.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build cgo && darwin
+//go:build !netgo && cgo && darwin
 
 package cgotest
 


### PR DESCRIPTION
When using bazel with hermetic_cc_toolchain resolv.h is not available.