### PR TITLE
reflect: add iterator equivalents for NumField, NumIn, NumOut and NumMethod

### DIFF
--- a/api/next/66631.txt
+++ b/api/next/66631.txt
@@ -1,0 +1,6 @@
+pkg reflect, type Type interface, Fields() iter.Seq[StructField] #66631
+pkg reflect, type Type interface, Methods() iter.Seq[Method] #66631
+pkg reflect, type Type interface, Ins() iter.Seq[Type] #66631
+pkg reflect, type Type interface, Outs() iter.Seq[Type] #66631
+pkg reflect, method (Value) Fields() iter.Seq2[StructField, Value] #66631
+pkg reflect, method (Value) Methods() iter.Seq2[Method, Value] #66631

--- a/doc/next/6-stdlib/99-minor/reflect/66631.md
+++ b/doc/next/6-stdlib/99-minor/reflect/66631.md
@@ -1,0 +1,4 @@
+[reflect.Type] includes new methods that return iterators for a type's fields, methods, inputs and outputs.
+Similarly, [reflect.Value] includes two new methods that return iterators over a value's fields or methods, 
+each element being a pair of the value ([reflect.Value]) and its type information ([reflect.StructField] or 
+[reflect.Method]).

--- a/src/reflect/abi_test.go
+++ b/src/reflect/abi_test.go
@@ -175,8 +175,8 @@ func TestReflectCallABI(t *testing.T) {
 				t.Fatalf("test case has different number of inputs and outputs: %d in, %d out", typ.NumIn(), typ.NumOut())
 			}
 			var args []reflect.Value
-			for i := 0; i < typ.NumIn(); i++ {
-				args = append(args, genValue(t, typ.In(i), r))
+			for arg := range typ.Ins() {
+				args = append(args, genValue(t, arg, r))
 			}
 			results := fn.Call(args)
 			for i := range results {

--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -8505,8 +8505,7 @@ func TestInitFuncTypes(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			ipT := TypeOf(net.IP{})
-			for i := 0; i < ipT.NumMethod(); i++ {
-				_ = ipT.Method(i)
+			for range ipT.Methods() {
 			}
 		}()
 	}

--- a/src/reflect/benchmark_test.go
+++ b/src/reflect/benchmark_test.go
@@ -146,10 +146,8 @@ func BenchmarkIsZero(b *testing.B) {
 	s.ArrayInt_1024_NoZero[512] = 1
 	source := ValueOf(s)
 
-	for i := 0; i < source.NumField(); i++ {
-		name := source.Type().Field(i).Name
-		value := source.Field(i)
-		b.Run(name, func(b *testing.B) {
+	for field, value := range source.Fields() {
+		b.Run(field.Name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				sink = value.IsZero()
 			}
@@ -175,9 +173,8 @@ func BenchmarkSetZero(b *testing.B) {
 		Struct    Value
 	})).Elem()
 
-	for i := 0; i < source.NumField(); i++ {
-		name := source.Type().Field(i).Name
-		value := source.Field(i)
+	for field, value := range source.Fields() {
+		name := field.Name
 		zero := Zero(value.Type())
 		b.Run(name+"/Direct", func(b *testing.B) {
 			for i := 0; i < b.N; i++ {

--- a/src/reflect/example_test.go
+++ b/src/reflect/example_test.go
@@ -96,8 +96,7 @@ func ExampleStructTag_Lookup() {
 
 	s := S{}
 	st := reflect.TypeOf(s)
-	for i := 0; i < st.NumField(); i++ {
-		field := st.Field(i)
+	for field := range st.Fields() {
 		if alias, ok := field.Tag.Lookup("alias"); ok {
 			if alias == "" {
 				fmt.Println("(blank)")

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -10,6 +10,7 @@ import (
 	"internal/goarch"
 	"internal/itoa"
 	"internal/unsafeheader"
+	"iter"
 	"math"
 	"runtime"
 	"unsafe"
@@ -2620,6 +2621,48 @@ func (v Value) UnsafePointer() unsafe.Pointer {
 	panic(&ValueError{"reflect.Value.UnsafePointer", v.kind()})
 }
 
+// Fields returns an iterator over each [StructField] of v along with its [Value].
+//
+// The sequence is equivalent to calling [Value.Field] successively
+// for each index i in the range [0, NumField()).
+//
+// It panics if v's Kind is not Struct.
+func (v Value) Fields() iter.Seq2[StructField, Value] {
+	t := v.Type()
+	if t.Kind() != Struct {
+		panic("reflect: Fields of non-struct type " + t.String())
+	}
+	return func(yield func(StructField, Value) bool) {
+		for i := range v.NumField() {
+			if !yield(t.Field(i), v.Field(i)) {
+				return
+			}
+		}
+	}
+}
+
+// Methods returns an iterator over each [Method] of v along with the corresponding
+// method [Value]; this is a function with v bound as the receiver. As such, the
+// receiver shouldn't be included in the arguments to [Value.Call].
+//
+// The sequence is equivalent to calling [Value.Method] successively
+// for each index i in the range [0, NumMethod()).
+//
+// Methods panics if v is a nil interface value.
+//
+// Calling this method will force the linker to retain all exported methods in all packages.
+// This may make the executable binary larger but will not affect execution time.
+func (v Value) Methods() iter.Seq2[Method, Value] {
+	return func(yield func(Method, Value) bool) {
+		rtype := v.Type()
+		for i := range v.NumMethod() {
+			if !yield(rtype.Method(i), v.Method(i)) {
+				return
+			}
+		}
+	}
+}
+
 // StringHeader is the runtime representation of a string.
 // It cannot be used safely or portably and its representation may
 // change in a later release.
@@ -3221,8 +3264,8 @@ func (v Value) Comparable() bool {
 		return v.IsNil() || v.Elem().Comparable()
 
 	case Struct:
-		for i := 0; i < v.NumField(); i++ {
-			if !v.Field(i).Comparable() {
+		for _, value := range v.Fields() {
+			if !value.Comparable() {
 				return false
 			}
 		}


### PR DESCRIPTION
The new methods are Type.Fields, Type.Methods, Type.Ins, Type.Outs, 
Value.Fields and Value.Methods.

These methods have been introduced into the reflect package (as well
as tests) replacing three-clause for loops where possible.

Fixes #66631