### PR TITLE
crypto/rand: add syscall number fallbacks in seccomp_linux

### DIFF
--- a/src/crypto/internal/sysrand/internal/seccomp/seccomp_linux.go
+++ b/src/crypto/internal/sysrand/internal/seccomp/seccomp_linux.go
@@ -58,6 +58,9 @@ struct seccomp_data {
 #endif
 
 int disable_getrandom() {
+    if (SYS_getrandom == -1 || SYS_seccomp == -1) {
+        return 3;
+    }
     if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
         return 1;
     }

--- a/src/crypto/internal/sysrand/internal/seccomp/seccomp_linux.go
+++ b/src/crypto/internal/sysrand/internal/seccomp/seccomp_linux.go
@@ -49,6 +49,14 @@ struct seccomp_data {
 #define SECCOMP_RET_ALLOW 0x7fff0000U
 #define SECCOMP_SET_MODE_FILTER 1
 
+#ifndef SYS_getrandom
+#define SYS_getrandom -1
+#endif
+
+#ifndef SYS_seccomp
+#define SYS_seccomp -1
+#endif
+
 int disable_getrandom() {
     if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
         return 1;


### PR DESCRIPTION
seccomp_linux.go is only used for Go's own tests (commit 644628536f24), but the package is included when building programs with CGO_ENABLED=1.

When using an older glibc (e.g. 2.17), SYS_getrandom and SYS_seccomp are not defined, causing cgo compilation to fail.

Note that there are already several types and defines copied from linux headers into seccomp_linux.go to support compilation on older systems.

Updates #69536