### PR TITLE
runtime: refactor goroutine profilerecord types

### DIFF
--- a/src/internal/profilerecord/profilerecord.go
+++ b/src/internal/profilerecord/profilerecord.go
@@ -8,9 +8,15 @@
 // TODO: Consider moving this to internal/runtime, see golang.org/issue/65355.
 package profilerecord
 
+import "unsafe"
+
 type StackRecord struct {
 	Stack []uintptr
 }
+
+func (r StackRecord) GetStack() []uintptr           { return r.Stack }
+func (r StackRecord) GetLabels() unsafe.Pointer     { return nil }
+func (r StackRecord) GetGoroutine() GoroutineRecord { return GoroutineRecord{} }
 
 type MemProfileRecord struct {
 	AllocBytes, FreeBytes     int64
@@ -26,3 +32,12 @@ type BlockProfileRecord struct {
 	Cycles int64
 	Stack  []uintptr
 }
+
+type GoroutineRecord struct {
+	Labels unsafe.Pointer
+	Stack  []uintptr
+}
+
+func (r GoroutineRecord) GetStack() []uintptr           { return r.Stack }
+func (r GoroutineRecord) GetLabels() unsafe.Pointer     { return r.Labels }
+func (r GoroutineRecord) GetGoroutine() GoroutineRecord { return r }

--- a/src/runtime/pprof/pprof_test.go
+++ b/src/runtime/pprof/pprof_test.go
@@ -1571,7 +1571,7 @@ func TestGoroutineProfileConcurrency(t *testing.T) {
 	goroutineProf := Lookup("goroutine")
 
 	profilerCalls := func(s string) int {
-		return strings.Count(s, "\truntime/pprof.runtime_goroutineProfileWithLabels+")
+		return strings.Count(s, "\truntime/pprof.runtime_goroutineProfile+")
 	}
 
 	includesFinalizerOrCleanup := func(s string) bool {


### PR DESCRIPTION
Previously, goroutine profiles were collected into two adjacent slices
each of length n, with the i'th index of the first holding the captured
stack of the i'th goroutine and the i'th index of the second holding its
captured labels.

This changes the representation used during collection to be a single
slice of length n, with the stack and labels of the i'th goroutine now
residing in two fields of each struct in that slice.

Switching from multiple slices each of a single attribute each to one
slice of multiple attributes avoids allocating multiple slices, as well
as needing to pass them both around, side-by-side, in all goroutine
profile collection code. While maintaining and passing two slices was
workable -- if perhaps slightly cumbersome -- passing side-by-side around
would quickly become unwieldy if or when any additional attributes such
as wait reasons or wait times are collected during goroutine profiling,
for example as proposed in #74954.

Regardless of the user-facing shape that any such extension to goroutine
profiling may end up taking, this updated internal representation should
be substantially easier to extend and maintain than side-by-side slices.

This is a pure refactor of this internal representation; it should have
no user-facing behavior change.

While in the area: concurrent goroutine collection has been the only
mechanism used for some time now, so the disused legacy implementation
goroutineProfileWithLabelsSync is removed and the single remaining
implementation is renamed to drop its 'concurrent' qualifier.

Updates #74954.
    
Change-Id: I3fd14834b2f3aae73317d3fad3294d539302713f