### PR TITLE
time: remove redundant int conversion in tzruleTime

### DIFF
--- a/src/time/zoneinfo.go
+++ b/src/time/zoneinfo.go
@@ -593,7 +593,7 @@ func tzruleTime(year int, r rule, off int) int {
 			}
 			d += 7
 		}
-		d += int(daysBefore(Month(r.mon)))
+		d += daysBefore(Month(r.mon))
 		if isLeap(year) && r.mon > 2 {
 			d++
 		}


### PR DESCRIPTION
daysBefore returns int.