### PR TITLE
archive/tar: optimize nanosecond parsing in parsePAXTime

### DIFF
--- a/src/archive/tar/strconv.go
+++ b/src/archive/tar/strconv.go
@@ -213,9 +213,9 @@ func parsePAXTime(s string) (time.Time, error) {
 	}
 
 	// Parse the nanoseconds.
-	// Initialize an array with '0's to handle right padding automatically
+	// Initialize an array with '0's to handle right padding automatically.
 	nanoDigits := [maxNanoSecondDigits]byte{'0', '0', '0', '0', '0', '0', '0', '0', '0'}
-	for i := range sn {
+	for i := range len(sn) {
 		switch c := sn[i]; {
 		case c < '0' || c > '9':
 			return time.Time{}, ErrHeader

--- a/src/archive/tar/strconv.go
+++ b/src/archive/tar/strconv.go
@@ -213,21 +213,15 @@ func parsePAXTime(s string) (time.Time, error) {
 	}
 
 	// Parse the nanoseconds.
-	nanoDigits := [maxNanoSecondDigits]byte{}
-	i := 0
-	for _, c := range sn {
-		if c < '0' || c > '9' {
+	// Initialize an array with '0's to handle right padding automatically
+	nanoDigits := [maxNanoSecondDigits]byte{'0', '0', '0', '0', '0', '0', '0', '0', '0'}
+	for i := range sn {
+		switch c := sn[i]; {
+		case c < '0' || c > '9':
 			return time.Time{}, ErrHeader
+		case i < len(nanoDigits):
+			nanoDigits[i] = c
 		}
-		// Right truncate
-		if i < maxNanoSecondDigits {
-			nanoDigits[i] = byte(c)
-			i++
-		}
-	}
-	// Right pad
-	for ; i < maxNanoSecondDigits; i++ {
-		nanoDigits[i] = '0'
 	}
 	nsecs, _ := strconv.ParseInt(string(nanoDigits[:]), 10, 64) // Must succeed after validation
 	if len(ss) > 0 && ss[0] == '-' {

--- a/src/archive/tar/strconv_test.go
+++ b/src/archive/tar/strconv_test.go
@@ -439,3 +439,63 @@ func TestFormatPAXRecord(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkParsePAXTimeNoTruncatePad(b *testing.B) {
+	sample := "1.123456789"
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := parsePAXTime(sample)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParsePAXTimeRightTruncate(b *testing.B) {
+	sample := "1.123456789123"
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := parsePAXTime(sample)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParsePAXTimeRightPad(b *testing.B) {
+	sample := "1.123"
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := parsePAXTime(sample)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParsePAXTimeError(b *testing.B) {
+	sample := "1.123abc"
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := parsePAXTime(sample)
+		if err == nil {
+			b.Fatal("Expected error")
+		}
+	}
+}
+
+func Benchmark_ParsePAXTimeError1(b *testing.B) {
+	sample := "1.a123abc"
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := parsePAXTime(sample)
+		if err == nil {
+			b.Fatal("Expected error")
+		}
+	}
+}

--- a/src/archive/tar/strconv_test.go
+++ b/src/archive/tar/strconv_test.go
@@ -488,7 +488,7 @@ func BenchmarkParsePAXTimeError(b *testing.B) {
 	}
 }
 
-func Benchmark_ParsePAXTimeError1(b *testing.B) {
+func BenchmarkParsePAXTimeError1(b *testing.B) {
 	sample := "1.a123abc"
 
 	b.ReportAllocs()

--- a/src/archive/tar/strconv_test.go
+++ b/src/archive/tar/strconv_test.go
@@ -440,62 +440,31 @@ func TestFormatPAXRecord(t *testing.T) {
 	}
 }
 
-func BenchmarkParsePAXTimeNoTruncatePad(b *testing.B) {
-	sample := "1.123456789"
-
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_, err := parsePAXTime(sample)
-		if err != nil {
-			b.Fatal(err)
-		}
+func BenchmarkParsePAXTIme(b *testing.B) {
+	tests := []struct {
+		name string
+		in   string
+		ok   bool
+	}{
+		{"NoNanos", "123456", true},
+		{"ExactNanos", "1.123456789", true},
+		{"WithNanoPadding", "1.123", true},
+		{"WithNanoTruncate", "1.123456789123", true},
+		{"TrailingError", "1.123abc", false},
+		{"LeadingError", "1.abc123", false},
 	}
-}
-
-func BenchmarkParsePAXTimeRightTruncate(b *testing.B) {
-	sample := "1.123456789123"
-
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_, err := parsePAXTime(sample)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func BenchmarkParsePAXTimeRightPad(b *testing.B) {
-	sample := "1.123"
-
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_, err := parsePAXTime(sample)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func BenchmarkParsePAXTimeError(b *testing.B) {
-	sample := "1.123abc"
-
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_, err := parsePAXTime(sample)
-		if err == nil {
-			b.Fatal("Expected error")
-		}
-	}
-}
-
-func BenchmarkParsePAXTimeError1(b *testing.B) {
-	sample := "1.a123abc"
-
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_, err := parsePAXTime(sample)
-		if err == nil {
-			b.Fatal("Expected error")
-		}
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_, err := parsePAXTime(tt.in)
+				if (err == nil) != tt.ok {
+					if err != nil {
+						b.Fatal(err)
+					}
+					b.Fatal("expected error")
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Modified parsePAXTime to use a byte array for nanosecond parsing, providing a more straightforward implementation with better performance when handling decimal fraction part.
Here are benchmark results:
goos: darwin
goarch: amd64
pkg: archive/tar
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
                                │   old.txt    │               new.txt                │
                                │    sec/op    │    sec/op     vs base                │
ParsePAXTIme/NoNanos-8            20.55n ±  4%   20.45n ± 12%        ~ (p=1.000 n=10)
ParsePAXTIme/ExactNanos-8         52.42n ±  2%   42.16n ±  3%  -19.57% (p=0.000 n=10)
ParsePAXTIme/WithNanoPadding-8    99.33n ±  2%   39.58n ±  2%  -60.16% (p=0.000 n=10)
ParsePAXTIme/WithNanoTruncate-8   54.78n ±  1%   43.64n ±  4%  -20.34% (p=0.000 n=10)
ParsePAXTIme/TrailingError-8      31.87n ±  4%   17.55n ±  2%  -44.94% (p=0.000 n=10)
ParsePAXTIme/LeadingError-8       31.03n ±  2%   15.81n ±  6%  -49.03% (p=0.000 n=10)