### PR TITLE
js/wasm: use the correctly captured `this` in wasm_exec::_makeFuncWrapper

### DIFF
--- a/lib/wasm/wasm_exec.js
+++ b/lib/wasm/wasm_exec.js
@@ -565,7 +565,7 @@
 		_makeFuncWrapper(id) {
 			const go = this;
 			return function () {
-				const event = { id: id, this: this, args: arguments };
+				const event = { id: id, this: go, args: arguments };
 				go._pendingEvent = event;
 				go._resume();
 				return event.result;


### PR DESCRIPTION
Fixes https://github.com/golang/go/issues/74927