### PR TITLE
crypto/x509: Add VerifyOptions.UnknownAlgorithmVerifier

### DIFF
--- a/src/crypto/x509/parser.go
+++ b/src/crypto/x509/parser.go
@@ -1038,11 +1038,14 @@ func parseCertificate(der []byte) (*Certificate, error) {
 	if !spki.ReadASN1BitString(&spk) {
 		return nil, errors.New("x509: malformed subjectPublicKey")
 	}
-	if cert.PublicKeyAlgorithm != UnknownPublicKeyAlgorithm {
-		cert.PublicKey, err = parsePublicKey(&publicKeyInfo{
-			Algorithm: pkAI,
-			PublicKey: spk,
-		})
+	pki := &publicKeyInfo{
+		Algorithm: pkAI,
+		PublicKey: spk,
+	}
+	if cert.PublicKeyAlgorithm == UnknownPublicKeyAlgorithm {
+		cert.PublicKey = pki
+	} else {
+		cert.PublicKey, err = parsePublicKey(pki)
 		if err != nil {
 			return nil, err
 		}

--- a/src/crypto/x509/root_windows.go
+++ b/src/crypto/x509/root_windows.go
@@ -190,8 +190,8 @@ func verifyChain(c *Certificate, chainCtx *syscall.CertChainContext, opts *Verif
 		if parent.PublicKeyAlgorithm != ECDSA {
 			continue
 		}
-		if err := parent.CheckSignature(chain[i].SignatureAlgorithm,
-			chain[i].RawTBSCertificate, chain[i].Signature); err != nil {
+		if err := checkSignature(chain[i].SignatureAlgorithm,
+			chain[i].RawTBSCertificate, chain[i].Signature, parent.PublicKey, true, opts); err != nil {
 			return nil, err
 		}
 	}

--- a/src/crypto/x509/verify.go
+++ b/src/crypto/x509/verify.go
@@ -218,6 +218,10 @@ type VerifyOptions struct {
 	// field implies any valid policy is acceptable.
 	CertificatePolicies []OID
 
+	// UnknownAlgorithmVerifier specifies a callback to use to verify
+	// a signature with an unknown AlgorithmIdentifier.
+	UnknownAlgorithmVerifier func(alg pkix.AlgorithmIdentifier, signed, signature, pk []byte) error
+
 	// The following policy fields are unexported, because we do not expect
 	// users to actually need to use them, but are useful for testing the
 	// policy validation code.
@@ -975,7 +979,7 @@ func (c *Certificate) buildChains(currentChain []*Certificate, sigChecks *int, o
 			return
 		}
 
-		if err := c.CheckSignatureFrom(candidate.cert); err != nil {
+		if err := c.checkSignatureFrom(candidate.cert, opts); err != nil {
 			if hintErr == nil {
 				hintErr = err
 				hintCert = candidate.cert


### PR DESCRIPTION
This allows callers to verify certificates using algorithms that Go does not support (yet).

For instance, here we're verifying the ML-KEM-512 example certificate from the LAMPS WG signed by a ML-DSA-44 public key.

- https://github.com/lamps-wg/dilithium-certificates/blob/main/examples/ML-DSA-44.crt
- https://github.com/lamps-wg/kyber-certificates/blob/main/example/ML-KEM-512.crt

```go
package main

import (
        "crypto/x509"
        "crypto/x509/pkix"
        "encoding/asn1"
        "encoding/pem"
        "errors"
        "fmt"
        "github.com/cloudflare/circl/sign/schemes"
        "os"
)

func loadCert(path string) (*x509.Certificate, error) {
        raw, err := os.ReadFile(path)
        if err != nil {
                return nil, fmt.Errorf("ReadFile(%s): %w", path, err)
        }
        block, _ := pem.Decode(raw)
        if block == nil {
                return nil, fmt.Errorf("pem.Decode(%s) failed", path)
        }
        return x509.ParseCertificate(block.Bytes)
}

func main() {
        dsaCert, err := loadCert("ML-DSA-44.crt")
        if err != nil {
                panic(err)
        }
        kemCert, err := loadCert("ML-KEM-512.crt")
        if err != nil {
                panic(err)
        }

        roots := x509.NewCertPool()
        roots.AddCert(dsaCert)
        _, err = kemCert.Verify(x509.VerifyOptions{
                Roots: roots,
                UnknownAlgorithmVerifier: func(alg pkix.AlgorithmIdentifier,
                        signed, signature, pk []byte) error {
                        if !alg.Algorithm.Equal(asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 3, 17}) {
                                return errors.New("unsupported scheme")
                        }
                        scheme := schemes.ByName("ML-DSA-44")
                        ppk, err := scheme.UnmarshalBinaryPublicKey(pk)
                        if err != nil {
                                return err
                        }
                        if !scheme.Verify(ppk, signed, signature, nil) {
                                return errors.New("invalid signature")
                        }
                        return nil
                },
        })
        if err != nil {
                panic(err)
        }
}
```
