### PR TITLE
iter: document that calling yield after terminated range loop causes runtime panic

### DIFF
--- a/src/iter/iter.go
+++ b/src/iter/iter.go
@@ -28,6 +28,8 @@ or index-value pairs.
 Yield returns true if the iterator should continue with the next
 element in the sequence, false if it should stop.
 
+Yield panics if called after it returns false.
+
 For instance, [maps.Keys] returns an iterator that produces the sequence
 of keys of the map m, implemented as follows:
 


### PR DESCRIPTION
The existing documentation isn't clear about the behaviour of when
the iterator function ignores the value returned from the yield function.

The changes here update the documentation, to explicitly explain
that.