### PR TITLE
maps: rename test files package to maps_test

### DIFF
--- a/src/maps/iter_test.go
+++ b/src/maps/iter_test.go
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package maps
+package maps_test
 
 import (
+	. "maps"
 	"slices"
 	"testing"
 )

--- a/src/maps/maps_test.go
+++ b/src/maps/maps_test.go
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package maps
+package maps_test
 
 import (
+	. "maps"
 	"math"
 	"strconv"
 	"testing"


### PR DESCRIPTION
All packages imported by the testing package have to
write their tests in a separate _test package.