### PR TITLE
database/sql: reduce memory footprint with errors.New

### DIFF
--- a/src/database/sql/convert_test.go
+++ b/src/database/sql/convert_test.go
@@ -6,6 +6,7 @@ package sql
 
 import (
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"internal/asan"
 	"reflect"
@@ -532,7 +533,7 @@ func (d *dec) Compose(form byte, negative bool, coefficient []byte, exponent int
 	// This isn't strictly correct, as the extra bytes could be all zero,
 	// ignore this for this test.
 	if len(coefficient) > 16 {
-		return fmt.Errorf("coefficient too large")
+		return errors.New("coefficient too large")
 	}
 	copy(d.coefficient[:], coefficient)
 
@@ -565,7 +566,7 @@ func (d *decFinite) Compose(form byte, negative bool, coefficient []byte, expone
 	// This isn't strictly correct, as the extra bytes could be all zero,
 	// ignore this for this test.
 	if len(coefficient) > 16 {
-		return fmt.Errorf("coefficient too large")
+		return errors.New("coefficient too large")
 	}
 	copy(d.coefficient[:], coefficient)
 

--- a/src/database/sql/driver/types.go
+++ b/src/database/sql/driver/types.go
@@ -5,6 +5,7 @@
 package driver
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -171,7 +172,7 @@ type NotNull struct {
 
 func (n NotNull) ConvertValue(v any) (Value, error) {
 	if v == nil {
-		return nil, fmt.Errorf("nil value not allowed")
+		return nil, errors.New("nil value not allowed")
 	}
 	return n.Converter.ConvertValue(v)
 }
@@ -275,7 +276,7 @@ func (defaultConverter) ConvertValue(v any) (Value, error) {
 	case reflect.Uint64:
 		u64 := rv.Uint()
 		if u64 >= 1<<63 {
-			return nil, fmt.Errorf("uint64 values with high bit set are not supported")
+			return nil, errors.New("uint64 values with high bit set are not supported")
 		}
 		return int64(u64), nil
 	case reflect.Float32, reflect.Float64:

--- a/src/database/sql/sql.go
+++ b/src/database/sql/sql.go
@@ -3366,7 +3366,7 @@ func (rs *Rows) Scan(dest ...any) error {
 	if rs.closemuScanHold {
 		// This should only be possible if the user calls Scan twice in a row
 		// without calling Next.
-		return fmt.Errorf("sql: Scan called without calling Next (closemuScanHold)")
+		return errors.New("sql: Scan called without calling Next (closemuScanHold)")
 	}
 
 	rs.closemu.RLock()


### PR DESCRIPTION
“errors.New” is more efficient and uses less memory than “fmt.Errorf”.
So use it for non-formatted strings.