### PR TITLE
src/cmd/compile/internal/ssa: Update html.go DOM text reinterpreted as HTM

### DIFF
--- a/src/cmd/compile/internal/ssa/html.go
+++ b/src/cmd/compile/internal/ssa/html.go
@@ -628,10 +628,10 @@ function hideBlock(el) {
     var e = es[0];
     if (e.style.display === 'block' || e.style.display === '') {
         e.style.display = 'none';
-        el.innerHTML = '+';
+        el.textContent = '+';
     } else {
         e.style.display = 'block';
-        el.innerHTML = '-';
+        el.textContent = '-';
     }
 }
 


### PR DESCRIPTION
Here instead of using innerhtml used textContent, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.