### PR TITLE
archive/zip: add trailing slash to directory names for Writer.AddFS

### DIFF
--- a/src/archive/zip/writer.go
+++ b/src/archive/zip/writer.go
@@ -520,6 +520,10 @@ func (w *Writer) AddFS(fsys fs.FS) error {
 			return err
 		}
 		h.Name = name
+		if d.IsDir() {
+			// See issue 71235.
+			h.Name += "/"
+		}
 		h.Method = Deflate
 		fw, err := w.CreateHeader(h)
 		if err != nil {

--- a/src/archive/zip/writer_test.go
+++ b/src/archive/zip/writer_test.go
@@ -633,7 +633,7 @@ func TestWriterAddFS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Add subfolder into fsys to match what we'll read from the tar.
+	// Add subfolder into fsys to match what we'll read from the zip.
 	tests = append(tests[:2:2], WriteTest{Name: "subfolder", Mode: 0o555 | os.ModeDir}, tests[2])
 
 	// read it back
@@ -642,6 +642,10 @@ func TestWriterAddFS(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i, wt := range tests {
+		if wt.Mode.IsDir() {
+			// See issue 71235.
+			wt.Name += "/"
+		}
 		testReadFile(t, r.File[i], &wt)
 	}
 }


### PR DESCRIPTION
This takes over CL 642375.

Fixes #71235.