### PR TITLE
net: use strings.SplitSeq and bytes.SplitSeq

### DIFF
--- a/src/net/http/fs.go
+++ b/src/net/http/fs.go
@@ -1014,7 +1014,7 @@ func parseRange(s string, size int64) ([]httpRange, error) {
 	}
 	var ranges []httpRange
 	noOverlap := false
-	for _, ra := range strings.Split(s[len(b):], ",") {
+	for ra := range strings.SplitSeq(s[len(b):], ",") {
 		ra = textproto.TrimString(ra)
 		if ra == "" {
 			continue

--- a/src/net/http/httptest/recorder.go
+++ b/src/net/http/httptest/recorder.go
@@ -207,7 +207,7 @@ func (rw *ResponseRecorder) Result() *http.Response {
 	if trailers, ok := rw.snapHeader["Trailer"]; ok {
 		res.Trailer = make(http.Header, len(trailers))
 		for _, k := range trailers {
-			for _, k := range strings.Split(k, ",") {
+			for k := range strings.SplitSeq(k, ",") {
 				k = http.CanonicalHeaderKey(textproto.TrimString(k))
 				if !httpguts.ValidTrailerHeader(k) {
 					// Ignore since forbidden by RFC 7230, section 4.1.2.

--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -577,7 +577,7 @@ func shouldPanicOnCopyError(req *http.Request) bool {
 func removeHopByHopHeaders(h http.Header) {
 	// RFC 7230, section 6.1: Remove headers listed in the "Connection" header.
 	for _, f := range h["Connection"] {
-		for _, sf := range strings.Split(f, ",") {
+		for sf := range strings.SplitSeq(f, ",") {
 			if sf = textproto.TrimString(sf); sf != "" {
 				h.Del(sf)
 			}

--- a/src/net/http/httputil/reverseproxy_test.go
+++ b/src/net/http/httputil/reverseproxy_test.go
@@ -197,7 +197,7 @@ func TestReverseProxyStripHeadersPresentInConnection(t *testing.T) {
 		c := r.Header["Connection"]
 		var cf []string
 		for _, f := range c {
-			for _, sf := range strings.Split(f, ",") {
+			for sf := range strings.SplitSeq(f, ",") {
 				if sf = strings.TrimSpace(sf); sf != "" {
 					cf = append(cf, sf)
 				}

--- a/src/net/http/main_test.go
+++ b/src/net/http/main_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 func interestingGoroutines() (gs []string) {
 	buf := make([]byte, 2<<20)
 	buf = buf[:runtime.Stack(buf, true)]
-	for _, g := range strings.Split(string(buf), "\n\n") {
+	for g := range strings.SplitSeq(string(buf), "\n\n") {
 		_, stack, _ := strings.Cut(g, "\n")
 		stack = strings.TrimSpace(stack)
 		if stack == "" ||

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -1590,7 +1590,7 @@ func foreachHeaderElement(v string, fn func(string)) {
 		fn(v)
 		return
 	}
-	for _, f := range strings.Split(v, ",") {
+	for f := range strings.SplitSeq(v, ",") {
 		if f = textproto.TrimString(f); f != "" {
 			fn(f)
 		}

--- a/src/net/main_test.go
+++ b/src/net/main_test.go
@@ -185,7 +185,7 @@ func runningGoroutines() []string {
 	var gss []string
 	b := make([]byte, 2<<20)
 	b = b[:runtime.Stack(b, true)]
-	for _, s := range strings.Split(string(b), "\n\n") {
+	for s := range strings.SplitSeq(string(b), "\n\n") {
 		_, stack, _ := strings.Cut(s, "\n")
 		stack = strings.TrimSpace(stack)
 		if !strings.Contains(stack, "created by net") {

--- a/src/net/net_windows_test.go
+++ b/src/net/net_windows_test.go
@@ -240,8 +240,7 @@ func netshInterfaceIPShowInterface(ipver string, ifaces map[string]bool) error {
 	//Metric                             : 10
 	//...
 	var name string
-	lines := bytes.Split(out, []byte{'\r', '\n'})
-	for _, line := range lines {
+	for line := range bytes.SplitSeq(out, []byte{'\r', '\n'}) {
 		if bytes.HasPrefix(line, []byte("Interface ")) && bytes.HasSuffix(line, []byte(" Parameters")) {
 			f := line[len("Interface "):]
 			f = f[:len(f)-len(" Parameters")]
@@ -330,8 +329,7 @@ func netshInterfaceIPv4ShowAddress(name string, netshOutput []byte) []string {
 	addrs := make([]string, 0)
 	var addr, subnetprefix string
 	var processingOurInterface bool
-	lines := bytes.Split(netshOutput, []byte{'\r', '\n'})
-	for _, line := range lines {
+	for line := range bytes.SplitSeq(netshOutput, []byte{'\r', '\n'}) {
 		if !processingOurInterface {
 			if !bytes.HasPrefix(line, []byte("Configuration for interface")) {
 				continue
@@ -398,8 +396,7 @@ func netshInterfaceIPv6ShowAddress(name string, netshOutput []byte) []string {
 	// TODO: need to test ipv6 netmask too, but netsh does not outputs it
 	var addr string
 	addrs := make([]string, 0)
-	lines := bytes.Split(netshOutput, []byte{'\r', '\n'})
-	for _, line := range lines {
+	for line := range bytes.SplitSeq(netshOutput, []byte{'\r', '\n'}) {
 		if addr != "" {
 			if len(line) == 0 {
 				addr = ""
@@ -584,8 +581,7 @@ func TestInterfaceHardwareAddrWithGetmac(t *testing.T) {
 		want[cname] = addr
 		group = make(map[string]string)
 	}
-	lines := bytes.Split(out, []byte{'\r', '\n'})
-	for _, line := range lines {
+	for line := range bytes.SplitSeq(out, []byte{'\r', '\n'}) {
 		if len(line) == 0 {
 			processGroup()
 			continue


### PR DESCRIPTION
Replace `for _, s := range {strings, bytes}.Split(v, sep)` with
`for s := range {strings, bytes}.SplitSeq(v, sep)`, to simplify
the code and reduce some memory allocations.