### PR TITLE
go/printer: do not set impliedSemi to false in print, while writing newlines

### DIFF
--- a/src/go/printer/printer.go
+++ b/src/go/printer/printer.go
@@ -1015,7 +1015,6 @@ func (p *printer) print(args ...any) {
 					ch = '\f' // use formfeed since we dropped one before
 				}
 				p.writeByte(ch, n)
-				impliedSemi = false
 			}
 		}
 


### PR DESCRIPTION
Lets say we are writing an *ast.Ident, and this code causes impliedSemi 
to set to false (from true), this doesn't make any sense to me, because
we are writing this ident **after** adding these newlines, thus impliedSemi
should be still set to true.

Fixes #70978
Fixes #77734