### PR TITLE
crypto: add digest truncate support to all hash types

### DIFF
--- a/src/crypto/crypto.go
+++ b/src/crypto/crypto.go
@@ -149,6 +149,11 @@ func RegisterHash(h Hash, f func() hash.Hash) {
 	hashes[h] = f
 }
 
+type HashResult interface {
+	String() string
+	Truncate(maxLength int) string
+}
+
 // PublicKey represents a public key using an unspecified algorithm.
 //
 // Although this type is an empty interface for backwards compatibility reasons,

--- a/src/crypto/crypto.go
+++ b/src/crypto/crypto.go
@@ -154,6 +154,10 @@ type HashResult interface {
 	Truncate(maxLength int) string
 }
 
+func TruncateHash(hash HashResult, maxLength int) string {
+	return hash.Truncate(maxLength)
+}
+
 // PublicKey represents a public key using an unspecified algorithm.
 //
 // Although this type is an empty interface for backwards compatibility reasons,

--- a/src/crypto/sha256/sha256.go
+++ b/src/crypto/sha256/sha256.go
@@ -87,3 +87,17 @@ func (h SHA256Hash) Truncate(maxLength int) string {
 	}
 	return full
 }
+
+type SHA224Hash [Size224]byte
+
+func (h SHA224Hash) String() string {
+	return hex.EncodeToString(h[:])
+}
+
+func (h SHA224Hash) Truncate(maxLength int) string {
+	full := h.String()
+	if len(full) > maxLength {
+		return full[:maxLength]
+	}
+	return full
+}

--- a/src/crypto/sha256/sha256.go
+++ b/src/crypto/sha256/sha256.go
@@ -10,6 +10,7 @@ import (
 	"crypto"
 	"crypto/internal/boring"
 	"crypto/internal/fips140/sha256"
+	"encoding/hex"
 	"hash"
 )
 
@@ -71,4 +72,18 @@ func Sum224(data []byte) [Size224]byte {
 	var sum [Size224]byte
 	h.Sum(sum[:0])
 	return sum
+}
+
+type SHA256Hash [Size]byte
+
+func (h SHA256Hash) String() string {
+	return hex.EncodeToString(h[:])
+}
+
+func (h SHA256Hash) Truncate(maxLength int) string {
+	full := h.String()
+	if len(full) > maxLength {
+		return full[:maxLength]
+	}
+	return full
 }


### PR DESCRIPTION
## Changes Description
This PR fixes: https://github.com/golang/go/issues/75797

This PR aims to create a interface for add native support for the digest truncate method in the crypto package covering all hash types.
In these changes we included the interface creation and a use case in the crypto/sha256 package that we can reply in all others hash packages.

### API Use

```go
hash := sha256.Sum256(bytesInput)
truncatedHash := crypto.TruncateHash(hash)
```