### PR TITLE
net: check for MPTCP in DialTCP and ListenTCP

### DIFF
--- a/src/net/tcpsock.go
+++ b/src/net/tcpsock.go
@@ -324,7 +324,15 @@ func DialTCP(network string, laddr, raddr *TCPAddr) (*TCPConn, error) {
 		return nil, &OpError{Op: "dial", Net: network, Source: laddr.opAddr(), Addr: nil, Err: errMissingAddress}
 	}
 	sd := &sysDialer{network: network, address: raddr.String()}
-	c, err := sd.dialTCP(context.Background(), laddr, raddr)
+	var (
+		c   *TCPConn
+		err error
+	)
+	if sd.MultipathTCP() {
+		c, err = sd.dialMPTCP(context.Background(), laddr, raddr)
+	} else {
+		c, err = sd.dialTCP(context.Background(), laddr, raddr)
+	}
 	if err != nil {
 		return nil, &OpError{Op: "dial", Net: network, Source: laddr.opAddr(), Addr: raddr.opAddr(), Err: err}
 	}
@@ -439,7 +447,15 @@ func ListenTCP(network string, laddr *TCPAddr) (*TCPListener, error) {
 		laddr = &TCPAddr{}
 	}
 	sl := &sysListener{network: network, address: laddr.String()}
-	ln, err := sl.listenTCP(context.Background(), laddr)
+	var (
+		ln  *TCPListener
+		err error
+	)
+	if sl.MultipathTCP() {
+		ln, err = sl.listenMPTCP(context.Background(), laddr)
+	} else {
+		ln, err = sl.listenTCP(context.Background(), laddr)
+	}
 	if err != nil {
 		return nil, &OpError{Op: "listen", Net: network, Source: nil, Addr: laddr.opAddr(), Err: err}
 	}


### PR DESCRIPTION
Setting GODEBUG=multipathtcp= [1] has no effects on apps using
ListenTCP or DialTCP directly.

According to the documentation, these functions are supposed to act like
Listen and Dial respectively:

    ListenTCP acts like Listen for TCP networks.
    DialTCP acts like Dial for TCP networks.

So when reading this, I think we should expect GODEBUG=multipathtcp= to
act on these functions as well.

Also, since #69016, MPTCP is used by default (if supported) with TCP
listeners. Similarly, when ListenTCP is used directly, MPTCP is
unexpectedly not used. It is strange to have a different behaviour.

So now, ListenTCP and DialTCP also check for MPTCP. Those are the exact
same checks that are done in dial.go, see Listen and dialSingle.

[1] https://pkg.go.dev/net#Dialer.SetMultipathTCP

Fixes #70500