### PR TITLE
net/http: simplify HTTP version parsing with strconv.Atoi

### DIFF
--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -830,15 +830,15 @@ func ParseHTTPVersion(vers string) (major, minor int, ok bool) {
 	if vers[6] != '.' {
 		return 0, 0, false
 	}
-	maj, err := strconv.ParseUint(vers[5:6], 10, 0)
+	maj, err := strconv.Atoi(vers[5:6])
 	if err != nil {
 		return 0, 0, false
 	}
-	min, err := strconv.ParseUint(vers[7:8], 10, 0)
+	min, err := strconv.Atoi(vers[7:8])
 	if err != nil {
 		return 0, 0, false
 	}
-	return int(maj), int(min), true
+	return maj, min, true
 }
 
 func validMethod(method string) bool {

--- a/src/net/http/transport_test.go
+++ b/src/net/http/transport_test.go
@@ -7561,21 +7561,24 @@ func TestTransportServerProtocols(t *testing.T) {
 }
 
 func BenchmarkParseHTTPVersion(b *testing.B) {
-	cases := map[string]string{
-		"Valid_HTTP_1_0":  "HTTP/1.0",
-		"Valid_HTTP_1_1":  "HTTP/1.1",
-		"Valid_HTTP_2_0":  "HTTP/2.0",
-		"Valid_HTTP_9_9":  "HTTP/9.9",
-		"Invalid_Prefix":  "HTP/1.1",
-		"Invalid_Length":  "HTTP/12.3",
-		"Invalid_Minor":   "HTTP/1.A",
-		"Invalid_Numeric": "HTTP/X.Y",
+	cases := []struct {
+		name string
+		vers string
+	}{
+		{"Valid_HTTP_1_0", "HTTP/1.0"},
+		{"Valid_HTTP_1_1", "HTTP/1.1"},
+		{"Valid_HTTP_2_0", "HTTP/2.0"},
+		{"Valid_HTTP_9_9", "HTTP/9.9"},
+		{"Invalid_Prefix", "HTP/1.1"},
+		{"Invalid_Length", "HTTP/12.3"},
+		{"Invalid_Minor", "HTTP/1.A"},
+		{"Invalid_Numeric", "HTTP/X.Y"},
 	}
 
-	for name, vers := range cases {
-		b.Run(name, func(b *testing.B) {
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				ParseHTTPVersion(vers)
+				ParseHTTPVersion(c.vers)
 			}
 		})
 	}

--- a/src/net/http/transport_test.go
+++ b/src/net/http/transport_test.go
@@ -7559,3 +7559,24 @@ func TestTransportServerProtocols(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkParseHTTPVersion(b *testing.B) {
+	cases := map[string]string{
+		"Valid_HTTP_1_0":  "HTTP/1.0",
+		"Valid_HTTP_1_1":  "HTTP/1.1",
+		"Valid_HTTP_2_0":  "HTTP/2.0",
+		"Valid_HTTP_9_9":  "HTTP/9.9",
+		"Invalid_Prefix":  "HTP/1.1",
+		"Invalid_Length":  "HTTP/12.3",
+		"Invalid_Minor":   "HTTP/1.A",
+		"Invalid_Numeric": "HTTP/X.Y",
+	}
+
+	for name, vers := range cases {
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				ParseHTTPVersion(vers)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Since vers[5:6] and vers[7:8] always extract single-digit positive numbers, Atoi is sufficient and avoids unnecessary uint-to-int conversion.