### PR TITLE
os: explicitly return nil for {rootChmod,rootMkdir,rootRemove} in root_openat.go

### DIFF
--- a/src/os/root_openat.go
+++ b/src/os/root_openat.go
@@ -71,7 +71,7 @@ func rootChmod(r *Root, name string, mode FileMode) error {
 	if err != nil {
 		return &PathError{Op: "chmodat", Path: name, Err: err}
 	}
-	return err
+	return nil
 }
 
 func rootMkdir(r *Root, name string, perm FileMode) error {
@@ -81,7 +81,7 @@ func rootMkdir(r *Root, name string, perm FileMode) error {
 	if err != nil {
 		return &PathError{Op: "mkdirat", Path: name, Err: err}
 	}
-	return err
+	return nil
 }
 
 func rootRemove(r *Root, name string) error {
@@ -91,7 +91,7 @@ func rootRemove(r *Root, name string) error {
 	if err != nil {
 		return &PathError{Op: "removeat", Path: name, Err: err}
 	}
-	return err
+	return nil
 }
 
 // doInRoot performs an operation on a path in a Root.


### PR DESCRIPTION
It is consistent with same functions in root_noopenat.go.