### PR TITLE
modcmd: silence unmatched warnings in empty modules

### DIFF
--- a/src/cmd/go/internal/modcmd/tidy.go
+++ b/src/cmd/go/internal/modcmd/tidy.go
@@ -142,6 +142,7 @@ func runTidy(ctx context.Context, cmd *base.Command, args []string) {
 		LoadTests:                true,
 		AllowErrors:              tidyE,
 		SilenceMissingStdImports: true,
+		SilenceUnmatchedWarnings: true,
 		Switcher:                 toolchain.NewSwitcher(moduleLoaderState),
 	}, "all")
 }


### PR DESCRIPTION
Previously, running the "go mod tidy" command in an empty module, i.e., one
containing a go.mod file but no .go files, caused a warning: "all" matched
no packages. This is not a valid warning.

This change ensures that "go mod tidy" completes silently when run in an
empty module.

Fixes #76076