### PR TITLE
mime: add mimetype for .jxl files

### DIFF
--- a/src/mime/type.go
+++ b/src/mime/type.go
@@ -60,6 +60,7 @@ var builtinTypesLower = map[string]string{
 	".jpg":  "image/jpeg",
 	".js":   "text/javascript; charset=utf-8",
 	".json": "application/json",
+	".jxl":  "image/jxl",
 	".mjs":  "text/javascript; charset=utf-8",
 	".pdf":  "application/pdf",
 	".png":  "image/png",


### PR DESCRIPTION
Serve .jxl files with image/jxl mimetype
Fixes #70165
