### PR TITLE
fix: fix issue 70753

### DIFF
--- a/src/encoding/json/encode.go
+++ b/src/encoding/json/encode.go
@@ -370,6 +370,7 @@ func typeEncoder(t reflect.Type) encoderFunc {
 		f(e, v, opts)
 	}))
 	if loaded {
+		wg.Done()
 		return fi.(encoderFunc)
 	}
 


### PR DESCRIPTION
This PR addresses and resolves the potential deadlock issue described in https://github.com/golang/go/issues/70753. The problem was identified in the file `src/encoding/json/encode.go` on line 373 of the Go 1.23 version. Previously, the `typeEncoder` function did not call `wg.Done()` before executing the return statement `return fi.(encoderFunc)`. This oversight could lead to cases where the waitgroup never reaches zero, causing deadlocks within concurrent executions. The modification introduced in this PR ensures that `wg.Done()` is called appropriately, thereby preventing any such deadlock situations and improving the stability and reliability of JSON encoding in concurrent environments.