### PR TITLE
net/url: make Values.Add accept variadic string

### DIFF
--- a/src/net/url/url.go
+++ b/src/net/url/url.go
@@ -937,10 +937,10 @@ func (v Values) Set(key, value string) {
 	v[key] = []string{value}
 }
 
-// Add adds the value to key. It appends to any existing
+// Add adds the values to key. It appends to any existing
 // values associated with key.
-func (v Values) Add(key, value string) {
-	v[key] = append(v[key], value)
+func (v Values) Add(key, values ...string) {
+	v[key] = append(v[key], values...)
 }
 
 // Del deletes the values associated with key.


### PR DESCRIPTION
This change modifies Values.Add method to accept variadic values

Fixes #74681
