### PR TITLE
mime: speed up ParseMediaType

### DIFF
--- a/src/mime/mediatype.go
+++ b/src/mime/mediatype.go
@@ -60,7 +60,7 @@ func FormatMediaType(t string, param map[string]string) string {
 				// attribute-char := <any (US-ASCII) CHAR except SPACE, CTLs, "*", "'", "%", or tspecials>
 				if ch <= ' ' || ch >= 0x7F ||
 					ch == '*' || ch == '\'' || ch == '%' ||
-					isTSpecial(rune(ch)) {
+					isTSpecial(ch) {
 
 					b.WriteString(value[offset:index])
 					offset = index + 1
@@ -250,23 +250,17 @@ func decode2231Enc(v string) (string, bool) {
 	return encv, true
 }
 
-func isNotTokenChar(r rune) bool {
-	return !isTokenChar(r)
-}
-
 // consumeToken consumes a token from the beginning of provided
 // string, per RFC 2045 section 5.1 (referenced from 2183), and return
 // the token consumed and the rest of the string. Returns ("", v) on
 // failure to consume at least one character.
 func consumeToken(v string) (token, rest string) {
-	notPos := strings.IndexFunc(v, isNotTokenChar)
-	if notPos == -1 {
-		return v, ""
+	for i := range len(v) {
+		if !isTokenChar(v[i]) {
+			return v[:i], v[i:]
+		}
 	}
-	if notPos == 0 {
-		return "", v
-	}
-	return v[0:notPos], v[notPos:]
+	return v, ""
 }
 
 // consumeValue consumes a "value" per RFC 2045, where a value is
@@ -299,7 +293,7 @@ func consumeValue(v string) (value, rest string) {
 		// and intended as a literal backslash. This makes Go servers deal better
 		// with MSIE without affecting the way they handle conforming MIME
 		// generators.
-		if r == '\\' && i+1 < len(v) && isTSpecial(rune(v[i+1])) {
+		if r == '\\' && i+1 < len(v) && isTSpecial(v[i+1]) {
 			buffer.WriteByte(v[i+1])
 			i++
 			continue

--- a/src/mime/mediatype_test.go
+++ b/src/mime/mediatype_test.go
@@ -96,7 +96,9 @@ type mediaTypeTest struct {
 	p  map[string]string
 }
 
-func TestParseMediaType(t *testing.T) {
+var parseMediaTypeTests []mediaTypeTest
+
+func init() {
 	// Convenience map initializer
 	m := func(s ...string) map[string]string {
 		sm := make(map[string]string)
@@ -107,7 +109,7 @@ func TestParseMediaType(t *testing.T) {
 	}
 
 	nameFoo := map[string]string{"name": "foo"}
-	tests := []mediaTypeTest{
+	parseMediaTypeTests = []mediaTypeTest{
 		{`form-data; name="foo"`, "form-data", nameFoo},
 		{` form-data ; name=foo`, "form-data", nameFoo},
 		{`FORM-DATA;name="foo"`, "form-data", nameFoo},
@@ -412,7 +414,10 @@ func TestParseMediaType(t *testing.T) {
 		{`text; charset=utf-8; charset=utf-8; format=fixed`, "text", m("charset", "utf-8", "format", "fixed")},
 		{`text; charset=utf-8; format=flowed; charset=utf-8`, "text", m("charset", "utf-8", "format", "flowed")},
 	}
-	for _, test := range tests {
+}
+
+func TestParseMediaType(t *testing.T) {
+	for _, test := range parseMediaTypeTests {
 		mt, params, err := ParseMediaType(test.in)
 		if err != nil {
 			if test.t != "" {
@@ -434,6 +439,14 @@ func TestParseMediaType(t *testing.T) {
 				"expected: %#v\n"+
 				"     got: %#v",
 				test.in, test.p, params)
+		}
+	}
+}
+
+func BenchmarkParseMediaType(b *testing.B) {
+	for range b.N {
+		for _, test := range parseMediaTypeTests {
+			ParseMediaType(test.in)
 		}
 	}
 }
@@ -482,6 +495,14 @@ func TestParseMediaTypeBogus(t *testing.T) {
 		}
 		if err == ErrInvalidMediaParameter && mt != tt.mt {
 			t.Errorf("ParseMediaType(%q): in case of invalid parameters: expected type %q, got %q", tt.in, tt.mt, mt)
+		}
+	}
+}
+
+func BenchmarkParseMediaTypeBogus(b *testing.B) {
+	for range b.N {
+		for _, test := range badMediaTypeTests {
+			ParseMediaType(test.in)
 		}
 	}
 }


### PR DESCRIPTION
Add benchmarks for ParseMediaType.

Eschew UTF-8 decoding and strings.IndexFunc where possible, and rely
on 128-bit bitmaps instead. Eliminate some bounds checks.

Some benchmark results (no changes to allocations):

goos: darwin
goarch: amd64
pkg: mime
cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
                      │     old     │                 new                 │
                      │   sec/op    │   sec/op     vs base                │
ParseMediaType-8        71.75µ ± 0%   55.53µ ± 0%  -22.60% (p=0.000 n=20)
ParseMediaTypeBogus-8   5.330µ ± 0%   3.603µ ± 0%  -32.41% (p=0.000 n=20)
geomean                 19.56µ        14.14µ       -27.67%
