### PR TITLE
os/signal: check int type of signal using reflection

### DIFF
--- a/src/os/signal/signal_unix.go
+++ b/src/os/signal/signal_unix.go
@@ -48,11 +48,11 @@ func signum(sig os.Signal) int {
 		// as they might be defined in external packages like golang.org/x/sys.
 		// Since we cannot import those platform-specific signal types,
 		// reflection allows us to handle them in a generic way.
-		kind := reflect.TypeOf(sig).Kind()
-		switch kind {
+		v := reflect.ValueOf(sig)
+		switch v.Kind() {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			// Extract the integer value from sig and validate it.
-			i := int(reflect.ValueOf(sig).Int())
+			i := int(v.Int())
 			if i < 0 || i >= numSig {
 				return -1
 			}


### PR DESCRIPTION
The current implementation of the signum function only checks if os.Signal is 
of type syscall.Signal, then converts it to int. However, golang.org/x/sys 
defines its own Signal type for Windows at 
https://cs.opensource.google/go/x/sys/+/refs/tags/v0.27.0:windows/syscall_windows.go;l=1472

This causes the signum function and the higher-level signal.Notify function 
to fail to recognize signals like windows.SIGINT defined in golang.org/x/sys.

One possible approach is to specifically handle windows.Signal in signum, 
but it's unreasonable to make go/src reference golang.org/x/sys.

Another approach is to make windows.Signal directly type alias to 
syscall.Signal in golang.org/x/sys, but windows.Signal is fundamentally 
different from syscall.Signal (the signals map is different), which is also 
not feasible.

Therefore, this PR attempts to use reflection to obtain the possible int 
type, to handle this special case for Windows.

Fixes #70369 