### PR TITLE
net/http: fix server-side http parse form error inaccurate issue

### DIFF
--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -510,7 +510,7 @@ func (r *Request) multipartReader(allowMixed bool) (*multipart.Reader, error) {
 	if v == "" {
 		return nil, ErrNotMultipart
 	}
-	if r.Body == nil {
+	if r.Body == nil || r.Body == NoBody {
 		return nil, errors.New("missing form body")
 	}
 	d, params, err := mime.ParseMediaType(v)
@@ -1261,7 +1261,7 @@ func copyValues(dst, src url.Values) {
 }
 
 func parsePostForm(r *Request) (vs url.Values, err error) {
-	if r.Body == nil {
+	if r.Body == nil || r.Body == NoBody {
 		err = errors.New("missing form body")
 		return
 	}


### PR DESCRIPTION
For POST form request without body, server-side parse form function should return missing form body error.
Current ParseForm function compare request Body with nil, but the server-side request Body is always non-nil.

Fixes #74955
