### PR TITLE
cmd: emit dwarf for string constants

### DIFF
--- a/src/cmd/compile/internal/gc/obj.go
+++ b/src/cmd/compile/internal/gc/obj.go
@@ -191,9 +191,12 @@ func dumpGlobalConst(n *ir.Name) {
 			t = types.Types[types.TSTRING]
 		}
 	} else {
-		// If the type of the constant is an instantiated generic, we need to emit
-		// that type so the linker knows about it. See issue 51245.
-		_ = reflectdata.TypeLinksym(t)
+		if t.IsInteger() {
+			// If the type of the constant is an instantiated generic, we need to emit
+			// that type so the linker knows about it. See issue 51245.
+			_ = reflectdata.TypeLinksym(t)
+		}
+		// For const string, type:string isn't the real type.
 	}
 
 	if t.IsInteger() {

--- a/src/cmd/compile/internal/gc/obj.go
+++ b/src/cmd/compile/internal/gc/obj.go
@@ -199,7 +199,7 @@ func dumpGlobalConst(n *ir.Name) {
 	if t.IsInteger() {
 		base.Ctxt.DwarfIntConst(n.Sym().Name, types.TypeSymName(t), ir.IntVal(t, v))
 	} else if t.IsString() {
-		base.Ctxt.DwarfStringConst(n.Sym().Name, ir.StringVal(n))
+		base.Ctxt.DwarfStringConst(n.Sym().Name, types.TypeSymName(t), ir.StringVal(n))
 	}
 }
 

--- a/src/cmd/internal/dwarf/dwarf.go
+++ b/src/cmd/internal/dwarf/dwarf.go
@@ -28,8 +28,8 @@ const InfoPrefix = "go:info."
 const ConstInfoPrefix = "go:constinfo."
 
 // ConstStringInfoPrefix is the prefix for all symbols containing
-// DWARF info entries that referred by string constants.
-const ConstStringInfoPrefix = "string$const."
+// DWARF info entries that are referred by string constants.
+const ConstStringInfoPrefix = "$const."
 
 // CUInfoPrefix is the prefix for symbols containing information to
 // populate the DWARF compilation unit info entries.

--- a/src/cmd/internal/obj/dwarf.go
+++ b/src/cmd/internal/obj/dwarf.go
@@ -419,12 +419,12 @@ func (ctxt *Link) DwarfIntConst(name, typename string, val int64) {
 
 // DwarfStringConst creates a link symbol for a string constant with the
 // given name and value.
-func (ctxt *Link) DwarfStringConst(name, value string) {
+func (ctxt *Link) DwarfStringConst(name, typename, value string) {
 	s := ctxt.ensureConstInfoSym()
 	if s == nil {
 		return
 	}
-	typSym := ctxt.Lookup(dwarf.InfoPrefix + dwarf.ConstStringInfoPrefix + strconv.Itoa(len(value)))
+	typSym := ctxt.Lookup(dwarf.InfoPrefix + dwarf.ConstStringInfoPrefix + typename + "." + strconv.Itoa(len(value)))
 	dwarf.PutStringConst(dwCtxt{ctxt}, s, typSym, ctxt.Pkgpath+"."+name, value)
 }
 

--- a/src/cmd/link/internal/ld/dwarf.go
+++ b/src/cmd/link/internal/ld/dwarf.go
@@ -291,7 +291,7 @@ func (d *dwctxt) newdie(parent *dwarf.DWDie, abbrev int, name string) *dwarf.DWD
 		panic("nameless DWARF DIE")
 	}
 
-	// for constant string types, we emit the nams later since it didn't use symbol name as DW_AT_name
+	// for constant string types, we defer emitting the DW_AT_name attribute because it is not identical to the symbol name.
 	if abbrev != dwarf.DW_ABRV_CONSTANT_STRINGTYPE {
 		newattr(die, dwarf.DW_AT_name, dwarf.DW_CLS_STRING, int64(len(name)), name)
 	}

--- a/src/cmd/link/internal/ld/dwarf.go
+++ b/src/cmd/link/internal/ld/dwarf.go
@@ -1188,12 +1188,16 @@ func (d *dwctxt) genConstStringType(name string) {
 	if d.find(name) != 0 {
 		return
 	}
-	size, err := strconv.Atoi(name[len(dwarf.ConstStringInfoPrefix):])
+	i := strings.LastIndex(name, ".")
+	if i < 0 {
+		log.Fatalf("error: invalid constant string type name %q", name)
+	}
+	size, err := strconv.ParseInt(name[i+1:], 10, 64)
 	if err != nil {
-		log.Fatalf("error: invalid constant string size %q: %v", name, err)
+		log.Fatalf("error: invalid constant string type name %q: %v", name, err)
 	}
 	die := d.newdie(&dwtypes, dwarf.DW_ABRV_CONSTANT_STRINGTYPE, name)
-	newattr(die, dwarf.DW_AT_byte_size, dwarf.DW_CLS_CONSTANT, int64(size), 0)
+	newattr(die, dwarf.DW_AT_byte_size, dwarf.DW_CLS_CONSTANT, size, 0)
 }
 
 func (d *dwctxt) importInfoSymbol(dsym loader.Sym) {

--- a/src/runtime/runtime-gdb_test.go
+++ b/src/runtime/runtime-gdb_test.go
@@ -662,6 +662,9 @@ package main
 const aConstant int = 42
 const largeConstant uint64 = ^uint64(0)
 const minusOne int64 = -1
+const typedS string = "typed string"
+const untypedS = "untyped string"
+const nulS string = "\x00str"
 
 func main() {
 	println("hello world")
@@ -700,6 +703,9 @@ func TestGdbConst(t *testing.T) {
 		"-ex", "print main.minusOne",
 		"-ex", "print 'runtime.mSpanInUse'",
 		"-ex", "print 'runtime._PageSize'",
+		"-ex", "print main.typedS",
+		"-ex", "print main.untypedS",
+		"-ex", "print main.nulS",
 		filepath.Join(dir, "a.exe"),
 	}
 	gdbArgsFixup(args)
@@ -711,7 +717,14 @@ func TestGdbConst(t *testing.T) {
 
 	sgot := strings.ReplaceAll(string(got), "\r\n", "\n")
 
-	if !strings.Contains(sgot, "\n$1 = 42\n$2 = 18446744073709551615\n$3 = -1\n$4 = 1 '\\001'\n$5 = 8192") {
+	if !strings.Contains(sgot, `$1 = 42
+$2 = 18446744073709551615
+$3 = -1
+$4 = 1 '\001'
+$5 = 8192
+$6 = "typed string"
+$7 = "untyped string"
+$8 = "\000str"`) {
 		t.Fatalf("output mismatch")
 	}
 }


### PR DESCRIPTION
After this patch, the size of bin/go increased from 18700k to 18712k (0.06%).

Updates #14517
Fixes #67744