### PR TITLE
syscall: use SYS_EPOLL_WAIT on linux/amd64 for compatibility

### DIFF
--- a/src/internal/runtime/syscall/defs_linux_386.go
+++ b/src/internal/runtime/syscall/defs_linux_386.go
@@ -10,11 +10,13 @@ const (
 	SYS_PRCTL         = 172
 	SYS_EPOLL_CTL     = 255
 	SYS_EPOLL_PWAIT   = 319
+	SYS_EPOLL_WAIT    = -1
 	SYS_EPOLL_CREATE1 = 329
 	SYS_EPOLL_PWAIT2  = 441
 	SYS_EVENTFD2      = 328
 
 	EFD_NONBLOCK = 0x800
+	NONE         = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_386.go
+++ b/src/internal/runtime/syscall/defs_linux_386.go
@@ -16,7 +16,7 @@ const (
 	SYS_EVENTFD2      = 328
 
 	EFD_NONBLOCK = 0x800
-	NONE         = -1
+	NOSYS        = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_amd64.go
+++ b/src/internal/runtime/syscall/defs_linux_amd64.go
@@ -16,7 +16,7 @@ const (
 	SYS_EVENTFD2      = 290
 
 	EFD_NONBLOCK = 0x800
-	NONE         = -1
+	NOSYS        = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_amd64.go
+++ b/src/internal/runtime/syscall/defs_linux_amd64.go
@@ -10,11 +10,13 @@ const (
 	SYS_PRCTL         = 157
 	SYS_EPOLL_CTL     = 233
 	SYS_EPOLL_PWAIT   = 281
+	SYS_EPOLL_WAIT    = 232
 	SYS_EPOLL_CREATE1 = 291
 	SYS_EPOLL_PWAIT2  = 441
 	SYS_EVENTFD2      = 290
 
 	EFD_NONBLOCK = 0x800
+	NONE         = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_arm.go
+++ b/src/internal/runtime/syscall/defs_linux_arm.go
@@ -16,7 +16,7 @@ const (
 	SYS_EVENTFD2      = 356
 
 	EFD_NONBLOCK = 0x800
-	NONE         = -1
+	NOSYS        = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_arm.go
+++ b/src/internal/runtime/syscall/defs_linux_arm.go
@@ -10,11 +10,13 @@ const (
 	SYS_PRCTL         = 172
 	SYS_EPOLL_CTL     = 251
 	SYS_EPOLL_PWAIT   = 346
+	SYS_EPOLL_WAIT    = -1
 	SYS_EPOLL_CREATE1 = 357
 	SYS_EPOLL_PWAIT2  = 441
 	SYS_EVENTFD2      = 356
 
 	EFD_NONBLOCK = 0x800
+	NONE         = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_arm64.go
+++ b/src/internal/runtime/syscall/defs_linux_arm64.go
@@ -16,7 +16,7 @@ const (
 	SYS_EVENTFD2      = 19
 
 	EFD_NONBLOCK = 0x800
-	NONE         = -1
+	NOSYS        = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_arm64.go
+++ b/src/internal/runtime/syscall/defs_linux_arm64.go
@@ -8,6 +8,7 @@ const (
 	SYS_EPOLL_CREATE1 = 20
 	SYS_EPOLL_CTL     = 21
 	SYS_EPOLL_PWAIT   = 22
+	SYS_EPOLL_WAIT    = -1
 	SYS_FCNTL         = 25
 	SYS_PRCTL         = 167
 	SYS_MPROTECT      = 226
@@ -15,6 +16,7 @@ const (
 	SYS_EVENTFD2      = 19
 
 	EFD_NONBLOCK = 0x800
+	NONE         = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_loong64.go
+++ b/src/internal/runtime/syscall/defs_linux_loong64.go
@@ -16,7 +16,7 @@ const (
 	SYS_EVENTFD2      = 19
 
 	EFD_NONBLOCK = 0x800
-	NONE         = -1
+	NOSYS        = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_loong64.go
+++ b/src/internal/runtime/syscall/defs_linux_loong64.go
@@ -8,6 +8,7 @@ const (
 	SYS_EPOLL_CREATE1 = 20
 	SYS_EPOLL_CTL     = 21
 	SYS_EPOLL_PWAIT   = 22
+	SYS_EPOLL_WAIT    = -1
 	SYS_FCNTL         = 25
 	SYS_PRCTL         = 167
 	SYS_MPROTECT      = 226
@@ -15,6 +16,7 @@ const (
 	SYS_EVENTFD2      = 19
 
 	EFD_NONBLOCK = 0x800
+	NONE         = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_mips64x.go
+++ b/src/internal/runtime/syscall/defs_linux_mips64x.go
@@ -12,11 +12,13 @@ const (
 	SYS_PRCTL         = 5153
 	SYS_EPOLL_CTL     = 5208
 	SYS_EPOLL_PWAIT   = 5272
+	SYS_EPOLL_WAIT    = -1
 	SYS_EPOLL_CREATE1 = 5285
 	SYS_EPOLL_PWAIT2  = 5441
 	SYS_EVENTFD2      = 5284
 
 	EFD_NONBLOCK = 0x80
+	NONE         = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_mips64x.go
+++ b/src/internal/runtime/syscall/defs_linux_mips64x.go
@@ -18,7 +18,7 @@ const (
 	SYS_EVENTFD2      = 5284
 
 	EFD_NONBLOCK = 0x80
-	NONE         = -1
+	NOSYS        = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_mipsx.go
+++ b/src/internal/runtime/syscall/defs_linux_mipsx.go
@@ -18,7 +18,7 @@ const (
 	SYS_EVENTFD2      = 4325
 
 	EFD_NONBLOCK = 0x80
-	NONE         = -1
+	NOSYS        = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_mipsx.go
+++ b/src/internal/runtime/syscall/defs_linux_mipsx.go
@@ -12,11 +12,13 @@ const (
 	SYS_PRCTL         = 4192
 	SYS_EPOLL_CTL     = 4249
 	SYS_EPOLL_PWAIT   = 4313
+	SYS_EPOLL_WAIT    = -1
 	SYS_EPOLL_CREATE1 = 4326
 	SYS_EPOLL_PWAIT2  = 4441
 	SYS_EVENTFD2      = 4325
 
 	EFD_NONBLOCK = 0x80
+	NONE         = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_ppc64x.go
+++ b/src/internal/runtime/syscall/defs_linux_ppc64x.go
@@ -12,11 +12,13 @@ const (
 	SYS_PRCTL         = 171
 	SYS_EPOLL_CTL     = 237
 	SYS_EPOLL_PWAIT   = 303
+	SYS_EPOLL_WAIT    = -1
 	SYS_EPOLL_CREATE1 = 315
 	SYS_EPOLL_PWAIT2  = 441
 	SYS_EVENTFD2      = 314
 
 	EFD_NONBLOCK = 0x800
+	NONE         = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_ppc64x.go
+++ b/src/internal/runtime/syscall/defs_linux_ppc64x.go
@@ -18,7 +18,7 @@ const (
 	SYS_EVENTFD2      = 314
 
 	EFD_NONBLOCK = 0x800
-	NONE         = -1
+	NOSYS        = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_riscv64.go
+++ b/src/internal/runtime/syscall/defs_linux_riscv64.go
@@ -16,7 +16,7 @@ const (
 	SYS_EVENTFD2      = 19
 
 	EFD_NONBLOCK = 0x800
-	NONE         = -1
+	NOSYS        = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_riscv64.go
+++ b/src/internal/runtime/syscall/defs_linux_riscv64.go
@@ -8,6 +8,7 @@ const (
 	SYS_EPOLL_CREATE1 = 20
 	SYS_EPOLL_CTL     = 21
 	SYS_EPOLL_PWAIT   = 22
+	SYS_EPOLL_WAIT    = -1
 	SYS_FCNTL         = 25
 	SYS_PRCTL         = 167
 	SYS_MPROTECT      = 226
@@ -15,6 +16,7 @@ const (
 	SYS_EVENTFD2      = 19
 
 	EFD_NONBLOCK = 0x800
+	NONE         = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_s390x.go
+++ b/src/internal/runtime/syscall/defs_linux_s390x.go
@@ -10,11 +10,13 @@ const (
 	SYS_PRCTL         = 172
 	SYS_EPOLL_CTL     = 250
 	SYS_EPOLL_PWAIT   = 312
+	SYS_EPOLL_WAIT    = -1
 	SYS_EPOLL_CREATE1 = 327
 	SYS_EPOLL_PWAIT2  = 441
 	SYS_EVENTFD2      = 323
 
 	EFD_NONBLOCK = 0x800
+	NONE         = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/defs_linux_s390x.go
+++ b/src/internal/runtime/syscall/defs_linux_s390x.go
@@ -16,7 +16,7 @@ const (
 	SYS_EVENTFD2      = 323
 
 	EFD_NONBLOCK = 0x800
-	NONE         = -1
+	NOSYS        = -1
 )
 
 type EpollEvent struct {

--- a/src/internal/runtime/syscall/syscall_linux.go
+++ b/src/internal/runtime/syscall/syscall_linux.go
@@ -29,8 +29,14 @@ func EpollWait(epfd int32, events []EpollEvent, maxev, waitms int32) (n int32, e
 	} else {
 		ev = unsafe.Pointer(&_zero)
 	}
-	r1, _, e := Syscall6(SYS_EPOLL_PWAIT, uintptr(epfd), uintptr(ev), uintptr(maxev), uintptr(waitms), 0, 0)
-	return int32(r1), e
+
+	if SYS_EPOLL_WAIT != NONE {
+		r1, _, e := Syscall6(SYS_EPOLL_WAIT, uintptr(epfd), uintptr(ev), uintptr(maxev), uintptr(waitms), 0, 0)
+		return int32(r1), e
+	} else {
+		r1, _, e := Syscall6(SYS_EPOLL_PWAIT, uintptr(epfd), uintptr(ev), uintptr(maxev), uintptr(waitms), 0, 0)
+		return int32(r1), e
+	}
 }
 
 func EpollCtl(epfd, op, fd int32, event *EpollEvent) (errno uintptr) {

--- a/src/internal/runtime/syscall/syscall_linux.go
+++ b/src/internal/runtime/syscall/syscall_linux.go
@@ -30,7 +30,7 @@ func EpollWait(epfd int32, events []EpollEvent, maxev, waitms int32) (n int32, e
 		ev = unsafe.Pointer(&_zero)
 	}
 
-	if SYS_EPOLL_WAIT != NONE {
+	if SYS_EPOLL_WAIT != NOSYS {
 		r1, _, e := Syscall6(SYS_EPOLL_WAIT, uintptr(epfd), uintptr(ev), uintptr(maxev), uintptr(waitms), 0, 0)
 		return int32(r1), e
 	} else {


### PR DESCRIPTION
Fixes #24980