### PR TITLE
time: improve ParseDuration performance for invalid input

### DIFF
--- a/src/time/time_test.go
+++ b/src/time/time_test.go
@@ -1620,6 +1620,13 @@ func BenchmarkParseDuration(b *testing.B) {
 	}
 }
 
+func BenchmarkParseDurationError(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ParseDuration("9223372036854775810ns") // overflow
+		ParseDuration("9007199254.740993")     // missing unit
+	}
+}
+
 func BenchmarkHour(b *testing.B) {
 	t := Now()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
Add "parseDurationError" to reduce memory allocation in the error path of
"ParseDuration" and delay the generation of error messages. This improves
the performance when dealing with invalid input.

The format of the error message remains unchanged.

Benchmarks:

                      │     old      │                 new                 │
                      │    sec/op    │   sec/op     vs base                │
ParseDurationError-10   132.10n ± 4%   45.93n ± 2%  -65.23% (p=0.000 n=10)

                      │     old     │                new                 │
                      │    B/op     │    B/op     vs base                │
ParseDurationError-10   192.00 ± 0%   64.00 ± 0%  -66.67% (p=0.000 n=10)

                      │    old     │                new                 │
                      │ allocs/op  │ allocs/op   vs base                │
ParseDurationError-10   6.000 ± 0%   2.000 ± 0%  -66.67% (p=0.000 n=10)

Fixes #75521