### PR TITLE
syscall: allow \x00-prefixed unix abstract socket to use full path length

### DIFF
--- a/src/net/unixsock_linux_test.go
+++ b/src/net/unixsock_linux_test.go
@@ -49,7 +49,7 @@ func TestUnixAutobindClose(t *testing.T) {
 	ln.Close()
 }
 
-func TestUnixAbstractLongNameNullStart(t *testing.T) {
+func TestUnixAbstractLongNameNulStart(t *testing.T) {
 	// Create an abstract socket name that starts with a null byte ("\x00")
 	// whose length is the maximum of RawSockaddrUnix Path len
 	paddedAddr := make([]byte, len(syscall.RawSockaddrUnix{}.Path))
@@ -63,7 +63,7 @@ func TestUnixAbstractLongNameNullStart(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Close()
+	c.Close()
 }
 
 func TestUnixgramLinuxAbstractLongName(t *testing.T) {

--- a/src/net/unixsock_linux_test.go
+++ b/src/net/unixsock_linux_test.go
@@ -50,6 +50,8 @@ func TestUnixAutobindClose(t *testing.T) {
 }
 
 func TestUnixAbstractLongNameNullStart(t *testing.T) {
+	// Create an abstract socket name that starts with a null byte ("\x00")
+	// whose length is the maximum of RawSockaddrUnix Path len
 	paddedAddr := make([]byte, len(syscall.RawSockaddrUnix{}.Path))
 	copy(paddedAddr, "\x00abstract_test")
 

--- a/src/net/unixsock_linux_test.go
+++ b/src/net/unixsock_linux_test.go
@@ -49,14 +49,11 @@ func TestUnixAutobindClose(t *testing.T) {
 	ln.Close()
 }
 
-func TestUnixAbstractLongNameeNullStart(t *testing.T) {
-	addr := "\x00abstract_test"
-	rsu := syscall.RawSockaddrUnix{}
-	paddedAddr := make([]byte, len(rsu.Path))
+func TestUnixAbstractLongNameNullStart(t *testing.T) {
+	paddedAddr := make([]byte, len(syscall.RawSockaddrUnix{}.Path))
 	copy(paddedAddr, "\x00abstract_test")
-	addr = string(paddedAddr)
 
-	la, err := ResolveUnixAddr("unix", addr)
+	la, err := ResolveUnixAddr("unix", string(paddedAddr))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/net/unixsock_linux_test.go
+++ b/src/net/unixsock_linux_test.go
@@ -49,6 +49,24 @@ func TestUnixAutobindClose(t *testing.T) {
 	ln.Close()
 }
 
+func TestUnixAbstractLongNameeNullStart(t *testing.T) {
+	addr := "\x00abstract_test"
+	rsu := syscall.RawSockaddrUnix{}
+	paddedAddr := make([]byte, len(rsu.Path))
+	copy(paddedAddr, "\x00abstract_test")
+	addr = string(paddedAddr)
+
+	la, err := ResolveUnixAddr("unix", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := ListenUnix("unix", la)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+}
+
 func TestUnixgramLinuxAbstractLongName(t *testing.T) {
 	if !testableNetwork("unixgram") {
 		t.Skip("abstract unix socket long name test")

--- a/src/net/unixsock_windows_test.go
+++ b/src/net/unixsock_windows_test.go
@@ -70,7 +70,7 @@ func TestUnixConnLocalWindows(t *testing.T) {
 	}
 }
 
-func TestUnixAbstractLongNameNullStart(t *testing.T) {
+func TestUnixAbstractLongNameNulStart(t *testing.T) {
 	if !windows.SupportUnixSocket() {
 		t.Skip("unix test")
 	}
@@ -88,7 +88,7 @@ func TestUnixAbstractLongNameNullStart(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Close()
+	c.Close()
 }
 
 func TestModeSocket(t *testing.T) {

--- a/src/net/unixsock_windows_test.go
+++ b/src/net/unixsock_windows_test.go
@@ -10,6 +10,7 @@ import (
 	"internal/syscall/windows"
 	"os"
 	"reflect"
+	"syscall"
 	"testing"
 )
 
@@ -67,6 +68,28 @@ func TestUnixConnLocalWindows(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestUnixAbstractLongNameNullStart(t *testing.T) {
+	if !windows.SupportUnixSocket() {
+		t.Skip("unix test")
+	}
+
+	addr := "\x00abstract_test"
+	rsu := syscall.RawSockaddrUnix{}
+	paddedAddr := make([]byte, len(rsu.Path))
+	copy(paddedAddr, "\x00abstract_test")
+	addr = string(paddedAddr)
+
+	la, err := ResolveUnixAddr("unix", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := ListenUnix("unix", la)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
 }
 
 func TestModeSocket(t *testing.T) {

--- a/src/net/unixsock_windows_test.go
+++ b/src/net/unixsock_windows_test.go
@@ -75,13 +75,12 @@ func TestUnixAbstractLongNameNullStart(t *testing.T) {
 		t.Skip("unix test")
 	}
 
-	addr := "\x00abstract_test"
-	rsu := syscall.RawSockaddrUnix{}
-	paddedAddr := make([]byte, len(rsu.Path))
+	// Create an abstract socket name that starts with a null byte ("\x00")
+	// whose length is the maximum of RawSockaddrUnix Path len
+	paddedAddr := make([]byte, len(syscall.RawSockaddrUnix{}.Path))
 	copy(paddedAddr, "\x00abstract_test")
-	addr = string(paddedAddr)
 
-	la, err := ResolveUnixAddr("unix", addr)
+	la, err := ResolveUnixAddr("unix", string(paddedAddr))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/syscall/syscall_linux.go
+++ b/src/syscall/syscall_linux.go
@@ -554,7 +554,7 @@ func (sa *SockaddrUnix) sockaddr() (unsafe.Pointer, _Socklen, error) {
 	// '@' is also a valid way to specify abstract addresses.
 	isAbstract := n > 0 && (name[0] == '@' || name[0] == '\x00')
 
-	// Non-abstract addresses is NUL terminated.
+	// Non-abstract named addresses are NUL terminated.
 	// The length can't use the full capacity as we need to add NUL.
 	if n == len(sa.raw.Path) && !isAbstract {
 		return nil, 0, EINVAL
@@ -570,8 +570,8 @@ func (sa *SockaddrUnix) sockaddr() (unsafe.Pointer, _Socklen, error) {
 		// Abstract addresses are not NUL terminated.
 		// We rewrite '@' prefix to NUL here.
 		sa.raw.Path[0] = 0
-	} else {
-		// Add NUL for non-abstract addresses.
+	} else if n > 0 {
+		// Add NUL for non-abstract named addresses.
 		sl++
 	}
 

--- a/src/syscall/syscall_linux.go
+++ b/src/syscall/syscall_linux.go
@@ -554,7 +554,8 @@ func (sa *SockaddrUnix) sockaddr() (unsafe.Pointer, _Socklen, error) {
 	if n > len(sa.raw.Path) {
 		return nil, 0, EINVAL
 	}
-	if n == len(sa.raw.Path) && name[0] != '@' {
+	isAbstract := n > 0 && (name[0] == '@' || name[0] == '\x00')
+	if n == len(sa.raw.Path) && !isAbstract {
 		return nil, 0, EINVAL
 	}
 	sa.raw.Family = AF_UNIX
@@ -566,8 +567,7 @@ func (sa *SockaddrUnix) sockaddr() (unsafe.Pointer, _Socklen, error) {
 	if n > 0 {
 		sl += _Socklen(n) + 1
 	}
-	if sa.raw.Path[0] == '@' || (sa.raw.Path[0] == 0 && sl > 3) {
-		// Check sl > 3 so we don't change unnamed socket behavior.
+	if isAbstract {
 		sa.raw.Path[0] = 0
 		// Don't count trailing NUL for abstract address.
 		sl--

--- a/src/syscall/syscall_windows.go
+++ b/src/syscall/syscall_windows.go
@@ -856,7 +856,8 @@ func (sa *SockaddrUnix) sockaddr() (unsafe.Pointer, int32, error) {
 	if n > len(sa.raw.Path) {
 		return nil, 0, EINVAL
 	}
-	if n == len(sa.raw.Path) && name[0] != '@' {
+	isAbstract := n > 0 && (name[0] == '@' || name[0] == '\x00')
+	if n == len(sa.raw.Path) && !isAbstract {
 		return nil, 0, EINVAL
 	}
 	sa.raw.Family = AF_UNIX
@@ -868,8 +869,7 @@ func (sa *SockaddrUnix) sockaddr() (unsafe.Pointer, int32, error) {
 	if n > 0 {
 		sl += int32(n) + 1
 	}
-	if sa.raw.Path[0] == '@' || (sa.raw.Path[0] == 0 && sl > 3) {
-		// Check sl > 3 so we don't change unnamed socket behavior.
+	if isAbstract {
 		sa.raw.Path[0] = 0
 		// Don't count trailing NUL for abstract address.
 		sl--

--- a/src/syscall/syscall_windows.go
+++ b/src/syscall/syscall_windows.go
@@ -862,7 +862,7 @@ func (sa *SockaddrUnix) sockaddr() (unsafe.Pointer, int32, error) {
 	// '@' is also a valid way to specify abstract addresses.
 	isAbstract := n > 0 && (name[0] == '@' || name[0] == '\x00')
 
-	// Non-abstract addresses is NUL terminated.
+	// Non-abstract named addresses are NUL terminated.
 	// The length can't use the full capacity as we need to add NUL.
 	if n == len(sa.raw.Path) && !isAbstract {
 		return nil, 0, EINVAL
@@ -878,8 +878,8 @@ func (sa *SockaddrUnix) sockaddr() (unsafe.Pointer, int32, error) {
 		// Abstract addresses are not NUL terminated.
 		// We rewrite '@' prefix to NUL here.
 		sa.raw.Path[0] = 0
-	} else {
-		// Add NUL for non-abstract addresses.
+	} else if n > 0 {
+		// Add NUL for non-abstract named addresses.
 		sl++
 	}
 

--- a/src/syscall/syscall_windows.go
+++ b/src/syscall/syscall_windows.go
@@ -873,7 +873,7 @@ func (sa *SockaddrUnix) sockaddr() (unsafe.Pointer, int32, error) {
 	}
 	// Length is family + name (+ NUL if non-abstract).
 	// Family is of type uint16 (2 bytes).
-	sl := _Socklen(2 + n)
+	sl := int32(2 + n)
 	if isAbstract {
 		// Abstract addresses are not NUL terminated.
 		// We rewrite '@' prefix to NUL here.

--- a/src/syscall/syscall_windows.go
+++ b/src/syscall/syscall_windows.go
@@ -858,7 +858,12 @@ func (sa *SockaddrUnix) sockaddr() (unsafe.Pointer, int32, error) {
 	if n > len(sa.raw.Path) {
 		return nil, 0, EINVAL
 	}
+	// Abstract addresses start with NUL.
+	// '@' is also a valid way to specify abstract addresses.
 	isAbstract := n > 0 && (name[0] == '@' || name[0] == '\x00')
+
+	// Non-abstract addresses is NUL terminated.
+	// The length can't use the full capacity as we need to add NUL.
 	if n == len(sa.raw.Path) && !isAbstract {
 		return nil, 0, EINVAL
 	}
@@ -866,15 +871,16 @@ func (sa *SockaddrUnix) sockaddr() (unsafe.Pointer, int32, error) {
 	for i := 0; i < n; i++ {
 		sa.raw.Path[i] = int8(name[i])
 	}
-	// length is family (uint16), name, NUL.
-	sl := int32(2)
-	if n > 0 {
-		sl += int32(n) + 1
-	}
+	// Length is family + name (+ NUL if non-abstract).
+	// Family is of type uint16 (2 bytes).
+	sl := _Socklen(2 + n)
 	if isAbstract {
+		// Abstract addresses are not NUL terminated.
+		// We rewrite '@' prefix to NUL here.
 		sa.raw.Path[0] = 0
-		// Don't count trailing NUL for abstract address.
-		sl--
+	} else {
+		// Add NUL for non-abstract addresses.
+		sl++
 	}
 
 	return unsafe.Pointer(&sa.raw), sl, nil


### PR DESCRIPTION
Fixes #70893 