### PR TITLE
encoding/asn1: use reflect.TypeAssert to improve performance

### DIFF
--- a/src/encoding/asn1/marshal.go
+++ b/src/encoding/asn1/marshal.go
@@ -460,17 +460,20 @@ func makeBody(value reflect.Value, params fieldParameters) (e encoder, err error
 	case flagType:
 		return bytesEncoder(nil), nil
 	case timeType:
-		t := value.Interface().(time.Time)
+		t, _ := reflect.TypeAssert[time.Time](value)
 		if params.timeType == TagGeneralizedTime || outsideUTCRange(t) {
 			return makeGeneralizedTime(t)
 		}
 		return makeUTCTime(t)
 	case bitStringType:
-		return bitStringEncoder(value.Interface().(BitString)), nil
+		v, _ := reflect.TypeAssert[BitString](value)
+		return bitStringEncoder(v), nil
 	case objectIdentifierType:
-		return makeObjectIdentifier(value.Interface().(ObjectIdentifier))
+		v, _ := reflect.TypeAssert[ObjectIdentifier](value)
+		return makeObjectIdentifier(v)
 	case bigIntType:
-		return makeBigInt(value.Interface().(*big.Int))
+		v, _ := reflect.TypeAssert[*big.Int](value)
+		return makeBigInt(v)
 	}
 
 	switch v := value; v.Kind() {
@@ -605,7 +608,7 @@ func makeField(v reflect.Value, params fieldParameters) (e encoder, err error) {
 	}
 
 	if v.Type() == rawValueType {
-		rv := v.Interface().(RawValue)
+		rv, _ := reflect.TypeAssert[RawValue](v)
 		if len(rv.FullBytes) != 0 {
 			return bytesEncoder(rv.FullBytes), nil
 		}
@@ -650,7 +653,8 @@ func makeField(v reflect.Value, params fieldParameters) (e encoder, err error) {
 			tag = params.stringType
 		}
 	case TagUTCTime:
-		if params.timeType == TagGeneralizedTime || outsideUTCRange(v.Interface().(time.Time)) {
+		t, _ := reflect.TypeAssert[time.Time](v)
+		if params.timeType == TagGeneralizedTime || outsideUTCRange(t) {
 			tag = TagGeneralizedTime
 		}
 	}


### PR DESCRIPTION
Use "reflect.TypeAssert" can gain some performance improvements:

goos: darwin
goarch: arm64
pkg: encoding/asn1
cpu: Apple M4
                          │     old     │                new                 │
                          │   sec/op    │   sec/op     vs base               │
ObjectIdentifierString-10   51.48n ± 1%   49.72n ± 2%  -3.41% (p=0.000 n=10)
Marshal-10                  7.549µ ± 0%   7.466µ ± 1%  -1.10% (p=0.000 n=10)
Unmarshal-10                1.808µ ± 0%   1.798µ ± 0%  -0.58% (p=0.000 n=10)
geomean                     889.0n        873.8n       -1.70%

                          │     old      │                  new                  │
                          │     B/op     │     B/op      vs base                 │
ObjectIdentifierString-10     32.00 ± 0%     32.00 ± 0%       ~ (p=1.000 n=10) ¹
Marshal-10                  7.336Ki ± 0%   7.336Ki ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal-10                  432.0 ± 0%     432.0 ± 0%       ~ (p=1.000 n=10) ¹
geomean                       470.0          470.0       +0.00%
¹ all samples are equal

                          │    old     │                 new                 │
                          │ allocs/op  │ allocs/op   vs base                 │
ObjectIdentifierString-10   1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
Marshal-10                  271.0 ± 0%   271.0 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal-10                24.00 ± 0%   24.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                     18.67        18.67       +0.00%
¹ all samples are equal

Updates #62121