### PR TITLE
time: optimize quote using byte(c) for ASCII

### DIFF
--- a/src/time/format.go
+++ b/src/time/format.go
@@ -891,7 +891,9 @@ func quote(s string) string {
 			if c == '"' || c == '\\' {
 				buf = append(buf, '\\')
 			}
-			buf = append(buf, string(c)...)
+			// Since c < runeSelf && c >= ' ' (i.e., 32 <= c < 128),
+			// `byte(c)` is used for better performance.
+			buf = append(buf, byte(c))
 		}
 	}
 	buf = append(buf, '"')

--- a/src/time/format.go
+++ b/src/time/format.go
@@ -891,8 +891,6 @@ func quote(s string) string {
 			if c == '"' || c == '\\' {
 				buf = append(buf, '\\')
 			}
-			// Since c < runeSelf && c >= ' ' (i.e., 32 <= c < 128),
-			// `byte(c)` is used for better performance.
 			buf = append(buf, byte(c))
 		}
 	}


### PR DESCRIPTION
Since c < runeSelf && c >= ' ' (i.e., 32 <= c < 128), using buf = append(buf, byte(c)) instead of buf = append(buf, string(c)...) is a better choice, as it provides better performance.