### PR TITLE
runtime/cgo: fix cgoCheckArg description

### DIFF
--- a/src/runtime/cgocall.go
+++ b/src/runtime/cgocall.go
@@ -33,7 +33,7 @@
 //
 // To make it possible for gcc-compiled C code to call a Go function p.GoF,
 // cgo writes a gcc-compiled function named GoF (not p.GoF, since gcc doesn't
-// know about packages).  The gcc-compiled C function f calls GoF.
+// know about packages). The gcc-compiled C function f calls GoF.
 //
 // GoF initializes "frame", a structure containing all of its
 // arguments and slots for p.GoF's results. It calls
@@ -58,10 +58,10 @@
 // m.g0 stack, so that it can be restored later.
 //
 // runtime.cgocallbackg (below) is now running on a real goroutine
-// stack (not an m.g0 stack).  First it calls runtime.exitsyscall, which will
+// stack (not an m.g0 stack). First it calls runtime.exitsyscall, which will
 // block until the $GOMAXPROCS limit allows running this goroutine.
 // Once exitsyscall has returned, it is safe to do things like call the memory
-// allocator or invoke the Go callback function.  runtime.cgocallbackg
+// allocator or invoke the Go callback function. runtime.cgocallbackg
 // first defers a function to unwind m.g0.sched.sp, so that if p.GoF
 // panics, m.g0.sched.sp will be restored to its old value: the m.g0 stack
 // and the m.curg stack will be unwound in lock step.
@@ -393,7 +393,7 @@ func cgocallbackg1(fn, frame unsafe.Pointer, ctxt uintptr) {
 		// Now we need to set gp.cgoCtxt = s, but we could get
 		// a SIGPROF signal while manipulating the slice, and
 		// the SIGPROF handler could pick up gp.cgoCtxt while
-		// tracing up the stack.  We need to ensure that the
+		// tracing up the stack. We need to ensure that the
 		// handler always sees a valid slice, so set the
 		// values in an order such that it always does.
 		p := (*slice)(unsafe.Pointer(&gp.cgoCtxt))
@@ -594,9 +594,9 @@ func cgoCheckPointer(ptr any, arg any) {
 const cgoCheckPointerFail = "cgo argument has Go pointer to unpinned Go pointer"
 const cgoResultFail = "cgo result is unpinned Go pointer or points to unpinned Go pointer"
 
-// cgoCheckArg is the real work of cgoCheckPointer. The argument p
-// is either a pointer to the value (of type t), or the value itself,
-// depending on indir. The top parameter is whether we are at the top
+// cgoCheckArg is the real work of cgoCheckPointer and cgoCheckResult.
+// The argument p is either a pointer to the value (of type t), or the value
+// itself, depending on indir. The top parameter is whether we are at the top
 // level, where Go pointers are allowed. Go pointers to pinned objects are
 // allowed as long as they don't reference other unpinned pointers.
 func cgoCheckArg(t *_type, p unsafe.Pointer, indir, top bool, msg string) {


### PR DESCRIPTION
The description is misleading: cgoCheckArg is called by both
cgoCheckPointer and cgoCheckResult.

Mention cgoCheckResult in the cgoCheckArg description. Remove extra
spaces between words.

For #75856