### PR TITLE
net/http, crypto/tls: add TLSErrorHandler for customizing response to HTTP over TLS

### DIFF
--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -568,6 +568,8 @@ type RecordHeaderError struct {
 	// RecordHeader contains the five bytes of TLS record header that
 	// triggered the error.
 	RecordHeader [5]byte
+	// RawData contains the bytes client sent that triggered the error.
+	RawData []byte
 	// Conn provides the underlying net.Conn in the case that a client
 	// sent an initial handshake that didn't look like TLS.
 	// It is nil if there's already been a handshake or a TLS alert has
@@ -581,6 +583,12 @@ func (c *Conn) newRecordHeaderError(conn net.Conn, msg string) (err RecordHeader
 	err.Msg = msg
 	err.Conn = conn
 	copy(err.RecordHeader[:], c.rawInput.Bytes())
+
+	// export the raw data to convert to HTTP if client sent an plaintext HTTP request
+	raw := c.rawInput.Bytes()
+	err.RawData = make([]byte, len(raw))
+	copy(err.RawData, raw)
+
 	return err
 }
 

--- a/src/net/http/cgi/child.go
+++ b/src/net/http/cgi/child.go
@@ -142,7 +142,8 @@ func RequestFromMap(params map[string]string) (*http.Request, error) {
 // request, if any. If there's no current CGI environment
 // an error is returned. The provided handler may be nil to use
 // [http.DefaultServeMux].
-func Serve(handler http.Handler) error {
+func Serve(handler http.Handler, _ ...TLSErrorHandler) error {
+	// _ TLSErrorHandler not implemented
 	req, err := Request()
 	if err != nil {
 		return err

--- a/src/net/http/cgi/child.go
+++ b/src/net/http/cgi/child.go
@@ -142,8 +142,8 @@ func RequestFromMap(params map[string]string) (*http.Request, error) {
 // request, if any. If there's no current CGI environment
 // an error is returned. The provided handler may be nil to use
 // [http.DefaultServeMux].
-func Serve(handler http.Handler, _ ...TLSErrorHandler) error {
-	// _ TLSErrorHandler not implemented
+func Serve(handler http.Handler, _ ...http.TLSErrorHandler) error {
+	// _ TLSErrorHandler not supported
 	req, err := Request()
 	if err != nil {
 		return err

--- a/src/net/http/fcgi/child.go
+++ b/src/net/http/fcgi/child.go
@@ -336,7 +336,8 @@ func (c *child) cleanUp() {
 // to reply to them.
 // If l is nil, Serve accepts connections from os.Stdin.
 // If handler is nil, [http.DefaultServeMux] is used.
-func Serve(l net.Listener, handler http.Handler, tlsErrorHandler ...TLSErrorHandler) error {
+func Serve(l net.Listener, handler http.Handler, _ ...http.TLSErrorHandler) error {
+	// _ TLSErrorHandler not supported
 	if l == nil {
 		var err error
 		l, err = net.FileListener(os.Stdin)
@@ -354,7 +355,7 @@ func Serve(l net.Listener, handler http.Handler, tlsErrorHandler ...TLSErrorHand
 			return err
 		}
 		c := newChild(rw, handler)
-		go c.serve(tlsErrorHandler...)
+		go c.serve()
 	}
 }
 

--- a/src/net/http/fcgi/child.go
+++ b/src/net/http/fcgi/child.go
@@ -336,7 +336,7 @@ func (c *child) cleanUp() {
 // to reply to them.
 // If l is nil, Serve accepts connections from os.Stdin.
 // If handler is nil, [http.DefaultServeMux] is used.
-func Serve(l net.Listener, handler http.Handler) error {
+func Serve(l net.Listener, handler http.Handler, tlsErrorHandler ...TLSErrorHandler) error {
 	if l == nil {
 		var err error
 		l, err = net.FileListener(os.Stdin)
@@ -354,7 +354,7 @@ func Serve(l net.Listener, handler http.Handler) error {
 			return err
 		}
 		c := newChild(rw, handler)
-		go c.serve()
+		go c.serve(tlsErrorHandler...)
 	}
 }
 

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -1929,7 +1929,7 @@ type connectionStater interface {
 	ConnectionState() tls.ConnectionState
 }
 
-type TLSErrorHandler func(rawData []byte, conn *tls.Conn, err error) string
+type TLSErrorHandler func(tlsErr tls.RecordHeaderError, err error) string
 
 // Serve a new connection.
 func (c *conn) serve(ctx context.Context, tlsErrorHandler ...TLSErrorHandler) {
@@ -1982,7 +1982,7 @@ func (c *conn) serve(ctx context.Context, tlsErrorHandler ...TLSErrorHandler) {
 					io.WriteString(re.Conn, "HTTP/1.0 500 Internal Server Error\r\n\r\nOnly one non-nil tlsErrorHandler is allowed.\n")
 					re.Conn.Close()
 				} else {
-					response = tlsErrorHandler[0](re.RawData, tlsConn, err)
+					response = tlsErrorHandler[0](re, err)
 
 					if response != "" {
 						io.WriteString(re.Conn, response)


### PR DESCRIPTION
This change modifies Go to support custom
TLS handshake error responses via TLSErrorHandler.

- `serve` in net/http to allow developers to provide a TLSErrorHandler.
- A new field `RawData` was added to `RecordHeaderError` to allow
  developers to get raw data from clients without TLS decryption.

- The function using `serve` was changed to pass the `TLSErrorHandler`
  argument through other functions down to `serve`.
