### PR TITLE
go/types: remove spurious quotes around package name in diagnostic message

### DIFF
--- a/src/cmd/compile/internal/types2/format.go
+++ b/src/cmd/compile/internal/types2/format.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"cmd/compile/internal/syntax"
 	"fmt"
-	"strconv"
 	"strings"
 )
 
@@ -129,7 +128,7 @@ func (check *Checker) qualifier(pkg *Package) string {
 		}
 		// If the same package name was used by multiple packages, display the full path.
 		if len(check.pkgPathMap[pkg.name]) > 1 {
-			return strconv.Quote(pkg.path)
+			return pkg.path
 		}
 		return pkg.name
 	}

--- a/src/go/types/format.go
+++ b/src/go/types/format.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
-	"strconv"
 	"strings"
 )
 
@@ -131,7 +130,7 @@ func (check *Checker) qualifier(pkg *Package) string {
 		}
 		// If the same package name was used by multiple packages, display the full path.
 		if len(check.pkgPathMap[pkg.name]) > 1 {
-			return strconv.Quote(pkg.path)
+			return pkg.path
 		}
 		return pkg.name
 	}


### PR DESCRIPTION
When you have a type error involving a type from a package whose name is used by multiple packages, spurious quotes are added around the package name.

Example:

```go
package main

import (
	"golang.org/x/oauth2"
	goauth2 "google.golang.org/api/oauth2/v2"
)

func main() {
	_, _ = goauth2.NewService(nil)

	_ = oauth2.StaticTokenSource(oauth2.Token{})
}
```

does not build with the message

```
./main.go:11:31: cannot use oauth2.Token{} (value of type "golang.org/x/oauth2".Token) as *"golang.org/x/oauth2".Token value in argument to oauth2.StaticTokenSource
```

it is expected to not build, but the quotes around “"golang.org/x/oauth2"” are unexpected.