### PR TITLE
chore: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/src/go/doc/doc.go
+++ b/src/go/doc/doc.go
@@ -6,6 +6,7 @@
 package doc
 
 import (
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/doc/comment"
@@ -208,7 +209,7 @@ func (p *Package) collectFuncs(funcs []*Func) {
 func NewFromFiles(fset *token.FileSet, files []*ast.File, importPath string, opts ...any) (*Package, error) {
 	// Check for invalid API usage.
 	if fset == nil {
-		panic(fmt.Errorf("doc.NewFromFiles: no token.FileSet provided (fset == nil)"))
+		panic(errors.New("doc.NewFromFiles: no token.FileSet provided (fset == nil)"))
 	}
 	var mode Mode
 	switch len(opts) { // There can only be 0 or 1 options, so a simple switch works for now.
@@ -217,11 +218,11 @@ func NewFromFiles(fset *token.FileSet, files []*ast.File, importPath string, opt
 	case 1:
 		m, ok := opts[0].(Mode)
 		if !ok {
-			panic(fmt.Errorf("doc.NewFromFiles: option argument type must be doc.Mode"))
+			panic(errors.New("doc.NewFromFiles: option argument type must be doc.Mode"))
 		}
 		mode = m
 	default:
-		panic(fmt.Errorf("doc.NewFromFiles: there must not be more than 1 option argument"))
+		panic(errors.New("doc.NewFromFiles: there must not be more than 1 option argument"))
 	}
 
 	// Collect .go and _test.go files.

--- a/src/go/internal/gccgoimporter/ar.go
+++ b/src/go/internal/gccgoimporter/ar.go
@@ -146,7 +146,7 @@ func aixBigArExportData(archive io.ReadSeeker) (io.ReadSeeker, error) {
 		}
 	}
 
-	return nil, fmt.Errorf(".go_export not found in this archive")
+	return nil, errors.New(".go_export not found in this archive")
 }
 
 // readerAtFromSeeker turns an io.ReadSeeker into an io.ReaderAt.

--- a/src/go/types/resolver.go
+++ b/src/go/types/resolver.go
@@ -6,6 +6,7 @@ package types
 
 import (
 	"cmp"
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/constant"
@@ -89,7 +90,7 @@ func validatedImportPath(path string) (string, error) {
 		return "", err
 	}
 	if s == "" {
-		return "", fmt.Errorf("empty string")
+		return "", errors.New("empty string")
 	}
 	const illegalChars = `!"#$%&'()*,:;<=>?[\]^{|}` + "`\uFFFD"
 	for _, r := range s {
@@ -157,7 +158,7 @@ func (check *Checker) importPackage(at positioner, path, dir string) *Package {
 		// ordinary import
 		var err error
 		if importer := check.conf.Importer; importer == nil {
-			err = fmt.Errorf("Config.Importer not installed")
+			err = errors.New("Config.Importer not installed")
 		} else if importerFrom, ok := importer.(ImporterFrom); ok {
 			imp, err = importerFrom.ImportFrom(path, dir, 0)
 			if imp == nil && err == nil {

--- a/src/io/io_test.go
+++ b/src/io/io_test.go
@@ -277,7 +277,7 @@ func TestReadAtLeastWithDataAndEOF(t *testing.T) {
 
 func TestReadAtLeastWithDataAndError(t *testing.T) {
 	var rb dataAndErrorBuffer
-	rb.err = fmt.Errorf("fake error")
+	rb.err = errors.New("fake error")
 	testReadAtLeast(t, &rb)
 }
 


### PR DESCRIPTION
use errors.New to replace fmt.Errorf with no parameters