### PR TITLE
path: make Base inlineable

### DIFF
--- a/src/cmd/compile/internal/test/inl_test.go
+++ b/src/cmd/compile/internal/test/inl_test.go
@@ -234,6 +234,7 @@ func TestIntendedInlining(t *testing.T) {
 			"(*B).Loop",
 		},
 		"path": {
+			"Base",
 			"scanChunk",
 		},
 		"path/filepath": {

--- a/src/path/path.go
+++ b/src/path/path.go
@@ -195,7 +195,7 @@ func Base(path string) string {
 	}
 	// Strip trailing slashes.
 	for len(path) > 0 && path[len(path)-1] == '/' {
-		path = path[0 : len(path)-1]
+		path = path[:len(path)-1]
 	}
 	// Find the last element
 	if i := bytealg.LastIndexByteString(path, '/'); i >= 0 {

--- a/src/path/path_test.go
+++ b/src/path/path_test.go
@@ -188,6 +188,19 @@ func TestBase(t *testing.T) {
 	}
 }
 
+func BenchmarkBase(b *testing.B) {
+	for _, tt := range basetests {
+		b.Run(tt.path, func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				strSink = Base(tt.path)
+			}
+		})
+	}
+}
+
+var strSink string
+
 var dirtests = []PathTest{
 	{"", "."},
 	{".", "."},


### PR DESCRIPTION
This change adds benchmarks for Base and simplifies it ever so slightly
to the point of making it inlineable, thereby unlocking a nice speedup.

Here are some benchmark results (no change to allocations):

goos: darwin
goarch: amd64
pkg: path
cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
               │     old      │                 new                  │
               │    sec/op    │    sec/op     vs base                │
Base/#00-8       1.9095n ± 4%   0.9338n ± 6%  -51.09% (p=0.000 n=20)
Base/.-8          4.678n ± 1%    3.793n ± 0%  -18.92% (p=0.000 n=20)
Base//.-8         4.145n ± 1%    4.683n ± 1%  +12.99% (p=0.000 n=20)
Base//-8          4.384n ± 0%    4.479n ± 2%   +2.17% (p=0.001 n=20)
Base/////-8       7.261n ± 1%    6.607n ± 1%   -9.00% (p=0.000 n=20)
Base/x/-8         5.723n ± 2%    4.337n ± 1%  -24.22% (p=0.000 n=20)
Base/abc-8        6.419n ± 1%    4.883n ± 1%  -23.93% (p=0.000 n=20)
Base/abc/def-8    5.916n ± 1%    5.494n ± 0%   -7.13% (p=0.000 n=20)
Base/a/b/.x-8     4.631n ± 1%    4.878n ± 1%   +5.34% (p=0.000 n=20)
Base/a/b/c.-8     4.954n ± 1%    4.890n ± 1%   -1.29% (p=0.028 n=20)
Base/a/b/c.x-8    6.457n ± 1%    5.482n ± 0%  -15.09% (p=0.000 n=20)
geomean           4.887n         4.216n       -13.73%
