### PR TITLE
cmd/compile,cmd/gofmt: use reflect.TypeFor

### DIFF
--- a/src/cmd/compile/internal/base/flag.go
+++ b/src/cmd/compile/internal/base/flag.go
@@ -383,14 +383,14 @@ func ParseFlags() {
 // See the comment on type CmdFlags for the rules.
 func registerFlags() {
 	var (
-		boolType      = reflect.TypeOf(bool(false))
-		intType       = reflect.TypeOf(int(0))
-		stringType    = reflect.TypeOf(string(""))
-		ptrBoolType   = reflect.TypeOf(new(bool))
-		ptrIntType    = reflect.TypeOf(new(int))
-		ptrStringType = reflect.TypeOf(new(string))
-		countType     = reflect.TypeOf(CountFlag(0))
-		funcType      = reflect.TypeOf((func(string))(nil))
+		boolType      = reflect.TypeFor[bool]()
+		intType       = reflect.TypeFor[int]()
+		stringType    = reflect.TypeFor[string]()
+		ptrBoolType   = reflect.TypeFor[*bool]()
+		ptrIntType    = reflect.TypeFor[*int]()
+		ptrStringType = reflect.TypeFor[*string]()
+		countType     = reflect.TypeFor[CountFlag]()
+		funcType      = reflect.TypeFor[func(string)]()
 	)
 
 	v := reflect.ValueOf(&Flag).Elem()

--- a/src/cmd/compile/internal/ir/fmt.go
+++ b/src/cmd/compile/internal/ir/fmt.go
@@ -1194,7 +1194,7 @@ func dumpNode(w io.Writer, n Node, depth int) {
 	}
 }
 
-var nodeType = reflect.TypeOf((*Node)(nil)).Elem()
+var nodeType = reflect.TypeFor[Node]()
 
 func dumpNodes(w io.Writer, list Nodes, depth int) {
 	if len(list) == 0 {

--- a/src/cmd/compile/internal/rttype/rttype.go
+++ b/src/cmd/compile/internal/rttype/rttype.go
@@ -49,25 +49,25 @@ func Init() {
 	// Note: this has to be called explicitly instead of being
 	// an init function so it runs after the types package has
 	// been properly initialized.
-	Type = FromReflect(reflect.TypeOf(abi.Type{}))
-	ArrayType = FromReflect(reflect.TypeOf(abi.ArrayType{}))
-	ChanType = FromReflect(reflect.TypeOf(abi.ChanType{}))
-	FuncType = FromReflect(reflect.TypeOf(abi.FuncType{}))
-	InterfaceType = FromReflect(reflect.TypeOf(abi.InterfaceType{}))
-	MapType = FromReflect(reflect.TypeOf(abi.MapType{}))
-	PtrType = FromReflect(reflect.TypeOf(abi.PtrType{}))
-	SliceType = FromReflect(reflect.TypeOf(abi.SliceType{}))
-	StructType = FromReflect(reflect.TypeOf(abi.StructType{}))
+	Type = FromReflect(reflect.TypeFor[abi.Type]())
+	ArrayType = FromReflect(reflect.TypeFor[abi.ArrayType]())
+	ChanType = FromReflect(reflect.TypeFor[abi.ChanType]())
+	FuncType = FromReflect(reflect.TypeFor[abi.FuncType]())
+	InterfaceType = FromReflect(reflect.TypeFor[abi.InterfaceType]())
+	MapType = FromReflect(reflect.TypeFor[abi.MapType]())
+	PtrType = FromReflect(reflect.TypeFor[abi.PtrType]())
+	SliceType = FromReflect(reflect.TypeFor[abi.SliceType]())
+	StructType = FromReflect(reflect.TypeFor[abi.StructType]())
 
-	IMethod = FromReflect(reflect.TypeOf(abi.Imethod{}))
-	Method = FromReflect(reflect.TypeOf(abi.Method{}))
-	StructField = FromReflect(reflect.TypeOf(abi.StructField{}))
-	UncommonType = FromReflect(reflect.TypeOf(abi.UncommonType{}))
+	IMethod = FromReflect(reflect.TypeFor[abi.Imethod]())
+	Method = FromReflect(reflect.TypeFor[abi.Method]())
+	StructField = FromReflect(reflect.TypeFor[abi.StructField]())
+	UncommonType = FromReflect(reflect.TypeFor[abi.UncommonType]())
 
-	InterfaceSwitch = FromReflect(reflect.TypeOf(abi.InterfaceSwitch{}))
-	TypeAssert = FromReflect(reflect.TypeOf(abi.TypeAssert{}))
+	InterfaceSwitch = FromReflect(reflect.TypeFor[abi.InterfaceSwitch]())
+	TypeAssert = FromReflect(reflect.TypeFor[abi.TypeAssert]())
 
-	ITab = FromReflect(reflect.TypeOf(abi.ITab{}))
+	ITab = FromReflect(reflect.TypeFor[abi.ITab]())
 
 	// Make sure abi functions are correct. These functions are used
 	// by the linker which doesn't have the ability to do type layout,

--- a/src/cmd/gofmt/rewrite.go
+++ b/src/cmd/gofmt/rewrite.go
@@ -105,11 +105,11 @@ var (
 	objectPtrNil = reflect.ValueOf((*ast.Object)(nil))
 	scopePtrNil  = reflect.ValueOf((*ast.Scope)(nil))
 
-	identType     = reflect.TypeOf((*ast.Ident)(nil))
-	objectPtrType = reflect.TypeOf((*ast.Object)(nil))
-	positionType  = reflect.TypeOf(token.NoPos)
-	callExprType  = reflect.TypeOf((*ast.CallExpr)(nil))
-	scopePtrType  = reflect.TypeOf((*ast.Scope)(nil))
+	identType     = reflect.TypeFor[*ast.Ident]()
+	objectPtrType = reflect.TypeFor[*ast.Object]()
+	positionType  = reflect.TypeFor[token.Pos]()
+	callExprType  = reflect.TypeFor[*ast.CallExpr]()
+	scopePtrType  = reflect.TypeFor[*ast.Scope]()
 )
 
 // apply replaces each AST field x in val with f(x), returning val.


### PR DESCRIPTION
Use "reflect.TypeFor" to simplify the code.

Updates #60088