### PR TITLE
unicode/utf8: remove init from utf8_test

### DIFF
--- a/src/unicode/utf8/utf8_test.go
+++ b/src/unicode/utf8/utf8_test.go
@@ -13,16 +13,6 @@ import (
 )
 
 // Validate the constants redefined from unicode.
-func init() {
-	if MaxRune != unicode.MaxRune {
-		panic("utf8.MaxRune is wrong")
-	}
-	if RuneError != unicode.ReplacementChar {
-		panic("utf8.RuneError is wrong")
-	}
-}
-
-// Validate the constants redefined from unicode.
 func TestConstants(t *testing.T) {
 	if MaxRune != unicode.MaxRune {
 		t.Errorf("utf8.MaxRune is wrong: %x should be %x", MaxRune, unicode.MaxRune)


### PR DESCRIPTION
TestConstants and init test the same thing, remove init,
it does not exist in utf16_test.go either.

Fixes #71579

