### PR TITLE
cmd/compile/internal/gc: handle errors from *bio.Writer

### DIFF
--- a/src/cmd/compile/internal/gc/export.go
+++ b/src/cmd/compile/internal/gc/export.go
@@ -47,5 +47,7 @@ func dumpasmhdr() {
 		}
 	}
 
-	b.Close()
+	if err := b.Close(); err != nil {
+		base.Fatalf("%v", err)
+	}
 }

--- a/src/cmd/compile/internal/gc/obj.go
+++ b/src/cmd/compile/internal/gc/obj.go
@@ -57,7 +57,7 @@ func dumpobj1(outfile string, mode int) {
 		fmt.Printf("can't create %s: %v\n", outfile, err)
 		base.ErrorExit()
 	}
-	defer bout.Close()
+
 	bout.WriteString("!<arch>\n")
 
 	if mode&modeCompilerObj != 0 {
@@ -69,6 +69,12 @@ func dumpobj1(outfile string, mode int) {
 		start := startArchiveEntry(bout)
 		dumpLinkerObj(bout)
 		finishArchiveEntry(bout, start, "_go_.o")
+	}
+
+	if err := bout.Close(); err != nil {
+		base.FlushErrors()
+		fmt.Printf("error while writing to file %s: %v\n", outfile, err)
+		base.ErrorExit()
 	}
 }
 


### PR DESCRIPTION
The error is stored internally in *bio.Writer, more specifically
in *bufio.Writer and the current code does not handle it, ignoring 
errors silently.