### PR TITLE
go/types: use documented version of gotypesalias GODEBUG

### DIFF
--- a/src/go/types/eval_test.go
+++ b/src/go/types/eval_test.go
@@ -209,7 +209,7 @@ func TestEvalPos(t *testing.T) {
 }
 
 // gotypesalias controls the use of Alias types.
-var gotypesalias = godebug.New("#gotypesalias")
+var gotypesalias = godebug.New("gotypesalias")
 
 // split splits string s at the first occurrence of s, trimming spaces.
 func split(s, sep string) (string, string) {


### PR DESCRIPTION
This way the code would panic, in case it does not exist.