### PR TITLE
hash/maphash: hash channels in purego version of maphash.Comparable

### DIFF
--- a/src/hash/maphash/maphash_purego.go
+++ b/src/hash/maphash/maphash_purego.go
@@ -161,7 +161,7 @@ func appendT(h *Hash, v reflect.Value) {
 	case reflect.Bool:
 		h.WriteByte(btoi(v.Bool()))
 		return
-	case reflect.UnsafePointer, reflect.Pointer:
+	case reflect.UnsafePointer, reflect.Pointer, reflect.Chan:
 		var buf [8]byte
 		// because pointing to the abi.Escape call in comparableReady,
 		// So this is ok to hash pointer,

--- a/src/hash/maphash/maphash_test.go
+++ b/src/hash/maphash/maphash_test.go
@@ -254,12 +254,17 @@ func TestComparable(t *testing.T) {
 	}
 	testComparable(t, s1, s2)
 	testComparable(t, s1.s, s2.s)
+	c1 := make(chan struct{})
+	c2 := make(chan struct{})
+	testComparable(t, c1, c1)
+	testComparable(t, chan struct{}(nil))
 	testComparable(t, float32(0), negativeZero[float32]())
 	testComparable(t, float64(0), negativeZero[float64]())
 	testComparableNoEqual(t, math.NaN(), math.NaN())
 	testComparableNoEqual(t, [2]string{"a", ""}, [2]string{"", "a"})
 	testComparableNoEqual(t, struct{ a, b string }{"foo", ""}, struct{ a, b string }{"", "foo"})
 	testComparableNoEqual(t, struct{ a, b any }{int(0), struct{}{}}, struct{ a, b any }{struct{}{}, int(0)})
+	testComparableNoEqual(t, c1, c2)
 }
 
 func testComparableNoEqual[T comparable](t *testing.T, v1, v2 T) {


### PR DESCRIPTION
This change makes purego implementation of maphash.Comparable consistent 
with the one in runtime and fixes hashing of channels.
    
Fixes #73657