### PR TITLE
cmd/go: mod edit: add -droptoolchain flag

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -1235,6 +1235,8 @@
 // This flag is mainly for tools that understand Go version dependencies.
 // Users should prefer 'go get toolchain@version'.
 //
+// The -droptoolchain flag removes the toolchain directive from the go.mod file.
+//
 // The -exclude=path@version and -dropexclude=path@version flags
 // add and drop an exclusion for the given module path and version.
 // Note that -exclude=path@version is a no-op if that exclusion already exists.
@@ -1264,7 +1266,7 @@
 //
 // The -godebug, -dropgodebug, -require, -droprequire, -exclude, -dropexclude,
 // -replace, -dropreplace, -retract, -dropretract, -tool, -droptool, -ignore,
-// and -dropignore editing flags may be repeated, and the changes are applied
+// -dropignore, and -droptoolchain editing flags may be repeated, and the changes are applied
 // in the order given.
 //
 // The -print flag prints the final go.mod in its text format instead of
@@ -1806,7 +1808,7 @@
 // To view the current telemetry mode, run "go telemetry".
 // To disable telemetry uploading, but keep local data collection, run
 // "go telemetry local".
-// To enable both collection and uploading, run “go telemetry on”.
+// To enable both collection and uploading, run "go telemetry on".
 // To disable both collection and uploading, run "go telemetry off".
 //
 // The current telemetry mode is also available as the value of the

--- a/src/cmd/go/testdata/script/mod_edit_droptoolchain.txt
+++ b/src/cmd/go/testdata/script/mod_edit_droptoolchain.txt
@@ -1,0 +1,35 @@
+# Test for go mod edit -droptoolchain
+
+# Setup
+env GO111MODULE=on
+env GOFLAGS=-mod=mod
+
+# Create a new module
+! exists go.mod
+go mod init example.com/test
+exists go.mod
+
+# Check that the toolchain directive is not present initially
+! grep toolchain go.mod
+
+# Add a toolchain directive
+go mod edit -toolchain=go1.21
+grep 'toolchain go1.21' go.mod
+
+# Remove the toolchain directive using -droptoolchain
+go mod edit -droptoolchain
+! grep toolchain go.mod
+
+# Add a toolchain directive again
+go mod edit -toolchain=go1.22
+grep 'toolchain go1.22' go.mod
+
+# Make sure that -toolchain=none still works as before
+go mod edit -toolchain=none
+! grep toolchain go.mod
+
+# Add a toolchain directive again and use -droptoolchain with an argument (should be ignored)
+go mod edit -toolchain=go1.23
+grep 'toolchain go1.23' go.mod
+go mod edit -droptoolchain
+! grep toolchain go.mod 


### PR DESCRIPTION
Add support for the -droptoolchain flag to `go mod edit`, which removes
the toolchain directive from go.mod. This complements the existing
-toolchain flag and allows users and tools to remove toolchain
constraints via CLI.

The -toolchain and -droptoolchain flags are mutually exclusive.

Fixes #73744
