### PR TITLE
net: avoid using Windows' TransmitFile on non-server machines

### DIFF
--- a/src/internal/syscall/windows/types_windows.go
+++ b/src/internal/syscall/windows/types_windows.go
@@ -256,3 +256,7 @@ type FILE_COMPLETION_INFORMATION struct {
 	Port syscall.Handle
 	Key  uintptr
 }
+
+// https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexa
+// https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/ns-wdm-_osversioninfoexw
+const VER_NT_WORKSTATION = 0x0000001

--- a/src/internal/syscall/windows/zsyscall_windows.go
+++ b/src/internal/syscall/windows/zsyscall_windows.go
@@ -539,7 +539,7 @@ func NtSetInformationFile(handle syscall.Handle, iosb *IO_STATUS_BLOCK, inBuffer
 	return
 }
 
-func rtlGetVersion(info *_OSVERSIONINFOW) {
+func rtlGetVersion(info *_OSVERSIONINFOEXW) {
 	syscall.Syscall(procRtlGetVersion.Addr(), 1, uintptr(unsafe.Pointer(info)), 0, 0)
 	return
 }

--- a/src/net/sendfile.go
+++ b/src/net/sendfile.go
@@ -12,8 +12,6 @@ import (
 	"syscall"
 )
 
-const supportsSendfile = true
-
 // sendFile copies the contents of r to c using the sendfile
 // system call to minimize copies.
 //
@@ -22,6 +20,9 @@ const supportsSendfile = true
 //
 // if handled == false, sendFile performed no work.
 func sendFile(c *netFD, r io.Reader) (written int64, err error, handled bool) {
+	if !supportsSendfile() {
+		return 0, nil, false
+	}
 	var remain int64 = 0 // 0 writes the entire file
 	lr, ok := r.(*io.LimitedReader)
 	if ok {

--- a/src/net/sendfile_nonwindows.go
+++ b/src/net/sendfile_nonwindows.go
@@ -1,0 +1,12 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux || (darwin && !ios) || dragonfly || freebsd || solaris
+
+package net
+
+// Always true except for workstation and client versions of Windows
+func supportsSendfile() bool {
+	return true
+}

--- a/src/net/sendfile_stub.go
+++ b/src/net/sendfile_stub.go
@@ -8,7 +8,9 @@ package net
 
 import "io"
 
-const supportsSendfile = false
+func supportsSendfile() bool {
+	return false
+}
 
 func sendFile(c *netFD, r io.Reader) (n int64, err error, handled bool) {
 	return 0, nil, false

--- a/src/net/sendfile_test.go
+++ b/src/net/sendfile_test.go
@@ -31,11 +31,11 @@ const (
 // expectSendfile runs f, and verifies that internal/poll.SendFile successfully handles
 // a write to wantConn during f's execution.
 //
-// On platforms where supportsSendfile is false, expectSendfile runs f but does not
+// On platforms where supportsSendfile() is false, expectSendfile runs f but does not
 // expect a call to SendFile.
 func expectSendfile(t *testing.T, wantConn Conn, f func()) {
 	t.Helper()
-	if !supportsSendfile {
+	if !supportsSendfile() {
 		f()
 		return
 	}

--- a/src/net/sendfile_windows.go
+++ b/src/net/sendfile_windows.go
@@ -1,0 +1,16 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package net
+
+import "internal/syscall/windows"
+
+// Workstation and client versions of Windows limit the number
+// of concurrent TransmitFile operations allowed on the system
+// to a maximum of two. Please see:
+// https://learn.microsoft.com/en-us/windows/win32/api/mswsock/nf-mswsock-transmitfile
+// https://golang.org/issue/73746
+func supportsSendfile() bool {
+	return windows.SupportUnlimitedTransmitFile()
+}


### PR DESCRIPTION
Windows API's TransmitFile function is limited to two concurrent
operations on workstation and client versions of Windows. This change
modifies the net.sendFile function to perform no work in such cases
so that TransmitFile is avoided.

Fixes #73746