### PR TITLE
text/template: limit pipeline command count

### DIFF
--- a/src/text/template/parse/parse.go
+++ b/src/text/template/parse/parse.go
@@ -47,6 +47,10 @@ const (
 // parenthesized expressions.
 var maxStackDepth = 10000
 
+// maxPipelineCmds is the maximum number of commands permitted
+// for a single template's pipeline.
+var maxPipelineCmds = 100000
+
 // init reduces maxStackDepth for WebAssembly due to its smaller stack size.
 func init() {
 	if runtime.GOARCH == "wasm" {
@@ -513,6 +517,9 @@ decls:
 			itemNumber, itemNil, itemRawString, itemString, itemVariable, itemLeftParen:
 			t.backup()
 			pipe.append(t.command())
+			if len(pipe.Cmds) > maxPipelineCmds {
+				t.errorf("pipeline too long")
+			}
 		default:
 			t.unexpected(token, context)
 		}

--- a/src/text/template/parse/parse_test.go
+++ b/src/text/template/parse/parse_test.go
@@ -89,6 +89,8 @@ var numberTests = []numberTest{
 func init() {
 	// Use a small stack limit for testing to avoid creating huge expressions.
 	maxStackDepth = 3
+	// Use a small pipeline limit for testing to avoid creating huge pipelines.
+	maxPipelineCmds = 3
 }
 
 func TestNumberParse(t *testing.T) {
@@ -341,6 +343,13 @@ var parseTests = []parseTest{
 	{"paren nesting in pipeline exceeds limit", "{{ (((( 1 )))) | printf }}", hasError, "template: test:1: max expression depth exceeded"},
 	{"paren nesting with other constructs", "{{ if ((( true ))) }}YES{{ end }}", noError, "{{if (((true)))}}\"YES\"{{end}}"},
 	{"paren nesting with other constructs exceeds limit", "{{ if (((( true )))) }}YES{{ end }}", hasError, "template: test:1: max expression depth exceeded"},
+
+	// Pipeline command count tests.
+	{"pipeline command count normal", "{{ printf \"x\" | printf \"y\" }}", noError, "{{printf \"x\" | printf \"y\"}}"},
+	{"pipeline command count at limit", "{{ printf \"x\" | printf \"y\" | printf \"z\" }}", noError, "{{printf \"x\" | printf \"y\" | printf \"z\"}}"},
+	{"pipeline command count exceeds limit", "{{ printf \"x\" | printf \"y\" | printf \"z\" | printf \"w\" }}", hasError, "template: test:1: pipeline too long"},
+	{"pipeline command count with other constructs", "{{if printf \"x\" | printf \"y\"}}YES{{ end }}", noError, "{{if printf \"x\" | printf \"y\"}}\"YES\"{{end}}"},
+	{"pipeline command count with other constructs exceeds limit", "{{ if printf \"x\" | printf \"y\" | printf \"z\" | printf \"w\" | printf \"v\" | printf \"u\" | printf \"t\" }}YES{{ end }}", hasError, "template: test:1: pipeline too long"},
 }
 
 var builtins = map[string]any{


### PR DESCRIPTION
Introduce a hard limit on the number of commands in a single
pipeline. Return a parse error when exceeded. This bounds
worst-case time and memory amplification for pathologically
long pipelines, mitigating issues when when templates are not
fully trusted.

Fixes #75231
