### PR TITLE
math: fix portable FMA implementation when x*y ~ 0, x*y < 0 and z = 0

### DIFF
--- a/src/math/all_test.go
+++ b/src/math/all_test.go
@@ -2126,6 +2126,9 @@ var fmaC = []struct{ x, y, z, want float64 }{
 	// Issue #61130
 	{-1, 1, 1, 0},
 	{1, 1, -1, 0},
+
+	// Issue #73757
+	{0x1p-1022, -0x1p-1022, 0, Copysign(0, -1)},
 }
 
 var sqrt32 = []float32{

--- a/src/math/all_test.go
+++ b/src/math/all_test.go
@@ -2129,6 +2129,8 @@ var fmaC = []struct{ x, y, z, want float64 }{
 
 	// Issue #73757
 	{0x1p-1022, -0x1p-1022, 0, Copysign(0, -1)},
+	{Copysign(0, -1), 1, 0, 0},
+	{1, Copysign(0, -1), 0, 0},
 }
 
 var sqrt32 = []float32{

--- a/src/math/fma.go
+++ b/src/math/fma.go
@@ -96,8 +96,15 @@ func FMA(x, y, z float64) float64 {
 	bx, by, bz := Float64bits(x), Float64bits(y), Float64bits(z)
 
 	// Inf or NaN or zero involved. At most one rounding will occur.
-	if x == 0.0 || y == 0.0 || z == 0.0 || bx&uvinf == uvinf || by&uvinf == uvinf {
+	if x == 0.0 || y == 0.0 || bx&uvinf == uvinf || by&uvinf == uvinf {
 		return x*y + z
+	}
+	// Handle z == 0.0 separately.
+	// Adding zero usually does not change the original value.
+	// However, there is an exception with negative zero. (e.g. (-0) + (+0) = (+0))
+	// This applies when x * y is negative and underflows.
+	if z == 0.0 {
+		return x * y
 	}
 	// Handle non-finite z separately. Evaluating x*y+z where
 	// x and y are finite, but z is infinite, should always result in z.


### PR DESCRIPTION
Adding zero usually does not change the original value.
However, there is an exception with negative zero. (e.g. (-0) + (+0) = (+0))
This applies when x * y is negative and underflows.

Fixes #73757
