### PR TITLE
net/http: optimize Cookie.sanitizeOrWarn and timeoutHandler.ServeHTTP

### DIFF
--- a/src/net/http/cookie.go
+++ b/src/net/http/cookie.go
@@ -483,25 +483,22 @@ func validCookiePathByte(b byte) bool {
 }
 
 func sanitizeOrWarn(fieldName string, valid func(byte) bool, v string) string {
-	ok := true
 	for i := 0; i < len(v); i++ {
 		if valid(v[i]) {
 			continue
 		}
 		log.Printf("net/http: invalid byte %q in %s; dropping invalid bytes", v[i], fieldName)
-		ok = false
-		break
-	}
-	if ok {
-		return v
-	}
-	buf := make([]byte, 0, len(v))
-	for i := 0; i < len(v); i++ {
-		if b := v[i]; valid(b) {
-			buf = append(buf, b)
+		buf := make([]byte, 0, len(v))
+		buf = append(buf, v[:i]...)
+		i++
+		for ; i < len(v); i++ {
+			if b := v[i]; valid(b) {
+				buf = append(buf, b)
+			}
 		}
+		return string(buf)
 	}
-	return string(buf)
+	return v
 }
 
 // parseCookieValue parses a cookie value according to RFC 6265.

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -3805,7 +3805,6 @@ func (h *timeoutHandler) ServeHTTP(w ResponseWriter, r *Request) {
 		defer cancelCtx()
 	}
 	r = r.WithContext(ctx)
-	done := make(chan struct{})
 	tw := &timeoutWriter{
 		w:   w,
 		h:   make(Header),
@@ -3819,12 +3818,13 @@ func (h *timeoutHandler) ServeHTTP(w ResponseWriter, r *Request) {
 			}
 		}()
 		h.handler.ServeHTTP(tw, r)
-		close(done)
+		close(panicChan)
 	}()
 	select {
 	case p := <-panicChan:
-		panic(p)
-	case <-done:
+		if p != nil {
+			panic(p)
+		}
 		tw.mu.Lock()
 		defer tw.mu.Unlock()
 		dst := w.Header()


### PR DESCRIPTION
Cookie.sanitizeOrWarn: Avoid restarting validation from the beginning when encountering invalid characters.

timeoutHandler.ServeHTTP: Use a single channel for both panic recovery and done signaling.