### PR TITLE
go/constant: fix complex != unknown comparison

### DIFF
--- a/src/go/constant/value.go
+++ b/src/go/constant/value.go
@@ -1083,7 +1083,10 @@ func match0(x, y Value) (_, _ Value) {
 			return rtof(x1), y
 		}
 	case complexVal:
-		return vtoc(x), y
+		switch x1 := x.(type) {
+		case int64Val, intVal, ratVal, floatVal:
+			return vtoc(x1), y
+		}
 	}
 
 	// force unknown and invalid values into "x position" in callers of match

--- a/src/go/constant/value_test.go
+++ b/src/go/constant/value_test.go
@@ -617,6 +617,9 @@ func TestUnknown(t *testing.T) {
 			if got := Compare(x, token.EQL, y); got {
 				t.Errorf("%s == %s: got true; want false", x, y)
 			}
+			if got := Compare(x, token.NEQ, y); got {
+				t.Errorf("%s != %s: got true; want false", x, y)
+			}
 		}
 	}
 }


### PR DESCRIPTION
By the contract of Compare, if one operand is Unknown, the result must be
false.

Fixes #75137
