### PR TITLE
runtime: avoid zeroing scavenged memory

### DIFF
--- a/src/runtime/arena.go
+++ b/src/runtime/arena.go
@@ -1051,7 +1051,11 @@ func (h *mheap) allocUserArenaChunk() *mspan {
 
 	// Model the user arena as a heap span for a large object.
 	spc := makeSpanClass(0, false)
-	h.initSpan(s, spanAllocHeap, spc, base, userArenaChunkPages)
+	// A user arena chunk is always fresh from the OS. It's either newly allocated
+	// via sysAlloc() or reused from the readyList after a sysFault(). The memory is
+	// then re-mapped via sysMap(), so we can safely treat it as scavenged; the
+	// kernel guarantees it will be zero-filled on its next use.
+	h.initSpan(s, spanAllocHeap, spc, base, userArenaChunkPages, userArenaChunkBytes)
 	s.isUserArenaChunk = true
 	s.elemsize -= userArenaChunkReserveBytes()
 	s.freeindex = 1

--- a/src/runtime/mem.go
+++ b/src/runtime/mem.go
@@ -70,6 +70,12 @@ func sysUnused(v unsafe.Pointer, n uintptr) {
 	sysUnusedOS(v, n)
 }
 
+// needZeroAfterSysUnused reports whether memory returned by sysUnused must be
+// zeroed for use.
+func needZeroAfterSysUnused() bool {
+	return needZeroAfterSysUnusedOS()
+}
+
 // sysUsed transitions a memory region from Prepared to Ready. It notifies the
 // operating system that the memory region is needed and ensures that the region
 // may be safely accessed. This is typically a no-op on systems that don't have

--- a/src/runtime/mem_aix.go
+++ b/src/runtime/mem_aix.go
@@ -79,3 +79,7 @@ func sysMapOS(v unsafe.Pointer, n uintptr, _ string) {
 		throw("runtime: cannot map pages in arena address space")
 	}
 }
+
+func needZeroAfterSysUnusedOS() bool {
+	return true
+}

--- a/src/runtime/mem_bsd.go
+++ b/src/runtime/mem_bsd.go
@@ -85,3 +85,7 @@ func sysMapOS(v unsafe.Pointer, n uintptr, _ string) {
 		throw("runtime: cannot map pages in arena address space")
 	}
 }
+
+func needZeroAfterSysUnusedOS() bool {
+	return true
+}

--- a/src/runtime/mem_darwin.go
+++ b/src/runtime/mem_darwin.go
@@ -74,3 +74,7 @@ func sysMapOS(v unsafe.Pointer, n uintptr, _ string) {
 		throw("runtime: cannot map pages in arena address space")
 	}
 }
+
+func needZeroAfterSysUnusedOS() bool {
+	return true
+}

--- a/src/runtime/mem_linux.go
+++ b/src/runtime/mem_linux.go
@@ -188,3 +188,7 @@ func sysMapOS(v unsafe.Pointer, n uintptr, vmaName string) {
 		sysNoHugePageOS(v, n)
 	}
 }
+
+func needZeroAfterSysUnusedOS() bool {
+	return debug.madvdontneed == 0
+}

--- a/src/runtime/mem_sbrk.go
+++ b/src/runtime/mem_sbrk.go
@@ -296,3 +296,7 @@ func sysReserveAlignedSbrk(size, align uintptr) (unsafe.Pointer, uintptr) {
 	})
 	return unsafe.Pointer(p), size
 }
+
+func needZeroAfterSysUnusedOS() bool {
+	return true
+}

--- a/src/runtime/mem_windows.go
+++ b/src/runtime/mem_windows.go
@@ -132,3 +132,7 @@ func sysReserveOS(v unsafe.Pointer, n uintptr, _ string) unsafe.Pointer {
 
 func sysMapOS(v unsafe.Pointer, n uintptr, _ string) {
 }
+
+func needZeroAfterSysUnusedOS() bool {
+	return true
+}


### PR DESCRIPTION
On Linux, memory returned to the kernel via MADV_DONTNEED is guaranteed
to be zero-filled on its next use.

This commit leverages this kernel behavior to avoid a redundant software
zeroing pass in the runtime, improving performance.