### PR TITLE
strings: replace asciiSpace element type uint8 with bool

### DIFF
--- a/src/strings/iter.go
+++ b/src/strings/iter.go
@@ -86,7 +86,7 @@ func FieldsSeq(s string) iter.Seq[string] {
 		for i := 0; i < len(s); {
 			size := 1
 			r := rune(s[i])
-			isSpace := asciiSpace[s[i]] != 0
+			isSpace := asciiSpace[s[i]]
 			if r >= utf8.RuneSelf {
 				r, size = utf8.DecodeRuneInString(s[i:])
 				isSpace = unicode.IsSpace(r)


### PR DESCRIPTION
Changed `asciiSpace` from `[256]uint8` to `[256]bool` to
1. Improve readability by using `true/false` instead of magic number
2. Simplify space-checking logic from `if asciiSpace[b] != 0` to `if asciiSpace[b]`
3. Maintain identical functionality while making intent clearer
The change reduces cognitive overhead without affecting performance.