### PR TITLE
os: disable splice to pipes to prevent busy-loop

### DIFF
--- a/src/os/zero_copy_linux.go
+++ b/src/os/zero_copy_linux.go
@@ -80,8 +80,8 @@ func (f *File) spliceToFile(r io.Reader) (written int64, handled bool, err error
 	// Don't use splice to a pipe, since it can lead to a busy loop if the
 	// reader is not reading.
 	// See issue 68303.
-	fi, err := f.Stat()
-	if err == nil && fi.Mode()&ModeNamedPipe != 0 {
+	var stat syscall.Stat_t
+	if err := syscall.Fstat(int(f.pfd.Sysfd), &stat); err == nil && stat.Mode&syscall.S_IFMT == syscall.S_IFIFO {
 		return 0, false, nil
 	}
 


### PR DESCRIPTION
os: disable splice to pipes to prevent busy-loop

When io.Copy copies data to a pipe, it may use the splice system call
for optimization. However, if the reading end of the pipe is not
consuming data, the internal poller fails to wait correctly, causing
a busy-loop that consumes 100% CPU.

This change adds a check to detect if the destination file descriptor
is a pipe using syscall.Fstat. If it is, the splice optimization
is disabled, falling back to standard I/O and allowing the process to
sleep correctly.

Fixes #75304