### PR TITLE
cmd/link: document that -s implies -w

### DIFF
--- a/src/cmd/link/doc.go
+++ b/src/cmd/link/doc.go
@@ -118,6 +118,7 @@ Flags:
 		Link with race detection libraries.
 	-s
 		Omit the symbol table and debug information.
+		Implies the -w flag, which can be negated with -w=0.
 	-tmpdir dir
 		Write temporary files to dir.
 		Temporary files are only used in external linking mode.


### PR DESCRIPTION
Existing documentation does not reference implicit behavior.
Updates the documentation to reflect that -s implies -w.

Fixes #71051