### PR TITLE
text/template: document function name rules and refactor goodName

### DIFF
--- a/src/html/template/template.go
+++ b/src/html/template/template.go
@@ -333,8 +333,11 @@ type FuncMap = template.FuncMap
 // Funcs adds the elements of the argument map to the template's function map.
 // It must be called before the template is parsed.
 // It panics if a value in the map is not a function with appropriate return
-// type. However, it is legal to overwrite elements of the map. The return
-// value is the template, so calls can be chained.
+// type or if the name cannot be used syntactically as a function in a template.
+// A valid function name is a sequence of letters, digits, and underscores,
+// starting with a letter or an underscore.
+// It is legal to overwrite elements of the map. The return value is the template,
+// so calls can be chained.
 func (t *Template) Funcs(funcMap FuncMap) *Template {
 	t.text.Funcs(template.FuncMap(funcMap))
 	return t

--- a/src/text/template/funcs.go
+++ b/src/text/template/funcs.go
@@ -130,10 +130,10 @@ func goodName(name string) bool {
 	}
 	for i, r := range name {
 		switch {
+        case unicode.IsLetter(r):
 		case r == '_':
-		case i == 0 && !unicode.IsLetter(r):
-			return false
-		case !unicode.IsLetter(r) && !unicode.IsDigit(r):
+		case i > 0 && unicode.IsDigit(r):
+        default:
 			return false
 		}
 	}

--- a/src/text/template/funcs.go
+++ b/src/text/template/funcs.go
@@ -130,10 +130,10 @@ func goodName(name string) bool {
 	}
 	for i, r := range name {
 		switch {
-        case unicode.IsLetter(r):
+		case unicode.IsLetter(r):
 		case r == '_':
 		case i > 0 && unicode.IsDigit(r):
-        default:
+		default:
 			return false
 		}
 	}

--- a/src/text/template/template.go
+++ b/src/text/template/template.go
@@ -169,6 +169,8 @@ func (t *Template) Delims(left, right string) *Template {
 // It must be called before the template is parsed.
 // It panics if a value in the map is not a function with appropriate return
 // type or if the name cannot be used syntactically as a function in a template.
+// A valid function name is a sequence of letters, digits, and underscores,
+// starting with a letter or an underscore.
 // It is legal to overwrite elements of the map. The return value is the template,
 // so calls can be chained.
 func (t *Template) Funcs(funcMap FuncMap) *Template {


### PR DESCRIPTION
This change enhances the documentation by specifying permissible function names in the `Funcs` function of both `text/template` and `html/template`.

Additionally, the `goodName` function has been refactored to improve readability and maintainability, ensuring it allows only letters, underscores, or digits, with the constraint that a digit cannot be the initial character.

While the primary modifications are in `text/template`, they also impact `html/template`, as it utilizes `goodName` internally.