### PR TITLE
sync: don't call Done when f() panics in WaitGroup.Go

### DIFF
--- a/src/sync/waitgroup_test.go
+++ b/src/sync/waitgroup_test.go
@@ -128,9 +128,7 @@ func TestIssue76126(t *testing.T) {
 		cmd.Stderr = buf
 		cmd.Run() // ignore error
 		got := buf.String()
-		if strings.Contains(got, "panic: test") {
-			// ok
-		} else {
+		if !strings.Contains(got, "panic: test") {
 			t.Errorf("missing panic: test\n%s", got)
 		}
 		return

--- a/src/sync/waitgroup_test.go
+++ b/src/sync/waitgroup_test.go
@@ -5,6 +5,12 @@
 package sync_test
 
 import (
+	"bytes"
+	"internal/testenv"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
 	. "sync"
 	"sync/atomic"
 	"testing"
@@ -108,6 +114,38 @@ func TestWaitGroupGo(t *testing.T) {
 	if i != 1 {
 		t.Fatalf("got %d, want 1", i)
 	}
+}
+
+// This test ensures that an unhandled panic in a Go goroutine terminates
+// the process without causing Wait to unblock; previously there was a race.
+func TestIssue76126(t *testing.T) {
+	testenv.MustHaveExec(t)
+	// Call child in a child process
+	// and inspect its failure message.
+	cmd := exec.Command(os.Args[0], "-test.run=^TestIssue76126Child$")
+	cmd.Env = append(os.Environ(), "SYNC_TEST_CHILD=1")
+	buf := new(bytes.Buffer)
+	cmd.Stderr = buf
+	cmd.Run() // ignore error
+
+	got := buf.String()
+	if strings.Contains(got, "panic: test") {
+		// ok
+	} else {
+		t.Errorf("missing panic: test\n%s", got)
+	}
+}
+
+func TestIssue76126Child(t *testing.T) {
+	if os.Getenv("SYNC_TEST_CHILD") != "1" {
+		t.Skip("not child")
+	}
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		panic("test")
+	})
+	wg.Wait()              // process should terminate here
+	panic("Wait returned") // must not be reached
 }
 
 func BenchmarkWaitGroupUncontended(b *testing.B) {


### PR DESCRIPTION
This change is based on
https://github.com/golang/go/issues/76126#issuecomment-3473417226
by adonovan.

Fixes #76126
Fixes #74702