### PR TITLE
cmd/link: fix outdated output mmap check

### DIFF
--- a/src/cmd/link/internal/ld/asmb.go
+++ b/src/cmd/link/internal/ld/asmb.go
@@ -195,10 +195,7 @@ func relocSectFn(ctxt *Link, relocSect func(*Link, *OutBuf, *sym.Section, []load
 		fn = func(ctxt *Link, sect *sym.Section, syms []loader.Sym) {
 			wg.Add(1)
 			sem <- 1
-			out, err := ctxt.Out.View(sect.Reloff)
-			if err != nil {
-				panic(err)
-			}
+			out := ctxt.Out.View(sect.Reloff)
 			go func() {
 				relocSect(ctxt, out, sect, syms)
 				wg.Done()

--- a/src/cmd/link/internal/ld/outbuf.go
+++ b/src/cmd/link/internal/ld/outbuf.go
@@ -92,9 +92,7 @@ func NewOutBuf(arch *sys.Arch) *OutBuf {
 	}
 }
 
-var viewError = errors.New("output not mmapped")
-
-func (out *OutBuf) View(start uint64) (*OutBuf, error) {
+func (out *OutBuf) View(start uint64) *OutBuf {
 	return &OutBuf{
 		arch:   out.arch,
 		name:   out.name,
@@ -102,7 +100,7 @@ func (out *OutBuf) View(start uint64) (*OutBuf, error) {
 		heap:   out.heap,
 		off:    int64(start),
 		isView: true,
-	}, nil
+	}
 }
 
 var viewCloseError = errors.New("cannot Close OutBuf from View")


### PR DESCRIPTION
Outbuf.View used to perform a mmap check by default 
and return an error if the check failed, 
this behavior has been changed so that now 
the View never returns any error, 
so the usage needs to be modified accordingly.