### PR TITLE
io: add Err field to LimitedReader

### DIFF
--- a/api/next/51115.txt
+++ b/api/next/51115.txt
@@ -1,0 +1,1 @@
+pkg io, type LimitedReader struct, Err error #51115

--- a/doc/next/6-stdlib/99-minor/io/51115.md
+++ b/doc/next/6-stdlib/99-minor/io/51115.md
@@ -1,0 +1,4 @@
+<!-- go.dev/issue/51115 -->
+The new [LimitedReader.Err] field allows returning a custom error
+when the read limit is exceeded. When nil (the default), [LimitedReader.Read]
+returns [EOF] when the limit is reached, maintaining backward compatibility.

--- a/src/io/example_test.go
+++ b/src/io/example_test.go
@@ -5,6 +5,7 @@
 package io_test
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -119,6 +120,29 @@ func ExampleLimitReader() {
 
 	// Output:
 	// some
+}
+
+func ExampleLimitedReader_Err() {
+	r := strings.NewReader("some io.Reader stream to be read\n")
+	sentinel := errors.New("read limit reached")
+	lr := &io.LimitedReader{R: r, N: 4, Err: sentinel}
+
+	buf := make([]byte, 10)
+	n, err := lr.Read(buf)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("read %d bytes: %q\n", n, buf[:n])
+
+	// try to read more and get the custom error
+	n, err = lr.Read(buf)
+	if errors.Is(err, sentinel) {
+		fmt.Println("error:", err)
+	}
+
+	// Output:
+	// read 4 bytes: "some"
+	// error: read limit reached
 }
 
 func ExampleMultiReader() {

--- a/src/io/example_test.go
+++ b/src/io/example_test.go
@@ -132,17 +132,15 @@ func ExampleLimitedReader_Err() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("read %d bytes: %q\n", n, buf[:n])
+	fmt.Printf("%d; %q\n", n, buf[:n])
 
 	// try to read more and get the custom error
 	n, err = lr.Read(buf)
-	if errors.Is(err, sentinel) {
-		fmt.Println("error:", err)
-	}
+	fmt.Printf("%d; error: %v\n", n, err)
 
 	// Output:
-	// read 4 bytes: "some"
-	// error: read limit reached
+	// 4; "some"
+	// 0; error: read limit reached
 }
 
 func ExampleMultiReader() {

--- a/src/io/io.go
+++ b/src/io/io.go
@@ -556,10 +556,8 @@ func (s *SectionReader) Read(p []byte) (n int, err error) {
 	return
 }
 
-var (
-	errWhence = errors.New("Seek: invalid whence")
-	errOffset = errors.New("Seek: invalid offset")
-)
+var errWhence = errors.New("Seek: invalid whence")
+var errOffset = errors.New("Seek: invalid offset")
 
 func (s *SectionReader) Seek(offset int64, whence int) (int64, error) {
 	switch whence {

--- a/src/io/io_test.go
+++ b/src/io/io_test.go
@@ -780,7 +780,7 @@ func TestLimitedReader(t *testing.T) {
 
 		n, err := lr.Read(buf)
 		if n != 5 || err != nil || string(buf[:5]) != "hello" {
-			t.Errorf("Read() = (%d, %v, %q), want (5, nil, \"hello\")", n, err, buf[:5])
+			t.Errorf(`Read() = (%d, %v, %q), want (5, nil, "hello")`, n, err, buf[:5])
 		}
 
 		n, err = lr.Read(buf)
@@ -826,7 +826,7 @@ func TestLimitedReader(t *testing.T) {
 		buf = make([]byte, 10)
 		n, err := lr.Read(buf)
 		if n != 5 || string(buf[:5]) != "hello" || err != nil {
-			t.Errorf("normal Read() = (%d, %q, %v), want (5, \"hello\", nil)", n, buf[:5], err)
+			t.Errorf(`normal Read() = (%d, %q, %v), want (5, "hello", nil)`, n, buf[:5], err)
 		}
 	})
 }
@@ -854,7 +854,7 @@ func TestLimitedReaderErrors(t *testing.T) {
 
 		n, err := lr.Read(buf)
 		if n != 5 || string(buf[:5]) != "hello" || err != nil {
-			t.Errorf("first Read() = (%d, %q, %v), want (5, \"hello\", nil)", n, buf[:5], err)
+			t.Errorf(`first Read() = (%d, %q, %v), want (5, "hello", nil)`, n, buf[:5], err)
 		}
 
 		n, err = lr.Read(buf)
@@ -870,7 +870,7 @@ func TestLimitedReaderErrors(t *testing.T) {
 
 		n, err := lr.Read(buf)
 		if n != 5 || string(buf[:5]) != "hello" || err != nil {
-			t.Errorf("first Read() = (%d, %q, %v), want (5, \"hello\", nil)", n, buf[:5], err)
+			t.Errorf(`first Read() = (%d, %q, %v), want (5, "hello", nil)`, n, buf[:5], err)
 		}
 
 		n, err = lr.Read(buf)


### PR DESCRIPTION
Add an Err field to LimitedReader that allows callers to return a
custom error when the read limit is exceeded, instead of always
returning EOF.

When Err is set to a non-nil, and the limit is reached, 
LimitedReader.Read probes the underlying reader with a 1-byte
read to distinguish two cases: stream had exactly N bytes
(returns EOF), or stream has more data. The probe result is cached
using negative N values to avoid repeated reads.

When Err is nil, Read returns EOF, maintaining backward compatibility.
Zero-length reads return (0, nil) without side effects when we
reached end of Reader.

Fixes #51115