### PR TITLE
internal/goos: fix bug in gengoos.go

### DIFF
--- a/src/internal/goos/gengoos.go
+++ b/src/internal/goos/gengoos.go
@@ -17,7 +17,7 @@ import (
 var gooses []string
 
 func main() {
-	data, err := os.ReadFile("../../internal/syslist/syslist..go")
+	data, err := os.ReadFile("../../internal/syslist/syslist.go")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
CL 601357 mistakenly added an extra period.