### PR TITLE
net/http: add context cancellation reason for server handlers

### DIFF
--- a/src/net/http/errors_plan9.go
+++ b/src/net/http/errors_plan9.go
@@ -1,15 +1,10 @@
-// Copyright 2015 The Go Authors. All rights reserved.
+// Copyright 2025 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build plan9
+//go:build plan9
 
 package http
-
-import (
-	"errors"
-	"syscall"
-)
 
 func isClientDisconnected(err error) bool {
 	return false

--- a/src/net/http/errors_plan9.go
+++ b/src/net/http/errors_plan9.go
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build plan9
-
 package http
 
 func isClientDisconnected(err error) bool {

--- a/src/net/http/errors_plan9.go
+++ b/src/net/http/errors_plan9.go
@@ -1,0 +1,16 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build plan9
+
+package http
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isClientDisconnected(err error) bool {
+	return false
+}

--- a/src/net/http/errors_posix.go
+++ b/src/net/http/errors_posix.go
@@ -1,0 +1,16 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !plan9
+
+package http
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isClientDisconnected(err error) bool {
+	return errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE)
+}

--- a/src/net/http/errors_posix.go
+++ b/src/net/http/errors_posix.go
@@ -1,8 +1,8 @@
-// Copyright 2015 The Go Authors. All rights reserved.
+// Copyright 2025 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !plan9
+//go:build !plan9
 
 package http
 

--- a/src/net/http/errors_posix_test.go
+++ b/src/net/http/errors_posix_test.go
@@ -1,0 +1,121 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !plan9
+
+package http
+
+import (
+	"context"
+	"errors"
+	"net"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Receive a single HTTP request on the given server socket, then close recvCh.
+// Wait for the context to close while handling this request, then record the
+// context Cause and return it over the causeCh.
+func getClosingCause(ln net.Listener, recvCh chan<-struct{}, causeCh chan<- error) {
+	mux := NewServeMux()
+	server := Server{
+		Handler: mux,
+	}
+
+	mux.HandleFunc("/", func(w ResponseWriter, req *Request) {
+		ctx := req.Context()
+		close(recvCh)
+
+		w.WriteHeader(200)
+
+		select {
+		case <-ctx.Done():
+			causeCh <- context.Cause(ctx)
+			close(causeCh)
+			server.Close()
+		}
+	})
+
+	server.Serve(ln)
+}
+
+func TestClientDisconnectedError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recvCh := make(chan struct{})
+	causeCh := make(chan error)
+	go getClosingCause(ln, recvCh, causeCh)
+
+	// Send a HTTP/1.1 request, then gracefully close the connection while it's being handled.
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn.Write([]byte("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"))
+	<-recvCh
+
+	if err := conn.(*net.TCPConn).Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case cause := <-causeCh:
+		if !errors.Is(cause, errClientDisconnected) {
+			t.Fatalf("after graceful client disconnect, context cancellation cause wasn't 'client disconnected': %v", cause)
+		}
+
+	case <-ctx.Done():
+		t.Fatal("never received a cause")
+	}
+}
+
+func TestClientConnectionResetError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recvCh := make(chan struct{})
+	causeCh := make(chan error)
+	go getClosingCause(ln, recvCh, causeCh)
+
+	// Send a HTTP/1.1 request, then hard-reset connection while it's being handled.
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn.Write([]byte("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"))
+	<-recvCh
+
+	tcp := conn.(*net.TCPConn)
+	if err := tcp.SetLinger(0); err != nil {
+		t.Fatal(err)
+	}
+	if err := tcp.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case cause := <-causeCh:
+		if !errors.Is(cause, errClientDisconnected) {
+			t.Fatalf("after client connection reset, context cancellation cause wasn't 'client disconnected': %v", cause)
+		}
+		if !errors.Is(cause, syscall.ECONNRESET) {
+			t.Fatalf("after client connection reset, context cancellation cause wasn't ECONNRESET: %v", cause)
+		}
+
+	case <-ctx.Done():
+		t.Fatal("never received a cause")
+	}
+}

--- a/src/net/http/errors_posix_test.go
+++ b/src/net/http/errors_posix_test.go
@@ -18,7 +18,7 @@ import (
 // Receive a single HTTP request on the given server socket, then close recvCh.
 // Wait for the context to close while handling this request, then record the
 // context Cause and return it over the causeCh.
-func getClosingCause(ln net.Listener, recvCh chan<-struct{}, causeCh chan<- error) {
+func getClosingCause(ln net.Listener, recvCh chan<- struct{}, causeCh chan<- error) {
 	mux := NewServeMux()
 	server := Server{
 		Handler: mux,
@@ -44,7 +44,7 @@ func getClosingCause(ln net.Listener, recvCh chan<-struct{}, causeCh chan<- erro
 func TestClientDisconnectedError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-	
+
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
@@ -80,7 +80,7 @@ func TestClientDisconnectedError(t *testing.T) {
 func TestClientConnectionResetError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-	
+
 	ln, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatal(err)

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -64,12 +64,12 @@ var (
 	// errConnectionClosed is used as a context Cause for contexts
 	// cancelled because the client closed their connection while
 	// a request was being handled.
-	errConnectionClosed = errors.New("connection closed")
+	errConnectionClosed = errors.New("connection closed by client")
 
 	// TODO: expose once proposal is accepted
-	// errConnectionHandled is used as a context Cause for contexts
-	// cancelled because the request handler returned.
-	errConnectionHandled = errors.New("connection handled")
+	// errRequestHandlerReturned is used as a context Cause for contexts
+	// cancelled because the request handler already returned.
+	errRequestHandlerReturned = errors.New("request handler returned")
 )
 
 // A Handler responds to an HTTP request.
@@ -2025,7 +2025,7 @@ func (c *conn) serve(ctx context.Context) {
 
 	ctx, cancelCtx := context.WithCancelCause(ctx)
 	c.cancelCtx = cancelCtx
-	defer cancelCtx(errConnectionHandled)
+	defer cancelCtx(errRequestHandlerReturned)
 
 	c.r = &connReader{conn: c, rwc: c.rwc}
 	c.bufr = newBufioReader(c.r)

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -3162,7 +3162,9 @@ func (s *Server) Close() error {
 	s.mu.Lock()
 
 	for c := range s.activeConn {
-		c.cancelCtx(errServerShutdown)
+		if c.cancelCtx != nil {
+			c.cancelCtx(errServerShutdown)
+		}
 		c.rwc.Close()
 		delete(s.activeConn, c)
 	}

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -64,10 +64,6 @@ var (
 	// cancelled because the client closed their connection while
 	// a request was being handled.
 	errConnectionClosed = errors.New("connection closed by client")
-
-	// errRequestHandlerReturned is used as a context Cause for contexts
-	// cancelled because the request handler already returned.
-	errRequestHandlerReturned = errors.New("request handler returned")
 )
 
 // A Handler responds to an HTTP request.
@@ -2023,7 +2019,7 @@ func (c *conn) serve(ctx context.Context) {
 
 	ctx, cancelCtx := context.WithCancelCause(ctx)
 	c.cancelCtx = cancelCtx
-	defer cancelCtx(errRequestHandlerReturned)
+	defer cancelCtx(nil)
 
 	c.r = &connReader{conn: c, rwc: c.rwc}
 	c.bufr = newBufioReader(c.r)

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -4088,9 +4088,7 @@ func (w checkConnErrorWriter) Write(p []byte) (n int, err error) {
 	n, err = w.c.rwc.Write(p)
 	if err != nil && w.c.werr == nil {
 		w.c.werr = err
-		if errors.Is(err, io.EOF) {
-			err = errClientDisconnected
-		} else if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
+		if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
 			err = fmt.Errorf("%w: %v", errClientDisconnected, err)
 		}
 		w.c.cancelCtx(fmt.Errorf("connection write error: %w", err))

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -60,13 +60,11 @@ var (
 	// compare errors against this variable.
 	ErrWriteAfterFlush = errors.New("unused")
 
-	// TODO: expose once proposal is accepted
 	// errConnectionClosed is used as a context Cause for contexts
 	// cancelled because the client closed their connection while
 	// a request was being handled.
 	errConnectionClosed = errors.New("connection closed by client")
 
-	// TODO: expose once proposal is accepted
 	// errRequestHandlerReturned is used as a context Cause for contexts
 	// cancelled because the request handler already returned.
 	errRequestHandlerReturned = errors.New("request handler returned")

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -781,7 +781,7 @@ func (cr *connReader) handleReadErrorLocked(err error) {
 	if errors.Is(err, io.EOF) {
 		err = errClientDisconnected
 	} else if isClientDisconnected(err) {
-		err = fmt.Errorf("%w: %v", errClientDisconnected, err)
+		err = fmt.Errorf("%w: %w", errClientDisconnected, err)
 	}
 	cr.conn.cancelCtx(fmt.Errorf("connection read error: %w", err))
 	if res := cr.conn.curReq.Load(); res != nil {
@@ -4090,7 +4090,7 @@ func (w checkConnErrorWriter) Write(p []byte) (n int, err error) {
 	if err != nil && w.c.werr == nil {
 		w.c.werr = err
 		if isClientDisconnected(err) {
-			err = fmt.Errorf("%w: %v", errClientDisconnected, err)
+			err = fmt.Errorf("%w: %w", errClientDisconnected, err)
 		}
 		w.c.cancelCtx(fmt.Errorf("connection write error: %w", err))
 	}

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -60,10 +60,9 @@ var (
 	// compare errors against this variable.
 	ErrWriteAfterFlush = errors.New("unused")
 
-	// errConnectionClosed is used as a context Cause for contexts
-	// cancelled because the client closed their connection while
-	// a request was being handled.
-	errConnectionClosed = errors.New("connection closed by client")
+	// errClientDisconnected is used as a context Cause for contexts
+	// cancelled because the client closed their connection.
+	errClientDisconnected = errors.New("client disconnected")
 )
 
 // A Handler responds to an HTTP request.
@@ -776,7 +775,7 @@ func (cr *connReader) handleReadErrorLocked(err error) {
 		return
 	}
 	if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
-		err = errConnectionClosed
+		err = errClientDisconnected
 	}
 	cr.conn.cancelCtx(fmt.Errorf("connection read error: %w", err))
 	if res := cr.conn.curReq.Load(); res != nil {
@@ -4082,7 +4081,7 @@ func (w checkConnErrorWriter) Write(p []byte) (n int, err error) {
 	if err != nil && w.c.werr == nil {
 		w.c.werr = err
 		if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
-			err = errConnectionClosed
+			err = errClientDisconnected
 		}
 		w.c.cancelCtx(fmt.Errorf("connection write error: %w", err))
 	}


### PR DESCRIPTION
When we cancel a HTTP server handler context, set an appropriate
cancel cause. This makes investigation of context cancellation
errors easier.

In this first CL, I only add the relevant cancellation cause, but I do
not expose it. Once this lands, I will create a separate proposal to
expose the "client disconnected" cancellation cause, so that it can
be handled separately by users of the library.

Fixes #64465