### PR TITLE
cmd/go: fix TestScript/list_std_vendor expected output for golang.org/x/net

### DIFF
--- a/src/cmd/go/testdata/script/list_std_vendor.txt
+++ b/src/cmd/go/testdata/script/list_std_vendor.txt
@@ -30,4 +30,4 @@ cmp stdout $WORK/net-deps.txt
 env GOPROXY=
 env GOWORK=off
 go mod why -m golang.org/x/net
-stdout '^# golang.org/x/net\nnet\ngolang.org/x/net'
+stdout '^# golang.org/x/net\nnet\ngolang.org/x/net(/dns/dnsmessage)?'


### PR DESCRIPTION
On darwin/arm64 the output of
"go mod why -m golang.org/x/net"
returns:
# golang.org/x/net
net
golang.org/x/net/dns/dnsmessage
instead of the previous expected module root.

This change updates the expected output in
src/cmd/go/testdata/script/list_std_vendor.txt
so that TestScript/list_std_vendor passes on darwin/arm64.

Fixes #75904
