### PR TITLE
js/wasm: introduce scope for JS object

### DIFF
--- a/lib/wasm/wasm_exec.js
+++ b/lib/wasm/wasm_exec.js
@@ -104,6 +104,7 @@
 		constructor() {
 			this.argv = ["js"];
 			this.env = {};
+			this.scope = globalThis;
 			this.exit = (code) => {
 				if (code !== 0) {
 					console.warn("exit code:", code);

--- a/lib/wasm/wasm_exec_node.js
+++ b/lib/wasm/wasm_exec_node.js
@@ -24,6 +24,7 @@ require("./wasm_exec");
 const go = new Go();
 go.argv = process.argv.slice(2);
 go.env = Object.assign({ TMPDIR: require("os").tmpdir() }, process.env);
+go.scope = {};
 go.exit = process.exit;
 WebAssembly.instantiate(fs.readFileSync(process.argv[2]), go.importObject).then((result) => {
 	process.on("exit", (code) => { // Node.js exits if no event handler is pending

--- a/src/syscall/js/js.go
+++ b/src/syscall/js/js.go
@@ -135,6 +135,12 @@ func Global() Value {
 	return valueGlobal
 }
 
+// Scope returns the Javascript object attached to the scope field of the Go class.
+// If nothing has been explicitly set, behaves like [js.Global].
+func Scope() Value {
+	return jsGo.Get("scope")
+}
+
 // ValueOf returns x as a JavaScript value:
 //
 //	| Go                     | JavaScript             |

--- a/src/syscall/js/js_test.go
+++ b/src/syscall/js/js_test.go
@@ -733,3 +733,19 @@ func TestGlobal(t *testing.T) {
 		t.Errorf("got %#v, want %#v", got, js.Global())
 	}
 }
+
+func TestScope(t *testing.T) {
+	ident := js.FuncOf(func(this js.Value, args []js.Value) any {
+		return args[0]
+	})
+	defer ident.Release()
+
+	js.Scope().Set("key", "value")
+	if js.Scope().Get("key").String() != "value" {
+		t.Errorf("get key %s: got %#v", "key", js.Scope().Get("key"))
+	}
+
+	if got := ident.Invoke(js.Scope()); got.Equal(js.Global()) {
+		t.Errorf("scope %#v mixed with global %#v", got, js.Global())
+	}
+}


### PR DESCRIPTION
This changes allow to attach a JS object (e.g. browser component) to a 
js/wasm Go program. This creates a scope to only capture relevant events,
enabling Web applications mixing Go / native components.

An example use is discussed in the GitHub issue.

Implementation-wise, this contains two changes:
 - on the JS side the go object gets a new field 'scope' that is checked
 - on the Go side, in package syscall/js, func Scope() Value returns 
   go.scope when it has been provided, or else window/global.

A small test uses a dummy object to perform a simple get/set action on this
new field.

Fixes #56084 