### PR TITLE
encoding/gob: add RegisteredTypes()

### DIFF
--- a/src/encoding/gob/type.go
+++ b/src/encoding/gob/type.go
@@ -8,6 +8,7 @@ import (
 	"encoding"
 	"errors"
 	"fmt"
+	"iter"
 	"maps"
 	"os"
 	"reflect"
@@ -897,6 +898,16 @@ func Register(value any) {
 	}
 
 	RegisterName(name, value)
+}
+
+// RegisteredTypes is list of registered type with their aliases
+// that registered with [Register] or [RegisterName] methods
+func RegisteredTypes() iter.Seq2[string, reflect.Type] {
+	return func(yield func(string, reflect.Type) bool) {
+		nameToConcreteType.Range(func(k, v any) bool {
+			return yield(k.(string), v.(reflect.Type))
+		})
+	}
 }
 
 func registerBasics() {

--- a/src/encoding/gob/type_test.go
+++ b/src/encoding/gob/type_test.go
@@ -260,3 +260,13 @@ func TestTypeRace(t *testing.T) {
 	close(c)
 	wg.Wait()
 }
+
+func TestRegisteredNames(t *testing.T) {
+	var names []string
+	for name, _ := range RegisteredTypes() {
+		names = append(names, name)
+	}
+	if len(names) < 34 {
+		t.Errorf("registered names should contains all primitive type")
+	}
+}


### PR DESCRIPTION
Starting from Go 1.23, direct access to `encoding/gob.nameToConcreteType` is no longer possible due to the removal of internal symbol linking. While this change improves encapsulation, it also removes the ability to retrieve a list of all registered types in the gob package.

Relates: golang/go#67401

Closes: golang/go#71602

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

