### PR TITLE
cmd/go/internal: remove unused result parameter

### DIFF
--- a/src/cmd/go/internal/list/list.go
+++ b/src/cmd/go/internal/list/list.go
@@ -673,7 +673,7 @@ func runList(ctx context.Context, cmd *base.Command, args []string) {
 					h := cache.NewHash("testmain")
 					h.Write([]byte("testmain\n"))
 					h.Write(data)
-					out, _, err := c.Put(h.Sum(), bytes.NewReader(data))
+					out, err := c.Put(h.Sum(), bytes.NewReader(data))
 					if err != nil {
 						base.Fatalf("%s", err)
 					}

--- a/src/cmd/go/internal/work/action.go
+++ b/src/cmd/go/internal/work/action.go
@@ -516,7 +516,7 @@ func (p *pgoActor) Act(b *Builder, ctx context.Context, a *Action) error {
 		}
 
 		c := cache.Default()
-		outputID, _, err := c.Put(a.actionID, r)
+		outputID, err := c.Put(a.actionID, r)
 		r.Close()
 		if err != nil {
 			return fmt.Errorf("error adding target to cache: %w", err)

--- a/src/cmd/go/internal/work/buildid.go
+++ b/src/cmd/go/internal/work/buildid.go
@@ -746,7 +746,7 @@ func (b *Builder) updateBuildID(a *Action, target string) error {
 			if a.output == nil {
 				panic("internal error: a.output not set")
 			}
-			outputID, _, err := c.Put(a.actionID, r)
+			outputID, err := c.Put(a.actionID, r)
 			r.Close()
 			if err == nil && cfg.BuildX {
 				sh.ShowCmd("", "%s # internal", joinUnambiguously(str.StringList("cp", target, c.OutputFile(outputID))))
@@ -770,7 +770,7 @@ func (b *Builder) updateBuildID(a *Action, target string) error {
 			if name == "" {
 				name = path.Base(a.Package.ImportPath)
 			}
-			outputID, _, err := c.PutExecutable(a.actionID, name+cfg.ExeSuffix, r)
+			outputID, err := c.PutExecutable(a.actionID, name+cfg.ExeSuffix, r)
 			r.Close()
 			if err == nil && cfg.BuildX {
 				sh.ShowCmd("", "%s # internal", joinUnambiguously(str.StringList("cp", target, c.OutputFile(outputID))))

--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -1028,7 +1028,7 @@ func (b *Builder) cacheObjdirFile(a *Action, c cache.Cache, name string) error {
 		return err
 	}
 	defer f.Close()
-	_, _, err = c.Put(cache.Subkey(a.actionID, name), f)
+	_, err = c.Put(cache.Subkey(a.actionID, name), f)
 	return err
 }
 


### PR DESCRIPTION
Incomplete Put operation already returns an error.