### PR TITLE
all: use slices.Sort

### DIFF
--- a/src/archive/tar/writer_test.go
+++ b/src/archive/tar/writer_test.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path"
 	"slices"
-	"sort"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -1365,7 +1364,7 @@ func TestWriterAddFS(t *testing.T) {
 	for name := range fsys {
 		names = append(names, name)
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 
 	entriesLeft := len(fsys)
 	for _, name := range names {

--- a/src/cmp/cmp_test.go
+++ b/src/cmp/cmp_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"math"
 	"slices"
-	"sort"
 	"strings"
 	"testing"
 	"unsafe"
@@ -94,9 +93,9 @@ func TestCompare(t *testing.T) {
 
 func TestSort(t *testing.T) {
 	// Test that our comparison function is consistent with
-	// sort.Float64s.
+	// slices.Sort.
 	input := []float64{1.0, 0.0, negzero, math.Inf(1), math.Inf(-1), math.NaN()}
-	sort.Float64s(input)
+	slices.Sort(input)
 	for i := 0; i < len(input)-1; i++ {
 		if cmp.Less(input[i+1], input[i]) {
 			t.Errorf("Less sort mismatch at %d in %v", i, input)

--- a/src/crypto/cipher/ctr_aes_test.go
+++ b/src/crypto/cipher/ctr_aes_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/rand"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -285,7 +285,7 @@ func TestCTR_AES_multiblock_XORKeyStreamAt(t *testing.T) {
 			}
 			boundaries = append(boundaries, 0)
 			boundaries = append(boundaries, Size)
-			sort.Ints(boundaries)
+			slices.Sort(boundaries)
 
 			for _, i := range r.Perm(N + 1) {
 				begin := boundaries[i]

--- a/src/go/ast/commentmap_test.go
+++ b/src/go/ast/commentmap_test.go
@@ -11,7 +11,7 @@ import (
 	. "go/ast"
 	"go/parser"
 	"go/token"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -132,7 +132,7 @@ func TestCommentMap(t *testing.T) {
 		for n, list := range cmap {
 			out = append(out, fmt.Sprintf("\t\"%2d: %T\":\t%q,", fset.Position(n.Pos()).Line, n, ctext(list)))
 		}
-		sort.Strings(out)
+		slices.Sort(out)
 		for _, s := range out {
 			fmt.Println(s)
 		}

--- a/src/go/types/api_test.go
+++ b/src/go/types/api_test.go
@@ -14,7 +14,6 @@ import (
 	"internal/goversion"
 	"internal/testenv"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -3162,7 +3161,7 @@ func (recv T) f(param int) (result int) {
 			got = append(got, fmt.Sprintf("%s: %v", v.Name(), v.Kind()))
 		}
 	}
-	sort.Strings(got)
+	slices.Sort(got)
 	want := []string{
 		"field: FieldVar",
 		"global: PackageVar",

--- a/src/internal/coverage/cformat/format.go
+++ b/src/internal/coverage/cformat/format.go
@@ -38,7 +38,6 @@ import (
 	"io"
 	"maps"
 	"slices"
-	"sort"
 	"strings"
 	"text/tabwriter"
 )
@@ -183,7 +182,7 @@ func (fm *Formatter) EmitTextual(pkgs []string, w io.Writer) error {
 	if _, err := fmt.Fprintf(w, "mode: %s\n", fm.cm.String()); err != nil {
 		return err
 	}
-	sort.Strings(pkgs)
+	slices.Sort(pkgs)
 	for _, importpath := range pkgs {
 		p := fm.pm[importpath]
 		if p == nil {

--- a/src/internal/profile/encode.go
+++ b/src/internal/profile/encode.go
@@ -7,7 +7,7 @@ package profile
 import (
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 )
 
 func (p *Profile) decoder() []decoder {
@@ -32,7 +32,7 @@ func (p *Profile) preEncode() {
 		for k := range s.Label {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			vs := s.Label[k]
 			for _, v := range vs {
@@ -48,7 +48,7 @@ func (p *Profile) preEncode() {
 		for k := range s.NumLabel {
 			numKeys = append(numKeys, k)
 		}
-		sort.Strings(numKeys)
+		slices.Sort(numKeys)
 		for _, k := range numKeys {
 			vs := s.NumLabel[k]
 			for _, v := range vs {

--- a/src/internal/profile/merge.go
+++ b/src/internal/profile/merge.go
@@ -6,7 +6,7 @@ package profile
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -183,13 +183,13 @@ func (sample *Sample) key() sampleKey {
 	for k, v := range sample.Label {
 		labels = append(labels, fmt.Sprintf("%q%q", k, v))
 	}
-	sort.Strings(labels)
+	slices.Sort(labels)
 
 	numlabels := make([]string, 0, len(sample.NumLabel))
 	for k, v := range sample.NumLabel {
 		numlabels = append(numlabels, fmt.Sprintf("%q%x%x", k, v, sample.NumUnit[k]))
 	}
-	sort.Strings(numlabels)
+	slices.Sort(numlabels)
 
 	return sampleKey{
 		strings.Join(ids, "|"),


### PR DESCRIPTION
This is a follow-up for CL 709756.

Split into two CLs to avoid a single CL being too large.

Updates #57433