### PR TITLE
flag: replace interface{} -> any for textValue.Get method

### DIFF
--- a/src/flag/flag.go
+++ b/src/flag/flag.go
@@ -318,7 +318,7 @@ func (v textValue) Set(s string) error {
 	return v.p.UnmarshalText([]byte(s))
 }
 
-func (v textValue) Get() interface{} {
+func (v textValue) Get() any {
 	return v.p
 }
 


### PR DESCRIPTION
Make it literally match the Getter interface.