### PR TITLE
bytes: fix panic in bytes.Buffer.Peek

### DIFF
--- a/src/bytes/buffer.go
+++ b/src/bytes/buffer.go
@@ -86,7 +86,7 @@ func (b *Buffer) Peek(n int) ([]byte, error) {
 	if b.Len() < n {
 		return b.buf[b.off:], io.EOF
 	}
-	return b.buf[b.off:n], nil
+	return b.buf[b.off : b.off+n], nil
 }
 
 // empty reports whether the unread portion of the buffer is empty.

--- a/src/bytes/buffer_test.go
+++ b/src/bytes/buffer_test.go
@@ -545,6 +545,7 @@ var peekTests = []struct {
 	{"helloworld", 4, 3, "owo", nil},
 	{"helloworld", 5, 5, "world", nil},
 	{"helloworld", 5, 6, "world", io.EOF},
+	{"helloworld", 10, 1, "", io.EOF},
 }
 
 func TestPeek(t *testing.T) {

--- a/src/bytes/buffer_test.go
+++ b/src/bytes/buffer_test.go
@@ -533,19 +533,24 @@ func TestReadString(t *testing.T) {
 
 var peekTests = []struct {
 	buffer   string
+	skip     int
 	n        int
 	expected string
 	err      error
 }{
-	{"", 0, "", nil},
-	{"aaa", 3, "aaa", nil},
-	{"foobar", 2, "fo", nil},
-	{"a", 2, "a", io.EOF},
+	{"", 0, 0, "", nil},
+	{"aaa", 0, 3, "aaa", nil},
+	{"foobar", 0, 2, "fo", nil},
+	{"a", 0, 2, "a", io.EOF},
+	{"helloworld", 4, 3, "owo", nil},
+	{"helloworld", 5, 5, "world", nil},
+	{"helloworld", 5, 6, "world", io.EOF},
 }
 
 func TestPeek(t *testing.T) {
 	for _, test := range peekTests {
 		buf := NewBufferString(test.buffer)
+		buf.Next(test.skip)
 		bytes, err := buf.Peek(test.n)
 		if string(bytes) != test.expected {
 			t.Errorf("expected %q, got %q", test.expected, bytes)
@@ -553,8 +558,8 @@ func TestPeek(t *testing.T) {
 		if err != test.err {
 			t.Errorf("expected error %v, got %v", test.err, err)
 		}
-		if buf.Len() != len(test.buffer) {
-			t.Errorf("bad length after peek: %d, want %d", buf.Len(), len(test.buffer))
+		if buf.Len() != len(test.buffer)-test.skip {
+			t.Errorf("bad length after peek: %d, want %d", buf.Len(), len(test.buffer)-test.skip)
 		}
 	}
 }


### PR DESCRIPTION
This change fixed the overlooked offset in bytes.Buffer.Peek.
Otherwise, it will either return wrong result or panic with
"runtime error: slice bounds out of range".