### PR TITLE
slices: ensure bounds check elimination in Equal

### DIFF
--- a/src/slices/slices.go
+++ b/src/slices/slices.go
@@ -38,6 +38,7 @@ func EqualFunc[S1 ~[]E1, S2 ~[]E2, E1, E2 any](s1 S1, s2 S2, eq func(E1, E2) boo
 	if len(s1) != len(s2) {
 		return false
 	}
+	s2 = s2[:len(s1)]
 	for i, v1 := range s1 {
 		v2 := s2[i]
 		if !eq(v1, v2) {


### PR DESCRIPTION
Explicitly slice s2 to the length of s1 before the loop:

    s2 = s2[:len(s1)]

This helps the compiler eliminate redundant bounds checks when
comparing elements, making the EqualFunc implementation more
predictable and efficient across Go versions.