### PR TITLE
crypto/rsa: implement EncryptOAEPWithOptions for custom MGF1 hash

### DIFF
--- a/api/next/75446.txt
+++ b/api/next/75446.txt
@@ -1,0 +1,1 @@
+pkg crypto/rsa, func EncryptOAEPWithOptions(random io.Reader, pub *PublicKey, msg []byte, opts OAEPOptions) ([]byte, error) #75446

--- a/doc/next/6-stdlib/99-minor/crypto/rsa/75446.md
+++ b/doc/next/6-stdlib/99-minor/crypto/rsa/75446.md
@@ -1,0 +1,1 @@
+Added [EncryptOAEPWithOptions] function that allows specifying different hash functions for OAEP padding and MGF1 mask generation independently.


### PR DESCRIPTION
EncryptOAEPWithOptions allows specifying hash 
for OAEP and MGF1 independently.

Fixes #65716