### PR TITLE
doc/go_mem: fix grammar issue

### DIFF
--- a/doc/go_mem.html
+++ b/doc/go_mem.html
@@ -453,7 +453,7 @@ crash, or do something else.)
 </p>
 
 <p class="rule">
-The <i>k</i>th receive on a channel with capacity <i>C</i> is synchronized before the completion of the <i>k</i>+<i>C</i>th send from that channel completes.
+The <i>k</i>th receive from a channel with capacity <i>C</i> is synchronized before the completion of the <i>k</i>+<i>C</i>th send on that channel.
 </p>
 
 <p>


### PR DESCRIPTION
In the passage about buffered channels, remove redundant words and match
the wording of the earlier passage about unbuffered channels.