### PR TITLE
cmd/compile: tweak example command in README

### DIFF
--- a/src/cmd/compile/README.md
+++ b/src/cmd/compile/README.md
@@ -281,10 +281,10 @@ dependencies, so is not suitable for distributed build systems.)
   ```
   $ go install golang.org/x/tools/cmd/toolstash@latest
   $ git clone https://go.googlesource.com/go
-  $ cd go
+  $ export PATH=$PWD/go/bin:$PATH
+  $ cd go/src
   $ git checkout -b mybranch
-  $ cd src && ./all.bash && cd ..   # build and confirm good starting point
-  $ export PATH=$PWD/bin:$PATH
+  $ ./all.bash                      # build and confirm good starting point
   $ toolstash save                  # save current tools
   ```
   After that, your edit/compile/test cycle can be similar to:

--- a/src/cmd/compile/README.md
+++ b/src/cmd/compile/README.md
@@ -283,9 +283,9 @@ dependencies, so is not suitable for distributed build systems.)
   $ git clone https://go.googlesource.com/go
   $ cd go
   $ git checkout -b mybranch
-  $ ./src/all.bash               # build and confirm good starting point
+  $ cd src && ./all.bash && cd ..   # build and confirm good starting point
   $ export PATH=$PWD/bin:$PATH
-  $ toolstash save               # save current tools
+  $ toolstash save                  # save current tools
   ```
   After that, your edit/compile/test cycle can be similar to:
   ```


### PR DESCRIPTION
While running ./src/all.bash, I got the following error:

all.bash must be run from $GOROOT/src