### PR TITLE
net/http/httputil: remove redundant pw.Close() call in DumpRequestOut

### DIFF
--- a/src/net/http/httputil/dump.go
+++ b/src/net/http/httputil/dump.go
@@ -147,7 +147,6 @@ func DumpRequestOut(req *http.Request, body bool) ([]byte, error) {
 
 	req.Body = save
 	if err != nil {
-		pw.Close()
 		dr.err = err
 		close(quitReadCh)
 		return nil, err


### PR DESCRIPTION
pw.Close() is already deferred earlier in DumpRequestOut.