### PR TITLE
syscall: skip testAmbientCaps tests if there is no nobody user

### DIFF
--- a/src/syscall/exec_linux_test.go
+++ b/src/syscall/exec_linux_test.go
@@ -646,7 +646,7 @@ func testAmbientCaps(t *testing.T, userns bool) {
 
 	u, err := user.Lookup("nobody")
 	if err != nil {
-		t.Fatal(err)
+		t.Skip("skipping: the nobody user does not exist; see Issue 71644")
 	}
 	uid, err := strconv.ParseInt(u.Uid, 0, 32)
 	if err != nil {


### PR DESCRIPTION
When there is not a nobody user (for example inside Docker), the
tests TestAmbientCaps and TestAmbientCapsUserns should be skipped
instead of failing.

Fixes #71644