### PR TITLE
slices: tolerate Chunk([]string{}, 0) without raising panic for n<1

### DIFF
--- a/src/slices/iter.go
+++ b/src/slices/iter.go
@@ -88,9 +88,9 @@ func SortedStableFunc[E any](seq iter.Seq[E], cmp func(E, E) int) []E {
 // All but the last sub-slice will have size n.
 // All sub-slices are clipped to have no capacity beyond the length.
 // If s is empty, the sequence is empty: there is no empty slice in the sequence.
-// Chunk panics if n is less than 1.
+// Chunk panics if n is less than 1, unless n=0 and s is empty which is tolerated.
 func Chunk[Slice ~[]E, E any](s Slice, n int) iter.Seq[Slice] {
-	if n < 1 {
+	if n < 1 && (len(s) > 0 || n < 0) {
 		panic("cannot be less than 1")
 	}
 

--- a/src/slices/iter_test.go
+++ b/src/slices/iter_test.go
@@ -259,15 +259,32 @@ func TestChunkPanics(t *testing.T) {
 		name string
 		x    []struct{}
 		n    int
+		p    bool
 	}{
 		{
 			name: "cannot be less than 1",
+			x:    make([]struct{}, 1),
+			n:    0,
+			p:    true,
+		},
+		{
+			name: "don't panic on an empty slice",
 			x:    make([]struct{}, 0),
 			n:    0,
+			p:    false,
+		},
+		{
+			name: "cannot be less than 0 on an empty slice",
+			x:    make([]struct{}, 0),
+			n:    -1,
+			p:    true,
 		},
 	} {
-		if !panics(func() { _ = Chunk(test.x, test.n) }) {
+		if test.p && !panics(func() { _ = Chunk(test.x, test.n) }) {
 			t.Errorf("Chunk %s: got no panic, want panic", test.name)
+		}
+		if !test.p && panics(func() { _ = Chunk(test.x, test.n) }) {
+			t.Errorf("Chunk %s: got panic, want no panic", test.name)
 		}
 	}
 }


### PR DESCRIPTION
I noticed many of my uses of Chunk have an optional value for n,
and it's ok to not split the data otherwise.

Unless the slice is empty, because if n is optional (0) the stdlib
implementation panics, so while migrating from my own implementation I
have to resort to an if/else or a contraption

```
for chunk := slices.Chunk(data, max(1, cmp.Or(size, len(data)))) {
...
}
```

which makes the code hard to follow and is prone to errors.

Tis PR keeps the panic for n<0 in all cases.