### PR TITLE
runtime/metrics: improve doc

### DIFF
--- a/src/runtime/metrics/description.go
+++ b/src/runtime/metrics/description.go
@@ -126,7 +126,7 @@ var allDesc = []Description{
 	{
 		Name: "/cpu/classes/scavenge/assist:cpu-seconds",
 		Description: "Estimated total CPU time spent returning unused memory to the " +
-			"underlying platform in response eagerly in response to memory pressure. " +
+			"underlying platform in response eagerly to memory pressure. " +
 			"This metric is an overestimate, and not directly comparable to " +
 			"system CPU time measurements. Compare only with other /cpu/classes " +
 			"metrics.",

--- a/src/runtime/metrics/doc.go
+++ b/src/runtime/metrics/doc.go
@@ -104,10 +104,10 @@ Below is the full list of supported metrics, ordered lexicographically.
 
 	/cpu/classes/scavenge/assist:cpu-seconds
 		Estimated total CPU time spent returning unused memory to the
-		underlying platform in response eagerly in response to memory
-		pressure. This metric is an overestimate, and not directly
-		comparable to system CPU time measurements. Compare only with
-		other /cpu/classes metrics.
+		underlying platform in response eagerly to memory pressure. This
+		metric is an overestimate, and not directly comparable to system
+		CPU time measurements. Compare only with other /cpu/classes
+		metrics.
 
 	/cpu/classes/scavenge/background:cpu-seconds
 		Estimated total CPU time spent performing background tasks to


### PR DESCRIPTION
Polish a sentence by removing redundant "in response".