### PR TITLE
mime/multipart: add field Reader.MaxMIMEHeaderSize

### DIFF
--- a/src/mime/multipart/multipart_test.go
+++ b/src/mime/multipart/multipart_test.go
@@ -931,6 +931,41 @@ Cases:
 	}
 }
 
+func TestParseMaxMIMEHeaderSize(t *testing.T) {
+	sep := "MyBoundary"
+	in := `This is a multi-part message.  This line is ignored.
+--MyBoundary
+Header1: value1
+Header2: value2
+Header3: value3
+Header4: value4
+Header5: value5
+Header6: value6
+Header7: value7
+Header8: value8
+
+My value
+The end.
+--MyBoundary--`
+
+	in = strings.Replace(in, "\n", "\r\n", -1)
+
+	// Control.
+	r := NewReader(strings.NewReader(in), sep)
+	_, err := r.NextPart()
+	if err != nil {
+		t.Fatalf("control failed: %v", err)
+	}
+
+	// Test MaxMIMEHeaderSize.
+	r = NewReader(strings.NewReader(in), sep)
+	r.MaxMIMEHeaderSize = 100
+	_, err = r.NextPart()
+	if err != ErrMessageTooLarge {
+		t.Fatalf("test failed: %v", err)
+	}
+}
+
 func partsFromReader(r *Reader) ([]headerBody, error) {
 	got := []headerBody{}
 	for {

--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -493,7 +493,8 @@ var multipartByReader = &multipart.Form{
 // MultipartReader returns a MIME multipart reader if this is a
 // multipart/form-data or a multipart/mixed POST request, else returns nil and an error.
 // Use this function instead of [Request.ParseMultipartForm] to
-// process the request body as a stream.
+// process the request body as a stream or to limit maximum MIME header size
+// using reader's field MaxMIMEHeaderSize.
 func (r *Request) MultipartReader() (*multipart.Reader, error) {
 	if r.MultipartForm == multipartByReader {
 		return nil, errors.New("http: MultipartReader called twice")
@@ -1367,6 +1368,7 @@ func (r *Request) ParseForm() error {
 // If ParseForm returns an error, ParseMultipartForm returns it but also
 // continues parsing the request body.
 // After one call to ParseMultipartForm, subsequent calls have no effect.
+// If you want to process the request body as a stream, use [MultipartReader].
 func (r *Request) ParseMultipartForm(maxMemory int64) error {
 	if r.MultipartForm == multipartByReader {
 		return errors.New("http: multipart handled by MultipartReader")


### PR DESCRIPTION
If the field is set, it is used instead of maxMIMEHeaderSize
constant, allowing to further constraint memory usage when
parsing multipart streams.

Fixes #68889
Fixes #73087
Fixes #26339