### PR TITLE
context: replace newAfterFuncContext with a global declaration using blank identifier

### DIFF
--- a/src/context/afterfunc_test.go
+++ b/src/context/afterfunc_test.go
@@ -20,9 +20,7 @@ type afterFuncContext struct {
 	err        error
 }
 
-func newAfterFuncContext() context.Context {
-	return &afterFuncContext{}
-}
+var _ context.Context = (*afterFuncContext)(nil)
 
 func (c *afterFuncContext) Deadline() (time.Time, bool) {
 	return time.Time{}, false


### PR DESCRIPTION
newAfterFuncContext has never been used, the only reason I can imagine
for its existence is to guarantee that the implementation is correct.

It is a small cleanup and make code more idiomatic.