### PR TITLE
runtime,runtime/pprof: clean up goroutine leak profile writing

### DIFF
--- a/src/runtime/mprof.go
+++ b/src/runtime/mprof.go
@@ -1364,7 +1364,7 @@ func goroutineLeakProfileWithLabelsConcurrent(p []profilerecord.StackRecord, lab
 		//	G1 completes profile  |/\/\/\/\/\/\/\/\/\/\/\/\/\/\/| G2 misses leaks
 		//
 		// While this is a bug, normal use cases presume that goroutine leak profile
-		// requests are issued on a single track. Adding synchronization between over
+		// requests are issued on a single track. Adding synchronization between
 		// goroutine leak profile requests would only needlessly increase overhead.
 		if readgstatus(gp1)&^_Gscan == _Gleaked {
 			systemstack(func() { saveg(^uintptr(0), ^uintptr(0), gp1, &p[offset], pcbuf) })

--- a/src/runtime/mprof.go
+++ b/src/runtime/mprof.go
@@ -1341,7 +1341,32 @@ func goroutineLeakProfileWithLabelsConcurrent(p []profilerecord.StackRecord, lab
 	// Visit each leaked goroutine and try to record its stack.
 	var offset int
 	forEachGRace(func(gp1 *g) {
-		if readgstatus(gp1) == _Gleaked {
+		// NOTE(vsaioc): Each goroutine leak profile request is preceded by a run of the GC
+		// in goroutine leak detection mode. At the beginning of the GC cycle, all previously
+		// reported goroutine leaks are reset to _Gwaiting. As a result, incomplete goroutine
+		// leak profiles may be produced if multiple goroutine leak profile requests are issued
+		// concurrently.
+		//
+		// Example trace:
+		//
+		//	G1                    | GC                          | G2
+		//	----------------------+-----------------------------+---------------------
+		//	Request profile       | .                           | .
+		//	.                     | .                           | Request profile
+		//	.                     | [G1] Resets leaked g status | .
+		//	.                     | [G1] Leaks detected         | .
+		//	.                     | <New cycle>                 | .
+		//	.                     | [G2] Resets leaked g status | .
+		//	.                     | .                           | Write profile
+		//	.                     | [G2] Leaks detected         | .
+		//	Write profile         | .                           | .
+		//	----------------------+-----------------------------+---------------------
+		//	G1 completes profile  |/\/\/\/\/\/\/\/\/\/\/\/\/\/\/| G2 misses leaks
+		//
+		// While this is a bug, normal use cases presume that goroutine leak profile
+		// requests are issued on a single track. Adding synchronization between over
+		// goroutine leak profile requests would only needlessly increase overhead.
+		if readgstatus(gp1)&^_Gscan == _Gleaked {
 			systemstack(func() { saveg(^uintptr(0), ^uintptr(0), gp1, &p[offset], pcbuf) })
 			if labels != nil {
 				labels[offset] = gp1.labels

--- a/src/runtime/mprof.go
+++ b/src/runtime/mprof.go
@@ -1323,10 +1323,6 @@ func goroutineLeakProfileWithLabelsConcurrent(p []profilerecord.StackRecord, lab
 		return work.goroutineLeak.count, false
 	}
 
-	// Unlike in goroutineProfileWithLabelsConcurrent, we don't need to
-	// save the current goroutine stack, because it is obviously not leaked.
-	// We also do not need acquire any semaphores on goroutineProfile, because
-	// we don't use it for storage.
 	pcbuf := makeProfStack() // see saveg() for explanation
 
 	// Prepare a profile large enough to store all leaked goroutines.

--- a/src/runtime/pprof/pprof.go
+++ b/src/runtime/pprof/pprof.go
@@ -230,11 +230,27 @@ var mutexProfile = &Profile{
 
 // goroutineLeakProfileLock ensures that the goroutine leak profile writer observes the
 // leaked goroutines discovered during the goroutine leak detection GC cycle
-// that was triggered when the profile was requested.
+// that was triggered by the profile request.
+// This prevents a race condition between the garbage collector and the profile writer
+// when multiple profile requests are issued concurrently: the status of leaked goroutines
+// is reset to _Gwaiting at the beginning of a leak detection cycle, which may lead the
+// profile writer of another concurrent request to produce an incomplete profile.
 //
-// This is needed to prevent a race condition between the garbage collector
-// and the goroutine leak profile writer when multiple profile requests are
-// issued concurrently.
+// Example trace:
+//
+//	G1                    | GC                          | G2
+//	----------------------+-----------------------------+---------------------
+//	Request profile       | .                           | .
+//	.                     | .                           | Request profile
+//	.                     | [G1] Resets leaked g status | .
+//	.                     | [G1] Leaks detected         | .
+//	.                     | <New cycle>                 | .
+//	.                     | [G2] Resets leaked g status | .
+//	Write profile         | .                           | .
+//	.                     | [G2] Leaks detected         | .
+//	.                     | .                           | Write profile
+//	----------------------+-----------------------------+---------------------
+//	Incomplete profile    |+++++++++++++++++++++++++++++| Complete profile
 var goroutineLeakProfileLock sync.Mutex
 
 func lockProfiles() {

--- a/src/runtime/pprof/pprof_test.go
+++ b/src/runtime/pprof/pprof_test.go
@@ -1727,16 +1727,8 @@ func TestGoroutineLeakProfileConcurrency(t *testing.T) {
 					for ctx.Err() == nil {
 						var w strings.Builder
 						goroutineLeakProf.WriteTo(&w, 1)
-						// NOTE(vsaioc): We cannot always guarantee that the leak will
-						// actually be recorded in the profile when making concurrent
-						// goroutine leak requests, because the GC runs concurrently with
-						// the profiler and may reset the leaked goroutines' status before
-						// a concurrent profiler has the chance to record them. However,
-						// the goroutine leak count will persist throughout.
-						//
-						// Other tests are not expected to leak goroutines,
-						// so the count should be consistent.
 						countLeaks(t, 2*leakCount, w.String())
+						includesLeak(t, "goroutineleak", w.String())
 					}
 				}()
 			})
@@ -1760,16 +1752,8 @@ func TestGoroutineLeakProfileConcurrency(t *testing.T) {
 					for ctx.Err() == nil {
 						var w strings.Builder
 						goroutineLeakProf.WriteTo(&w, 1)
-						// NOTE(vsaioc): We cannot always guarantee that the leak will
-						// actually be recorded in the profile when making concurrent
-						// goroutine leak requests, because the GC runs concurrently with
-						// the profiler and may reset the leaked goroutines' status before
-						// a concurrent profiler has the chance to record them. However,
-						// the goroutine leak count will persist throughout.
-						//
-						// Other tests are not expected to leak goroutines,
-						// so the count should be consistent.
 						countLeaks(t, 2*leakCount, w.String())
+						includesLeak(t, "goroutineleak", w.String())
 					}
 				}()
 				go func() {

--- a/src/runtime/pprof/pprof_test.go
+++ b/src/runtime/pprof/pprof_test.go
@@ -1584,7 +1584,7 @@ func TestGoroutineLeakProfileConcurrency(t *testing.T) {
 	// Regular goroutine profile. Used to check that there is no interference between
 	// the two profile types.
 	goroutineProf := Lookup("goroutine")
-	goroutineLeakProf := Lookup("goroutineleak")
+	goroutineLeakProf := goroutineLeakProfile
 
 	// Check that a profile with debug information contains
 	includesLeak := func(t *testing.T, name, s string) {


### PR DESCRIPTION
Cleaned up goroutine leak profile extraction:
- removed the acquisition of goroutineProfile semaphore
- inlined the call to saveg when recording stacks instead of using
doRecordGoroutineProfile, which had side-effects over
goroutineProfile fields.

Added regression tests for goroutine leak profiling frontend for binary
and debug=1 profile formats.
Added stress tests for concurrent goroutine and goroutine leak profile requests.
