### PR TITLE
net/http: reuse connection if entire unread body is in buffer

### DIFF
--- a/src/net/http/client_test.go
+++ b/src/net/http/client_test.go
@@ -845,6 +845,7 @@ func testClientInsecureTransport(t *testing.T, mode testMode) {
 		if res != nil {
 			res.Body.Close()
 		}
+		c.CloseIdleConnections()
 	}
 
 	cst.close()


### PR DESCRIPTION
Currently, if an http response body is closed before fully read (fully means till EOF),
the underlying HTTP connection won't be reused. But in the current implementation,
body is first read into `bufio` buffer by `bufio` reader, then from buffer by body `Reader`.
So even if the body is closed before fully read, as long as the entire body has been
read into buffer, after discard buffer, the connection can be reused.

Fixes #75309 

This will be useful when go client only read body if status is 200 while server sends
HTTP body in a non 200 status response.
