### PR TITLE
strings: don't assert on Replace's allocs for ASAN

### DIFF
--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -7,6 +7,7 @@ package strings_test
 import (
 	"bytes"
 	"fmt"
+	"internal/asan"
 	"io"
 	"iter"
 	"math"
@@ -1473,9 +1474,11 @@ var ReplaceTests = []struct {
 
 func TestReplace(t *testing.T) {
 	for _, tt := range ReplaceTests {
-		allocs := testing.AllocsPerRun(10, func() { Replace(tt.in, tt.old, tt.new, tt.n) })
-		if allocs > 1 {
-			t.Errorf("Replace(%q, %q, %q, %d) allocates %.2f objects", tt.in, tt.old, tt.new, tt.n, allocs)
+		if !asan.Enabled { // See issue #72973.
+			allocs := testing.AllocsPerRun(10, func() { Replace(tt.in, tt.old, tt.new, tt.n) })
+			if allocs > 1 {
+				t.Errorf("Replace(%q, %q, %q, %d) allocates %.2f objects", tt.in, tt.old, tt.new, tt.n, allocs)
+			}
 		}
 		if s := Replace(tt.in, tt.old, tt.new, tt.n); s != tt.out {
 			t.Errorf("Replace(%q, %q, %q, %d) = %q, want %q", tt.in, tt.old, tt.new, tt.n, s, tt.out)


### PR DESCRIPTION
CL 657935 caused failures on the ASAN builder.

Under ASAN, do not assert on the number of allocations incurred by Replace.

Fixes #72973