### PR TITLE
testing/synctest: fix inverted test failure message in TestContextAfterFunc

### DIFF
--- a/src/testing/synctest/example_test.go
+++ b/src/testing/synctest/example_test.go
@@ -66,7 +66,7 @@ func TestContextAfterFunc(t *testing.T) {
 		cancel()
 		synctest.Wait()
 		if !afterFuncCalled {
-			t.Fatalf("before context is canceled: AfterFunc not called")
+			t.Fatalf("after context is canceled: AfterFunc not called")
 		}
 	})
 }

--- a/src/testing/synctest/synctest.go
+++ b/src/testing/synctest/synctest.go
@@ -147,7 +147,7 @@
 //			cancel()
 //			synctest.Wait()
 //			if !afterFuncCalled {
-//				t.Fatalf("before context is canceled: AfterFunc not called")
+//				t.Fatalf("after context is canceled: AfterFunc not called")
 //			}
 //		})
 //	}


### PR DESCRIPTION
Fixes #75685