### PR TITLE
cmd/link: ignore mapping symbols on riscv64

### DIFF
--- a/src/cmd/link/internal/loadelf/ldelf.go
+++ b/src/cmd/link/internal/loadelf/ldelf.go
@@ -602,6 +602,14 @@ func Load(l *loader.Loader, arch *sys.Arch, localSymVersion int, f *bio.Reader, 
 					// See https://sourceware.org/bugzilla/show_bug.cgi?id=21809
 					continue
 				}
+
+				if arch.Family == sys.RISCV64 &&
+					(strings.HasPrefix(elfsym.name, "$d") || strings.HasPrefix(elfsym.name, "$x")) {
+					// Ignore RISC-V mapping symbols, which
+					// are similar to ARM64's case.
+					// See issue 73591.
+					continue
+				}
 			}
 
 			if strings.HasPrefix(elfsym.name, ".Linfo_string") {


### PR DESCRIPTION
Specified in RISC-V ELF psABI[1], mapping symbols are symbols starting
with "$d" or "$x" with STT_NOTYPE, STB_LOCAL and zero sizes, indicating
boundaries between code and data in the same section.

Let's simply ignore them as they're only markers instead of real symbols.
This fixes linking errors like

	sym#63 ("$d"): ignoring symbol in section 4 (".riscv.attributes") (type 0)

when using CGO together with Clang and internal linker, which are caused
by unnecessary (but technically correct) mapping symbols created by LLVM
for various sections.

[1]: https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/87aecf601722171c570120a46003be3c17ad3108/riscv-elf.adoc?plain=1#L1448

Fixes #73516
