### PR TITLE
internal/trace/raw: use strings.Cut instead of strings.SplitN 2

### DIFF
--- a/src/internal/trace/raw/textreader.go
+++ b/src/internal/trace/raw/textreader.go
@@ -165,14 +165,13 @@ func readArg(s string) (arg string, value uint64, rest string, err error) {
 	if len(tok) == 0 {
 		return "", 0, s, fmt.Errorf("no argument")
 	}
-	parts := strings.SplitN(tok, "=", 2)
-	if len(parts) < 2 {
+	arg, val, found := strings.Cut(tok, "=")
+	if !found {
 		return "", 0, s, fmt.Errorf("malformed argument: %q", tok)
 	}
-	arg = parts[0]
-	value, err = strconv.ParseUint(parts[1], 10, 64)
+	value, err = strconv.ParseUint(val, 10, 64)
 	if err != nil {
-		return arg, value, s, fmt.Errorf("failed to parse argument value %q for arg %q", parts[1], parts[0])
+		return arg, value, s, fmt.Errorf("failed to parse argument value %q for arg %q", val, arg)
 	}
 	return
 }
@@ -205,11 +204,11 @@ func readToken(s string) (token, rest string) {
 }
 
 func readData(line string) ([]byte, error) {
-	parts := strings.SplitN(line, "=", 2)
-	if len(parts) < 2 || strings.TrimSpace(parts[0]) != "data" {
+	dk, dv, found := strings.Cut(line, "=")
+	if !found || strings.TrimSpace(dk) != "data" {
 		return nil, fmt.Errorf("malformed data: %q", line)
 	}
-	data, err := strconv.Unquote(strings.TrimSpace(parts[1]))
+	data, err := strconv.Unquote(strings.TrimSpace(dv))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse data: %q: %v", line, err)
 	}


### PR DESCRIPTION
Replace strings.SplitN with strings.Cut for better performance and readability.