### PR TITLE
encoding/json: return JSON field with all unmarshal errors

### DIFF
--- a/src/encoding/json/decode_test.go
+++ b/src/encoding/json/decode_test.go
@@ -77,6 +77,18 @@ type TOuter struct {
 	T TAlias
 }
 
+type EV struct {
+	EVS EVS
+}
+
+type EVS string
+
+var EVerr = errors.New("error")
+
+func (*EVS) UnmarshalJSON(_ []byte) error {
+	return EVerr
+}
+
 // ifaceNumAsFloat64/ifaceNumAsNumber are used to test unmarshaling with and
 // without UseNumber
 var ifaceNumAsFloat64 = map[string]any{
@@ -437,17 +449,18 @@ var unmarshalTests = []struct {
 	{CaseName: Name(""), in: `"g-clef: \uD834\uDD1E"`, ptr: new(string), out: "g-clef: \U0001D11E"},
 	{CaseName: Name(""), in: `"invalid: \uD834x\uDD1E"`, ptr: new(string), out: "invalid: \uFFFDx\uFFFD"},
 	{CaseName: Name(""), in: "null", ptr: new(any), out: nil},
-	{CaseName: Name(""), in: `{"X": [1,2,3], "Y": 4}`, ptr: new(T), out: T{Y: 4}, err: &UnmarshalTypeError{"array", reflect.TypeFor[string](), 7, "T", "X"}},
-	{CaseName: Name(""), in: `{"X": 23}`, ptr: new(T), out: T{}, err: &UnmarshalTypeError{"number", reflect.TypeFor[string](), 8, "T", "X"}},
+	{CaseName: Name(""), in: `{"X": [1,2,3], "Y": 4}`, ptr: new(T), out: T{Y: 4}, err: &UnmarshalTypeError{"array", reflect.TypeFor[string](), 7, "T", "X", nil}},
+	{CaseName: Name(""), in: `{"X": 23}`, ptr: new(T), out: T{}, err: &UnmarshalTypeError{"number", reflect.TypeFor[string](), 8, "T", "X", nil}},
 	{CaseName: Name(""), in: `{"x": 1}`, ptr: new(tx), out: tx{}},
 	{CaseName: Name(""), in: `{"x": 1}`, ptr: new(tx), out: tx{}},
 	{CaseName: Name(""), in: `{"x": 1}`, ptr: new(tx), err: fmt.Errorf("json: unknown field \"x\""), disallowUnknownFields: true},
-	{CaseName: Name(""), in: `{"S": 23}`, ptr: new(W), out: W{}, err: &UnmarshalTypeError{"number", reflect.TypeFor[SS](), 0, "W", "S"}},
-	{CaseName: Name(""), in: `{"T": {"X": 23}}`, ptr: new(TOuter), out: TOuter{}, err: &UnmarshalTypeError{"number", reflect.TypeFor[string](), 0, "TOuter", "T.X"}},
+	{CaseName: Name(""), in: `{"S": 23}`, ptr: new(W), out: W{}, err: &UnmarshalTypeError{"number", reflect.TypeFor[SS](), 0, "W", "S", nil}},
+	{CaseName: Name(""), in: `{"T": {"X": 23}}`, ptr: new(TOuter), out: TOuter{}, err: &UnmarshalTypeError{"number", reflect.TypeFor[string](), 0, "TOuter", "T.X", nil}},
 	{CaseName: Name(""), in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: float64(1), F2: int32(2), F3: Number("3")}},
 	{CaseName: Name(""), in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: Number("1"), F2: int32(2), F3: Number("3")}, useNumber: true},
 	{CaseName: Name(""), in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(any), out: ifaceNumAsFloat64},
 	{CaseName: Name(""), in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(any), out: ifaceNumAsNumber, useNumber: true},
+	{CaseName: Name(""), in: `{"EVS": 23}`, ptr: new(EV), out: EV{}, err: &UnmarshalTypeError{"string", reflect.TypeFor[EVS](), 0, "EV", "EVS", EVerr}},
 
 	// raw values with whitespace
 	{CaseName: Name(""), in: "\n true ", ptr: new(bool), out: true},


### PR DESCRIPTION
Fixes #22816 

JSON unmarshal can return an error type, UnmarshalTypeError, that contains very useful information such as the field that an error originated from.  Unfortunately, this error type is not always returned and that information is not bubbled up during unmarshaling.  This makes it difficult to return helpful API or CLI responses to users so they can correct invalid JSON.

This PR changes unmarshal to always wrap errors using this type.  The behavior stays mostly the same:

- if an error is returned by an unmarshal interface, it will be the `Error()` value
- all current tests pass with minor changes to fix the type instantiation

This PR has the possibility of breaking error comparisons if folks are doing something like this:

```go
if err := json.Unmarshal(b, &v); err == UnmarshalSentinelError
```

As the err type will no longer be returned as the Unmarshal error but wrapped using UnmarshalTypeError.  To work around this, users can do:

```go
if err := json.Unmarshal(b, &v); errors.Is(err, UnmarshalSentinelError)
```

If this is too much of a breaking change, I would like to rework the PR into a new function that performs this new error behavior.  Feedback welcome on what to call it, UnmarshalWithErr seems a bit wordy.