### PR TITLE
bytes: speed up Replace

### DIFF
--- a/src/bytes/bytes.go
+++ b/src/bytes/bytes.go
@@ -1192,19 +1192,22 @@ func Replace(s, old, new []byte, n int) []byte {
 	t := make([]byte, len(s)+n*(len(new)-len(old)))
 	w := 0
 	start := 0
-	for i := 0; i < n; i++ {
-		j := start
-		if len(old) == 0 {
-			if i > 0 {
-				_, wid := utf8.DecodeRune(s[start:])
-				j += wid
-			}
-		} else {
-			j += Index(s[start:], old)
+	if len(old) > 0 {
+		for range n {
+			j := start + Index(s[start:], old)
+			w += copy(t[w:], s[start:j])
+			w += copy(t[w:], new)
+			start = j + len(old)
 		}
-		w += copy(t[w:], s[start:j])
+	} else { // len(old) == 0
 		w += copy(t[w:], new)
-		start = j + len(old)
+		for range n - 1 {
+			_, wid := utf8.DecodeRune(s[start:])
+			j := start + wid
+			w += copy(t[w:], s[start:j])
+			w += copy(t[w:], new)
+			start = j
+		}
 	}
 	w += copy(t[w:], s[start:])
 	return t[0:w]


### PR DESCRIPTION
This CL is to package bytes what CL 657935 was to package strings.

Add fuzz test and benchmarks for Replace.

The length of parameter old does not change. Move the corresponding length
check outside the loop. Use range-over-int loops where possible.

Some benchmark results (no changes to allocations):

goos: darwin
goarch: amd64
pkg: bytes
cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
                                 │     old      │                 new                 │
                                 │    sec/op    │   sec/op     vs base                │
Replace/"hello"_"l"_"L"_0-8         27.83n ± 2%   27.22n ± 1%   -2.17% (p=0.000 n=20)
Replace/"hello"_"l"_"L"_-1-8        60.64n ± 0%   57.97n ± 1%   -4.40% (p=0.000 n=20)
Replace/"hello"_"x"_"X"_-1-8        33.99n ± 0%   33.88n ± 0%        ~ (p=0.140 n=20)
Replace/""_"x"_"X"_-1-8             10.40n ± 1%   10.57n ± 0%   +1.64% (p=0.000 n=20)
Replace/"radar"_"r"_"<r>"_-1-8      62.63n ± 0%   61.39n ± 0%   -1.98% (p=0.000 n=20)
Replace/""_""_"<>"_-1-8             29.76n ± 1%   24.18n ± 1%  -18.75% (p=0.000 n=20)
Replace/"banana"_"a"_"<>"_-1-8      77.00n ± 0%   77.10n ± 1%        ~ (p=0.525 n=20)
Replace/"banana"_"a"_"<>"_1-8       44.24n ± 0%   43.57n ± 1%   -1.54% (p=0.000 n=20)
Replace/"banana"_"a"_"<>"_1000-8    78.23n ± 0%   77.16n ± 1%   -1.36% (p=0.000 n=20)
Replace/"banana"_"an"_"<>"_-1-8     72.78n ± 1%   69.97n ± 1%   -3.85% (p=0.000 n=20)
Replace/"banana"_"ana"_"<>"_-1-8    54.41n ± 0%   54.04n ± 1%   -0.67% (p=0.033 n=20)
Replace/"banana"_""_"<>"_-1-8       116.8n ± 1%   103.5n ± 1%  -11.42% (p=0.000 n=20)
Replace/"banana"_""_"<>"_10-8       117.2n ± 1%   103.6n ± 0%  -11.60% (p=0.000 n=20)
Replace/"banana"_""_"<>"_6-8       105.30n ± 0%   92.50n ± 0%  -12.16% (p=0.000 n=20)
Replace/"banana"_""_"<>"_5-8        91.81n ± 0%   79.87n ± 1%  -13.01% (p=0.000 n=20)
Replace/"banana"_""_"<>"_1-8        35.87n ± 1%   30.33n ± 1%  -15.43% (p=0.000 n=20)
Replace/"banana"_"a"_"a"_-1-8       70.84n ± 0%   68.83n ± 0%   -2.84% (p=0.000 n=20)
Replace/"banana"_"a"_"a"_1-8        44.27n ± 1%   43.47n ± 1%   -1.80% (p=0.000 n=20)
Replace/"☺☻☹"_""_"<>"_-1-8         104.25n ± 1%   93.33n ± 0%  -10.48% (p=0.000 n=20)
geomean                             56.31n        52.88n        -6.09%
