### PR TITLE
database/sql/driver: fix Rows.Next() comment

### DIFF
--- a/src/database/sql/driver/driver.go
+++ b/src/database/sql/driver/driver.go
@@ -436,10 +436,6 @@ type Rows interface {
 	// size as the Columns() are wide.
 	//
 	// Next should return io.EOF when there are no more rows.
-	//
-	// The dest should not be written to outside of Next. Care
-	// should be taken when closing Rows not to modify
-	// a buffer held in dest.
 	Next(dest []Value) error
 }
 


### PR DESCRIPTION
CL 89936 introduced restriction that Rows.Close() shouldn't modify dest
in previous Next().
CL 497675 for #60304 removed that restriction. But it didn't remove doc
about the restriction.