### PR TITLE
internal/importpath: extract shared import path validation logic

### DIFF
--- a/src/cmd/go/internal/modindex/build_read.go
+++ b/src/cmd/go/internal/modindex/build_read.go
@@ -17,10 +17,10 @@ import (
 	"go/parser"
 	"go/scanner"
 	"go/token"
+	"internal/importpath"
 	"io"
 	"strconv"
 	"strings"
-	"unicode"
 	"unicode/utf8"
 )
 
@@ -325,7 +325,7 @@ func readGoInfo(f io.Reader, info *fileInfo) error {
 			if err != nil {
 				return fmt.Errorf("parser returned invalid quoted string: <%s>", quoted)
 			}
-			if !isValidImport(path) {
+			if !(importpath.IsValidImport(path)) {
 				// The parser used to return a parse error for invalid import paths, but
 				// no longer does, so check for and create the error here instead.
 				info.parseErr = scanner.Error{Pos: info.fset.Position(spec.Pos()), Msg: "invalid import path: " + path}
@@ -387,20 +387,6 @@ func readGoInfo(f io.Reader, info *fileInfo) error {
 	}
 
 	return nil
-}
-
-// isValidImport checks if the import is a valid import using the more strict
-// checks allowed by the implementation restriction in https://go.dev/ref/spec#Import_declarations.
-// It was ported from the function of the same name that was removed from the
-// parser in CL 424855, when the parser stopped doing these checks.
-func isValidImport(s string) bool {
-	const illegalChars = `!"#$%&'()*,:;<=>?[\]^{|}` + "`\uFFFD"
-	for _, r := range s {
-		if !unicode.IsGraphic(r) || unicode.IsSpace(r) || strings.ContainsRune(illegalChars, r) {
-			return false
-		}
-	}
-	return s != ""
 }
 
 // parseGoEmbed parses a "//go:embed" to extract the glob patterns.

--- a/src/internal/importpath/importpath.go
+++ b/src/internal/importpath/importpath.go
@@ -1,0 +1,28 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package importpath
+
+import (
+	"strings"
+	"unicode"
+)
+
+const illegalChars = `!"#$%&'()*,:;<=>?[\]^{|}` + "`\uFFFD"
+
+func isValidImportPathChar(r rune) bool {
+	return unicode.IsGraphic(r) && !unicode.IsSpace(r) && !strings.ContainsRune(illegalChars, r)
+}
+
+// IsValidImport checks if the import is a valid import using the more strict
+// checks allowed by the implementation restriction in https://go.dev/ref/spec#Import_declarations.
+// This logic was previously duplicated across several packages.
+func IsValidImport(s string) bool {
+	for _, r := range s {
+		if !isValidImportPathChar(r) {
+			return false
+		}
+	}
+	return s != ""
+}

--- a/src/internal/importpath/importpath_test.go
+++ b/src/internal/importpath/importpath_test.go
@@ -1,0 +1,36 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package importpath
+
+import (
+	"testing"
+)
+
+func TestImportPath(t *testing.T) {
+	tests := []string{
+		"net",
+		"net/http",
+		"a/b/c",
+	}
+	for _, tc := range tests {
+		if !IsValidImport(tc) {
+			t.Errorf("expected %q to be valid import path", tc)
+		}
+	}
+}
+
+func TestImportPathInvalid(t *testing.T) {
+	tests := []string{
+		"",
+		"foo bar",
+		"\uFFFD",
+		"hello!",
+	}
+	for _, tc := range tests {
+		if IsValidImport(tc) {
+			t.Errorf("expected %q to be invalid import path", tc)
+		}
+	}
+}


### PR DESCRIPTION
Extracts duplicated import path validation logic to new package

I created a new package: internal/importpath.

I've only refactored one call site so reviewers can validate my approach
and package placement before I proceed with the remaining sites.
I've placed it under internal/ but that doesn't seem correct.
The code is failing the TestDependencies test.

The remaining call sites are: go/build/read.go, go/printer/nodes.go, 
go/types/resolver.go, cmd/go/internal/load/pkg.go, 
cmd/compile/internal/types2/resolver.go.

Updates #74446