### PR TITLE
sys/windows: update docs about secure way to load system DLLs

### DIFF
--- a/src/syscall/dll_windows.go
+++ b/src/syscall/dll_windows.go
@@ -175,7 +175,7 @@ func (p *Proc) Call(a ...uintptr) (uintptr, uintptr, error) {
 // LazyDLL is subject to the same DLL preloading attacks as documented
 // on [LoadDLL].
 //
-// Use LazyDLL in golang.org/x/sys/windows for a secure way to
+// Use NewLazySystemDLL in golang.org/x/sys/windows for a secure way to
 // load system DLLs.
 type LazyDLL struct {
 	mu   sync.Mutex


### PR DESCRIPTION
Before this change, the documentation of the `syscall.LazyDLL` states to use `windows.LazyDLL` for secure loading of system DLLs. However, the use of the `windows.LazyDLL` structure is only secure (not vulnerable to DLL preloading/injection attacks) if the user creates the object through the `windows.NewLazySystemDLL` function or if they use `windows.NewLazyDLL` with an absolute path.

Given all this, I think it is better to point to `windows.NewLazySystemDLL` function instead of the `windows.LazyDLL` structure in the `syscall.LazyDLL` documentation.
