### PR TITLE
database/sql: update Rollback docstring to clarify that it's a no-op if already committed

### DIFF
--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -2354,7 +2354,7 @@ func (tx *Tx) rollback(discardConn bool) error {
 	return err
 }
 
-// Rollback aborts the transaction.
+// Rollback aborts the transaction. This is a no-op if the transaction is already committed or aborted.
 func (tx *Tx) Rollback() error {
 	return tx.rollback(false)
 }


### PR DESCRIPTION
Clarify Rollback method behavior in documentation.

I know I read that Rollback is safe to call in defer 
but it's not mentioned in the docs. It's only 
mentioned here:
https://go.dev/doc/database/execute-transactions