### PR TITLE
comments: fix typos

### DIFF
--- a/src/cmd/internal/objabi/reloctype.go
+++ b/src/cmd/internal/objabi/reloctype.go
@@ -496,7 +496,7 @@ func FuncCountToDwTxtAddrFlavor(fncount int) (RelocType, int) {
 //
 // Background/motivation: let's say we have a package P with some
 // assembly functions (in "a.s") and some Go functions (in
-// "b.go"). The compilation sequence used by the Go commmand will be:
+// "b.go"). The compilation sequence used by the Go command will be:
 //
 // 1. run the assembler on a.s to generate a "symabis" file
 // 2. run the compiler on b.go passing it the symabis file and generating a "go_defs.h" asm header

--- a/src/cmd/link/internal/ld/dwarf.go
+++ b/src/cmd/link/internal/ld/dwarf.go
@@ -1120,7 +1120,7 @@ func expandFile(fname string) string {
 // are emitted to the directory table first, then the file table is
 // emitted after that.
 //
-// Note that there are some differences betwen DWARF versions 4 and 5
+// Note that there are some differences between DWARF versions 4 and 5
 // regarding how files and directories are handled; the chief item is
 // that in version 4 we have an implicit directory index 0 that holds
 // the compilation dir, and an implicit file index 0 that holds the

--- a/src/cmd/link/internal/ld/dwarf_test.go
+++ b/src/cmd/link/internal/ld/dwarf_test.go
@@ -279,7 +279,7 @@ func TestSizes(t *testing.T) {
 
 	// External linking may bring in C symbols with unknown size. Skip.
 	//
-	// N.B. go build below explictly doesn't pass through
+	// N.B. go build below explicitly doesn't pass through
 	// -asan/-msan/-race, so we don't care about those.
 	testenv.MustInternalLink(t, testenv.NoSpecialBuildTypes)
 
@@ -855,7 +855,7 @@ func TestAbstractOriginSanityIssue26237(t *testing.T) {
 
 func TestRuntimeTypeAttrInternal(t *testing.T) {
 	testenv.MustHaveGoBuild(t)
-	// N.B. go build below explictly doesn't pass through
+	// N.B. go build below explicitly doesn't pass through
 	// -asan/-msan/-race, so we don't care about those.
 	testenv.MustInternalLink(t, testenv.NoSpecialBuildTypes)
 
@@ -1489,7 +1489,7 @@ func TestIssue42484(t *testing.T) {
 	testenv.MustHaveGoBuild(t)
 	// Avoid spurious failures from external linkers.
 	//
-	// N.B. go build below explictly doesn't pass through
+	// N.B. go build below explicitly doesn't pass through
 	// -asan/-msan/-race, so we don't care about those.
 	testenv.MustInternalLink(t, testenv.NoSpecialBuildTypes)
 

--- a/src/cmd/link/internal/ld/ld_test.go
+++ b/src/cmd/link/internal/ld/ld_test.go
@@ -22,7 +22,7 @@ func TestUndefinedRelocErrors(t *testing.T) {
 	// When external linking, symbols may be defined externally, so we allow
 	// undefined symbols and let external linker resolve. Skip the test.
 	//
-	// N.B. go build below explictly doesn't pass through
+	// N.B. go build below explicitly doesn't pass through
 	// -asan/-msan/-race, so we don't care about those.
 	testenv.MustInternalLink(t, testenv.NoSpecialBuildTypes)
 

--- a/src/cmd/link/link_test.go
+++ b/src/cmd/link/link_test.go
@@ -46,7 +46,7 @@ func TestIssue21703(t *testing.T) {
 	t.Parallel()
 
 	testenv.MustHaveGoBuild(t)
-	// N.B. the build below explictly doesn't pass through
+	// N.B. the build below explicitly doesn't pass through
 	// -asan/-msan/-race, so we don't care about those.
 	testenv.MustInternalLink(t, testenv.NoSpecialBuildTypes)
 
@@ -93,7 +93,7 @@ func TestIssue28429(t *testing.T) {
 	t.Parallel()
 
 	testenv.MustHaveGoBuild(t)
-	// N.B. go build below explictly doesn't pass through
+	// N.B. go build below explicitly doesn't pass through
 	// -asan/-msan/-race, so we don't care about those.
 	testenv.MustInternalLink(t, testenv.NoSpecialBuildTypes)
 
@@ -193,7 +193,7 @@ main.x: relocation target main.zero not defined
 func TestIssue33979(t *testing.T) {
 	testenv.MustHaveGoBuild(t)
 	testenv.MustHaveCGO(t)
-	// N.B. go build below explictly doesn't pass through
+	// N.B. go build below explicitly doesn't pass through
 	// -asan/-msan/-race, so we don't care about those.
 	testenv.MustInternalLink(t, testenv.SpecialBuildTypes{Cgo: true})
 
@@ -959,7 +959,7 @@ func TestIndexMismatch(t *testing.T) {
 	// This shouldn't happen with "go build". We invoke the compiler and the linker
 	// manually, and try to "trick" the linker with an inconsistent object file.
 	testenv.MustHaveGoBuild(t)
-	// N.B. the build below explictly doesn't pass through
+	// N.B. the build below explicitly doesn't pass through
 	// -asan/-msan/-race, so we don't care about those.
 	testenv.MustInternalLink(t, testenv.NoSpecialBuildTypes)
 

--- a/src/cmd/nm/nm_cgo_test.go
+++ b/src/cmd/nm/nm_cgo_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestInternalLinkerCgoExec(t *testing.T) {
 	testenv.MustHaveCGO(t)
-	// N.B. the go build explictly doesn't pass through
+	// N.B. the go build explicitly doesn't pass through
 	// -asan/-msan/-race, so we don't care about those.
 	testenv.MustInternalLink(t, testenv.SpecialBuildTypes{Cgo: true})
 	testGoExec(t, true, false)

--- a/src/cmd/pack/pack_test.go
+++ b/src/cmd/pack/pack_test.go
@@ -163,7 +163,7 @@ func TestExtract(t *testing.T) {
 // Test that pack-created archives can be understood by the tools.
 func TestHello(t *testing.T) {
 	testenv.MustHaveGoBuild(t)
-	// N.B. the build below explictly doesn't pass through
+	// N.B. the build below explicitly doesn't pass through
 	// -asan/-msan/-race, so we don't care about those.
 	testenv.MustInternalLink(t, testenv.NoSpecialBuildTypes)
 

--- a/src/encoding/json/internal/jsontest/testdata.go
+++ b/src/encoding/json/internal/jsontest/testdata.go
@@ -198,7 +198,7 @@ type (
 		HangulSyllables                    string `json:"Hangul Syllables"`
 		Hebrew                             string `json:"Hebrew"`
 		Hiragana                           string `json:"Hiragana"`
-		IPAExtentions                      string `json:"IPA Extentions"`
+		IPAExtensions                      string `json:"IPA Extensions"`
 		KangxiRadicals                     string `json:"Kangxi Radicals"`
 		Katakana                           string `json:"Katakana"`
 		Khmer                              string `json:"Khmer"`

--- a/src/internal/runtime/cgroup/cgroup_linux.go
+++ b/src/internal/runtime/cgroup/cgroup_linux.go
@@ -610,7 +610,7 @@ func parseCPUMount(fd int, read func(fd int, b []byte) (int, uintptr), out []byt
 		}
 
 		// As in findCPUPath, cgroup v1 with a CPU controller takes
-		// precendence over cgroup v2.
+		// precedence over cgroup v2.
 		if string(ftype) == "cgroup2" {
 			// v2 hierarchy.
 			n, err = unescapePath(out, mnt)

--- a/src/internal/trace/trace_test.go
+++ b/src/internal/trace/trace_test.go
@@ -630,7 +630,7 @@ func testTraceProg(t *testing.T, progName string, extra func(t *testing.T, trace
 		}
 		cmd.Env = append(cmd.Env, "GODEBUG="+godebug)
 		if _, ok := os.LookupEnv("GOTRACEBACK"); !ok {
-			// Unless overriden, set GOTRACEBACK=crash.
+			// Unless overridden, set GOTRACEBACK=crash.
 			cmd.Env = append(cmd.Env, "GOTRACEBACK=crash")
 		}
 

--- a/src/internal/trace/traceviewer/static/trace_viewer_full.html
+++ b/src/internal/trace/traceviewer/static/trace_viewer_full.html
@@ -6683,7 +6683,7 @@ function define(className,opt_parentConstructor,opt_tagNS){if(typeof className==
 className=className.toLowerCase();if(opt_parentConstructor&&!opt_parentConstructor.tagName){throw new Error('opt_parentConstructor was not '+'created by tr.ui.b.define');}
 let tagName=className;let tagNS=undefined;if(opt_parentConstructor){if(opt_tagNS){throw new Error('Must not specify tagNS if parentConstructor is given');}
 let parent=opt_parentConstructor;while(parent&&parent.tagName){tagName=parent.tagName;tagNS=parent.tagNS;parent=parent.parentConstructor;}}else{tagNS=opt_tagNS;}
-function f(){if(opt_parentConstructor&&f.prototype.__proto__!==opt_parentConstructor.prototype){throw new Error(className+' prototye\'s __proto__ field is messed up. '+'It MUST be the prototype of '+opt_parentConstructor.tagName);}
+function f(){if(opt_parentConstructor&&f.prototype.__proto__!==opt_parentConstructor.prototype){throw new Error(className+' prototype\'s __proto__ field is messed up. '+'It MUST be the prototype of '+opt_parentConstructor.tagName);}
 let el;if(tagNS===undefined){el=tr.doc.createElement(tagName);}else{el=tr.doc.createElementNS(tagNS,tagName);}
 f.decorate.call(this,el,arguments);return el;}
 f.decorate=function(el){el.__proto__=f.prototype;el.decorate.apply(el,arguments[1]);el.constructor=f;};f.className=className;f.tagName=tagName;f.tagNS=tagNS;f.parentConstructor=(opt_parentConstructor?opt_parentConstructor:undefined);f.toString=function(){if(!f.parentConstructor){return f.tagName;}

--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -885,7 +885,7 @@ func (c switchProtocolCopier) copyFromBackend(errc chan<- error) {
 		return
 	}
 
-	// backend conn has reached EOF so propogate close write to user conn
+	// backend conn has reached EOF so propagate close write to user conn
 	if wc, ok := c.user.(interface{ CloseWrite() error }); ok {
 		errc <- wc.CloseWrite()
 		return
@@ -900,7 +900,7 @@ func (c switchProtocolCopier) copyToBackend(errc chan<- error) {
 		return
 	}
 
-	// user conn has reached EOF so propogate close write to backend conn
+	// user conn has reached EOF so propagate close write to backend conn
 	if wc, ok := c.backend.(interface{ CloseWrite() error }); ok {
 		errc <- wc.CloseWrite()
 		return

--- a/src/os/exec/exec_test.go
+++ b/src/os/exec/exec_test.go
@@ -684,7 +684,7 @@ func TestExtraFiles(t *testing.T) {
 	// This test runs with cgo disabled. External linking needs cgo, so
 	// it doesn't work if external linking is required.
 	//
-	// N.B. go build below explictly doesn't pass through
+	// N.B. go build below explicitly doesn't pass through
 	// -asan/-msan/-race, so we don't care about those.
 	testenv.MustInternalLink(t, testenv.NoSpecialBuildTypes)
 

--- a/src/runtime/cgroup_linux_test.go
+++ b/src/runtime/cgroup_linux_test.go
@@ -19,7 +19,7 @@ func mustHaveFourCPUs(t *testing.T) {
 	// NumCPU.
 	//
 	// cgroup GOMAXPROCS also have a minimum of 2. We need some room above
-	// that to test interesting properies.
+	// that to test interesting properties.
 	if runtime.NumCPU() < 4 {
 		t.Helper()
 		t.Skip("skipping test: fewer than 4 CPUs")

--- a/src/runtime/testdata/testgoroutineleakprofile/goker/istio16224.go
+++ b/src/runtime/testdata/testgoroutineleakprofile/goker/istio16224.go
@@ -33,7 +33,7 @@ func (m *configstoreMonitor_istio16224) Run(stop <-chan struct{}) {
 	for {
 		select {
 		case <-stop:
-			// This bug is not descibed, but is a true positive (in our eyes)
+			// This bug is not described, but is a true positive (in our eyes)
 			// In a real run main exits when the goro is blocked here.
 			if _, ok := <-m.eventCh; ok {
 				close(m.eventCh)

--- a/src/syscall/syscall_linux.go
+++ b/src/syscall/syscall_linux.go
@@ -24,7 +24,7 @@ import (
 // Note that this can't be a push linkname because the runtime already has a
 // nameless linkname to export to assembly here and in x/sys. Additionally,
 // entersyscall fetches the caller PC and SP and thus can't have a wrapper
-// inbetween.
+// in between.
 
 //go:linkname runtime_entersyscall runtime.entersyscall
 func runtime_entersyscall()


### PR DESCRIPTION
Fixed typos in comments and struct names
