### PR TITLE
cmd/go: support `-help`

### DIFF
--- a/src/cmd/go/main.go
+++ b/src/cmd/go/main.go
@@ -109,23 +109,22 @@ func main() {
 	if !cmdIsGoTelemetryOff {
 		telemetry.MaybeParent() // Run the upload process. Opening the counter file is idempotent.
 	}
-	// Add global --help flag support
+	// Add global -help flag support
 	var globalHelp bool
 	flag.BoolVar(&globalHelp, "help", false, "show help")
-	
 	flag.Usage = base.Usage
 	flag.Parse()
 	counter.Inc("go/invocations")
 	counter.CountFlags("go/flag:", *flag.CommandLine)
 
 	args := flag.Args()
-	
-	// Handle global --help flag
+
+	// Handle global -help flag
 	if globalHelp {
 		help.Help(os.Stdout, nil)
 		return
 	}
-	
+
 	if len(args) < 1 {
 		base.Usage()
 	}
@@ -321,7 +320,7 @@ func invoke(cmd *base.Command, args []string) {
 		}
 	}
 
-	// Add --help flag support to all commands
+	// Add -help flag support to all commands
 	var helpFlag bool
 	if !cmd.CustomFlags {
 		cmd.Flag.BoolVar(&helpFlag, "help", false, "show help")
@@ -342,7 +341,7 @@ func invoke(cmd *base.Command, args []string) {
 		base.SetFromGOFLAGS(&cmd.Flag)
 		cmd.Flag.Parse(args[1:])
 
-		// Check if --help flag was set and show full help
+		// Check if -help flag was set and show full help
 		if helpFlag {
 			help.Help(os.Stdout, strings.Fields(cmd.LongName()))
 			base.Exit()

--- a/src/cmd/go/main.go
+++ b/src/cmd/go/main.go
@@ -109,12 +109,23 @@ func main() {
 	if !cmdIsGoTelemetryOff {
 		telemetry.MaybeParent() // Run the upload process. Opening the counter file is idempotent.
 	}
+	// Add global --help flag support
+	var globalHelp bool
+	flag.BoolVar(&globalHelp, "help", false, "show help")
+	
 	flag.Usage = base.Usage
 	flag.Parse()
 	counter.Inc("go/invocations")
 	counter.CountFlags("go/flag:", *flag.CommandLine)
 
 	args := flag.Args()
+	
+	// Handle global --help flag
+	if globalHelp {
+		help.Help(os.Stdout, nil)
+		return
+	}
+	
 	if len(args) < 1 {
 		base.Usage()
 	}

--- a/src/cmd/go/testdata/script/help_flag.txt
+++ b/src/cmd/go/testdata/script/help_flag.txt
@@ -1,5 +1,11 @@
 # Test that --help flag works for go commands
 
+# go --help shows main help (not an error)
+go --help
+stdout 'Go is a tool for managing Go source code'
+stdout 'Usage:'
+stdout 'go <command> \[arguments\]'
+
 # go build --help shows full help
 go build --help
 stdout 'usage: go build'

--- a/src/cmd/go/testdata/script/help_flag.txt
+++ b/src/cmd/go/testdata/script/help_flag.txt
@@ -1,45 +1,45 @@
-# Test that --help flag works for go commands
+# Test that -help flag works for go commands
 
-# go --help shows main help (not an error)
-go --help
+# go -help shows main help (not an error)
+go -help
 stdout 'Go is a tool for managing Go source code'
 stdout 'Usage:'
 stdout 'go <command> \[arguments\]'
 
-# go build --help shows full help
-go build --help
+# go build -help shows full help
+go build -help
 stdout 'usage: go build'
 stdout 'Build compiles the packages'
 stdout 'For more about specifying packages'
 
-# go install --help shows full help  
-go install --help
+# go install -help shows full help  
+go install -help
 stdout 'usage: go install'
 stdout 'Install compiles and installs'
 stdout 'For more about specifying packages'
 
-# go get --help shows full help
-go get --help
+# go get -help shows full help
+go get -help
 stdout 'usage: go get'
 stdout 'Get resolves its command-line arguments'
 stdout 'See also: go build, go install'
 
-# go fmt --help shows full help
-go fmt --help
+# go fmt -help shows full help
+go fmt -help
 stdout 'usage: go fmt'
 stdout 'Fmt runs the command'
 stdout 'See also: go fix, go vet'
 
-# go run --help shows full help
-go run --help
+# go run -help shows full help
+go run -help
 stdout 'usage: go run'
 stdout 'Run compiles and runs'
 stdout 'See also: go build'
 
-# go run program.go --help should pass --help to the program, not show go run help
-go run helpprog.go --help
+# go run program.go -help should pass -help to the program, not show go run help
+go run helpprog.go -help
 stdout 'Program help message'
-stdout 'Arguments: \[.*helpprog.*--help\]'
+stdout 'Arguments: \[.*helpprog.*-help\]'
 
 -- helpprog.go --
 package main

--- a/src/cmd/go/testdata/script/help_flag.txt
+++ b/src/cmd/go/testdata/script/help_flag.txt
@@ -1,0 +1,56 @@
+# Test that --help flag works for go commands
+
+# go build --help shows full help
+go build --help
+stdout 'usage: go build'
+stdout 'Build compiles the packages'
+stdout 'For more about specifying packages'
+
+# go install --help shows full help  
+go install --help
+stdout 'usage: go install'
+stdout 'Install compiles and installs'
+stdout 'For more about specifying packages'
+
+# go get --help shows full help
+go get --help
+stdout 'usage: go get'
+stdout 'Get resolves its command-line arguments'
+stdout 'See also: go build, go install'
+
+# go fmt --help shows full help
+go fmt --help
+stdout 'usage: go fmt'
+stdout 'Fmt runs the command'
+stdout 'See also: go fix, go vet'
+
+# go run --help shows full help
+go run --help
+stdout 'usage: go run'
+stdout 'Run compiles and runs'
+stdout 'See also: go build'
+
+# go run program.go --help should pass --help to the program, not show go run help
+go run helpprog.go --help
+stdout 'Program help message'
+stdout 'Arguments: \[.*helpprog.*--help\]'
+
+-- helpprog.go --
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+func main() {
+	var help = flag.Bool("help", false, "show help")
+	flag.Parse()
+	
+	fmt.Printf("Arguments: %v\n", os.Args)
+	
+	if *help {
+		fmt.Println("Program help message")
+	}
+}


### PR DESCRIPTION
Add support for the `-help` command line argument, e.g. `go install -help`. 

Related to https://go.dev/issue/63659, but the help messages remain
unchanged in this PR