### PR TITLE
crypto/aes: more precise description for AES keys requirements

### DIFF
--- a/src/crypto/aes/aes.go
+++ b/src/crypto/aes/aes.go
@@ -30,7 +30,7 @@ func (k KeySizeError) Error() string {
 }
 
 // NewCipher creates and returns a new [cipher.Block].
-// The key argument should be the AES key,
+// The key argument must be the AES key,
 // either 16, 24, or 32 bytes to select
 // AES-128, AES-192, or AES-256.
 func NewCipher(key []byte) (cipher.Block, error) {


### PR DESCRIPTION
The existing documentation is not certain in the place regarding requirements about AES key.
Added some notes for precise description.