### PR TITLE
cmd/go/internal/modfetch: retry failed fetches

### DIFF
--- a/src/cmd/go/internal/modfetch/proxy.go
+++ b/src/cmd/go/internal/modfetch/proxy.go
@@ -54,7 +54,7 @@ type proxySpec struct {
 	// fallBackOnError is true if a request should be attempted on the next proxy
 	// in the list after any error from this proxy. If fallBackOnError is false,
 	// the request will only be attempted on the next proxy if the error is
-	// equivalent to os.ErrNotFound, which is true for 404 and 410 responses.
+	// equivalent to fs.ErrNotExist, which is true for 404 and 410 responses.
 	fallBackOnError bool
 }
 


### PR DESCRIPTION
Attempts to fetch go modules are not retried, impacting the reliability of many go toolchain commands, especially when a go module proxy is used. This adds a repo implementation to cmd/go/internal/modfetch that retries failed operations with exponential backoff unless errors are known to be permanent.

Fixes #28194.