### PR TITLE
debug/dwarf: improve error when debugging information is absent

### DIFF
--- a/src/debug/dwarf/open.go
+++ b/src/debug/dwarf/open.go
@@ -79,7 +79,7 @@ func New(abbrev, aranges, frame, info, line, pubnames, ranges, str []byte) (*Dat
 	// 32-bit DWARF: 4 byte length, 2 byte version.
 	// 64-bit DWARf: 4 bytes of 0xff, 8 byte length, 2 byte version.
 	if len(d.info) < 6 {
-		return nil, DecodeError{"info", Offset(len(d.info)), "too short"}
+		return nil, DecodeError{"info", Offset(len(d.info)), "too short. make sure you compiled with debugging information."}
 	}
 	offset := 4
 	if d.info[0] == 0xff && d.info[1] == 0xff && d.info[2] == 0xff && d.info[3] == 0xff {

--- a/src/debug/dwarf/open.go
+++ b/src/debug/dwarf/open.go
@@ -79,7 +79,7 @@ func New(abbrev, aranges, frame, info, line, pubnames, ranges, str []byte) (*Dat
 	// 32-bit DWARF: 4 byte length, 2 byte version.
 	// 64-bit DWARf: 4 bytes of 0xff, 8 byte length, 2 byte version.
 	if len(d.info) < 6 {
-		return nil, DecodeError{"info", Offset(len(d.info)), "too short. make sure you compiled with debugging information."}
+		return nil, DecodeError{"info", Offset(len(d.info)), "no debugging information found."}
 	}
 	offset := 4
 	if d.info[0] == 0xff && d.info[1] == 0xff && d.info[2] == 0xff && d.info[3] == 0xff {


### PR DESCRIPTION
While debugging an application using Delve I got the cryptic error: 

    *decoding dwarf section info at offset 0x0: too short.*

After spending some time debugging the debugger I found out that the 
application was built without debugging information, generating this error 
message. This PR will improve the error message to help people quickly find 
the root cause.