### PR TITLE
syscall: ignore O_DIRECTORY on Windows for js/wasm

### DIFF
--- a/src/syscall/fs_js.go
+++ b/src/syscall/fs_js.go
@@ -98,8 +98,6 @@ func Open(path string, openmode int, perm uint32) (int, error) {
 	if openmode&O_DIRECTORY != 0 {
 		if nodeDIRECTORY != -1 {
 			flags |= nodeDIRECTORY
-		} else {
-			return 0, errors.New("syscall.Open: O_DIRECTORY is not supported on Windows")
 		}
 	}
 


### PR DESCRIPTION
Updates #71758

Due to CL 588915, opening folders will always fail 
when wasm is running on a Windows host.
A common use case is to write coverage files in unit tests.

Since we'll check isDirectory later, this shouldn't affect functionality.
