### PR TITLE
context: add default to select example in comment of Done

### DIFF
--- a/src/context/context.go
+++ b/src/context/context.go
@@ -96,7 +96,8 @@ type Context interface {
 	//  		select {
 	//  		case <-ctx.Done():
 	//  			return ctx.Err()
-	//  		case out <- v:
+	//  		default:
+	//  			out <- v
 	//  		}
 	//  	}
 	//  }


### PR DESCRIPTION
According to the comment of Stream, it should return once ctx.Done is
closed, but the current implementation may select another case instead
if out is ready to receive an element.

Quoting from the related Go spec: "If one or more of the
communications can proceed, a single one that can proceed is chosen
via a uniform pseudo-random selection."

https://go.dev/ref/spec#Select_statements