### PR TITLE
testing: allow specify temp dir by GOTMPDIR environment variable

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -2405,9 +2405,10 @@
 //		The name of checksum database to use and optionally its public key and
 //		URL. See https://golang.org/ref/mod#authenticating.
 //	GOTMPDIR
-//		The directory where the go command will write temporary source files,
-//		packages, and binaries.
-//		Also used to specify the prefix of TmpDir function in testing package.
+//		Temporary directory used by the go command and testing package.
+//		Overrides the platform-specific temporary directory such as "/tmp".
+//		The go command and testing package will write temporary source files,
+//		packages, and binaries here.
 //	GOTOOLCHAIN
 //		Controls which Go toolchain is used. See https://go.dev/doc/toolchain.
 //	GOVCS

--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -2405,8 +2405,9 @@
 //		The name of checksum database to use and optionally its public key and
 //		URL. See https://golang.org/ref/mod#authenticating.
 //	GOTMPDIR
-//		The directory where the go command will write
-//		temporary source files, packages, and binaries.
+//		The directory where the go command will write temporary source files,
+//		packages, and binaries.
+//		Also used to specify the prefix of TmpDir function in testing package.
 //	GOTOOLCHAIN
 //		Controls which Go toolchain is used. See https://go.dev/doc/toolchain.
 //	GOVCS

--- a/src/cmd/go/internal/help/helpdoc.go
+++ b/src/cmd/go/internal/help/helpdoc.go
@@ -573,9 +573,10 @@ General-purpose environment variables:
 		The name of checksum database to use and optionally its public key and
 		URL. See https://golang.org/ref/mod#authenticating.
 	GOTMPDIR
-		The directory where the go command will write temporary source files,
-		packages, and binaries.
-		Also used to specify the prefix of TmpDir function in testing package.
+		Temporary directory used by the go command and testing package.
+		Overrides the platform-specific temporary directory such as "/tmp".
+		The go command and testing package will write temporary source files,
+		packages, and binaries here.
 	GOTOOLCHAIN
 		Controls which Go toolchain is used. See https://go.dev/doc/toolchain.
 	GOVCS

--- a/src/cmd/go/internal/help/helpdoc.go
+++ b/src/cmd/go/internal/help/helpdoc.go
@@ -573,8 +573,9 @@ General-purpose environment variables:
 		The name of checksum database to use and optionally its public key and
 		URL. See https://golang.org/ref/mod#authenticating.
 	GOTMPDIR
-		The directory where the go command will write
-		temporary source files, packages, and binaries.
+		The directory where the go command will write temporary source files,
+		packages, and binaries.
+		Also used to specify the prefix of TmpDir function in testing package.
 	GOTOOLCHAIN
 		Controls which Go toolchain is used. See https://go.dev/doc/toolchain.
 	GOVCS

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -1362,7 +1362,7 @@ func (c *common) TempDir() string {
 			return -1
 		}
 		pattern = strings.Map(mapper, pattern)
-		c.tempDir, c.tempDirErr = os.MkdirTemp("", pattern)
+		c.tempDir, c.tempDirErr = os.MkdirTemp(os.Getenv("GOTMPDIR"), pattern)
 		if c.tempDirErr == nil {
 			c.Cleanup(func() {
 				if err := removeAll(c.tempDir); err != nil {

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -1318,6 +1318,8 @@ func (c *common) Cleanup(f func()) {
 // all its subtests complete.
 // Each subsequent call to TempDir returns a unique directory;
 // if the directory creation fails, TempDir terminates the test by calling Fatal.
+// If the environment variable GOTMPDIR is set, the temporary directory will
+// be created somewhere beneath it.
 func (c *common) TempDir() string {
 	c.checkFuzzFn("TempDir")
 	// Use a single parent directory for all the temporary directories

--- a/src/testing/testing_test.go
+++ b/src/testing/testing_test.go
@@ -148,6 +148,12 @@ func testTempDir(t *testing.T) {
 }
 
 func TestTempDirGOTMPDIR(t *testing.T) {
+	// The first call to t.TempDir will create a parent temporary directory
+	// that will contain all temporary directories created by TempDir.
+	//
+	// Use os.TempDir (not t.TempDir) to get a temporary directory,
+	// set GOTMPDIR to that directory,
+	// and then verify that t.TempDir creates a directory in GOTMPDIR.
 	customTmpDir := filepath.Join(os.TempDir(), "custom-gotmpdir-test")
 	if err := os.MkdirAll(customTmpDir, 0777); err != nil {
 		t.Fatal(err)
@@ -171,13 +177,6 @@ func TestTempDirGOTMPDIR(t *testing.T) {
 	}
 	if !fi.IsDir() {
 		t.Errorf("dir %q is not a dir", dir)
-	}
-
-	t.Setenv("GOTMPDIR", "another-custom-gotmpdir-test")
-
-	dir2 := t.TempDir()
-	if filepath.Dir(dir) != filepath.Dir(dir2) {
-		t.Fatalf("calls to TempDir after changed GOTMPDIR do not share a parent; got %q, %q", dir, dir2)
 	}
 }
 

--- a/src/testing/testing_test.go
+++ b/src/testing/testing_test.go
@@ -147,6 +147,41 @@ func testTempDir(t *testing.T) {
 	}
 }
 
+func TestTempDirGOTMPDIR(t *testing.T) {
+	customTmpDir := filepath.Join(os.TempDir(), "custom-gotmpdir-test")
+	if err := os.MkdirAll(customTmpDir, 0777); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(customTmpDir)
+
+	oldValue, hadOld := os.LookupEnv("GOTMPDIR")
+	if err := os.Setenv("GOTMPDIR", customTmpDir); err != nil {
+		t.Fatal(err)
+	}
+	if hadOld {
+		defer os.Setenv("GOTMPDIR", oldValue)
+	} else {
+		defer os.Unsetenv("GOTMPDIR")
+	}
+
+	dir := t.TempDir()
+	if dir == "" {
+		t.Fatal("expected dir")
+	}
+
+	if !strings.HasPrefix(dir, customTmpDir) {
+		t.Errorf("TempDir did not use GOTMPDIR: got %q, want prefix %q", dir, customTmpDir)
+	}
+
+	fi, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fi.IsDir() {
+		t.Errorf("dir %q is not a dir", dir)
+	}
+}
+
 func TestSetenv(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/src/testing/testing_test.go
+++ b/src/testing/testing_test.go
@@ -154,15 +154,7 @@ func TestTempDirGOTMPDIR(t *testing.T) {
 	}
 	defer os.RemoveAll(customTmpDir)
 
-	oldValue, hadOld := os.LookupEnv("GOTMPDIR")
-	if err := os.Setenv("GOTMPDIR", customTmpDir); err != nil {
-		t.Fatal(err)
-	}
-	if hadOld {
-		defer os.Setenv("GOTMPDIR", oldValue)
-	} else {
-		defer os.Unsetenv("GOTMPDIR")
-	}
+	t.Setenv("GOTMPDIR", customTmpDir)
 
 	dir := t.TempDir()
 	if dir == "" {

--- a/src/testing/testing_test.go
+++ b/src/testing/testing_test.go
@@ -172,6 +172,13 @@ func TestTempDirGOTMPDIR(t *testing.T) {
 	if !fi.IsDir() {
 		t.Errorf("dir %q is not a dir", dir)
 	}
+
+	t.Setenv("GOTMPDIR", "another-custom-gotmpdir-test")
+
+	dir2 := t.TempDir()
+	if filepath.Dir(dir) != filepath.Dir(dir2) {
+		t.Fatalf("calls to TempDir after changed GOTMPDIR do not share a parent; got %q, %q", dir, dir2)
+	}
 }
 
 func TestSetenv(t *testing.T) {


### PR DESCRIPTION
Allow change the default temp directory returned by t.TempDir()
by environment variable GOTMPDIR.

Fixes #61585

