### PR TITLE
crypto/internal/fips140/aes: fix CTR generator

### DIFF
--- a/src/crypto/internal/fips140/aes/_asm/ctr/ctr_amd64_asm.go
+++ b/src/crypto/internal/fips140/aes/_asm/ctr/ctr_amd64_asm.go
@@ -16,7 +16,7 @@ import (
 //go:generate go run . -out ../../ctr_amd64.s
 
 func main() {
-	Package("crypto/aes")
+	Package("crypto/internal/fips140/aes")
 	ConstraintExpr("!purego")
 
 	ctrBlocks(1)

--- a/src/crypto/internal/fips140/aes/_asm/ctr/go.mod
+++ b/src/crypto/internal/fips140/aes/_asm/ctr/go.mod
@@ -1,11 +1,11 @@
 module crypto/aes/_asm/ctr
 
-go 1.24
+go 1.25
 
 require github.com/mmcloughlin/avo v0.6.0
 
 require (
-	golang.org/x/mod v0.20.0 // indirect
-	golang.org/x/sync v0.8.0 // indirect
-	golang.org/x/tools v0.24.0 // indirect
+	golang.org/x/mod v0.29.0 // indirect
+	golang.org/x/sync v0.17.0 // indirect
+	golang.org/x/tools v0.38.0 // indirect
 )

--- a/src/crypto/internal/fips140/aes/_asm/ctr/go.sum
+++ b/src/crypto/internal/fips140/aes/_asm/ctr/go.sum
@@ -1,8 +1,10 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/mmcloughlin/avo v0.6.0 h1:QH6FU8SKoTLaVs80GA8TJuLNkUYl4VokHKlPhVDg4YY=
 github.com/mmcloughlin/avo v0.6.0/go.mod h1:8CoAGaCSYXtCPR+8y18Y9aB/kxb8JSS6FRI7mSkvD+8=
-golang.org/x/mod v0.20.0 h1:utOm6MM3R3dnawAiJgn0y+xvuYRsm1RKM/4giyfDgV0=
-golang.org/x/mod v0.20.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
-golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/tools v0.24.0 h1:J1shsA93PJUEVaUSaay7UXAyE8aimq3GW0pjlolpa24=
-golang.org/x/tools v0.24.0/go.mod h1:YhNqVBIfWHdzvTLs0d8LCuMhkKUgSUKldakyV7W/WDQ=
+golang.org/x/mod v0.29.0 h1:HV8lRxZC4l2cr3Zq1LvtOsi/ThTgWnUk/y64QSs8GwA=
+golang.org/x/mod v0.29.0/go.mod h1:NyhrlYXJ2H4eJiRy/WDBO6HMqZQ6q9nk4JzS3NuCK+w=
+golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
+golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/tools v0.38.0 h1:Hx2Xv8hISq8Lm16jvBZ2VQf+RLmbd7wVUsALibYI/IQ=
+golang.org/x/tools v0.38.0/go.mod h1:yEsQ/d/YK8cjh0L6rZlY8tgtlKiBNTL14pGDJPJpYQs=


### PR DESCRIPTION
Fixed two issues in AVO based generator of amd64 asm code.

1. Updated golang.org/x/tools dependency to prevent build issue in Go 1.25.

> golang.org/x/tools@v0.24.0/internal/tokeninternal/tokeninternal.go:64:9:
> invalid array length -delta * delta (constant -256 of type int64)

This error was caused by changes in layout of data structures in Go. Package
golang.org/x/tools has a mirror of that struct and a static assert that it
matches the Go's struct.

2. Changed the package name from crypto/aes to crypto/internal/fips140/aes.

This fixed run time error:

> ctr_amd64_asm.go:31: could not find function "ctrBlocks1Asm"
and other errors

Now the following works as expected:

$ cd src/crypto/internal/fips140/aes/_asm/ctr/
$ go generate

The command re-generates file "src/crypto/internal/fips140/aes/ctr_amd64.s".

Fixes #75972