### PR TITLE
cmd/go/internal/work: allow @ character in some -Wl, linker flags on darwin

### DIFF
--- a/src/cmd/go/internal/work/security.go
+++ b/src/cmd/go/internal/work/security.go
@@ -236,7 +236,7 @@ var validLinkerFlagsOnDarwin = []*lazyregexp.Regexp{
 	// conjunction with the `-install_name` and `-rpath` linker flags.
 	// Since the GNU linker does not support Mach-O, targeting Darwin
 	// implies not using the GNU linker. Therefore, we allow @ in the linker
-	// flags if and only if cfg.GOOS == "darwin".
+	// flags if and only if cfg.Goos == "darwin".
 	re(`-Wl,-dylib_install_name,@rpath(/[^,]*)?`),
 	re(`-Wl,-install_name,@rpath(/[^,]*)?`),
 	re(`-Wl,-rpath,@(executable_path|loader_path)(/[^,]*)?`),

--- a/src/cmd/go/internal/work/security.go
+++ b/src/cmd/go/internal/work/security.go
@@ -237,9 +237,9 @@ var validLinkerFlagsOnDarwin = []*lazyregexp.Regexp{
 	// Since the GNU linker does not support Mach-O, targeting Darwin
 	// implies not using the GNU linker. Therefore, we allow @ in the linker
 	// flags if and only if cfg.GOOS == "darwin".
-	re(`-Wl,-dylib_install_name,[^,]+`),
-	re(`-Wl,-install_name,[^,]+`),
-	re(`-Wl,-rpath,[^,]+`),
+	re(`-Wl,-dylib_install_name,@rpath(/[^,]*)?`),
+	re(`-Wl,-install_name,@rpath(/[^,]*)?`),
+	re(`-Wl,-rpath,@(executable_path|loader_path)(/[^,]*)?`),
 }
 
 var validLinkerFlagsWithNextArg = []string{

--- a/src/cmd/go/internal/work/security.go
+++ b/src/cmd/go/internal/work/security.go
@@ -236,7 +236,7 @@ var validLinkerFlagsOnDarwin = []*lazyregexp.Regexp{
 	// conjunction with the `-install_name` and `-rpath` linker flags.
 	// Since the GNU linker does not support Mach-O, targeting Darwin
 	// implies not using the GNU linker. Therefore, we allow @ in the linker
-	// flags if and only if cfg.Goos == "darwin".
+	// flags if and only if cfg.Goos == "darwin" || cfg.Goos == "ios".
 	re(`-Wl,-dylib_install_name,@rpath(/[^,]*)?`),
 	re(`-Wl,-install_name,@rpath(/[^,]*)?`),
 	re(`-Wl,-rpath,@(executable_path|loader_path)(/[^,]*)?`),
@@ -265,7 +265,7 @@ func checkCompilerFlags(name, source string, list []string) error {
 
 func checkLinkerFlags(name, source string, list []string) error {
 	validLinkerFlagsForPlatform := validLinkerFlags
-	if cfg.Goos == "darwin" {
+	if cfg.Goos == "darwin" || cfg.Goos == "ios" {
 		validLinkerFlagsForPlatform = append(validLinkerFlags, validLinkerFlagsOnDarwin...)
 	}
 

--- a/src/cmd/go/internal/work/security.go
+++ b/src/cmd/go/internal/work/security.go
@@ -227,6 +227,21 @@ var validLinkerFlags = []*lazyregexp.Regexp{
 	re(`\./.*\.(a|o|obj|dll|dylib|so|tbd)`),
 }
 
+var validLinkerFlagsOnDarwin = []*lazyregexp.Regexp{
+	// The GNU linker interprets `@file` as "read command-line options from
+	// file". Thus, we forbid values starting with `@` on linker flags.
+	// However, this causes a problem when targeting Darwin.
+	// `@executable_path`, `@loader_path`, and `@rpath` are special values
+	// used in Mach-O to change the library search path and can be used in
+	// conjunction with the `-install_name` and `-rpath` linker flags.
+	// Since the GNU linker does not support Mach-O, targeting Darwin
+	// implies not using the GNU linker. Therefore, we allow @ in the linker
+	// flags if and only if cfg.GOOS == "darwin".
+	re(`-Wl,-dylib_install_name,[^,]+`),
+	re(`-Wl,-install_name,[^,]+`),
+	re(`-Wl,-rpath,[^,]+`),
+}
+
 var validLinkerFlagsWithNextArg = []string{
 	"-arch",
 	"-F",
@@ -249,8 +264,13 @@ func checkCompilerFlags(name, source string, list []string) error {
 }
 
 func checkLinkerFlags(name, source string, list []string) error {
+	validLinkerFlagsForPlatform := validLinkerFlags
+	if cfg.Goos == "darwin" {
+		validLinkerFlagsForPlatform = append(validLinkerFlags, validLinkerFlagsOnDarwin...)
+	}
+
 	checkOverrides := true
-	return checkFlags(name, source, list, invalidLinkerFlags, validLinkerFlags, validLinkerFlagsWithNextArg, checkOverrides)
+	return checkFlags(name, source, list, invalidLinkerFlags, validLinkerFlagsForPlatform, validLinkerFlagsWithNextArg, checkOverrides)
 }
 
 // checkCompilerFlagsForInternalLink returns an error if 'list'

--- a/src/cmd/go/internal/work/security_test.go
+++ b/src/cmd/go/internal/work/security_test.go
@@ -239,6 +239,9 @@ var badLinkerFlags = [][]string{
 	{"-Wl,--hash-style=foo"},
 	{"-x", "--c"},
 	{"-x", "@obj"},
+	{"-Wl,-dylib_install_name,@foo"},
+	{"-Wl,-install_name,@foo"},
+	{"-Wl,-rpath,@foo"},
 	{"-Wl,-R,foo,bar"},
 	{"-Wl,-R,@foo"},
 	{"-Wl,--just-symbols,@foo"},
@@ -256,13 +259,17 @@ var badLinkerFlags = [][]string{
 
 var goodLinkerFlagsOnDarwin = [][]string{
 	{"-Wl,-dylib_install_name,@rpath"},
+	{"-Wl,-dylib_install_name,@rpath/"},
+	{"-Wl,-dylib_install_name,@rpath/foo"},
 	{"-Wl,-install_name,@rpath"},
+	{"-Wl,-install_name,@rpath/"},
+	{"-Wl,-install_name,@rpath/foo"},
 	{"-Wl,-rpath,@executable_path"},
+	{"-Wl,-rpath,@executable_path/"},
+	{"-Wl,-rpath,@executable_path/foo"},
 	{"-Wl,-rpath,@loader_path"},
-}
-
-var badLinkerFlagsNotDarwin = [][]string{
-	{"-Wl,-rpath,@foo"},
+	{"-Wl,-rpath,@loader_path/"},
+	{"-Wl,-rpath,@loader_path/foo"},
 }
 
 func TestCheckLinkerFlags(t *testing.T) {
@@ -287,7 +294,7 @@ func TestCheckLinkerFlags(t *testing.T) {
 	}
 
 	cfg.Goos = "linux"
-	for _, f := range badLinkerFlagsNotDarwin {
+	for _, f := range goodLinkerFlagsOnDarwin {
 		if err := checkLinkerFlags("test", "test", f); err == nil {
 			t.Errorf("missing error for %q", f)
 		}

--- a/src/cmd/go/internal/work/security_test.go
+++ b/src/cmd/go/internal/work/security_test.go
@@ -5,10 +5,11 @@
 package work
 
 import (
-	"internal/cfg"
 	"os"
 	"strings"
 	"testing"
+
+	"cmd/go/internal/cfg"
 )
 
 var goodCompilerFlags = [][]string{
@@ -300,7 +301,7 @@ func TestCheckLinkerFlags(t *testing.T) {
 		}
 	}
 
-	goos = cfg.Goos
+	cfg.Goos = goos
 }
 
 func TestCheckFlagAllowDisallow(t *testing.T) {

--- a/src/cmd/go/internal/work/security_test.go
+++ b/src/cmd/go/internal/work/security_test.go
@@ -294,6 +294,13 @@ func TestCheckLinkerFlags(t *testing.T) {
 		}
 	}
 
+	cfg.Goos = "ios"
+	for _, f := range goodLinkerFlagsOnDarwin {
+		if err := checkLinkerFlags("test", "test", f); err != nil {
+			t.Errorf("unexpected error for %q: %v", f, err)
+		}
+	}
+
 	cfg.Goos = "linux"
 	for _, f := range goodLinkerFlagsOnDarwin {
 		if err := checkLinkerFlags("test", "test", f); err == nil {


### PR DESCRIPTION
The GNU linker interprets @file as "read command-line options from file".
Thus, we forbid values starting with @ on linker flags. However, this
causes a problem when targeting Darwin. @executable_path, @loader_path, and
@rpath are special values used in Mach-O to change the library search path
and can be used in conjunction with the -install_name and -rpath linker
flags. Since the GNU linker does not support Mach-O, targeting Darwin
implies not using the GNU linker. Therefore, we allow @ in the linker flags
if and only if cfg.Goos == "darwin".

Fixes #40559