### PR TITLE
go/printer: don't strip parens around *ast.Ellipsis in return field list

### DIFF
--- a/src/cmd/compile/internal/syntax/printer.go
+++ b/src/cmd/compile/internal/syntax/printer.go
@@ -886,10 +886,12 @@ func (p *printer) printSignature(sig *FuncType) {
 	if list := sig.ResultList; list != nil {
 		p.print(blank)
 		if len(list) == 1 && list[0].Name == nil {
-			p.printNode(list[0].Type)
-		} else {
-			p.printParameterList(list, 0)
+			if _, ok := list[0].Type.(*DotsType); !ok {
+				p.printNode(list[0].Type)
+				return
+			}
 		}
+		p.printParameterList(list, 0)
 	}
 }
 

--- a/src/cmd/compile/internal/syntax/printer_test.go
+++ b/src/cmd/compile/internal/syntax/printer_test.go
@@ -140,6 +140,8 @@ var stringTests = [][2]string{
 	{"package p; type _[P ((C)),] int", "package p; type _[P C] int"},
 	{"package p; type _[P, Q ((C))] int", "package p; type _[P, Q C] int"},
 
+	dup("package A; func A() (...A)"),
+
 	// TODO(gri) expand
 }
 

--- a/src/go/printer/nodes.go
+++ b/src/go/printer/nodes.go
@@ -447,9 +447,13 @@ func (p *printer) signature(sig *ast.FuncType) {
 		// res != nil
 		p.print(blank)
 		if n == 1 && res.List[0].Names == nil {
-			// single anonymous res; no ()'s
-			p.expr(stripParensAlways(res.List[0].Type))
-			return
+			// Parser permits ellipsis inside of a return field list, like: func A() (...int),
+			// removing them would cause a parse error.
+			if _, ok := res.List[0].Type.(*ast.Ellipsis); !ok {
+				// single anonymous res; no ()'s
+				p.expr(stripParensAlways(res.List[0].Type))
+				return
+			}
 		}
 		p.parameters(res, funcParam)
 	}

--- a/src/go/printer/printer_test.go
+++ b/src/go/printer/printer_test.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -861,5 +862,22 @@ func TestEmptyDecl(t *testing.T) { // issue 63566
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}
+	}
+}
+
+func TestPrintParsableEllipsisInReturnFieldList(t *testing.T) {
+	const src = "package A\n\nfunc A() (...A)\n"
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	Fprint(&out, fset, f)
+
+	if out.String() != src {
+		t.Fatalf("source = %q; printed as = %q want = %q", src, out.String(), src)
 	}
 }


### PR DESCRIPTION
Before this change:

func A() (...A)

was formatted into:

func A() ...A

which causes a parse error.

With this change it is going to be formatted as (no change):

func A() (...A)


