### PR TITLE
net: return proper error from Context

### DIFF
--- a/src/net/lookup_plan9.go
+++ b/src/net/lookup_plan9.go
@@ -65,7 +65,7 @@ func query(ctx context.Context, filename, query string, bufSize int) (addrs []st
 	case r := <-ch:
 		return r.addrs, r.err
 	case <-ctx.Done():
-		return nil, mapErr(err)
+		return nil, mapErr(ctx.Err())
 	}
 }
 


### PR DESCRIPTION
Sadly err was a named parameter so this did not cause
compile error.

Fixes #71974