### PR TITLE
runtime: remove obsolete osArchInit function

### DIFF
--- a/src/runtime/os_freebsd_riscv64.go
+++ b/src/runtime/os_freebsd_riscv64.go
@@ -1,7 +1,0 @@
-// Copyright 2022 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
-package runtime
-
-func osArchInit() {}

--- a/src/runtime/os_linux.go
+++ b/src/runtime/os_linux.go
@@ -356,7 +356,6 @@ func getHugePageSize() uintptr {
 func osinit() {
 	numCPUStartup = getCPUCount()
 	physHugePageSize = getHugePageSize()
-	osArchInit()
 	vgetrandomInit()
 }
 

--- a/src/runtime/os_linux_arm.go
+++ b/src/runtime/os_linux_arm.go
@@ -48,8 +48,6 @@ func archauxv(tag, val uintptr) {
 	}
 }
 
-func osArchInit() {}
-
 //go:nosplit
 func cputicks() int64 {
 	// nanotime() is a poor approximation of CPU ticks that is enough for the profiler.

--- a/src/runtime/os_linux_arm64.go
+++ b/src/runtime/os_linux_arm64.go
@@ -15,8 +15,6 @@ func archauxv(tag, val uintptr) {
 	}
 }
 
-func osArchInit() {}
-
 //go:nosplit
 func cputicks() int64 {
 	// nanotime() is a poor approximation of CPU ticks that is enough for the profiler.

--- a/src/runtime/os_linux_loong64.go
+++ b/src/runtime/os_linux_loong64.go
@@ -14,5 +14,3 @@ func archauxv(tag, val uintptr) {
 		cpu.HWCap = uint(val)
 	}
 }
-
-func osArchInit() {}

--- a/src/runtime/os_linux_mips64x.go
+++ b/src/runtime/os_linux_mips64x.go
@@ -15,8 +15,6 @@ func archauxv(tag, val uintptr) {
 	}
 }
 
-func osArchInit() {}
-
 //go:nosplit
 func cputicks() int64 {
 	// nanotime() is a poor approximation of CPU ticks that is enough for the profiler.

--- a/src/runtime/os_linux_mipsx.go
+++ b/src/runtime/os_linux_mipsx.go
@@ -9,8 +9,6 @@ package runtime
 func archauxv(tag, val uintptr) {
 }
 
-func osArchInit() {}
-
 //go:nosplit
 func cputicks() int64 {
 	// nanotime() is a poor approximation of CPU ticks that is enough for the profiler.

--- a/src/runtime/os_linux_ppc64x.go
+++ b/src/runtime/os_linux_ppc64x.go
@@ -19,5 +19,3 @@ func archauxv(tag, val uintptr) {
 		cpu.HWCap2 = uint(val)
 	}
 }
-
-func osArchInit() {}

--- a/src/runtime/os_linux_riscv64.go
+++ b/src/runtime/os_linux_riscv64.go
@@ -9,8 +9,6 @@ import (
 	"unsafe"
 )
 
-func osArchInit() {}
-
 type riscvHWProbePairs = struct {
 	key   int64
 	value uint64

--- a/src/runtime/os_linux_s390x.go
+++ b/src/runtime/os_linux_s390x.go
@@ -17,8 +17,6 @@ func archauxv(tag, val uintptr) {
 	}
 }
 
-func osArchInit() {}
-
 func checkS390xCPU() {
 	// Check if the present z-system has the hardware capability to carryout
 	// floating point operations. Check if hwcap reflects CPU capability for the

--- a/src/runtime/os_linux_x86.go
+++ b/src/runtime/os_linux_x86.go
@@ -1,9 +1,0 @@
-// Copyright 2019 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
-//go:build linux && (386 || amd64)
-
-package runtime
-
-func osArchInit() {}


### PR DESCRIPTION
The osArchInit function was introduced as a workaround for a Linux kernel bug
that corrupted vector registers on x86 CPUs during signal delivery.
The bug was introduced in Linux 5.2 and fixed in 5.3.15, 5.4.2, and all 5.5 and later kernels.
The fix was also back-ported by major distros.