### PR TITLE
net/http: delegate the reset proxy logic to the test

### DIFF
--- a/src/net/http/export_test.go
+++ b/src/net/http/export_test.go
@@ -102,7 +102,8 @@ func NewTestTimeoutHandler(handler Handler, ctx context.Context) Handler {
 }
 
 func ResetCachedEnvironment() {
-	resetProxyConfig()
+	envProxyOnce = sync.Once{}
+	envProxyFuncValue = nil
 }
 
 func (t *Transport) NumPendingRequestsForTesting() int {

--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -965,12 +965,6 @@ func envProxyFunc() func(*url.URL) (*url.URL, error) {
 	return envProxyFuncValue
 }
 
-// resetProxyConfig is used by tests.
-func resetProxyConfig() {
-	envProxyOnce = sync.Once{}
-	envProxyFuncValue = nil
-}
-
 func (t *Transport) connectMethodForRequest(treq *transportRequest) (cm connectMethod, err error) {
 	cm.targetScheme = treq.URL.Scheme
 	cm.targetAddr = canonicalAddr(treq.URL)


### PR DESCRIPTION
Remove useless function in the `net/http` `transport.go`.