### PR TITLE
cmd/compile: allow wasmexport used without exportname

### DIFF
--- a/src/cmd/compile/doc.go
+++ b/src/cmd/compile/doc.go
@@ -320,17 +320,19 @@ by ``importmodule'' and ``importname''. For example,
 
 causes g to refer to the WebAssembly function f from module a_module.
 
-	//go:wasmexport exportname
+	//go:wasmexport [exportname]
 
 The //go:wasmexport directive is wasm-only and must be followed by a
 function definition.
 It specifies that the function is exported to the wasm host as ``exportname''.
+If exportname is omitted, the function's own name will be used as the export name.
 For example,
-
 	//go:wasmexport h
 	func hWasm() { ... }
-
-make Go function hWasm available outside this WebAssembly module as h.
+makes Go function hWasm available outside this WebAssembly module as h.
+	//go:wasmexport
+	func hWasm() { ... }
+makes Go function hWasm available outside this WebAssembly module as hWasm.
 
 For both go:wasmimport and go:wasmexport,
 the types of parameters and return values to the Go function are translated to

--- a/src/cmd/compile/internal/noder/noder.go
+++ b/src/cmd/compile/internal/noder/noder.go
@@ -258,19 +258,23 @@ func (p *noder) pragma(pos syntax.Pos, blankLine bool, text string, old syntax.P
 			}
 		}
 
-	case strings.HasPrefix(text, "go:wasmexport "):
+	case strings.HasPrefix(text, "go:wasmexport"):
 		f := strings.Fields(text)
-		if len(f) != 2 {
-			// TODO: maybe make the name optional? It was once mentioned on proposal 65199.
-			p.error(syntax.Error{Pos: pos, Msg: "usage: //go:wasmexport exportname"})
+		if len(f) > 2 {
+			p.error(syntax.Error{Pos: pos, Msg: "usage: //go:wasmexport [exportname]"})
 			break
+		}
+
+		var exportName string
+		if len(f) == 2 {
+			exportName = f[1]
 		}
 
 		if buildcfg.GOARCH == "wasm" {
 			// Only actually use them if we're compiling to WASM though.
 			pragma.WasmExport = &WasmExport{
 				Pos:  pos,
-				Name: f[1],
+				Name: exportName,
 			}
 		}
 

--- a/src/cmd/compile/internal/noder/writer.go
+++ b/src/cmd/compile/internal/noder/writer.go
@@ -1125,7 +1125,11 @@ func (w *writer) funcExt(obj *types2.Func) {
 			w.String("")
 		}
 		if we != nil {
-			w.String(we.Name)
+			if we.Name != "" {
+				w.String(we.Name)
+			} else {
+				w.String(decl.Name.Value)
+			}
 		} else {
 			w.String("")
 		}

--- a/test/wasmexport.go
+++ b/test/wasmexport.go
@@ -13,6 +13,9 @@ package p
 //go:wasmexport F
 func F() {} // OK
 
+//go:wasmexport
+func G() {} // OK
+
 type S int32
 
 //go:wasmexport M


### PR DESCRIPTION
When exportname is omitted, the name of the function is used as exportname

Updates #65199