### PR TITLE
crypto/rsa: reimplement GenerateKey per FIPS 186-5

### DIFF
--- a/src/crypto/rsa/rsa_test.go
+++ b/src/crypto/rsa/rsa_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestKeyGeneration(t *testing.T) {
-	for _, size := range []int{128, 1024, 2048, 3072} {
+	for _, size := range []int{128, 1024, 2048, 3072, 4096, 8192} {
 		priv, err := GenerateKey(rand.Reader, size)
 		if err != nil {
 			t.Errorf("GenerateKey(%d): %v", size, err)


### PR DESCRIPTION
Submitting on behalf of @archanaravindar.

This patch implements RSA Key Generation per FIPS 186-5. The implementation uses math/big despite eventually needing to port to bigmod in order to not have to validate the math/big package in the FIPS certification. The port to bigmod will be committed as a follow-up patch.

For #69799