### PR TITLE
maps: add KeysSlice and ValuesSlice functions

### DIFF
--- a/src/maps/example_test.go
+++ b/src/maps/example_test.go
@@ -191,3 +191,37 @@ func ExampleCollect() {
 	// Output:
 	// m1 is: map[0:zero 1:one 2:two 3:three]
 }
+
+func ExampleKeysSlice() {
+	m := map[string]int{
+		"one":   1,
+		"two":   2,
+		"three": 3,
+	}
+
+	// Get all keys as a slice
+	keys := maps.KeysSlice(m)
+
+	// Since map iteration is not ordered, we sort the keys for predictable output
+	slices.Sort(keys)
+	fmt.Println(keys)
+	// Output:
+	// [one three two]
+}
+
+func ExampleValuesSlice() {
+	m := map[int]string{
+		1: "one",
+		2: "two",
+		3: "three",
+	}
+
+	// Get all values as a slice
+	values := maps.ValuesSlice(m)
+
+	// Since map iteration is not ordered, we sort the values for predictable output
+	slices.Sort(values)
+	fmt.Println(values)
+	// Output:
+	// [one three two]
+}

--- a/src/maps/maps.go
+++ b/src/maps/maps.go
@@ -73,3 +73,23 @@ func DeleteFunc[M ~map[K]V, K comparable, V any](m M, del func(K, V) bool) {
 		}
 	}
 }
+
+// KeysSlice returns a new slice containing the keys of m.
+// The keys will be in an indeterminate order.
+func KeysSlice[M ~map[K]V, K comparable, V any](m M) []K {
+	r := make([]K, 0, len(m))
+	for k := range m {
+		r = append(r, k)
+	}
+	return r
+}
+
+// ValuesSlice returns a new slice containing the values of m.
+// The values will be in an indeterminate order.
+func ValuesSlice[M ~map[K]V, K comparable, V any](m M) []V {
+	r := make([]V, 0, len(m))
+	for _, v := range m {
+		r = append(r, v)
+	}
+	return r
+}

--- a/src/maps/maps_test.go
+++ b/src/maps/maps_test.go
@@ -240,3 +240,73 @@ func TestCloneLarge(t *testing.T) {
 		}
 	}
 }
+
+func TestKeysSlice(t *testing.T) {
+	testCases := []struct {
+		m    map[string]int
+		want []string
+	}{
+		{nil, nil},
+		{map[string]int{}, []string{}},
+		{map[string]int{"a": 1}, []string{"a"}},
+		{map[string]int{"a": 1, "b": 2, "c": 3}, []string{"a", "b", "c"}},
+	}
+
+	for _, tc := range testCases {
+		got := KeysSlice(tc.m)
+		if len(got) != len(tc.want) {
+			t.Errorf("KeysSlice(%v) = %v, want slice of length %d", tc.m, got, len(tc.want))
+			continue
+		}
+
+		// Keys are returned in indeterminate order, so we need to check for inclusion
+		want := make(map[string]bool)
+		for _, k := range tc.want {
+			want[k] = true
+		}
+		for _, k := range got {
+			if !want[k] {
+				t.Errorf("KeysSlice(%v) = %v, unexpected key %v", tc.m, got, k)
+			}
+			delete(want, k)
+		}
+		if len(want) > 0 {
+			t.Errorf("KeysSlice(%v) = %v, missing keys %v", tc.m, got, want)
+		}
+	}
+}
+
+func TestValuesSlice(t *testing.T) {
+	testCases := []struct {
+		m    map[string]int
+		want []int
+	}{
+		{nil, nil},
+		{map[string]int{}, []int{}},
+		{map[string]int{"a": 1}, []int{1}},
+		{map[string]int{"a": 1, "b": 2, "c": 3}, []int{1, 2, 3}},
+	}
+
+	for _, tc := range testCases {
+		got := ValuesSlice(tc.m)
+		if len(got) != len(tc.want) {
+			t.Errorf("ValuesSlice(%v) = %v, want slice of length %d", tc.m, got, len(tc.want))
+			continue
+		}
+
+		// Values are returned in indeterminate order, so we need to count occurrences
+		wantCounts := make(map[int]int)
+		for _, v := range tc.want {
+			wantCounts[v]++
+		}
+
+		gotCounts := make(map[int]int)
+		for _, v := range got {
+			gotCounts[v]++
+		}
+
+		if !Equal(gotCounts, wantCounts) {
+			t.Errorf("ValuesSlice(%v) = %v, want values %v", tc.m, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
maps: add KeysSlice and ValuesSlice functions

This change adds two new helper functions to the maps package:

1. KeysSlice - returns a slice containing all the keys of a map
2. ValuesSlice - returns a slice containing all the values of a map

These functions complement the existing iterator-based Keys and Values
functions by directly providing slices, which is often more convenient for
simple use cases where iterators are not needed.

Example usage:
- To get all keys as a slice:
  m := map[string]int{"one": 1, "two": 2, "three": 3}
  keys := maps.KeysSlice(m)
  slices.Sort(keys) // Sort if order matters

- To get all values as a slice:
  m := map[int]string{1: "one", 2: "two", 3: "three"}
  values := maps.ValuesSlice(m)
  slices.Sort(values) // Sort if order matters

The implementation includes comprehensive tests that verify the functions
work correctly with regular maps, empty maps, and nil maps.
