### PR TITLE
doc/go_mem: fix broken paper link in go_mem.html

### DIFF
--- a/doc/go_mem.html
+++ b/doc/go_mem.html
@@ -82,7 +82,7 @@ while still insisting that races are errors and that tools can diagnose and repo
 <p>
 The following formal definition of Go's memory model closely follows
 the approach presented by Hans-J. Boehm and Sarita V. Adve in
-“<a href="https://www.hpl.hp.com/techreports/2008/HPL-2008-56.pdf">Foundations of the C++ Concurrency Memory Model</a>”,
+“<a href="https://dl.acm.org/doi/10.1145/1375581.1375591">Foundations of the C++ Concurrency Memory Model</a>”,
 published in PLDI 2008.
 The definition of data-race-free programs and the guarantee of sequential consistency
 for race-free programs are equivalent to the ones in that work.


### PR DESCRIPTION
The link is no longer accessible.

Replace it with the ACM one.