### PR TITLE
os: explicitly return nil for rootChown in root_openat.go

### DIFF
--- a/src/os/root_openat.go
+++ b/src/os/root_openat.go
@@ -84,7 +84,7 @@ func rootChown(r *Root, name string, uid, gid int) error {
 	if err != nil {
 		return &PathError{Op: "chownat", Path: name, Err: err}
 	}
-	return err
+	return nil
 }
 
 func rootMkdir(r *Root, name string, perm FileMode) error {


### PR DESCRIPTION
It is consistent with the same function in root_noopenat.go.