### PR TITLE
spec: close tag

### DIFF
--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -3173,7 +3173,7 @@ Element      = Expression | LiteralValue .
 
 <p>
 Unless the LiteralType is a type parameter,
-its <a href="#Underlying_types">underlying type
+its <a href="#Underlying_types">underlying type</a>
 must be a struct, array, slice, or map type
 (the syntax enforces this constraint except when the type is given
 as a TypeName).
@@ -4873,7 +4873,7 @@ For instance, <code>x / y * z</code> is the same as <code>(x / y) * z</code>.
 x &lt;= f()                   // x &lt;= f()
 ^a &gt;&gt; b                    // (^a) >> b
 f() || g()                 // f() || g()
-x == y+1 &amp;&amp; &lt;-chanInt &gt; 0  // (x == (y+1)) && ((<-chanInt) > 0)
+x == y+1 &amp;&amp; &lt;-chanInt &gt; 0  // (x == (y+1)) && ((&lt;-chanInt) > 0)
 </pre>
 
 
@@ -6635,7 +6635,7 @@ iteration's variable at that moment.
 
 <pre>
 var prints []func()
-for i := 0; i < 5; i++ {
+for i := 0; i &lt; 5; i++ {
 	prints = append(prints, func() { println(i) })
 	i++
 }
@@ -6772,7 +6772,7 @@ if the iteration variable is preexisting, the type of the iteration values is th
 variable, which must be of integer type.
 Otherwise, if the iteration variable is declared by the "range" clause or is absent,
 the type of the iteration values is the <a href="#Constants">default type</a> for <code>n</code>.
-If <code>n</code> &lt= 0, the loop does not run any iterations.
+If <code>n</code> &lt;= 0, the loop does not run any iterations.
 </li>
 
 <li>
@@ -7799,7 +7799,7 @@ compared lexically byte-wise:
 </p>
 
 <pre>
-min(x, y)    == if x <= y then x else y
+min(x, y)    == if x &lt;= y then x else y
 min(x, y, z) == min(min(x, y), z)
 </pre>
 


### PR DESCRIPTION
Close an "a" tag. While we are here, fix some escapes.