### PR TITLE
flag: document CommandLine is the global FlagSet

### DIFF
--- a/src/flag/flag.go
+++ b/src/flag/flag.go
@@ -1193,9 +1193,8 @@ func Parsed() bool {
 	return CommandLine.Parsed()
 }
 
-// CommandLine is the default set of command-line flags, parsed from [os.Args].
-// The top-level functions such as [BoolVar], [Arg], and so on are wrappers for the
-// methods of CommandLine.
+// CommandLine holds [FlagSet] for global flags. Its methods are exposed
+// as top-level functions such as [BoolVar], [Arg], and so on.
 var CommandLine *FlagSet
 
 func init() {


### PR DESCRIPTION
Not just defaults, but a state holder for the flag API.