### PR TITLE
errors: omit redundant nil check in type assertion for Join

### DIFF
--- a/src/errors/join.go
+++ b/src/errors/join.go
@@ -28,12 +28,10 @@ func Join(errs ...error) error {
 	}
 	if n == 1 {
 		for _, err := range errs {
-			if err != nil {
-				if _, ok := err.(interface {
-					Unwrap() []error
-				}); ok {
-					return err
-				}
+			if _, ok := err.(interface {
+				Unwrap() []error
+			}); ok {
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
When ok is true, err can't be nil.

Make it behave more like the Unwrap function.
