### PR TITLE
cmd/compile/internal/abi: fix ComputePadding

### DIFF
--- a/src/cmd/compile/internal/abi/abiutils.go
+++ b/src/cmd/compile/internal/abi/abiutils.go
@@ -673,10 +673,9 @@ func (pa *ABIParamAssignment) ComputePadding(storage []uint64) []uint64 {
 		panic("internal error")
 	}
 	offsets, _ := appendParamOffsets([]int64{}, 0, pa.Type)
-	off := int64(0)
 	for idx, t := range types {
 		ts := t.Size()
-		off += int64(ts)
+		off := offsets[idx] + ts
 		if idx < len(types)-1 {
 			noff := offsets[idx+1]
 			if noff != off {

--- a/src/cmd/compile/internal/ssa/debug.go
+++ b/src/cmd/compile/internal/ssa/debug.go
@@ -557,7 +557,7 @@ func PopulateABIInRegArgOps(f *Func) {
 	f.Entry.Values = append(newValues, f.Entry.Values...)
 }
 
-// BuildFuncDebug debug information for f, placing the results
+// BuildFuncDebug builds debug information for f, placing the results
 // in "rval". f must be fully processed, so that each Value is where it
 // will be when machine code is emitted.
 func BuildFuncDebug(ctxt *obj.Link, f *Func, loggingLevel int, stackOffset func(LocalSlot) int32, rval *FuncDebug) {

--- a/src/cmd/compile/internal/test/abiutils_test.go
+++ b/src/cmd/compile/internal/test/abiutils_test.go
@@ -390,9 +390,9 @@ func TestABIUtilsComputePadding(t *testing.T) {
 	padding := make([]uint64, 32)
 	parm := regRes.InParams()[1]
 	padding = parm.ComputePadding(padding)
-	want := "[1 1 1 0]"
+	want := "[1 0 0 0]"
 	got := fmt.Sprintf("%+v", padding)
 	if got != want {
-		t.Errorf("padding mismatch: wanted %q got %q\n", got, want)
+		t.Errorf("padding mismatch: wanted %q got %q\n", want, got)
 	}
 }


### PR DESCRIPTION
Fixes the ComputePadding calculation to take into account the padding 
added for the current offset. This fixes an issue where padding can be 
added incorrectly for certain structs.

Related: https://github.com/go-delve/delve/issues/3923

Same as https://go-review.googlesource.com/c/go/+/656736 just without
the brittle test.

Fixes #72053