### PR TITLE
reflect: add TypeAssert[T]

### DIFF
--- a/api/next/62121.txt
+++ b/api/next/62121.txt
@@ -1,0 +1,1 @@
+pkg reflect, func TypeAssert[$0 interface{}](Value) ($0, bool) #62121

--- a/doc/next/6-stdlib/99-minor/reflect/62121.md
+++ b/doc/next/6-stdlib/99-minor/reflect/62121.md
@@ -1,2 +1,2 @@
-The new [TypeAssert] function permits converting a [Value] directly to a Go type.
-This is like using a type assertion on the result of [Value.Interface].
+The new [TypeAssert] function permits converting a [Value] directly to a Go value
+of the given type. This is like using a type assertion on the result of [Value.Interface].

--- a/doc/next/6-stdlib/99-minor/reflect/62121.md
+++ b/doc/next/6-stdlib/99-minor/reflect/62121.md
@@ -1,0 +1,2 @@
+The new [TypeAssert] function permits converting a [Value] directly to a Go type.
+This is like using a type assertion on the result of [Value.Interface].

--- a/doc/next/6-stdlib/99-minor/reflect/62121.md
+++ b/doc/next/6-stdlib/99-minor/reflect/62121.md
@@ -1,2 +1,3 @@
 The new [TypeAssert] function permits converting a [Value] directly to a Go value
-of the given type. This is like using a type assertion on the result of [Value.Interface].
+of the given type. This is like using a type assertion on the result of [Value.Interface],
+but avoids unnecessary memory allocations.

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -8701,7 +8701,7 @@ func newPtr[T any](t T) *T {
 	return &t
 }
 
-func TestTypeAssert(t *testing.T) {
+func TestTypeAssertConcreteTypes(t *testing.T) {
 	testTypeAssert(t, int(1111))
 	testTypeAssert(t, int(111111111))
 	testTypeAssert(t, int(-111111111))
@@ -8714,11 +8714,39 @@ func TestTypeAssert(t *testing.T) {
 	testTypeAssert(t, newPtr(111111111))
 	testTypeAssert(t, newPtr(-111111111))
 	testTypeAssert(t, newPtr([2]int{-111111111, -22222222}))
-
+	testTypeAssert(t, [2]*int{newPtr(-111111111), newPtr(-22222222)})
 	testTypeAssert(t, newPtr(time.Now()))
 
 	testTypeAssertDifferentType[uint](t, int(111111111))
 	testTypeAssertDifferentType[uint](t, int(-111111111))
+}
+
+func TestTypeAssertInterfaceTypes(t *testing.T) {
+	v, ok := TypeAssert[any](ValueOf(1))
+	if v != any(1) || !ok {
+		t.Errorf("TypeAssert[any](1) = (%v, %v); want = (1, true)", v, ok)
+	}
+
+	v, ok = TypeAssert[fmt.Stringer](ValueOf(1))
+	if v != nil || ok {
+		t.Errorf("TypeAssert[fmt.Stringer](1) = (%v, %v); want = (1, false)", v, ok)
+	}
+
+	v, ok = TypeAssert[any](ValueOf(testTypeWithMethod{"test"}))
+	if v != any(testTypeWithMethod{"test"}) || !ok {
+		t.Errorf(`TypeAssert[any](testTypeWithMethod{"test"}) = (%v, %v); want = (testTypeWithMethod{"test"}, true)`, v, ok)
+	}
+
+	v, ok = TypeAssert[fmt.Stringer](ValueOf(testTypeWithMethod{"test"}))
+	if v != fmt.Stringer(testTypeWithMethod{"test"}) || !ok {
+		t.Errorf(`TypeAssert[fmt.Stringer](testTypeWithMethod{"test"}) = (%v, %v); want = (testTypeWithMethod{"test"}, true)`, v, ok)
+	}
+
+	val := &testTypeWithMethod{"test"}
+	v, ok = TypeAssert[fmt.Stringer](ValueOf(val))
+	if v != fmt.Stringer(val) || !ok {
+		t.Errorf(`TypeAssert[fmt.Stringer](&testTypeWithMethod{"test"}) = (%v, %v); want = (&testTypeWithMethod{"test"}, true)`, v, ok)
+	}
 }
 
 type testTypeWithMethod struct {

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -8747,6 +8747,14 @@ func TestTypeAssertInterfaceTypes(t *testing.T) {
 	if v != fmt.Stringer(val) || !ok {
 		t.Errorf(`TypeAssert[fmt.Stringer](&testTypeWithMethod{"test"}) = (%v, %v); want = (&testTypeWithMethod{"test"}, true)`, v, ok)
 	}
+
+	if v, ok := TypeAssert[int](ValueOf(newPtr(any(1))).Elem()); v != 1 || !ok {
+		t.Errorf(`TypeAssert[int](ValueOf(newPtr(any(1))).Elem()) = (%v, %v); want = (1, true)`, v, ok)
+	}
+
+	if v, ok := TypeAssert[testTypeWithMethod](ValueOf(newPtr(fmt.Stringer(testTypeWithMethod{"test"}))).Elem()); v.val != "test" || !ok {
+		t.Errorf(`TypeAssert[testTypeWithMethod](newPtr(fmt.Stringer(testTypeWithMethod{"test"}))) = (%v, %v); want = (testTypeWithMethod{"test"}, true)`, v, ok)
+	}
 }
 
 type testTypeWithMethod struct {
@@ -8787,5 +8795,12 @@ func TestTypeAssertAllocs(t *testing.T) {
 	})
 	if allocs != 0 {
 		t.Errorf("unexpected amount of allocations = %v; want = 0", allocs)
+	}
+}
+
+func BenchmarkTypeAssertTime(b *testing.B) {
+	val := ValueOf(time.Now())
+	for b.Loop() {
+		TypeAssert[time.Time](val)
 	}
 }

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -1219,7 +1219,7 @@ func (v Value) Elem() Value {
 	k := v.kind()
 	switch k {
 	case Interface:
-		x := unpackEface(packIntoEmptyIface(v))
+		x := unpackEface(packIfaceValueIntoEmptyIface(v))
 		if x.flag != 0 {
 			x.flag |= v.flag.ro()
 		}
@@ -1492,7 +1492,7 @@ func valueInterface(v Value, safe bool) any {
 
 	if v.kind() == Interface {
 		// Special case: return the element inside the interface.
-		return packIntoEmptyIface(v)
+		return packIfaceValueIntoEmptyIface(v)
 	}
 
 	return packEface(v)
@@ -1540,7 +1540,7 @@ func TypeAssert[T any](v Value) (T, bool) {
 		// val := ValueOf(&v).Elem()
 		// TypeAssert[error](val) == val.Interface().(error)
 		if v.kind() == Interface {
-			v, ok := packIntoEmptyIface(v).(T)
+			v, ok := packIfaceValueIntoEmptyIface(v).(T)
 			return v, ok
 		}
 
@@ -1563,10 +1563,10 @@ func TypeAssert[T any](v Value) (T, bool) {
 	return *(*T)(v.ptr), true
 }
 
-// packIntoEmptyIface converts an interface Value into an empty interface.
+// packIfaceValueIntoEmptyIface converts an interface Value into an empty interface.
 //
 // Precondition: v.kind() == Interface
-func packIntoEmptyIface(v Value) any {
+func packIfaceValueIntoEmptyIface(v Value) any {
 	// Empty interface has one layout, all interfaces with
 	// methods have a second layout.
 	if v.NumMethod() == 0 {

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -1534,7 +1534,7 @@ func TypeAssert[T any](v Value) (T, bool) {
 	if abi.TypeFor[T]() != v.typ() {
 		// TypeAssert[T] should work the same way as v.Interface().(T), thus we need
 		// to handle following case properly: TypeAssert[any](ValueOf(1)).
-		// Note that we will not hit here is such case: TypeAssert[any](ValueOf(any(1))).
+		// Note that we will not hit here is such case: TypeAssert[any](ValueOf(new(any)).Elem()).
 		if abi.TypeFor[T]().Kind() == abi.Interface {
 			v, ok := packEface(v).(T)
 			return v, ok


### PR DESCRIPTION
This implementation is zero-alloc when T is a concrete type,
allocates when val contains a method or when T is a interface
and Value was obtained for example through Elem(), in which case
it has to be allocated to avoid sharing the same memory. 

goos: linux
goarch: amd64
pkg: reflect
cpu: AMD Ryzen 5 4600G with Radeon Graphics
                                                                         │ /tmp/bench2 │
                                                                         │   sec/op    │
TypeAssert/TypeAssert[int](int)-12                                         2.725n ± 1%
TypeAssert/TypeAssert[uint8](int)-12                                       2.599n ± 1%
TypeAssert/TypeAssert[fmt.Stringer](reflect_test.testTypeWithMethod)-12    8.470n ± 0%
TypeAssert/TypeAssert[fmt.Stringer](*reflect_test.testTypeWithMethod)-12   8.460n ± 1%
TypeAssert/TypeAssert[interface_{}](int)-12                                4.181n ± 1%
TypeAssert/TypeAssert[interface_{}](reflect_test.testTypeWithMethod)-12    4.178n ± 1%
TypeAssert/TypeAssert[time.Time](time.Time)-12                             2.839n ± 0%
TypeAssert/TypeAssert[func()_string](func()_string)-12                     151.1n ± 1%
geomean                                                                    6.645n

                                                                         │ /tmp/bench2  │
                                                                         │     B/op     │
TypeAssert/TypeAssert[int](int)-12                                         0.000 ± 0%
TypeAssert/TypeAssert[uint8](int)-12                                       0.000 ± 0%
TypeAssert/TypeAssert[fmt.Stringer](reflect_test.testTypeWithMethod)-12    0.000 ± 0%
TypeAssert/TypeAssert[fmt.Stringer](*reflect_test.testTypeWithMethod)-12   0.000 ± 0%
TypeAssert/TypeAssert[interface_{}](int)-12                                0.000 ± 0%
TypeAssert/TypeAssert[interface_{}](reflect_test.testTypeWithMethod)-12    0.000 ± 0%
TypeAssert/TypeAssert[time.Time](time.Time)-12                             0.000 ± 0%
TypeAssert/TypeAssert[func()_string](func()_string)-12                     72.00 ± 0%
geomean                                                                               ¹

Fixes #62121