### PR TITLE
runtime: add some linknames back for `github.com/bytedance/sonic`

### DIFF
--- a/src/runtime/stubs.go
+++ b/src/runtime/stubs.go
@@ -312,6 +312,16 @@ func asmcgocall(fn, arg unsafe.Pointer) int32
 
 func morestack()
 
+// morestack_noctxt should be an internal detail,
+// but widely used packages access it using linkname.
+// Notable members of the hall of shame include:
+//   - github.com/bytedance/sonic
+//
+// Do not remove or change the type signature.
+// See go.dev/issues/67401.
+// See go.dev/issues/71672.
+//
+//go:linkname morestack_noctxt
 func morestack_noctxt()
 
 func rt0_go()

--- a/src/runtime/symtab.go
+++ b/src/runtime/symtab.go
@@ -491,7 +491,7 @@ var firstmoduledata moduledata // linker symbol
 // See go.dev/issues/67401.
 // See go.dev/issues/71672.
 //
-//go:linkname lastmoduledatap runtime.lastmoduledatap
+//go:linkname lastmoduledatap
 var lastmoduledatap *moduledata // linker symbol
 
 var modulesSlice *[]*moduledata // see activeModules
@@ -602,6 +602,16 @@ func moduledataverify() {
 
 const debugPcln = false
 
+// moduledataverify1 should be an internal detail,
+// but widely used packages access it using linkname.
+// Notable members of the hall of shame include:
+//   - github.com/bytedance/sonic
+//
+// Do not remove or change the type signature.
+// See go.dev/issues/67401.
+// See go.dev/issues/71672.
+//
+//go:linkname moduledataverify1
 func moduledataverify1(datap *moduledata) {
 	// Check that the pclntab's format is valid.
 	hdr := datap.pcHeader

--- a/src/runtime/symtab.go
+++ b/src/runtime/symtab.go
@@ -480,7 +480,18 @@ var pinnedTypemaps []map[typeOff]*_type
 // the relocated one.
 var aixStaticDataBase uintptr // linker symbol
 
-var firstmoduledata moduledata  // linker symbol
+var firstmoduledata moduledata // linker symbol
+
+// lastmoduledatap should be an internal detail,
+// but widely used packages access it using linkname.
+// Notable members of the hall of shame include:
+//   - github.com/bytedance/sonic
+//
+// Do not remove or change the type signature.
+// See go.dev/issues/67401.
+// See go.dev/issues/71672.
+//
+//go:linkname lastmoduledatap runtime.lastmoduledatap
 var lastmoduledatap *moduledata // linker symbol
 
 var modulesSlice *[]*moduledata // see activeModules


### PR DESCRIPTION
Add some linknames back, therefore sonic (github.com/bytedance/sonic) can work correctly.

Fixes #71672 
