### PR TITLE
html/template,text/template: use errors.New instead of fmt.Errorf

### DIFF
--- a/src/html/template/template.go
+++ b/src/html/template/template.go
@@ -5,6 +5,7 @@
 package template
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -31,7 +32,7 @@ type Template struct {
 }
 
 // escapeOK is a sentinel value used to indicate valid escaping.
-var escapeOK = fmt.Errorf("template escaped correctly")
+var escapeOK = errors.New("template escaped correctly")
 
 // nameSpace is the data structure shared by all templates in an association.
 type nameSpace struct {
@@ -87,7 +88,7 @@ func (t *Template) checkCanParse() error {
 	t.nameSpace.mu.Lock()
 	defer t.nameSpace.mu.Unlock()
 	if t.nameSpace.escaped {
-		return fmt.Errorf("html/template: cannot Parse after Execute")
+		return errors.New("html/template: cannot Parse after Execute")
 	}
 	return nil
 }
@@ -404,7 +405,7 @@ func parseFiles(t *Template, readFile func(string) (string, []byte, error), file
 
 	if len(filenames) == 0 {
 		// Not really a problem, but be consistent.
-		return nil, fmt.Errorf("html/template: no files named in call to ParseFiles")
+		return nil, errors.New("html/template: no files named in call to ParseFiles")
 	}
 	for _, filename := range filenames {
 		name, b, err := readFile(filename)

--- a/src/text/template/funcs.go
+++ b/src/text/template/funcs.go
@@ -180,7 +180,7 @@ func indexArg(index reflect.Value, cap int) (int, error) {
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		x = int64(index.Uint())
 	case reflect.Invalid:
-		return 0, fmt.Errorf("cannot index slice/array with nil")
+		return 0, errors.New("cannot index slice/array with nil")
 	default:
 		return 0, fmt.Errorf("cannot index slice/array with type %s", index.Type())
 	}
@@ -198,13 +198,13 @@ func indexArg(index reflect.Value, cap int) (int, error) {
 func index(item reflect.Value, indexes ...reflect.Value) (reflect.Value, error) {
 	item = indirectInterface(item)
 	if !item.IsValid() {
-		return reflect.Value{}, fmt.Errorf("index of untyped nil")
+		return reflect.Value{}, errors.New("index of untyped nil")
 	}
 	for _, index := range indexes {
 		index = indirectInterface(index)
 		var isNil bool
 		if item, isNil = indirect(item); isNil {
-			return reflect.Value{}, fmt.Errorf("index of nil pointer")
+			return reflect.Value{}, errors.New("index of nil pointer")
 		}
 		switch item.Kind() {
 		case reflect.Array, reflect.Slice, reflect.String:
@@ -242,7 +242,7 @@ func index(item reflect.Value, indexes ...reflect.Value) (reflect.Value, error) 
 func slice(item reflect.Value, indexes ...reflect.Value) (reflect.Value, error) {
 	item = indirectInterface(item)
 	if !item.IsValid() {
-		return reflect.Value{}, fmt.Errorf("slice of untyped nil")
+		return reflect.Value{}, errors.New("slice of untyped nil")
 	}
 	if len(indexes) > 3 {
 		return reflect.Value{}, fmt.Errorf("too many slice indexes: %d", len(indexes))
@@ -251,7 +251,7 @@ func slice(item reflect.Value, indexes ...reflect.Value) (reflect.Value, error) 
 	switch item.Kind() {
 	case reflect.String:
 		if len(indexes) == 3 {
-			return reflect.Value{}, fmt.Errorf("cannot 3-index slice a string")
+			return reflect.Value{}, errors.New("cannot 3-index slice a string")
 		}
 		cap = item.Len()
 	case reflect.Array, reflect.Slice:
@@ -288,7 +288,7 @@ func slice(item reflect.Value, indexes ...reflect.Value) (reflect.Value, error) 
 func length(item reflect.Value) (int, error) {
 	item, isNil := indirect(item)
 	if isNil {
-		return 0, fmt.Errorf("len of nil pointer")
+		return 0, errors.New("len of nil pointer")
 	}
 	switch item.Kind() {
 	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:
@@ -308,7 +308,7 @@ func emptyCall(fn reflect.Value, args ...reflect.Value) reflect.Value {
 func call(name string, fn reflect.Value, args ...reflect.Value) (reflect.Value, error) {
 	fn = indirectInterface(fn)
 	if !fn.IsValid() {
-		return reflect.Value{}, fmt.Errorf("call of nil")
+		return reflect.Value{}, errors.New("call of nil")
 	}
 	typ := fn.Type()
 	if typ.Kind() != reflect.Func {

--- a/src/text/template/helper.go
+++ b/src/text/template/helper.go
@@ -7,6 +7,7 @@
 package template
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -62,7 +63,7 @@ func (t *Template) ParseFiles(filenames ...string) (*Template, error) {
 func parseFiles(t *Template, readFile func(string) (string, []byte, error), filenames ...string) (*Template, error) {
 	if len(filenames) == 0 {
 		// Not really a problem, but be consistent.
-		return nil, fmt.Errorf("template: no files named in call to ParseFiles")
+		return nil, errors.New("template: no files named in call to ParseFiles")
 	}
 	for _, filename := range filenames {
 		name, b, err := readFile(filename)


### PR DESCRIPTION
For non-formatted strings "fmt.Errorf" and "errors.New" have the same result,
but the former is slower and allocates more memory.

So it is better to call "errors.New" directly for non-formatted strings.