### PR TITLE
cmd: use slices to simplify the code

### DIFF
--- a/src/cmd/asm/internal/asm/endtoend_test.go
+++ b/src/cmd/asm/internal/asm/endtoend_test.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -245,7 +245,7 @@ Diff:
 		for key := range hexByLine {
 			missing = append(missing, key)
 		}
-		sort.Strings(missing)
+		slices.Sort(missing)
 		for _, line := range missing {
 			t.Errorf("%s: did not find instruction encoding", line)
 		}
@@ -367,7 +367,7 @@ func testErrors(t *testing.T, goarch, file string, flags ...string) {
 	for key := range errors {
 		extra = append(extra, key)
 	}
-	sort.Strings(extra)
+	slices.Sort(extra)
 	for _, fileline := range extra {
 		t.Errorf("unexpected error on %s: %v", fileline, errors[fileline])
 	}

--- a/src/cmd/cgo/internal/testshared/shared_test.go
+++ b/src/cmd/cgo/internal/testshared/shared_test.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -232,7 +232,7 @@ func cloneGOROOTDeps(goroot string) error {
 
 	pkgs := append(strings.Split(strings.TrimSpace(stdDeps), "\n"),
 		strings.Split(strings.TrimSpace(testdataDeps), "\n")...)
-	sort.Strings(pkgs)
+	slices.Sort(pkgs)
 	var pkgRoots []string
 	for _, pkg := range pkgs {
 		parentFound := false

--- a/src/cmd/cgo/main.go
+++ b/src/cmd/cgo/main.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 
@@ -88,7 +88,7 @@ func nameKeys(m map[string]*Name) []string {
 	for k := range m {
 		ks = append(ks, k)
 	}
-	sort.Strings(ks)
+	slices.Sort(ks)
 	return ks
 }
 

--- a/src/cmd/cgo/out.go
+++ b/src/cmd/cgo/out.go
@@ -20,7 +20,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 	"unicode"
 )
@@ -120,7 +120,7 @@ func (p *Package) writeDefs() {
 		}
 		typedefNames = append(typedefNames, name)
 	}
-	sort.Strings(typedefNames)
+	slices.Sort(typedefNames)
 	for _, name := range typedefNames {
 		def := typedef[name]
 		fmt.Fprintf(fgo2, "type %s ", name)

--- a/src/cmd/compile/internal/inline/inlheur/callsite.go
+++ b/src/cmd/compile/internal/inline/inlheur/callsite.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -140,7 +140,7 @@ func dumpCallSiteComments(w io.Writer, tab CallSiteTab, ecst encodedCallSiteTab)
 	for k := range ecst {
 		tags = append(tags, k)
 	}
-	sort.Strings(tags)
+	slices.Sort(tags)
 	for _, s := range tags {
 		v := ecst[s]
 		fmt.Fprintf(w, "// callsite: %s flagstr %q flagval %d score %d mask %d maskstr %q\n", s, v.props.String(), v.props, v.score, v.mask, v.mask.String())

--- a/src/cmd/compile/internal/liveness/intervals_test.go
+++ b/src/cmd/compile/internal/liveness/intervals_test.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"sort"
+	"slices"
 	"testing"
 )
 
@@ -306,7 +306,7 @@ func TestRandomIntervalsOverlap(t *testing.T) {
 		// decide how many segments
 		segs := rand.Intn(int(*segsflag))
 		picked := vals[:(segs * 2)]
-		sort.Ints(picked)
+		slices.Sort(picked)
 		ii, err := makeIntervals(picked...)
 		if err != nil {
 			t.Fatalf("makeIntervals(%+v) returns err %v", picked, err)

--- a/src/cmd/compile/internal/liveness/plive.go
+++ b/src/cmd/compile/internal/liveness/plive.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"slices"
-	"sort"
 	"strings"
 
 	"cmd/compile/internal/abi"
@@ -1163,7 +1162,7 @@ func (lv *Liveness) format(v *ssa.Value, live bitvec.BitVec) (src.XPos, string) 
 			names = append(names, n.Sym().Name)
 		}
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 	for _, v := range names {
 		s += " " + v
 	}

--- a/src/cmd/compile/internal/ssa/_gen/rulegen.go
+++ b/src/cmd/compile/internal/ssa/_gen/rulegen.go
@@ -25,7 +25,7 @@ import (
 	"os"
 	"path"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -170,7 +170,7 @@ func genRulesSuffix(arch arch, suff string) {
 	for op := range oprules {
 		ops = append(ops, op)
 	}
-	sort.Strings(ops)
+	slices.Sort(ops)
 
 	genFile := &File{Arch: arch, Suffix: suff}
 	// Main rewrite routine is a switch on v.Op.
@@ -257,7 +257,7 @@ func genRulesSuffix(arch arch, suff string) {
 	for op := range blockrules {
 		ops = append(ops, op)
 	}
-	sort.Strings(ops)
+	slices.Sort(ops)
 	for _, op := range ops {
 		name, data := getBlockInfo(op, arch)
 		swc := &Case{Expr: exprf("%s", name)}

--- a/src/cmd/compile/internal/ssa/compile.go
+++ b/src/cmd/compile/internal/ssa/compile.go
@@ -16,7 +16,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 )
@@ -150,7 +150,7 @@ func Compile(f *Func) {
 		for key := range f.ruleMatches {
 			keys = append(keys, key)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		buf := new(strings.Builder)
 		fmt.Fprintf(buf, "%s: ", f.Name)
 		for _, key := range keys {

--- a/src/cmd/compile/internal/ssa/value.go
+++ b/src/cmd/compile/internal/ssa/value.go
@@ -10,7 +10,7 @@ import (
 	"cmd/internal/src"
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -182,7 +182,7 @@ func (v *Value) LongString() string {
 		}
 	}
 	if len(names) != 0 {
-		sort.Strings(names) // Otherwise a source of variation in debugging output.
+		slices.Sort(names) // Otherwise a source of variation in debugging output.
 		s += " (" + strings.Join(names, ", ") + ")"
 	}
 	return s

--- a/src/cmd/compile/internal/types2/api_test.go
+++ b/src/cmd/compile/internal/types2/api_test.go
@@ -11,7 +11,6 @@ import (
 	"internal/goversion"
 	"internal/testenv"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -3098,7 +3097,7 @@ func (recv T) f(param int) (result int) {
 			got = append(got, fmt.Sprintf("%s: %v", v.Name(), v.Kind()))
 		}
 	}
-	sort.Strings(got)
+	slices.Sort(got)
 	want := []string{
 		"field: FieldVar",
 		"global: PackageVar",

--- a/src/cmd/covdata/dump.go
+++ b/src/cmd/covdata/dump.go
@@ -20,7 +20,7 @@ import (
 	"internal/coverage/decodemeta"
 	"internal/coverage/pods"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -349,7 +349,7 @@ func (d *dstate) Finish() {
 		for p := range d.pkgpaths {
 			pkgs = append(pkgs, p)
 		}
-		sort.Strings(pkgs)
+		slices.Sort(pkgs)
 		for _, p := range pkgs {
 			fmt.Printf("%s\n", p)
 		}

--- a/src/cmd/covdata/metamerge.go
+++ b/src/cmd/covdata/metamerge.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"time"
 	"unsafe"
 )
@@ -296,7 +296,7 @@ func (mm *metaMerge) VisitFuncs(f encodecounter.CounterVisitorFn) error {
 		for fid := range p.ctab {
 			fids = append(fids, int(fid))
 		}
-		sort.Ints(fids)
+		slices.Sort(fids)
 		if *verbflag >= 4 {
 			fmt.Printf("fids for pk=%d: %+v\n", pidx, fids)
 		}

--- a/src/cmd/dist/build.go
+++ b/src/cmd/dist/build.go
@@ -17,7 +17,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -886,7 +885,7 @@ func runInstall(pkg string, ch chan struct{}) {
 	for imp := range importMap {
 		sortedImports = append(sortedImports, imp)
 	}
-	sort.Strings(sortedImports)
+	slices.Sort(sortedImports)
 
 	for _, dep := range importMap {
 		if dep == "C" {
@@ -1979,7 +1978,7 @@ func cmdlist() {
 		}
 		plats = append(plats, p)
 	}
-	sort.Strings(plats)
+	slices.Sort(plats)
 
 	if !*jsonFlag {
 		for _, p := range plats {

--- a/src/cmd/dist/buildgo.go
+++ b/src/cmd/dist/buildgo.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -77,7 +77,7 @@ func defaultCCFunc(name string, defaultcc map[string]string) string {
 			keys = append(keys, k)
 		}
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	for _, k := range keys {
 		fmt.Fprintf(&buf, "\tcase %s:\n\t\treturn %s\n", quote(k), quote(defaultcc[k]))
 	}

--- a/src/cmd/dist/util.go
+++ b/src/cmd/dist/util.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -40,7 +40,7 @@ func filter(list []string, f func(string) bool) []string {
 func uniq(list []string) []string {
 	out := make([]string, len(list))
 	copy(out, list)
-	sort.Strings(out)
+	slices.Sort(out)
 	keep := out[:0]
 	for _, x := range out {
 		if len(keep) == 0 || keep[len(keep)-1] != x {

--- a/src/cmd/go/internal/fsys/glob.go
+++ b/src/cmd/go/internal/fsys/glob.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -153,7 +153,7 @@ func glob(dir, pattern string, matches []string) (m []string, e error) {
 	for _, info := range list {
 		names = append(names, info.Name())
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 
 	for _, n := range names {
 		matched, err := filepath.Match(pattern, n)

--- a/src/cmd/go/internal/imports/scan.go
+++ b/src/cmd/go/internal/imports/scan.go
@@ -7,8 +7,9 @@ package imports
 import (
 	"fmt"
 	"io/fs"
+	"maps"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -93,16 +94,7 @@ Files:
 	if numFiles == 0 {
 		return nil, nil, ErrNoGo
 	}
-	return keys(imports), keys(testImports), nil
+	return slices.Sorted(maps.Keys(imports)), slices.Sorted(maps.Keys(testImports)), nil
 }
 
 var ErrNoGo = fmt.Errorf("no Go source files")
-
-func keys(m map[string]bool) []string {
-	list := make([]string, 0, len(m))
-	for k := range m {
-		list = append(list, k)
-	}
-	sort.Strings(list)
-	return list
-}

--- a/src/cmd/go/internal/list/list.go
+++ b/src/cmd/go/internal/list/list.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -392,7 +393,7 @@ func (v *jsonFlag) String() string {
 	for f := range *v {
 		fields = append(fields, f)
 	}
-	sort.Strings(fields)
+	slices.Sort(fields)
 	return strings.Join(fields, ",")
 }
 
@@ -927,7 +928,7 @@ func collectDeps(p *load.Package) {
 	for dep := range deps {
 		p.Deps = append(p.Deps, dep)
 	}
-	sort.Strings(p.Deps)
+	slices.Sort(p.Deps)
 }
 
 // collectDepsErrors populates p.DepsErrors by iterating over p.Internal.Imports.

--- a/src/cmd/go/internal/load/godebug.go
+++ b/src/cmd/go/internal/load/godebug.go
@@ -10,7 +10,7 @@ import (
 	"go/build"
 	"internal/godebugs"
 	"maps"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -112,7 +112,7 @@ func defaultGODEBUG(p *Package, directives, testDirectives, xtestDirectives []bu
 	for k := range m {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	var b strings.Builder
 	for _, k := range keys {
 		if b.Len() > 0 {

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -24,7 +24,6 @@ import (
 	"runtime"
 	"runtime/debug"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -368,7 +367,7 @@ func (p *Package) Resolve(imports []string) []string {
 			all = append(all, path)
 		}
 	}
-	sort.Strings(all)
+	slices.Sort(all)
 	return all
 }
 
@@ -2271,14 +2270,14 @@ func resolveEmbed(pkgdir string, patterns []string) (files []string, pmap map[st
 		if len(list) == 0 {
 			return nil, nil, fmt.Errorf("no matching files found")
 		}
-		sort.Strings(list)
+		slices.Sort(list)
 		pmap[pattern] = list
 	}
 
 	for file := range have {
 		files = append(files, file)
 	}
-	sort.Strings(files)
+	slices.Sort(files)
 	return files, pmap, nil
 }
 
@@ -2739,7 +2738,7 @@ func (p *Package) mkAbs(list []string) []string {
 	for i, f := range list {
 		list[i] = filepath.Join(p.Dir, f)
 	}
-	sort.Strings(list)
+	slices.Sort(list)
 	return list
 }
 

--- a/src/cmd/go/internal/load/test.go
+++ b/src/cmd/go/internal/load/test.go
@@ -360,7 +360,7 @@ func TestPackagesAndErrors(ctx context.Context, done func(), opts PackageOpts, p
 
 		// Sort and dedup pmain.Imports.
 		// Only matters for go list -test output.
-		sort.Strings(pmain.Imports)
+		slices.Sort(pmain.Imports)
 		w := 0
 		for _, path := range pmain.Imports {
 			if w == 0 || path != pmain.Imports[w-1] {

--- a/src/cmd/go/internal/modcmd/vendor.go
+++ b/src/cmd/go/internal/modcmd/vendor.go
@@ -15,7 +15,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	"cmd/go/internal/base"
@@ -181,7 +181,7 @@ func RunVendor(ctx context.Context, vendorE bool, vendorO string, args []string)
 		}
 
 		pkgs := modpkgs[m]
-		sort.Strings(pkgs)
+		slices.Sort(pkgs)
 		for _, pkg := range pkgs {
 			fmt.Fprintf(w, "%s\n", pkg)
 			vendorPkg(vdir, pkg)

--- a/src/cmd/go/internal/modfetch/codehost/git.go
+++ b/src/cmd/go/internal/modfetch/codehost/git.go
@@ -19,7 +19,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -317,8 +316,8 @@ func (r *gitRepo) Tags(ctx context.Context, prefix string) (*Tags, error) {
 		}
 		tags.List = append(tags.List, Tag{tag, hash})
 	}
-	sort.Slice(tags.List, func(i, j int) bool {
-		return tags.List[i].Name < tags.List[j].Name
+	slices.SortFunc(tags.List, func(i, j Tag) int {
+		return strings.Compare(i.Name, j.Name)
 	})
 
 	dir := prefix[:strings.LastIndex(prefix, "/")+1]
@@ -341,7 +340,7 @@ func (r *gitRepo) repoSum(refs map[string]string) string {
 	for ref := range refs {
 		list = append(list, ref)
 	}
-	sort.Strings(list)
+	slices.Sort(list)
 	h := sha256.New()
 	for _, ref := range list {
 		fmt.Fprintf(h, "%q %s\n", ref, refs[ref])

--- a/src/cmd/go/internal/modfetch/codehost/vcs.go
+++ b/src/cmd/go/internal/modfetch/codehost/vcs.go
@@ -13,7 +13,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -337,8 +337,8 @@ func (r *vcsRepo) Tags(ctx context.Context, prefix string) (*Tags, error) {
 			tags.List = append(tags.List, Tag{tag, ""})
 		}
 	}
-	sort.Slice(tags.List, func(i, j int) bool {
-		return tags.List[i].Name < tags.List[j].Name
+	slices.SortFunc(tags.List, func(i, j Tag) int {
+		return strings.Compare(i.Name, j.Name)
 	})
 	return tags, nil
 }
@@ -542,7 +542,7 @@ func hgParseStat(rev, out string) (*RevInfo, error) {
 			tags = append(tags, tag)
 		}
 	}
-	sort.Strings(tags)
+	slices.Sort(tags)
 
 	info := &RevInfo{
 		Origin: &Origin{

--- a/src/cmd/go/internal/modfetch/fetch.go
+++ b/src/cmd/go/internal/modfetch/fetch.go
@@ -16,7 +16,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 
@@ -994,7 +994,7 @@ func tidyGoSum(data []byte, keep map[module.Version]bool) []byte {
 	var buf bytes.Buffer
 	for _, m := range mods {
 		list := goSum.m[m]
-		sort.Strings(list)
+		slices.Sort(list)
 		str.Uniq(&list)
 		for _, h := range list {
 			st := goSum.status[modSum{m, h}]

--- a/src/cmd/go/internal/modindex/build.go
+++ b/src/cmd/go/internal/modindex/build.go
@@ -21,7 +21,6 @@ import (
 	"io/fs"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -291,7 +290,7 @@ func cleanDecls(m map[string][]token.Position) ([]string, map[string][]token.Pos
 	for path := range m {
 		all = append(all, path)
 	}
-	sort.Strings(all)
+	slices.Sort(all)
 	return all, m
 }
 

--- a/src/cmd/go/internal/modindex/read.go
+++ b/src/cmd/go/internal/modindex/read.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -656,14 +657,14 @@ func (rp *IndexPackage) Import(bctxt build.Context, mode build.ImportMode) (p *b
 	for tag := range allTags {
 		p.AllTags = append(p.AllTags, tag)
 	}
-	sort.Strings(p.AllTags)
+	slices.Sort(p.AllTags)
 
 	if len(p.CgoFiles) > 0 {
 		p.SFiles = append(p.SFiles, Sfiles...)
-		sort.Strings(p.SFiles)
+		slices.Sort(p.SFiles)
 	} else {
 		p.IgnoredOtherFiles = append(p.IgnoredOtherFiles, Sfiles...)
-		sort.Strings(p.IgnoredOtherFiles)
+		slices.Sort(p.IgnoredOtherFiles)
 	}
 
 	if badGoError != nil {
@@ -778,7 +779,7 @@ func keys(m map[string]bool) []string {
 	for k := range m {
 		list = append(list, k)
 	}
-	sort.Strings(list)
+	slices.Sort(list)
 	return list
 }
 

--- a/src/cmd/go/internal/modload/load.go
+++ b/src/cmd/go/internal/modload/load.go
@@ -107,7 +107,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -512,7 +511,7 @@ func LoadPackages(ctx context.Context, opts PackageOpts, patterns ...string) (ma
 			loadedPackages = append(loadedPackages, pkg.path)
 		}
 	}
-	sort.Strings(loadedPackages)
+	slices.Sort(loadedPackages)
 
 	if !ExplicitWriteGoMod && opts.ResolveMissingImports {
 		if err := commitRequirements(ctx, WriteOpts{}); err != nil {
@@ -2020,7 +2019,7 @@ func (ld *loader) computePatternAll() (all []string) {
 			all = append(all, pkg.path)
 		}
 	}
-	sort.Strings(all)
+	slices.Sort(all)
 	return all
 }
 

--- a/src/cmd/go/internal/modload/search.go
+++ b/src/cmd/go/internal/modload/search.go
@@ -13,7 +13,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 
@@ -160,7 +160,7 @@ func matchPackages(ctx context.Context, m *search.Match, tags map[string]bool, f
 	// Wait for all in-flight operations to complete before returning.
 	defer func() {
 		<-q.Idle()
-		sort.Strings(m.Pkgs) // sort everything we added for determinism
+		slices.Sort(m.Pkgs) // sort everything we added for determinism
 	}()
 
 	if filter == includeStd {

--- a/src/cmd/go/internal/tool/tool.go
+++ b/src/cmd/go/internal/tool/tool.go
@@ -20,7 +20,6 @@ import (
 	"os/signal"
 	"path"
 	"slices"
-	"sort"
 	"strings"
 
 	"cmd/go/internal/base"
@@ -147,7 +146,7 @@ func listTools(ctx context.Context) {
 		return
 	}
 
-	sort.Strings(names)
+	slices.Sort(names)
 	for _, name := range names {
 		// Unify presentation by going to lower case.
 		// If it's windows, don't show the .exe suffix.

--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -27,7 +27,6 @@ import (
 	"regexp"
 	"runtime"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -3159,7 +3158,7 @@ func (b *Builder) dynimport(a *Action, objdir, importGo, cgoExe string, cflags, 
 		}
 	}
 	gatherSyso(a)
-	sort.Strings(syso)
+	slices.Sort(syso)
 	str.Uniq(&syso)
 	linkobj := str.StringList(ofile, outObj, syso)
 	dynobj := objdir + "_cgo_.o"

--- a/src/cmd/internal/objabi/flag.go
+++ b/src/cmd/internal/objabi/flag.go
@@ -13,7 +13,7 @@ import (
 	"log"
 	"os"
 	"reflect"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -294,7 +294,7 @@ func (f *DebugFlag) Set(debugstr string) error {
 				}
 				names = append(names, name)
 			}
-			sort.Strings(names)
+			slices.Sort(names)
 			// Indent multi-line help messages.
 			nl := fmt.Sprintf("\n\t%-*s\t", maxLen, "")
 			for _, name := range names {

--- a/src/cmd/internal/script/engine.go
+++ b/src/cmd/internal/script/engine.go
@@ -55,7 +55,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 )
@@ -650,7 +650,7 @@ func (e *Engine) ListCmds(w io.Writer, verbose bool, names ...string) error {
 		for name := range e.Cmds {
 			names = append(names, name)
 		}
-		sort.Strings(names)
+		slices.Sort(names)
 	}
 
 	for _, name := range names {
@@ -727,7 +727,7 @@ func (e *Engine) ListConds(w io.Writer, s *State, tags ...string) error {
 		for name := range e.Conds {
 			tags = append(tags, name)
 		}
-		sort.Strings(tags)
+		slices.Sort(tags)
 	}
 
 	for _, tag := range tags {

--- a/src/cmd/internal/testdir/testdir_test.go
+++ b/src/cmd/internal/testdir/testdir_test.go
@@ -1337,7 +1337,7 @@ func (test) updateErrors(out, file string) {
 		for e := range errs {
 			sorted = append(sorted, e)
 		}
-		sort.Strings(sorted)
+		slices.Sort(sorted)
 		lines[line] += " // ERROR"
 		for _, e := range sorted {
 			lines[line] += fmt.Sprintf(` "%s$"`, e)

--- a/src/cmd/link/internal/ld/dwarf_test.go
+++ b/src/cmd/link/internal/ld/dwarf_test.go
@@ -15,7 +15,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -1603,7 +1603,7 @@ func processParams(die *dwarf.Entry, ex *dwtest.Examiner) string {
 	for k, v := range foundParams {
 		found = append(found, fmt.Sprintf("%s:%s", k, v))
 	}
-	sort.Strings(found)
+	slices.Sort(found)
 
 	return fmt.Sprintf("%+v", found)
 }

--- a/src/cmd/link/internal/ld/go.go
+++ b/src/cmd/link/internal/ld/go.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -329,7 +329,7 @@ func dedupLibrariesOpenBSD(ctxt *Link, libs []string) []string {
 	for _, lib := range libraries {
 		libs = append(libs, lib)
 	}
-	sort.Strings(libs)
+	slices.Sort(libs)
 
 	return libs
 }

--- a/src/cmd/link/internal/ld/lib.go
+++ b/src/cmd/link/internal/ld/lib.go
@@ -45,7 +45,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -1781,7 +1780,7 @@ func (ctxt *Link) hostlink() {
 			ctxt.loader.ForAllCgoExportDynamic(func(s loader.Sym) {
 				exports = append(exports, "-Wl,--export-dynamic-symbol="+ctxt.loader.SymExtname(s))
 			})
-			sort.Strings(exports)
+			slices.Sort(exports)
 			argv = append(argv, exports...)
 		}
 	case ctxt.IsAIX():

--- a/src/cmd/link/internal/ld/pe.go
+++ b/src/cmd/link/internal/ld/pe.go
@@ -1784,7 +1784,7 @@ func peCreateExportFile(ctxt *Link, libName string) (fname string) {
 		// See runtime/cgo/windows.go for details.
 		exports = append(exports, "_cgo_stub_export")
 	}
-	sort.Strings(exports)
+	slices.Sort(exports)
 	buf.WriteString(strings.Join(exports, "\n"))
 
 	err := os.WriteFile(fname, buf.Bytes(), 0666)

--- a/src/cmd/trace/goroutines.go
+++ b/src/cmd/trace/goroutines.go
@@ -15,7 +15,6 @@ import (
 	"log"
 	"net/http"
 	"slices"
-	"sort"
 	"strings"
 	"time"
 )
@@ -182,7 +181,7 @@ func GoroutineHandler(summaries map[trace.GoID]*trace.GoroutineSummary) http.Han
 		for name := range validRangeStats {
 			allRangeStats = append(allRangeStats, name)
 		}
-		sort.Strings(allRangeStats)
+		slices.Sort(allRangeStats)
 
 		err := templGoroutine.Execute(w, struct {
 			Name                string

--- a/src/cmd/trace/regions.go
+++ b/src/cmd/trace/regions.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -235,7 +234,7 @@ func UserRegionHandlerFunc(t *parsedTrace) http.HandlerFunc {
 		for name := range validRangeStats {
 			allRangeStats = append(allRangeStats, name)
 		}
-		sort.Strings(allRangeStats)
+		slices.Sort(allRangeStats)
 
 		err = templUserRegionType.Execute(w, struct {
 			MaxTotal            time.Duration


### PR DESCRIPTION
Go 1.26 and later requires Go 1.24.6 as the minimum bootstrap toolchain,
so it's safe to replace "sort.Strings/Ints/..." with "slices.Sort/Sorted"
and simplify the code.

Updates #57433
