### PR TITLE
text/template: limit expression parenthesis nesting

### DIFF
--- a/src/text/template/doc.go
+++ b/src/text/template/doc.go
@@ -16,7 +16,7 @@ by a period '.' and called "dot", to the value at the current location in the
 structure as execution proceeds.
 
 The security model used by this package assumes that template authors are
-trusted. text/template does not auto-escape output, so injecting code into
+trusted. The package does not auto-escape output, so injecting code into
 a template can lead to arbitrary code execution if the template is executed
 by an untrusted source.
 

--- a/src/text/template/doc.go
+++ b/src/text/template/doc.go
@@ -15,6 +15,11 @@ Execution of the template walks the structure and sets the cursor, represented
 by a period '.' and called "dot", to the value at the current location in the
 structure as execution proceeds.
 
+The security model used by this package assumes that template authors are
+trusted. text/template does not auto-escape output, so injecting code into
+a template can lead to arbitrary code execution if the template is executed
+by an untrusted source.
+
 The input text for a template is UTF-8-encoded text in any format.
 "Actions"--data evaluations or control structures--are delimited by
 "{{" and "}}"; all text outside actions is copied to the output unchanged.

--- a/src/text/template/parse/parse.go
+++ b/src/text/template/parse/parse.go
@@ -32,6 +32,7 @@ type Tree struct {
 	treeSet    map[string]*Tree
 	actionLine int // line of left delim starting action
 	rangeDepth int
+	parenDepth int // current depth of nested parenthesized expressions
 }
 
 // A mode value is a set of flags (or 0). Modes control parser behavior.
@@ -41,6 +42,10 @@ const (
 	ParseComments Mode = 1 << iota // parse comments and add them to AST
 	SkipFuncCheck                  // do not check that functions are defined
 )
+
+// maxExpressionParenDepth is the maximum depth of nested parenthesized expressions.
+// It is used to prevent stack overflows from deep finite recursion in the parser.
+const maxExpressionParenDepth = 10000
 
 // Copy returns a copy of the [Tree]. Any parsing state is discarded.
 func (t *Tree) Copy() *Tree {
@@ -223,6 +228,7 @@ func (t *Tree) startParse(funcs []map[string]any, lex *lexer, treeSet map[string
 	t.vars = []string{"$"}
 	t.funcs = funcs
 	t.treeSet = treeSet
+	t.parenDepth = 0
 	lex.options = lexOptions{
 		emitComment: t.Mode&ParseComments != 0,
 		breakOK:     !t.hasFunction("break"),
@@ -787,6 +793,11 @@ func (t *Tree) term() Node {
 		}
 		return number
 	case itemLeftParen:
+		if t.parenDepth >= maxExpressionParenDepth {
+			t.errorf("max expression depth exceeded")
+		}
+		t.parenDepth++
+		defer func() { t.parenDepth-- }()
 		return t.pipeline("parenthesized pipeline", itemRightParen)
 	case itemString, itemRawString:
 		s, err := strconv.Unquote(token.val)

--- a/src/text/template/parse/parse.go
+++ b/src/text/template/parse/parse.go
@@ -46,6 +46,7 @@ const (
 // maxExpressionParenDepth is the maximum depth of nested parenthesized expressions.
 // It is used to prevent stack overflows from deep finite recursion in the parser.
 const maxExpressionParenDepth = 10000
+const maxExpressionParenDepthWasm = 1000 // Lower limit for WASM environments
 
 // Copy returns a copy of the [Tree]. Any parsing state is discarded.
 func (t *Tree) Copy() *Tree {
@@ -793,7 +794,8 @@ func (t *Tree) term() Node {
 		}
 		return number
 	case itemLeftParen:
-		if t.parenDepth >= maxExpressionParenDepth {
+		if t.parenDepth >= maxExpressionParenDepth ||
+			runtime.GOARCH == "wasm" && t.parenDepth >= maxExpressionParenDepthWasm {
 			t.errorf("max expression depth exceeded")
 		}
 		t.parenDepth++

--- a/src/text/template/parse/parse_test.go
+++ b/src/text/template/parse/parse_test.go
@@ -87,8 +87,8 @@ var numberTests = []numberTest{
 }
 
 func init() {
-	// Use a small depth limit for testing to avoid creating huge expressions.
-	maxExpressionParenDepth = 3
+	// Use a small stack limit for testing to avoid creating huge expressions.
+	maxStackDepth = 3
 }
 
 func TestNumberParse(t *testing.T) {
@@ -333,7 +333,7 @@ var parseTests = []parseTest{
 	// Missing pipeline in block
 	{"block definition", `{{block "foo"}}hello{{end}}`, hasError, ""},
 
-	// Parenthesis nesting depth tests
+	// Expression nested depth tests.
 	{"paren nesting normal", "{{ (( 1 )) }}", noError, "{{((1))}}"},
 	{"paren nesting at limit", "{{ ((( 1 ))) }}", noError, "{{(((1)))}}"},
 	{"paren nesting exceeds limit", "{{ (((( 1 )))) }}", hasError, "template: test:1: max expression depth exceeded"},


### PR DESCRIPTION
Deeply nested parenthesized expressions could cause a stack
overflow during parsing. This change introduces a depth limit
(maxStackDepth) tracked in Tree.stackDepth to prevent this.

Additionally, this commit clarifies the security model in
the package documentation, noting that template authors
are trusted as text/template does not auto-escape.

Fixes #71201
