### PR TITLE
net: simplify readProtocols via sync.OnceFunc

### DIFF
--- a/src/net/lookup_unix.go
+++ b/src/net/lookup_unix.go
@@ -12,11 +12,9 @@ import (
 	"sync"
 )
 
-var onceReadProtocols sync.Once
-
-// readProtocols loads contents of /etc/protocols into protocols map
+// readProtocolsOnce loads contents of /etc/protocols into protocols map
 // for quick access.
-func readProtocols() {
+var readProtocolsOnce = sync.OnceFunc(func() {
 	file, err := open("/etc/protocols")
 	if err != nil {
 		return
@@ -43,12 +41,12 @@ func readProtocols() {
 			}
 		}
 	}
-}
+})
 
 // lookupProtocol looks up IP protocol name in /etc/protocols and
 // returns correspondent protocol number.
 func lookupProtocol(_ context.Context, name string) (int, error) {
-	onceReadProtocols.Do(readProtocols)
+	readProtocolsOnce()
 	return lookupProtocolMap(name)
 }
 


### PR DESCRIPTION
In this case, using sync.OnceFunc is a better choice.