### PR TITLE
net/url: clarify why @ is allowed in userinfo

### DIFF
--- a/src/net/url/url.go
+++ b/src/net/url/url.go
@@ -1280,6 +1280,17 @@ func validUserinfo(s string) bool {
 		case '-', '.', '_', ':', '~', '!', '$', '&', '\'',
 			'(', ')', '*', '+', ',', ';', '=', '%':
 			continue
+		case '@':
+			// `RFC 3986 section 3.2.1` does not allow '@' in userinfo.
+			// It is a delimiter between userinfo and host.
+			// However, URLs are diverse, and in some cases,
+			// the userinfo may contain an '@' character,
+			// for example, in "http://username:p@ssword@google.com",
+			// the string "username:p@ssword" should be treated as valid userinfo.
+			// Ref:
+			//   https://go.dev/issue/3439
+			//   https://go.dev/issue/22655
+			continue
 		default:
 			return false
 		}

--- a/src/net/url/url.go
+++ b/src/net/url/url.go
@@ -1278,7 +1278,7 @@ func validUserinfo(s string) bool {
 		}
 		switch r {
 		case '-', '.', '_', ':', '~', '!', '$', '&', '\'',
-			'(', ')', '*', '+', ',', ';', '=', '%', '@':
+			'(', ')', '*', '+', ',', ';', '=', '%':
 			continue
 		default:
 			return false

--- a/src/net/url/url_test.go
+++ b/src/net/url/url_test.go
@@ -231,6 +231,37 @@ var urltests = []URLTest{
 		},
 		"http://user:password@google.com",
 	},
+	// unescaped @ in username should not confuse host
+	{
+		"http://j@ne:password@google.com",
+		&URL{
+			Scheme: "http",
+			User:   UserPassword("j@ne", "password"),
+			Host:   "google.com",
+		},
+		"http://j%40ne:password@google.com",
+	},
+	// unescaped @ in password should not confuse host
+	{
+		"http://jane:p@ssword@google.com",
+		&URL{
+			Scheme: "http",
+			User:   UserPassword("jane", "p@ssword"),
+			Host:   "google.com",
+		},
+		"http://jane:p%40ssword@google.com",
+	},
+	{
+		"http://j@ne:password@google.com/p@th?q=@go",
+		&URL{
+			Scheme:   "http",
+			User:     UserPassword("j@ne", "password"),
+			Host:     "google.com",
+			Path:     "/p@th",
+			RawQuery: "q=@go",
+		},
+		"http://j%40ne:password@google.com/p@th?q=@go",
+	},
 	{
 		"http://www.google.com/?q=go+language#foo",
 		&URL{

--- a/src/net/url/url_test.go
+++ b/src/net/url/url_test.go
@@ -231,37 +231,6 @@ var urltests = []URLTest{
 		},
 		"http://user:password@google.com",
 	},
-	// unescaped @ in username should not confuse host
-	{
-		"http://j@ne:password@google.com",
-		&URL{
-			Scheme: "http",
-			User:   UserPassword("j@ne", "password"),
-			Host:   "google.com",
-		},
-		"http://j%40ne:password@google.com",
-	},
-	// unescaped @ in password should not confuse host
-	{
-		"http://jane:p@ssword@google.com",
-		&URL{
-			Scheme: "http",
-			User:   UserPassword("jane", "p@ssword"),
-			Host:   "google.com",
-		},
-		"http://jane:p%40ssword@google.com",
-	},
-	{
-		"http://j@ne:password@google.com/p@th?q=@go",
-		&URL{
-			Scheme:   "http",
-			User:     UserPassword("j@ne", "password"),
-			Host:     "google.com",
-			Path:     "/p@th",
-			RawQuery: "q=@go",
-		},
-		"http://j%40ne:password@google.com/p@th?q=@go",
-	},
 	{
 		"http://www.google.com/?q=go+language#foo",
 		&URL{


### PR DESCRIPTION
Add comment to clarify why '@' is allowed in validUserinfo func.