### PR TITLE
os/signal: let Reset reset Ignored signals

### DIFF
--- a/src/os/signal/signal.go
+++ b/src/os/signal/signal.go
@@ -168,8 +168,8 @@ func Notify(c chan<- os.Signal, sig ...os.Signal) {
 	}
 }
 
-// Reset undoes the effect of any prior calls to [Notify] for the provided
-// signals.
+// Reset undoes the effect of any prior calls to [Notify] or [Ignore] for the
+// provided signals.
 // If no signals are provided, all signal handlers will be reset.
 func Reset(sig ...os.Signal) {
 	cancel(sig, disableSignal)

--- a/src/runtime/os3_plan9.go
+++ b/src/runtime/os3_plan9.go
@@ -149,7 +149,8 @@ Exit:
 func sigenable(sig uint32) {
 }
 
-func sigdisable(sig uint32) {
+func sigdisable(sig uint32) bool {
+	return false
 }
 
 func sigignore(sig uint32) {

--- a/src/runtime/os_wasm.go
+++ b/src/runtime/os_wasm.go
@@ -142,7 +142,7 @@ func getfp() uintptr { return 0 }
 
 func setProcessCPUProfiler(hz int32) {}
 func setThreadCPUProfiler(hz int32)  {}
-func sigdisable(uint32)              {}
+func sigdisable(uint32) bool         { return false }
 func sigenable(uint32)               {}
 func sigignore(uint32)               {}
 

--- a/src/runtime/signal_unix.go
+++ b/src/runtime/signal_unix.go
@@ -215,7 +215,7 @@ func sigenable(sig uint32) {
 // at program startup or the last custom handler registered by cgo.
 // It is only called while holding the os/signal.handlers lock,
 // via os/signal.disableSignal and signal_disable.
-// Returns true if the signal is ignored after the change.
+// Reports whether the signal is ignored after the change.
 func sigdisable(sig uint32) bool {
 	if sig >= uint32(len(sigtable)) {
 		return false

--- a/src/runtime/signal_windows.go
+++ b/src/runtime/signal_windows.go
@@ -434,7 +434,8 @@ func initsig(preinit bool) {
 func sigenable(sig uint32) {
 }
 
-func sigdisable(sig uint32) {
+func sigdisable(sig uint32) bool {
+	return false
 }
 
 func sigignore(sig uint32) {

--- a/src/runtime/sigqueue.go
+++ b/src/runtime/sigqueue.go
@@ -230,11 +230,19 @@ func signal_disable(s uint32) {
 	if s >= uint32(len(sig.wanted)*32) {
 		return
 	}
-	sigdisable(s)
+	ignored := sigdisable(s)
 
 	w := sig.wanted[s/32]
 	w &^= 1 << (s & 31)
 	atomic.Store(&sig.wanted[s/32], w)
+
+	i := sig.ignored[s/32]
+	if ignored {
+		i |= 1 << (s & 31)
+	} else {
+		i &^= 1 << (s & 31)
+	}
+	atomic.Store(&sig.ignored[s/32], i)
 }
 
 // Must only be called from a single goroutine at a time.


### PR DESCRIPTION
`signal.Reset` now also undoes previous calls to `signal.Ignore`. 
More precisely, it resets signal handlers to the state they had 
at startup or the latest custom signal handler registered via cgo.

Fixes #46321
