### PR TITLE
runtime/maps: fix typo in group.go comment (H1 -> H2)

### DIFF
--- a/src/internal/runtime/maps/group.go
+++ b/src/internal/runtime/maps/group.go
@@ -111,7 +111,7 @@ func bitsetShiftOutLowest(b bitset) bitset {
 //
 //	  empty: 1 0 0 0 0 0 0 0
 //	deleted: 1 1 1 1 1 1 1 0
-//	   full: 0 h h h h h h h  // h represents the H1 hash bits
+//	   full: 0 h h h h h h h  // h represents the H2 hash bits
 //
 // TODO(prattmic): Consider inverting the top bit so that the zero value is empty.
 type ctrl uint8


### PR DESCRIPTION
Fixes a typo to correctly describe the hash bits of the control word.