### PR TITLE
cmd/compile/internal/ir: reduce size of miniExpr by 8 bytes

### DIFF
--- a/src/cmd/compile/internal/ir/expr.go
+++ b/src/cmd/compile/internal/ir/expr.go
@@ -24,12 +24,12 @@ type Expr interface {
 // A miniExpr is a miniNode with extra fields common to expressions.
 // TODO(rsc): Once we are sure about the contents, compact the bools
 // into a bit field and leave extra bits available for implementations
-// embedding miniExpr. Right now there are ~60 unused bits sitting here.
+// embedding miniExpr. Right now there are ~24 unused bits sitting here.
 type miniExpr struct {
 	miniNode
+	flags bitset8
 	typ   *types.Type
 	init  Nodes // TODO(rsc): Don't require every Node to have an init
-	flags bitset8
 }
 
 const (

--- a/src/cmd/compile/internal/ir/sizeof_test.go
+++ b/src/cmd/compile/internal/ir/sizeof_test.go
@@ -22,6 +22,7 @@ func TestSizeof(t *testing.T) {
 	}{
 		{Func{}, 184, 312},
 		{Name{}, 96, 160},
+		{miniExpr{}, 32, 48},
 	}
 
 	for _, tt := range tests {

--- a/src/cmd/compile/internal/ir/sizeof_test.go
+++ b/src/cmd/compile/internal/ir/sizeof_test.go
@@ -21,7 +21,7 @@ func TestSizeof(t *testing.T) {
 		_64bit uintptr     // size on 64bit platforms
 	}{
 		{Func{}, 184, 312},
-		{Name{}, 96, 168},
+		{Name{}, 96, 160},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
By moving the bit field, we can reduce the miniExpr size by
8 bytes, reducing the sizes of Exprs embedding this type.
Hopefully we get a few types to a lower memory size class.
