### PR TITLE
lib/wasm: utf8 is an invalid param for `TextEncoder`

### DIFF
--- a/lib/wasm/wasm_exec.js
+++ b/lib/wasm/wasm_exec.js
@@ -97,8 +97,8 @@
 		throw new Error("globalThis.TextDecoder is not available, polyfill required");
 	}
 
-	const encoder = new TextEncoder("utf-8");
-	const decoder = new TextDecoder("utf-8");
+	const encoder = new TextEncoder();
+	const decoder = new TextDecoder();
 
 	globalThis.Go = class {
 		constructor() {


### PR DESCRIPTION
As per https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder or more specifically https://www.w3.org/TR/2020/NOTE-encoding-20200602/#ref-for-dom-textencoder

PS: This is a two line commit, I have an additional 1-line commit I can add to this if you like:
```patch
diff --git a/lib/wasm/wasm_exec.js b/lib/wasm/wasm_exec.js
index 11ac5a0..3754a89 100644
--- a/lib/wasm/wasm_exec.js
+++ b/lib/wasm/wasm_exec.js
@@ -18,7 +18,7 @@
 			writeSync(fd, buf) {
 				outputBuf += decoder.decode(buf);
 				const nl = outputBuf.lastIndexOf("\n");
-				if (nl != -1) {
+				if (nl !== -1) {
 					console.log(outputBuf.substring(0, nl));
 					outputBuf = outputBuf.substring(nl + 1);
 				}
```