### PR TITLE
cmd/compile: create LSym for closures with type conversion

### DIFF
--- a/src/cmd/compile/internal/inline/inl.go
+++ b/src/cmd/compile/internal/inline/inl.go
@@ -1117,12 +1117,18 @@ func mkinlcall(callerfn *ir.Func, n *ir.CallExpr, fn *ir.Func, bigCaller, closur
 			// Not a standard call.
 			return
 		}
-		if n.Fun.Op() != ir.OCLOSURE {
-			// Not a direct closure call.
+
+		var nf = n.Fun
+		// Skips ir.OCONVNOPs, see issue #73716.
+		for nf.Op() == ir.OCONVNOP {
+			nf = nf.(*ir.ConvExpr).X
+		}
+		if nf.Op() != ir.OCLOSURE {
+			// Not a direct closure call or one with type conversion.
 			return
 		}
 
-		clo := n.Fun.(*ir.ClosureExpr)
+		clo := nf.(*ir.ClosureExpr)
 		if !clo.Func.IsClosure() {
 			// enqueueFunc will handle non closures anyways.
 			return

--- a/test/fixedbugs/issue73716.go
+++ b/test/fixedbugs/issue73716.go
@@ -1,0 +1,37 @@
+// build
+
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Issue 73716: cmd/compile: unnamed functions missing FuncInfo
+
+package main
+
+import "fmt"
+
+type EP func()
+type F func(EP) EP
+
+func main() {
+	eps := []EP{ep1, ep2}
+	var h EP
+
+	for _, ep := range eps {
+		h = F(func(e EP) EP {
+			return func() {
+				ep()
+				e()
+			}
+		})(h)
+	}
+	h()
+}
+
+func ep1() {
+	fmt.Printf("ep1\n")
+}
+
+func ep2() {
+	fmt.Printf("ep2\n")
+}


### PR DESCRIPTION
Follow-up to #54959 with another failing case.

The linker needs FuncInfo metadata for all inlined functions. CL 436240 explicitly creates LSym for direct closure calls to ensure we keep the FuncInfo metadata.

However, CL 436240 won't work if the direct closure call is wrapped by a no-effect type conversion, even if that closure could be inlined.

This commit should fix such case.

Fixes #73716
