### PR TITLE
cmd/cgo: skip escape checks if call site has no argument

### DIFF
--- a/src/cmd/cgo/out.go
+++ b/src/cmd/cgo/out.go
@@ -649,13 +649,15 @@ func (p *Package) writeDefsFunc(fgo2 io.Writer, n *Name, callsMalloc *bool) {
 	if p.noEscapes[n.C] && p.noCallbacks[n.C] {
 		touchFunc = "_Cgo_keepalive"
 	}
-	fmt.Fprintf(fgo2, "\tif _Cgo_always_false {\n")
-	if d.Type.Params != nil {
+
+	if len(paramnames) > 0 {
+		fmt.Fprintf(fgo2, "\tif _Cgo_always_false {\n")
 		for _, name := range paramnames {
 			fmt.Fprintf(fgo2, "\t\t%s(%s)\n", touchFunc, name)
 		}
+		fmt.Fprintf(fgo2, "\t}\n")
 	}
-	fmt.Fprintf(fgo2, "\t}\n")
+
 	fmt.Fprintf(fgo2, "\treturn\n")
 	fmt.Fprintf(fgo2, "}\n")
 }


### PR DESCRIPTION
This CL improves on CL 579955.

When the call site has no argument,

     1  package main
     2
     3  /*
     4     #include <stdio.h>
     5     void foo() {printf("Hello from C\n");}
     6  */
     7  import "C"
     8
     9  func main() {
    10          C.foo()
    11  }

Escape checks are not needed,

    $ go tool cgo -objdir dir cgonoargs.go
    $ cat -n dir/_cgo_gotypes.go | sed -n '43,$p'
        43  func _Cfunc_foo() (r1 _Ctype_void) {
        44          _cgo_runtime_cgocall(_cgo_c8ba2f813f11_Cfunc_foo, uintptr(unsafe.Pointer(&r1)))
        45          if _Cgo_always_false {
        46          }
        47          return
        48  }

Skip escape checks if call site has no argument.

    $ cat -n dir/_cgo_gotypes.go | sed -n '43,$p'
        43  func _Cfunc_foo() (r1 _Ctype_void) {
        44          _cgo_runtime_cgocall(_cgo_c8ba2f813f11_Cfunc_foo, uintptr(unsafe.Pointer(&r1)))
        45          return
        46  }

For #75856