### PR TITLE
Adicionar benchmark para algoritmos pós-quanticos

### DIFF
--- a/src/crypto/hybrid/hybrid_sig.go
+++ b/src/crypto/hybrid/hybrid_sig.go
@@ -39,6 +39,12 @@ const (
 	CROSS_128_FAST_ED25519  OID = "0.2.1.5.F"
 	CROSS_192_SMALL_ED25519 OID = "0.2.3.5.S"
 	CROSS_256_SMALL_ED25519 OID = "0.2.5.5.S"
+
+	ML_DSA_44_P256 OID = "0.3.1.2"
+	ML_DSA_65_P384 OID = "0.3.1.3"
+	ML_DSA_87_P521 OID = "0.3.1.5"
+
+	ML_DSA_65_ED25519 OID = "0.3.2.2"
 )
 
 type SigName struct {
@@ -66,6 +72,12 @@ var SigOIDtoName = map[OID]SigName{
 	CROSS_128_FAST_ED25519:  {"cross-rsdpg-128-fast", ed25519.PrivateKey{}},
 	CROSS_192_SMALL_ED25519: {"cross-rsdpg-192-small", ed25519.PrivateKey{}},
 	CROSS_256_SMALL_ED25519: {"cross-rsdpg-256-small", ed25519.PrivateKey{}},
+
+	ML_DSA_44_P256: {"ML-DSA-44", elliptic.P256()},
+	ML_DSA_65_P384: {"ML-DSA-65", elliptic.P384()},
+	ML_DSA_87_P521: {"ML-DSA-87", elliptic.P521()},
+
+	ML_DSA_65_ED25519: {"ML-DSA-65", ed25519.PrivateKey{}},
 }
 
 type PublicKey struct {
@@ -82,13 +94,13 @@ type PrivateKey struct {
 }
 
 // GetPublicKeys returns the classic and post-quantum private keys from a sig receiver.
-func (pub *PublicKey) GetPublicKeys() (classic *ecdsa.PublicKey, pqc []byte) {
-	return (*pub.classic).(*ecdsa.PublicKey), pub.pqc
+func (pub *PublicKey) GetPublicKeys() (classic *interface{}, pqc []byte) {
+	return pub.classic, pub.pqc
 }
 
 // GetPrivateKeys returns the classic and post-quantum private keys from a sig receiver.
-func (priv *PrivateKey) GetPrivateKeys() (classic *ecdsa.PrivateKey, pqc []byte) {
-	return (*priv.classic).(*ecdsa.PrivateKey), priv.pqc
+func (priv *PrivateKey) GetPrivateKeys() (classic *interface{}, pqc []byte) {
+	return priv.classic, priv.pqc
 }
 
 // ExportPublicKey exports the corresponding public hybrid key from the sig receiver.

--- a/src/crypto/hybrid/hybrid_sig.go
+++ b/src/crypto/hybrid/hybrid_sig.go
@@ -1,0 +1,127 @@
+// hybrid_sig.go
+// hybrid signature cryptography for the go std library using liboqs-go.
+
+package hybrid
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+
+	"github.com/open-quantum-safe/liboqs-go/oqs"
+	"golang.org/x/crypto/cryptobyte"
+
+	"errors"
+)
+
+// Object IDentifiers for PQC and Composite
+// https://github.com/IETF-Hackathon/pqc-certificates/blob/master/docs/oid_mapping.md
+type OID string
+
+const (
+	MAYO1_P256 OID = "0.1.1.1" // TODO: use proper OID values
+	MAYO2_P256 OID = "0.1.2.2"
+	MAYO3_P384 OID = "0.1.3.3"
+	MAYO5_P521 OID = "0.1.5.4"
+)
+
+const (
+	HYBRID_SIG uint8 = 0 // used for Verify(), which signature to check for
+	PQC_SIG
+	CLASSIC_SIG
+)
+
+type SigName struct {
+	pqc     string
+	classic elliptic.Curve
+}
+
+var SigOIDtoName = map[OID]SigName{
+	MAYO1_P256: {"Mayo-1", elliptic.P256()},
+	MAYO2_P256: {"Mayo-2", elliptic.P256()},
+	MAYO3_P384: {"Mayo-3", elliptic.P384()},
+	MAYO5_P521: {"Mayo-5", elliptic.P521()},
+}
+
+type PublicKey struct {
+	SigOID  OID
+	pqc     []byte
+	classic *ecdsa.PublicKey
+}
+
+type PrivateKey struct {
+	SigOID  OID
+	pqc     []byte
+	classic *ecdsa.PrivateKey
+	public  *PublicKey
+}
+
+func (pub *PublicKey) ExportPublicKeys() (pqc []byte, classic *ecdsa.PublicKey) {
+	return pub.pqc, pub.classic
+}
+
+func (priv *PrivateKey) ExportPublicKeys() (pqc []byte, classic *ecdsa.PublicKey) {
+	return priv.public.pqc, priv.public.classic
+}
+
+func (priv *PrivateKey) ExportPrivateKeys() (pqc []byte, classic *ecdsa.PrivateKey) {
+	return priv.pqc, priv.classic
+}
+
+func GenerateKey(sigOID OID) (priv PrivateKey, err error) {
+	var pub PublicKey
+
+	// Post-quantum LibOQS
+	pqcSigner := oqs.Signature{}
+	if err = pqcSigner.Init(SigOIDtoName[sigOID].pqc, nil); err != nil {
+		return PrivateKey{}, err
+	}
+	if pub.pqc, err = pqcSigner.GenerateKeyPair(); err != nil {
+		return PrivateKey{}, err
+	}
+	priv.pqc = pqcSigner.ExportSecretKey()
+
+	// Classic NIST curves
+	if priv.classic, err = ecdsa.GenerateKey(SigOIDtoName[sigOID].classic, rand.Reader); err != nil {
+		return PrivateKey{}, err
+	}
+	pub.classic = &priv.classic.PublicKey
+
+	pub.SigOID = sigOID
+	priv.SigOID = sigOID
+	priv.public = &pub
+
+	return priv, err
+}
+
+func (priv *PrivateKey) Sign(message []byte) (signature []byte, err error) {
+	var hybridSig cryptobyte.Builder
+	var pqcSig []byte
+	var classicSig []byte
+
+	// Post-quantum LibOQS
+	pqcSigner := oqs.Signature{}
+	if err := pqcSigner.Init(SigOIDtoName[priv.SigOID].pqc, priv.pqc); err != nil {
+		return nil, err
+	}
+	if pqcSig, err = pqcSigner.Sign(message); err != nil {
+		return nil, err
+	}
+
+	// Classic NIST curves
+	if classicSig, err = ecdsa.SignASN1(rand.Reader, priv.classic, message); err != nil {
+		return nil, err
+	}
+
+	// Concat both to make the hybrid signature
+	hybridSig.AddUint16(uint16(len(classicSig)))
+	hybridSig.AddBytes(classicSig)
+	hybridSig.AddUint16(uint16(len(pqcSig)))
+	hybridSig.AddBytes(pqcSig)
+
+	return hybridSig.BytesOrPanic(), err
+}
+
+func Verify(option uint8, pub PublicKey, signature []byte) (valid bool, err error) {
+	return false, errors.New("not implemented yet")
+}

--- a/src/crypto/hybrid/hybrid_sig.go
+++ b/src/crypto/hybrid/hybrid_sig.go
@@ -30,6 +30,11 @@ const (
 	MAYO3_ED25519 OID = "0.1.3.5"
 	MAYO5_ED25519 OID = "0.1.5.5"
 
+	CROSS_128_SMALL_P256 OID = "0.2.1.1.S"
+	CROSS_128_FAST_P256  OID = "0.2.1.2.F"
+	CROSS_192_SMALL_P384 OID = "0.2.3.3.S"
+	CROSS_256_SMALL_P521 OID = "0.2.5.4.S"
+
 	CROSS_128_SMALL_ED25519 OID = "0.2.1.5.S"
 	CROSS_128_FAST_ED25519  OID = "0.2.1.5.F"
 	CROSS_192_SMALL_ED25519 OID = "0.2.3.5.S"
@@ -51,6 +56,11 @@ var SigOIDtoName = map[OID]SigName{
 	MAYO2_ED25519: {"Mayo-2", ed25519.PrivateKey{}},
 	MAYO3_ED25519: {"Mayo-3", ed25519.PrivateKey{}},
 	MAYO5_ED25519: {"Mayo-5", ed25519.PrivateKey{}},
+
+	CROSS_128_SMALL_P256: {"cross-rsdpg-128-small", elliptic.P256()},
+	CROSS_128_FAST_P256:  {"cross-rsdpg-128-fast", elliptic.P256()},
+	CROSS_192_SMALL_P384: {"cross-rsdpg-192-small", elliptic.P384()},
+	CROSS_256_SMALL_P521: {"cross-rsdpg-256-small", elliptic.P521()},
 
 	CROSS_128_SMALL_ED25519: {"cross-rsdpg-128-small", ed25519.PrivateKey{}},
 	CROSS_128_FAST_ED25519:  {"cross-rsdpg-128-fast", ed25519.PrivateKey{}},

--- a/src/crypto/hybrid/hybrid_sig_test.go
+++ b/src/crypto/hybrid/hybrid_sig_test.go
@@ -1,0 +1,188 @@
+package hybrid
+
+import (
+	"crypto/sha256"
+	"flag"
+  "fmt"
+	"testing"
+  "time"
+	"os"
+
+  "github.com/dterei/gotsc"
+)
+
+var algorithms = []OID{
+	MAYO1_ED25519,
+	MAYO2_ED25519,
+	MAYO3_ED25519,
+	MAYO5_ED25519,
+	CROSS_128_SMALL_ED25519,
+	CROSS_128_FAST_ED25519,
+	CROSS_192_SMALL_ED25519,
+	CROSS_256_SMALL_ED25519,
+  ML_DSA_44_P256,
+  ML_DSA_65_P384,
+  ML_DSA_87_P521,
+	ML_DSA_65_ED25519,
+}
+
+var (
+	duration time.Duration
+)
+
+func init() {
+	// Define the duration flag and set its default value
+	flag.DurationVar(&duration, "duration", 3*time.Second, "duration for each test")
+}
+
+// TestMain processes flags before running tests
+func TestMain(m *testing.M) {
+	flag.Parse()
+	fmt.Printf("Duration set to: %v\n", duration)
+	os.Exit(m.Run())
+}
+
+var hash = sha256.Sum256([]byte("Test message for hybrid signature"))
+
+func TestKeygenHybrid(t *testing.T) {
+	for _, alg := range algorithms {
+		t.Run(string(alg), func(t *testing.T) {
+			tsc := gotsc.TSCOverhead()
+
+			start := time.Now()
+			startCycles := gotsc.BenchStart()
+			var keyGenCPU []int64
+			var keyGenTime []int64
+
+			iterations := 0
+			for time.Since(start) < duration {
+				// Test key generation
+				_, err := GenerateKey(alg)
+				if err != nil {
+					t.Fatalf("Failed to generate keys for %s: %v", alg, err)
+				}
+
+				keyGenTime = append(keyGenTime, time.Since(start).Microseconds())
+				keyGenCPU = append(keyGenCPU, int64(gotsc.BenchEnd()-startCycles-tsc))
+
+				iterations++
+			}
+
+			mean := func(data []int64) int64 {
+				var sum int64
+				for _, v := range data {
+					sum += v
+				}
+				return sum / int64(len(data))
+			}
+
+      opsPerS := float64(iterations) / duration.Seconds()
+			meanCPU := mean(keyGenCPU)
+			meanTime := mean(keyGenTime)
+
+			// Print results
+      fmt.Printf("TESTING KEYGEN - Algorithm: %s | Iterations: %d | Mean CPU Cycles: %d | Mean Time: %d µs | Operations/S: %f s\n", alg, iterations, meanCPU, meanTime, opsPerS)
+		})
+	}
+}
+
+func TestSignHybrid(t *testing.T) {
+	for _, alg := range algorithms {
+		t.Run(string(alg), func(t *testing.T) {
+
+      privKey, err := GenerateKey(alg)
+      if err != nil {
+        t.Fatalf("Failed to generate keys for %s: %v", alg, err)
+      }
+
+			tsc := gotsc.TSCOverhead()
+
+			start := time.Now()
+			startCycles := gotsc.BenchStart()
+			var signCPU []int64
+			var signTime []int64
+
+			iterations := 0
+
+			for time.Since(start) < duration {
+				// Test signing
+				_, err = privKey.Sign(hash[:])
+				if err != nil {
+					t.Fatalf("Failed to sign message for %s: %v", alg, err)
+				}
+
+				signTime = append(signTime, time.Since(start).Microseconds())
+				signCPU = append(signCPU, int64(gotsc.BenchEnd()-startCycles-tsc))
+
+				iterations++
+			}
+
+			mean := func(data []int64) int64 {
+				var sum int64
+				for _, v := range data {
+					sum += v
+				}
+				return sum / int64(len(data))
+			}
+
+      opsPerS := float64(iterations) / duration.Seconds()
+			meanCPU := mean(signCPU)
+			meanTime := mean(signTime)
+
+			// Print results
+			fmt.Printf("TESTING SIGN - Algorithm: %s | Iterations: %d | Mean CPU Cycles: %d | Mean Time: %d µs | Operations/S: %f s\n", alg, iterations, meanCPU, meanTime, opsPerS)
+		})
+	}
+}
+
+func TestVerifyHybrid(t *testing.T) {
+	for _, alg := range algorithms {
+		t.Run(string(alg), func(t *testing.T) {
+      privKey, err := GenerateKey(alg)
+      if err != nil {
+        t.Fatalf("Failed to generate keys for %s: %v", alg, err)
+      }
+      pubKey := privKey.ExportPublicKey()
+
+      signature, err := privKey.Sign(hash[:])
+      if err != nil {
+        t.Fatalf("Failed to sign message for %s: %v", alg, err)
+      }
+
+			tsc := gotsc.TSCOverhead()
+
+			start := time.Now()
+			startCycles := gotsc.BenchStart()
+			var verifyCPU []int64
+			var verifyTime []int64
+
+			iterations := 0
+			for time.Since(start) < duration {
+				// Test verification
+				if !VerifyHybrid(pubKey, hash[:], signature) {
+					t.Errorf("Signature verification failed for %s", alg)
+				}
+
+				verifyTime = append(verifyTime, time.Since(start).Microseconds())
+				verifyCPU = append(verifyCPU, int64(gotsc.BenchEnd()-startCycles-tsc))
+
+				iterations++
+			}
+
+			mean := func(data []int64) int64 {
+				var sum int64
+				for _, v := range data {
+					sum += v
+				}
+				return sum / int64(len(data))
+			}
+
+      opsPerS := float64(iterations) / duration.Seconds()
+			meanCPU := mean(verifyCPU)
+			meanTime := mean(verifyTime)
+
+			// Print results
+			fmt.Printf("TESTING VERIFY - Algorithm: %s | Iterations: %d | Mean CPU Cycles: %d | Mean Time: %d µs | Operations/S: %f s\n", alg, iterations, meanCPU, meanTime, opsPerS)
+		})
+	}
+}

--- a/src/testing/pqc_benchmark_test.go
+++ b/src/testing/pqc_benchmark_test.go
@@ -1,0 +1,190 @@
+package testing
+
+import (
+	"crypto/sha256"
+	"flag"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/dterei/gotsc"
+	"github.com/open-quantum-safe/liboqs-go/oqs"
+)
+
+var algorithms = []string{
+	"ML-DSA-44",
+	"ML-DSA-65",
+	"ML-DSA-87",
+	"cross-rsdp-128-small",
+	"cross-rsdp-128-fast",
+	"cross-rsdp-192-small",
+	"cross-rsdp-256-small",
+}
+
+var duration time.Duration
+
+func init() {
+	// Define the duration flag and set its default value
+	flag.DurationVar(&duration, "duration", 3*time.Second, "duration for each test")
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	fmt.Printf("Duration set to: %v\n", duration)
+	m.Run()
+}
+
+var hash = sha256.Sum256([]byte("Test message for post-quantum signature"))
+
+func TestKeygenPQC(t *testing.T) {
+	for _, alg := range algorithms {
+		t.Run(alg, func(t *testing.T) {
+			signer := oqs.Signature{}
+			if err := signer.Init(alg, nil); err != nil {
+				t.Fatalf("Failed to initialize algorithm %s: %v", alg, err)
+			}
+			defer signer.Clean()
+
+			tsc := gotsc.TSCOverhead()
+
+			start := time.Now()
+			startCycles := gotsc.BenchStart()
+			var keyGenCPU []int64
+			var keyGenTime []int64
+
+			iterations := 0
+			for time.Since(start) < duration {
+				_, err := signer.GenerateKeyPair()
+				if err != nil {
+					t.Fatalf("Failed to generate keys for %s: %v", alg, err)
+				}
+
+				keyGenTime = append(keyGenTime, time.Since(start).Microseconds())
+				keyGenCPU = append(keyGenCPU, int64(gotsc.BenchEnd()-startCycles-tsc))
+
+				iterations++
+			}
+
+			mean := func(data []int64) int64 {
+				var sum int64
+				for _, v := range data {
+					sum += v
+				}
+				return sum / int64(len(data))
+			}
+
+			opsPerS := float64(iterations) / duration.Seconds()
+			meanCPU := mean(keyGenCPU)
+			meanTime := mean(keyGenTime)
+
+			fmt.Printf("TESTING KEYGEN - Algorithm: %s | Iterations: %d | Mean CPU Cycles: %d | Mean Time: %d µs | Operations/S: %f s\n", alg, iterations, meanCPU, meanTime, opsPerS)
+		})
+	}
+}
+
+func TestSignPQC(t *testing.T) {
+	for _, alg := range algorithms {
+		t.Run(alg, func(t *testing.T) {
+			signer := oqs.Signature{}
+			if err := signer.Init(alg, nil); err != nil {
+				t.Fatalf("Failed to initialize algorithm %s: %v", alg, err)
+			}
+			defer signer.Clean()
+
+			_, err := signer.GenerateKeyPair()
+			if err != nil {
+				t.Fatalf("Failed to generate keys for %s: %v", alg, err)
+			}
+
+			tsc := gotsc.TSCOverhead()
+
+			start := time.Now()
+			startCycles := gotsc.BenchStart()
+			var signCPU []int64
+			var signTime []int64
+
+			iterations := 0
+			for time.Since(start) < duration {
+				_, err := signer.Sign(hash[:])
+				if err != nil {
+					t.Fatalf("Failed to sign message for %s: %v", alg, err)
+				}
+
+				signTime = append(signTime, time.Since(start).Microseconds())
+				signCPU = append(signCPU, int64(gotsc.BenchEnd()-startCycles-tsc))
+
+				iterations++
+			}
+
+			mean := func(data []int64) int64 {
+				var sum int64
+				for _, v := range data {
+					sum += v
+				}
+				return sum / int64(len(data))
+			}
+
+			opsPerS := float64(iterations) / duration.Seconds()
+			meanCPU := mean(signCPU)
+			meanTime := mean(signTime)
+
+			fmt.Printf("TESTING SIGN - Algorithm: %s | Iterations: %d | Mean CPU Cycles: %d | Mean Time: %d µs | Operations/S: %f s\n", alg, iterations, meanCPU, meanTime, opsPerS)
+		})
+	}
+}
+
+func TestVerifyPQC(t *testing.T) {
+	for _, alg := range algorithms {
+		t.Run(alg, func(t *testing.T) {
+			signer := oqs.Signature{}
+			if err := signer.Init(alg, nil); err != nil {
+				t.Fatalf("Failed to initialize algorithm %s: %v", alg, err)
+			}
+			defer signer.Clean()
+
+			publicKey, err := signer.GenerateKeyPair()
+			if err != nil {
+				t.Fatalf("Failed to generate keys for %s: %v", alg, err)
+			}
+
+			signature, err := signer.Sign(hash[:])
+			if err != nil {
+				t.Fatalf("Failed to sign message for %s: %v", alg, err)
+			}
+
+			tsc := gotsc.TSCOverhead()
+
+			start := time.Now()
+			startCycles := gotsc.BenchStart()
+			var verifyCPU []int64
+			var verifyTime []int64
+
+			iterations := 0
+			for time.Since(start) < duration {
+				valid, err := signer.Verify(hash[:], signature, publicKey)
+				if err != nil || !valid {
+					t.Fatalf("Failed to verify signature for %s", alg)
+				}
+
+				verifyTime = append(verifyTime, time.Since(start).Microseconds())
+				verifyCPU = append(verifyCPU, int64(gotsc.BenchEnd()-startCycles-tsc))
+
+				iterations++
+			}
+
+			mean := func(data []int64) int64 {
+				var sum int64
+				for _, v := range data {
+					sum += v
+				}
+				return sum / int64(len(data))
+			}
+
+			opsPerS := float64(iterations) / duration.Seconds()
+			meanCPU := mean(verifyCPU)
+			meanTime := mean(verifyTime)
+
+			fmt.Printf("TESTING VERIFY - Algorithm: %s | Iterations: %d | Mean CPU Cycles: %d | Mean Time: %d µs | Operations/S: %f s\n", alg, iterations, meanCPU, meanTime, opsPerS)
+		})
+	}
+}


### PR DESCRIPTION
### O que foi feito:
- Implementados testes funcionais para os algoritmos pós-quânticos, cobrindo as operações de:
  - Geração de chaves (Keygen)
  - Assinatura de mensagens (Sign)
  - Verificação de assinaturas (Verify)
- Cada teste executa os algoritmos dentro de um período fixo de tempo (3 segundos por padrão).
- Métricas de desempenho adicionais foram calculadas para cada algoritmo.

### Algoritmos testados:
- ML-DSA-44
- ML-DSA-65
- ML-DSA-87
- cross-rsdp-128-small
- cross-rsdp-128-fast
- cross-rsdp-192-small
- cross-rsdp-256-small

### Métricas calculadas:
1. **Número de iterações**: Quantidade de operações executadas dentro do tempo fixo.
2. **Tempo médio por operação (µs/op)**: Tempo médio em microssegundos para completar cada operação.
3. **Ciclos médios por operação (cycles/op)**: Número médio de ciclos da CPU consumidos por operação, usando a biblioteca `gotsc`.
4. **Operações por segundo (ops/sec)**: Taxa de operações realizadas por segundo.

### Como rodar os testes:
1. Certifique-se de que as dependências estão instaladas:
   - Biblioteca `liboqs-go` para algoritmos pós-quânticos.
   - Biblioteca `gotsc` para medição de ciclos da CPU.

2. Execute os testes com o comando:
```
go test -v -duration=5s
```
3. Exemplos de saida
```
TESTING KEYGEN - Algorithm: ML-DSA-65 | Iterations: 18701 | Mean CPU Cycles: 2196813163 | Mean Time: 1157334 µs | Operations/S: 6233.666667 s
```

### Observações:
- O tempo de execução dos testes é configurável via flag `-duration` (padrão: 3 segundos).
- Resultados podem variar dependendo do hardware e da carga do sistema.
