### PR TITLE
bufio: optimize struct memory layout to reduce size

### DIFF
--- a/src/bufio/bufio.go
+++ b/src/bufio/bufio.go
@@ -38,8 +38,10 @@ type Reader struct {
 	lastRuneSize int // size of last rune read for UnreadRune; -1 means invalid
 }
 
-const minReadBufferSize = 16
-const maxConsecutiveEmptyReads = 100
+const (
+	minReadBufferSize        = 16
+	maxConsecutiveEmptyReads = 100
+)
 
 // NewReaderSize returns a new [Reader] whose buffer has at least the specified
 // size. If the argument io.Reader is already a [Reader] with large enough
@@ -575,9 +577,9 @@ func (b *Reader) writeBuf(w io.Writer) (int64, error) {
 // the underlying [io.Writer].
 type Writer struct {
 	err error
+	wr  io.Writer
 	buf []byte
 	n   int
-	wr  io.Writer
 }
 
 // NewWriterSize returns a new [Writer] whose buffer has at least the specified

--- a/src/bufio/scan.go
+++ b/src/bufio/scan.go
@@ -28,13 +28,13 @@ import (
 // on a reader, should use [bufio.Reader] instead.
 type Scanner struct {
 	r            io.Reader // The reader provided by the client.
+	err          error     // Sticky error.
 	split        SplitFunc // The function to split the tokens.
-	maxTokenSize int       // Maximum size of a token; modified by tests.
 	token        []byte    // Last token returned by split.
 	buf          []byte    // Buffer used as argument to split.
+	maxTokenSize int       // Maximum size of a token; modified by tests.
 	start        int       // First non-processed byte in buf.
 	end          int       // End of data in buf.
-	err          error     // Sticky error.
 	empties      int       // Count of successive empty tokens.
 	scanCalled   bool      // Scan has been called; buffer is in use.
 	done         bool      // Scan has finished.


### PR DESCRIPTION
Scanner struct with 112 pointer bytes to 72
Writer struct with 64 pointer bytes to be 40