### PR TITLE
net/http/cookiejar: implement concurrent-safe Clear method

### DIFF
--- a/src/net/http/cookiejar/jar.go
+++ b/src/net/http/cookiejar/jar.go
@@ -544,3 +544,13 @@ func (j *Jar) domainAndType(host, domain string) (string, bool, error) {
 
 	return domain, false, nil
 }
+
+// Clear deletes all stored cookies.
+//
+// Clear is safe for concurrent use.
+func (j *Jar) Clear() {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	clear(j.entries)
+	j.nextSeqNum = 0
+}

--- a/src/net/http/cookiejar/jar_test.go
+++ b/src/net/http/cookiejar/jar_test.go
@@ -670,6 +670,14 @@ func TestBasics(t *testing.T) {
 	}
 }
 
+func TestClear(t *testing.T) {
+	jar := newTestJar()
+	for _, test := range basicsTests {
+		test.run(t, jar)
+		jar.Clear()
+	}
+}
+
 // updateAndDeleteTests contains jarTests which must be performed on the same
 // Jar.
 var updateAndDeleteTests = [...]jarTest{


### PR DESCRIPTION
Currently clearing all stored cookies puts a needless burden on package
consumers, especially when used within http/Client where the calls to the
cookiejar are not directly done by the consumer.  This change just
directly implements a safe clear of all entries.

Fixes #70258
