### PR TITLE
os: deal with chmod error for TestRootConsistencyChmod

### DIFF
--- a/src/os/root_test.go
+++ b/src/os/root_test.go
@@ -928,12 +928,16 @@ func TestRootConsistencyChmod(t *testing.T) {
 			}
 
 			var m1, m2 os.FileMode
-			err := chmod(path, 0o555)
+			if err := chmod(path, 0o555); err != nil {
+				return "chmod 0o555", err
+			}
 			fi, err := lstat(path)
 			if err == nil {
 				m1 = fi.Mode()
 			}
-			err = chmod(path, 0o777)
+			if err := chmod(path, 0o777); err != nil {
+				return "chmod 0o777", err
+			}
 			fi, err = lstat(path)
 			if err == nil {
 				m2 = fi.Mode()

--- a/src/os/root_test.go
+++ b/src/os/root_test.go
@@ -935,7 +935,7 @@ func TestRootConsistencyChmod(t *testing.T) {
 			if err == nil {
 				m1 = fi.Mode()
 			}
-			if err := chmod(path, 0o777); err != nil {
+			if err = chmod(path, 0o777); err != nil {
 				return "chmod 0o777", err
 			}
 			fi, err = lstat(path)


### PR DESCRIPTION
Previously the error returned by chmod has not actually been used.