### PR TITLE
doc/next: added release notes for goroutine leak profiles

### DIFF
--- a/doc/next/4-runtime.md
+++ b/doc/next/4-runtime.md
@@ -85,6 +85,6 @@ Special thanks to Vlad Saioc at Uber for contributing this work.
 The underlying theory is presented in detail by Saioc et al. in [this publication](https://dl.acm.org/doi/pdf/10.1145/3676641.3715990).
 
 <!-- More details about the implementation are presented in the [design document](https://github.com/golang/proposal/blob/master/design/74609-goroutine-leak-detection-gc.md). -->
-We encourage users to try out the new feature with examples derived from known patterns in [the Go playground](https://go.dev/play/p/aZc-HJiSH-R?v=gotip),
+We encourage users to try out the new feature with examples derived from known patterns in [the Go playground](https://go.dev/play/p/3C71z4Dpav-?v=gotip),
 as well as experiment with different environments (tests, CI, production).
 We welcome feedback on the [proposal issue](https://github.com/golang/go/issues/74609).

--- a/doc/next/4-runtime.md
+++ b/doc/next/4-runtime.md
@@ -68,17 +68,11 @@ func processWorkItems(ws []workItem) ([]workResult, error) {
 ```
 Because `ch` is unbuffered, if `processWorkItems` returns early due to
 an error, all remaining `processWorkItem` goroutines will leak.
-However, `ch` also becomes inaccessible to all other goroutines
+However, `ch` also becomes unreachable to all other goroutines
 not involved in the leak soon after the leak itself occurs.
-
-In general, a goroutine is leaked if it is blocked on an operation
-over concurrency primitives (e.g., channels,
-[sync.Mutex]) that are only reachable via leaked goroutines.
-In the example above, the culprit send operation involves
-a channel only reachable to `processWorkItem` goroutines.
-The runtime is now equipped to detect such leaks via goroutine
-leak profiles. All leaks reported by profiles are real, i.e.,
-there are no false positives.
+In general, the runtime is now equipped to identify as leaked
+any goroutines blocked on operations over concurrency primitives
+(e.g., channels, [sync.Mutex]) that are not reachable from runnable goroutines.
 
 Note, however, that the runtime may fail to identify leaks caused by
 blocking on operations over concurrency primitives reachable

--- a/doc/next/4-runtime.md
+++ b/doc/next/4-runtime.md
@@ -74,7 +74,7 @@ not involved in the leak soon after the leak itself occurs.
 In general, a goroutine is leaked if it is blocked on an operation
 over concurrency primitives (e.g., channels,
 [sync.Mutex]) that are only reachable via leaked goroutines.
-In the example above, the culprit channel send operation involves
+In the example above, the culprit send operation involves
 a channel only reachable to `processWorkItem` goroutines.
 The runtime is now equipped to detect such leaks via goroutine
 leak profiles. All leaks reported by profiles are real, i.e.,

--- a/doc/next/4-runtime.md
+++ b/doc/next/4-runtime.md
@@ -85,5 +85,6 @@ Special thanks to Vlad Saioc at Uber for contributing this work.
 The underlying theory is presented in detail by Saioc et al. in [this publication](https://dl.acm.org/doi/pdf/10.1145/3676641.3715990).
 
 <!-- More details about the implementation are presented in the [design document](https://github.com/golang/proposal/blob/master/design/74609-goroutine-leak-detection-gc.md). -->
-We encourage users to experiment with the new feature in different environments
-(tests, CI, production), and welcome feedback on the [proposal issue](https://github.com/golang/go/issues/74609).
+We encourage users to try out the new feature with examples derived from known patterns in [the Go playground](https://go.dev/play/p/aZc-HJiSH-R?v=gotip),
+as well as experiment with different environments (tests, CI, production).
+We welcome feedback on the [proposal issue](https://github.com/golang/go/issues/74609).

--- a/doc/next/4-runtime.md
+++ b/doc/next/4-runtime.md
@@ -26,3 +26,64 @@ performance or behavior, please [file an issue](/issue/new).
 <!-- CL 646198 -->
 
 The baseline runtime overhead of cgo calls has been reduced by ~30%.
+
+### Goroutine leak profiles {#goroutineleak-profiles}
+
+We introduce a new profile type for goroutine leaks. With the experimental flag set to `GOEXPERIMENT=goroutineleakprofile`, it becomes accessible through `pprof` under the name `"goroutineleak"`.
+
+The following snippet showcases a common anti-pattern that leads to goroutine leaks:
+```go
+// AggregateResults concurrently processes each request and aggregates the results.
+// If one of the requests returns an error, the function returns immediately with the error.
+func (s *Server[T, R]) AggregateResults(reqs []T) ([]R, error) {
+	ch := make(chan wrap[R])
+	for _, req := range reqs {
+		go func(req T) {
+      res, err := s.processRequest(req)
+      ch <- wrap[R]{
+        res: res,
+        err: err,
+      }
+		}(req)
+	}
+
+	var results []R
+	for range len(reqs) {
+		x := <-ch
+		if x.err != nil {
+			return nil, x.err
+		}
+		results = append(results, x.res)
+	}
+	return results, nil
+}
+```
+Channel `ch` is used to synchronize when concurrently processing each request in the slice `reqs`.
+The responses are aggregated in a slice if all requests succeed.
+Conversely, if any request produces an error, `AggregateResults` is shortcircuited to
+return the error.
+However, because `ch` is unbuffered, all pending request goroutines beyond the first to produce
+the error will leak.
+
+The key insight is that `ch` is inaccessible outside the scope of `AggregateResults`.
+The Go runtime is now equipped to detect such patterns as they occur at execution time,
+and record them in the goroutine leak profile.
+For the case above, the goroutine leak profile would appear as:
+```
+Samples:
+goroutineleak/count
+          6: 1 2 3 4
+Locations
+     1: 0x104235daf M=1 runtime.gopark src/runtime/proc.go:464:0 s=447
+     2: 0x1041c1ce7 M=1 runtime.chansend src/runtime/chan.go:283:0 s=176
+     3: 0x1041c18f7 M=1 runtime.chansend1 src/runtime/chan.go:161:0 s=160
+     4: 0x10428dd6b M=1 app.(*Server[go.shape.int,go.shape.int]).AggregateResults.func1 app/server.go:37:0 s=35
+```
+The leaked goroutines' stack precisely pinpoints the leaking operation in the source code.
+
+The main advantage of goroutine leak profiles is that they have **no false positives**, but, for theoretical reasons, they may nevertheless
+miss some goroutine leaks, e.g., when caused by global channels.
+The underlying theory is presented in detail in [this publication by Saioc et al.](https://dl.acm.org/doi/pdf/10.1145/3676641.3715990).
+
+More details about the implementation are presented in the [design document](https://github.com/golang/proposal/blob/master/design/74609-goroutine-leak-detection-gc.md).
+We encourage users to experiment with the new feature in different environments (tests, CI, production), and welcome feedback on the [proposal issue](https://github.com/golang/go/issues/74609).

--- a/doc/next/4-runtime.md
+++ b/doc/next/4-runtime.md
@@ -29,12 +29,14 @@ The baseline runtime overhead of cgo calls has been reduced by ~30%.
 
 ### Goroutine leak profiles {#goroutineleak-profiles}
 
-We introduce a new profile type for goroutine leaks. With the experimental
-flag set to `GOEXPERIMENT=goroutineleakprofile`, it becomes accessible
-through `pprof` under the name `"goroutineleak"`.
+A new profile type that reports leaked goroutines is now available as an
+experiment. The new profile type, named `goroutineleak` in the [runtime/pprof]
+package, may be enabled by setting `GOEXPERIMENT=goroutineleakprofile`
+at build time. Enabling the experiment also makes the profile available
+as a [net/http/pprof] endpoint, `debug/pprof/goroutineleak`.
 
-The following snippet showcases a common, but erroneous pattern
-that leads to goroutine leaks:
+The following example showcases a real-world goroutine leak that
+can be revealed by the new profile:
 ```go
 type result struct{
 		res workResult
@@ -64,27 +66,27 @@ func processWorkItems(ws []workItem) ([]workResult, error) {
 	return results, nil
 }
 ```
-Because `ch` is unbuffered, if `processWorkItems` returns early due to an error,
-all remaining work item goroutines will leak.
-However, also note that, soon after the leak occurs, `ch` is inaccessible
-to any other goroutine, except those involved in the leak.
+Because `ch` is unbuffered, if `processWorkItems` returns early due to
+an error, all remaining `processWorkItem` goroutines will leak.
+However, `ch` also becomes inaccessible to all other goroutines
+not involved in the leak soon after the leak itself occurs.
 
-To generalize, a goroutine is leaked if it is blocked by concurrency
-primitives (specifically channels, and `sync` primitives such as mutex) that
-are only referenced by the blocked goroutine itself, or other leaked goroutines.
-The Go runtime is now equipped to reveal leaked goroutines by recording their stacks in
-goroutine leak profiles.
-In the example above, the stacks of work item goroutines point to the culprit channel send
-operation.
+In general, a goroutine is leaked if it is blocked on an operation
+over concurrency primitives (e.g., channels,
+[sync.Mutex]) that are only reachable via leaked goroutines.
+In the example above, the culprit channel send operation involves
+a channel only reachable to `processWorkItem` goroutines.
+The runtime is now equipped to detect such leaks via goroutine
+leak profiles. All leaks reported by profiles are real, i.e.,
+there are no false positives.
 
-Note that, while goroutine leak profiles only include true positives, goroutine leaks may be
-missed when caused by concurrency primitives that are accessible globally, or referenced
-by runnable goroutines.
+Note, however, that the runtime may fail to identify leaks caused by
+blocking on operations over concurrency primitives reachable
+through global variables or the local variables of runnable goroutines.
 
 Special thanks to Vlad Saioc at Uber for contributing this work.
 The underlying theory is presented in detail by Saioc et al. in [this publication](https://dl.acm.org/doi/pdf/10.1145/3676641.3715990).
 
-<!-- More details about the implementation are presented in the [design document](https://github.com/golang/proposal/blob/master/design/74609-goroutine-leak-detection-gc.md). -->
 We encourage users to try out the new feature with examples derived from known patterns in [the Go playground](https://go.dev/play/p/3C71z4Dpav-?v=gotip),
 as well as experiment with different environments (tests, CI, production).
 We welcome feedback on the [proposal issue](https://github.com/golang/go/issues/74609).


### PR DESCRIPTION
Described goroutine leak profiles in the
release notes, under the runtime section.