### PR TITLE
os: trivial comment fix

### DIFF
--- a/src/os/file.go
+++ b/src/os/file.go
@@ -616,7 +616,7 @@ func UserHomeDir() (string, error) {
 	if v := Getenv(env); v != "" {
 		return v, nil
 	}
-	// On some geese the home directory is not always defined.
+	// On some operating systems the home directory is not always defined.
 	switch runtime.GOOS {
 	case "android":
 		return "/sdcard", nil


### PR DESCRIPTION
"Geese" here looks like an autocorrect-o of "oses", I think writing it out
makes more sense.
