### PR TITLE
doc: fix comment format for reference to Go spec

### DIFF
--- a/test/fixedbugs/bug285.go
+++ b/test/fixedbugs/bug285.go
@@ -6,7 +6,7 @@
 
 // Test for issue 778: Map key values that are assignment
 // compatible with the map key type must be accepted according
-// to the spec: https://golang.org/doc/go_spec.html#Indexes .
+// to the spec: https://golang.org/doc/go_spec.html#Indexes.
 
 package main
 


### PR DESCRIPTION
The comment referencing the Go spec URL was reformatted to conform to the standard comment style.
This ensures consistent formatting in the documentation comments.