### PR TITLE
net/textproto: eliminate some bounds checks

### DIFF
--- a/src/net/textproto/reader.go
+++ b/src/net/textproto/reader.go
@@ -110,11 +110,12 @@ func trim(s []byte) []byte {
 	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
 		i++
 	}
-	n := len(s)
-	for n > i && (s[n-1] == ' ' || s[n-1] == '\t') {
+	s = s[i:]
+	n := len(s) - 1
+	for n >= 0 && (s[n] == ' ' || s[n] == '\t') {
 		n--
 	}
-	return s[i:n]
+	return s[:n+1]
 }
 
 // ReadContinuedLineBytes is like [Reader.ReadContinuedLine] but


### PR DESCRIPTION
This change lifts bounds checks out of loops in the trim function.
Here are some benchmark results (no change to allocations):

goos: darwin
goarch: amd64
pkg: net/textproto
cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
                                │     old     │                new                 │
                                │   sec/op    │   sec/op     vs base               │
ReadMIMEHeader/client_headers-8   3.531µ ± 3%   3.506µ ± 1%       ~ (p=0.068 n=20)
ReadMIMEHeader/server_headers-8   2.409µ ± 0%   2.384µ ± 1%  -1.02% (p=0.000 n=20)
Uncommon-8                        545.2n ± 1%   536.7n ± 0%  -1.58% (p=0.000 n=20)
geomean                           1.667µ        1.649µ       -1.10%
