### PR TITLE
log/slog: export Source method in Record for custom handler support

### DIFF
--- a/api/next/70280.txt
+++ b/api/next/70280.txt
@@ -1,0 +1,1 @@
+pkg log/slog, method (Record) Source() *Source #70280

--- a/doc/next/6-stdlib/99-minor/log/slog/70280.md
+++ b/doc/next/6-stdlib/99-minor/log/slog/70280.md
@@ -1,0 +1,1 @@
+[Record] now has a Source() method, returning its source location or nil if unavailable.

--- a/src/log/slog/handler.go
+++ b/src/log/slog/handler.go
@@ -299,7 +299,11 @@ func (h *commonHandler) handle(r Record) error {
 	}
 	// source
 	if h.opts.AddSource {
-		state.appendAttr(Any(SourceKey, r.Source()))
+		src := r.Source()
+		if src == nil {
+			src = &Source{}
+		}
+		state.appendAttr(Any(SourceKey, src))
 	}
 	key = MessageKey
 	msg := r.Message

--- a/src/log/slog/handler.go
+++ b/src/log/slog/handler.go
@@ -299,7 +299,7 @@ func (h *commonHandler) handle(r Record) error {
 	}
 	// source
 	if h.opts.AddSource {
-		state.appendAttr(Any(SourceKey, r.source()))
+		state.appendAttr(Any(SourceKey, r.Source()))
 	}
 	key = MessageKey
 	msg := r.Message

--- a/src/log/slog/handler_test.go
+++ b/src/log/slog/handler_test.go
@@ -547,7 +547,7 @@ func TestJSONAndTextHandlers(t *testing.T) {
 		},
 	} {
 		r := NewRecord(testTime, LevelInfo, "message", callerPC(2))
-		line := strconv.Itoa(r.source().Line)
+		line := strconv.Itoa(r.Source().Line)
 		r.AddAttrs(test.attrs...)
 		var buf bytes.Buffer
 		opts := HandlerOptions{ReplaceAttr: test.replace, AddSource: test.addSource}

--- a/src/log/slog/logger_test.go
+++ b/src/log/slog/logger_test.go
@@ -191,6 +191,9 @@ func TestCallDepth(t *testing.T) {
 		const wantFile = "logger_test.go"
 		wantLine := startLine + count*2
 		got := h.r.Source()
+		if got == nil {
+			t.Fatal("got nil source")
+		}
 		gotFile := filepath.Base(got.File)
 		if got.Function != wantFunc || gotFile != wantFile || got.Line != wantLine {
 			t.Errorf("got (%s, %s, %d), want (%s, %s, %d)",

--- a/src/log/slog/logger_test.go
+++ b/src/log/slog/logger_test.go
@@ -190,7 +190,7 @@ func TestCallDepth(t *testing.T) {
 		const wantFunc = "log/slog.TestCallDepth"
 		const wantFile = "logger_test.go"
 		wantLine := startLine + count*2
-		got := h.r.source()
+		got := h.r.Source()
 		gotFile := filepath.Base(got.File)
 		if got.Function != wantFunc || gotFile != wantFile || got.Line != wantLine {
 			t.Errorf("got (%s, %s, %d), want (%s, %s, %d)",

--- a/src/log/slog/record.go
+++ b/src/log/slog/record.go
@@ -211,11 +211,11 @@ func (s *Source) group() Value {
 	return GroupValue(as...)
 }
 
-// source returns a Source for the log event.
+// Source returns a Source for the log event.
 // If the Record was created without the necessary information,
 // or if the location is unavailable, it returns a non-nil *Source
 // with zero fields.
-func (r Record) source() *Source {
+func (r Record) Source() *Source {
 	fs := runtime.CallersFrames([]uintptr{r.PC})
 	f, _ := fs.Next()
 	return &Source{

--- a/src/log/slog/record.go
+++ b/src/log/slog/record.go
@@ -211,11 +211,14 @@ func (s *Source) group() Value {
 	return GroupValue(as...)
 }
 
-// Source returns a Source for the log event.
-// If the Record was created without the necessary information,
-// or if the location is unavailable, it returns a non-nil *Source
-// with zero fields.
+// Source returns a new Source for the log event using r's PC.
+// If the PC field is zero, meaning the Record was created without the necessary information
+// or the location is unavailable, then nil is returned.
 func (r Record) Source() *Source {
+	if r.PC == 0 {
+		return nil
+	}
+
 	fs := runtime.CallersFrames([]uintptr{r.PC})
 	f, _ := fs.Next()
 	return &Source{

--- a/src/log/slog/record_test.go
+++ b/src/log/slog/record_test.go
@@ -56,7 +56,7 @@ func TestRecordSource(t *testing.T) {
 			pc = callerPC(test.depth + 1)
 		}
 		r := NewRecord(time.Time{}, 0, "", pc)
-		got := r.source()
+		got := r.Source()
 		if i := strings.LastIndexByte(got.File, '/'); i >= 0 {
 			got.File = got.File[i+1:]
 		}

--- a/src/log/slog/record_test.go
+++ b/src/log/slog/record_test.go
@@ -39,17 +39,18 @@ func TestRecordAttrs(t *testing.T) {
 }
 
 func TestRecordSource(t *testing.T) {
-	// Zero call depth => empty *Source.
+	// Zero call depth => nil *Source.
 	for _, test := range []struct {
 		depth            int
 		wantFunction     string
 		wantFile         string
 		wantLinePositive bool
+		wantNil          bool
 	}{
-		{0, "", "", false},
-		{-16, "", "", false},
-		{1, "log/slog.TestRecordSource", "record_test.go", true}, // 1: caller of NewRecord
-		{2, "testing.tRunner", "testing.go", true},
+		{0, "", "", false, true},
+		{-16, "", "", false, true},
+		{1, "log/slog.TestRecordSource", "record_test.go", true, false}, // 1: caller of NewRecord
+		{2, "testing.tRunner", "testing.go", true, false},
 	} {
 		var pc uintptr
 		if test.depth > 0 {
@@ -57,6 +58,16 @@ func TestRecordSource(t *testing.T) {
 		}
 		r := NewRecord(time.Time{}, 0, "", pc)
 		got := r.Source()
+		if test.wantNil {
+			if got != nil {
+				t.Errorf("depth %d: got non-nil Source, want nil", test.depth)
+			}
+			continue
+		}
+		if got == nil {
+			t.Errorf("depth %d: got nil Source, want non-nil", test.depth)
+			continue
+		}
 		if i := strings.LastIndexByte(got.File, '/'); i >= 0 {
 			got.File = got.File[i+1:]
 		}


### PR DESCRIPTION
Currently, the `source` method in `slog.Record` is not accessible to
custom handlers, requiring developers to re-implement logic for
retrieving source location information. This commit exports the `source`
method as `Source`, enabling consistent access for custom logging
handlers and reducing code redundancy.

Fixes #70280