### PR TITLE
testing: modify got,want equal comparison for unordered example output

### DIFF
--- a/src/testing/example.go
+++ b/src/testing/example.go
@@ -46,12 +46,6 @@ func runExamples(matchString func(pat, str string) (bool, error), examples []Int
 	return ran, ok
 }
 
-func sortLines(output string) string {
-	lines := strings.Split(output, "\n")
-	slices.Sort(lines)
-	return strings.Join(lines, "\n")
-}
-
 // processRunResult computes a summary and status of the result of running an example test.
 // stdout is the captured output from stdout of the test.
 // recovered is the result of invoking recover after running the test, in case it panicked.
@@ -72,7 +66,9 @@ func (eg *InternalExample) processRunResult(stdout string, timeSpent time.Durati
 		want = strings.ReplaceAll(want, "\r\n", "\n")
 	}
 	if eg.Unordered {
-		if sortLines(got) != sortLines(want) && recovered == nil {
+		gotLines := slices.Sorted(strings.SplitSeq(got, "\n"))
+		wantLines := slices.Sorted(strings.SplitSeq(want, "\n"))
+		if !slices.Equal(gotLines, wantLines) && recovered == nil {
 			fail = fmt.Sprintf("got:\n%s\nwant (unordered):\n%s\n", stdout, eg.Output)
 		}
 	} else {


### PR DESCRIPTION
This change eliminates sortLines function to avoid strings.Join calls.

It's not a performance problem, this change tries to make the comparison
more straightforward.
