### PR TITLE
encoding/json: remove redundant c <= ' ' check in isSpace

### DIFF
--- a/src/encoding/json/scanner.go
+++ b/src/encoding/json/scanner.go
@@ -199,7 +199,7 @@ func (s *scanner) popParseState() {
 }
 
 func isSpace(c byte) bool {
-	return c <= ' ' && (c == ' ' || c == '\t' || c == '\r' || c == '\n')
+	return c == ' ' || c == '\t' || c == '\r' || c == '\n'
 }
 
 // stateBeginValueOrEmpty is the state after reading `[`.

--- a/src/encoding/json/scanner_test.go
+++ b/src/encoding/json/scanner_test.go
@@ -304,3 +304,41 @@ func genMap(n int) map[string]any {
 	}
 	return x
 }
+
+var (
+	isSpaceRes bool
+
+	nonPrintable      = []byte{0x01, 0x08}
+	printableNonSpace = []byte{'a', 'z', '1', 'X'}
+	spaceChars        = []byte{' ', '\t', '\r', '\n'}
+)
+
+func BenchmarkIsSpace_NonPrintable(b *testing.B) {
+	var r bool
+	for i := 0; i < b.N; i++ {
+		for _, c := range nonPrintable {
+			r = isSpace(c)
+		}
+	}
+	isSpaceRes = r
+}
+
+func BenchmarkIsSpace_PrintableNonSpace(b *testing.B) {
+	var r bool
+	for i := 0; i < b.N; i++ {
+		for _, c := range printableNonSpace {
+			r = isSpace(c)
+		}
+	}
+	isSpaceRes = r
+}
+
+func BenchmarkIsSpace_SpaceChars(b *testing.B) {
+	var r bool
+	for i := 0; i < b.N; i++ {
+		for _, c := range spaceChars {
+			r = isSpace(c)
+		}
+	}
+	isSpaceRes = r
+}


### PR DESCRIPTION
Simplified isSpace by directly checking byte values: ' ' = 32, '\t' = 9, '\r' = 13, and '\n' = 10. The c <= ' ' check is unnecessary.