### PR TITLE
strconv: use switch for '+'/'-' prefix handling

### DIFF
--- a/src/strconv/atof.go
+++ b/src/strconv/atof.go
@@ -77,12 +77,12 @@ func (b *decimal) set(s string) (ok bool) {
 	if i >= len(s) {
 		return
 	}
-	switch {
-	case s[i] == '+':
+	switch s[i] {
+	case '+':
 		i++
-	case s[i] == '-':
+	case '-':
+		i++
 		b.neg = true
-		i++
 	}
 
 	// digits
@@ -135,9 +135,10 @@ func (b *decimal) set(s string) (ok bool) {
 			return
 		}
 		esign := 1
-		if s[i] == '+' {
+		switch s[i] {
+		case '+':
 			i++
-		} else if s[i] == '-' {
+		case '-':
 			i++
 			esign = -1
 		}
@@ -176,12 +177,12 @@ func readFloat(s string) (mantissa uint64, exp int, neg, trunc, hex bool, i int,
 	if i >= len(s) {
 		return
 	}
-	switch {
-	case s[i] == '+':
+	switch s[i] {
+	case '+':
 		i++
-	case s[i] == '-':
+	case '-':
+		i++
 		neg = true
-		i++
 	}
 
 	// digits
@@ -268,9 +269,10 @@ loop:
 			return
 		}
 		esign := 1
-		if s[i] == '+' {
+		switch s[i] {
+		case '+':
 			i++
-		} else if s[i] == '-' {
+		case '-':
 			i++
 			esign = -1
 		}

--- a/src/strconv/atoi.go
+++ b/src/strconv/atoi.go
@@ -204,11 +204,12 @@ func ParseInt(s string, base int, bitSize int) (i int64, err error) {
 	// Pick off leading sign.
 	s0 := s
 	neg := false
-	if s[0] == '+' {
+	switch s[0] {
+	case '+':
 		s = s[1:]
-	} else if s[0] == '-' {
+	case '-':
+		s = s[1:]
 		neg = true
-		s = s[1:]
 	}
 
 	// Convert unsigned and check range.


### PR DESCRIPTION
Follow the approach used in strconv's readFloat, decimal.set, and Atoi,
where leading '+' and '-' are handled using a switch for clarity and
consistency.