### PR TITLE
syscall: disable O_DIRECTORY on Windows for js/wasm

### DIFF
--- a/src/syscall/fs_js.go
+++ b/src/syscall/fs_js.go
@@ -29,7 +29,7 @@ var (
 	nodeTRUNC  = constants.Get("O_TRUNC").Int()
 	nodeAPPEND = constants.Get("O_APPEND").Int()
 	nodeEXCL   = constants.Get("O_EXCL").Int()
-	
+
 	// NodeJS on Windows does not support O_DIRECTORY, so we default
 	// to -1 and assign it in init if available.
 	// See https://nodejs.org/docs/latest/api/fs.html#file-open-constants.

--- a/src/syscall/fs_js.go
+++ b/src/syscall/fs_js.go
@@ -29,8 +29,10 @@ var (
 	nodeTRUNC  = constants.Get("O_TRUNC").Int()
 	nodeAPPEND = constants.Get("O_APPEND").Int()
 	nodeEXCL   = constants.Get("O_EXCL").Int()
-
-	// Windows didn't have O_DIRECTORY, so we assign it in init.
+	
+	// NodeJS on Windows does not support O_DIRECTORY, so we default
+	// to -1 and assign it in init if available.
+	// See https://nodejs.org/docs/latest/api/fs.html#file-open-constants.
 	nodeDIRECTORY = -1
 )
 


### PR DESCRIPTION
O_DIRECTORY is not available on all platforms, as described at

https://nodejs.org/docs/latest/api/fs.html#file-open-constants .

On Windows, only O_APPEND, O_CREAT, O_EXCL, O_RDONLY, O_RDWR, 
O_TRUNC, O_WRONLY, and UV_FS_O_FILEMAP are available.

Fixes #71758