### PR TITLE
bytes,strings: remove redundant return statement for Lines

### DIFF
--- a/src/bytes/iter.go
+++ b/src/bytes/iter.go
@@ -28,7 +28,6 @@ func Lines(s []byte) iter.Seq[[]byte] {
 				return
 			}
 		}
-		return
 	}
 }
 

--- a/src/strings/iter.go
+++ b/src/strings/iter.go
@@ -28,7 +28,6 @@ func Lines(s string) iter.Seq[string] {
 				return
 			}
 		}
-		return
 	}
 }
 


### PR DESCRIPTION
To make it more idiomatic.