### PR TITLE
net/http: add rfc citation to SetBasicAuth documentation

### DIFF
--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -1018,7 +1018,7 @@ func parseBasicAuth(auth string) (username, password string, ok bool) {
 // The username may not contain a colon. Some protocols may impose
 // additional requirements on pre-escaping the username and
 // password. For instance, when used with OAuth2, both arguments must
-// be URL encoded first with [url.QueryEscape].
+// be URL encoded first with [url.QueryEscape] (rfc6749 section-2.3.1).
 func (r *Request) SetBasicAuth(username, password string) {
 	r.Header.Set("Authorization", "Basic "+basicAuth(username, password))
 }


### PR DESCRIPTION
Cites relevant RFC and section information in reference to oauth2
requirements.