### PR TITLE
runtime/cgo: add support for `any` param and return type

### DIFF
--- a/src/cmd/cgo/gcc.go
+++ b/src/cmd/cgo/gcc.go
@@ -1121,6 +1121,9 @@ func (p *Package) hasPointer(f *File, t ast.Expr, top bool) bool {
 		if t.Name == "error" {
 			return true
 		}
+		if t.Name == "any" {
+			return true
+		}
 		if goTypes[t.Name] != nil {
 			return false
 		}

--- a/src/cmd/cgo/internal/test/cgo_test.go
+++ b/src/cmd/cgo/internal/test/cgo_test.go
@@ -106,6 +106,7 @@ func TestSetEnv(t *testing.T)                { testSetEnv(t) }
 func TestThreadLock(t *testing.T)            { testThreadLockFunc(t) }
 func TestUnsignedInt(t *testing.T)           { testUnsignedInt(t) }
 func TestZeroArgCallback(t *testing.T)       { testZeroArgCallback(t) }
+func Test76340(t *testing.T)                 { test76340(t) }
 
 func BenchmarkCgoCall(b *testing.B)      { benchCgoCall(b) }
 func BenchmarkGoString(b *testing.B)     { benchGoString(b) }

--- a/src/cmd/cgo/internal/test/test.go
+++ b/src/cmd/cgo/internal/test/test.go
@@ -959,6 +959,18 @@ char * const issue75751p = &issue75751v;
 #define issue75751m issue75751p
 char * const volatile issue75751p2 = &issue75751v;
 #define issue75751m2 issue75751p2
+
+typedef struct { void *t; void *v; } GoInterface;
+extern int exportAny76340Param(GoInterface);
+extern GoInterface exportAny76340Return(int);
+
+int issue76340testFromC(GoInterface obj) {
+	return exportAny76340Param(obj);
+}
+
+GoInterface issue76340returnFromC(int val) {
+	return exportAny76340Return(val);
+}
 */
 import "C"
 
@@ -2406,4 +2418,23 @@ func test69086(t *testing.T) {
 // Issue 75751: no runtime test, just make sure it compiles.
 func test75751() int {
 	return int(*C.issue75751m) + int(*C.issue75751m2)
+}
+
+// Issue 76340.
+func test76340(t *testing.T) {
+	var emptyInterface C.GoInterface
+	r1 := C.issue76340testFromC(emptyInterface)
+	if r1 != 0 {
+		t.Errorf("issue76340testFromC with nil interface: got %d, want 0", r1)
+	}
+
+	r2 := C.issue76340returnFromC(42)
+	if r2.t == nil && r2.v == nil {
+		t.Error("issue76340returnFromC(42) returned nil interface")
+	}
+
+	r3 := C.issue76340returnFromC(0)
+	if r3.t != nil || r3.v != nil {
+		t.Errorf("issue76340returnFromC(0) returned non-nil interface: got %v, want nil", r3)
+	}
 }

--- a/src/cmd/cgo/internal/test/testx.go
+++ b/src/cmd/cgo/internal/test/testx.go
@@ -595,3 +595,21 @@ func test49633(t *testing.T) {
 		t.Errorf("msg = %q, want 'hello'", v.msg)
 	}
 }
+
+//export exportAny76340Param
+func exportAny76340Param(obj any) C.int {
+	if obj == nil {
+		return 0
+	}
+
+	return 1
+}
+
+//export exportAny76340Return
+func exportAny76340Return(val C.int) any {
+	if val == 0 {
+		return nil
+	}
+
+	return int(val)
+}

--- a/src/cmd/cgo/out.go
+++ b/src/cmd/cgo/out.go
@@ -1558,6 +1558,9 @@ func (p *Package) doCgoType(e ast.Expr, m map[ast.Expr]bool) *Type {
 		if t.Name == "error" {
 			return &Type{Size: 2 * p.PtrSize, Align: p.PtrSize, C: c("GoInterface")}
 		}
+		if t.Name == "any" {
+			return &Type{Size: 2 * p.PtrSize, Align: p.PtrSize, C: c("GoInterface")}
+		}
 		if r, ok := goTypes[t.Name]; ok {
 			return goTypesFixup(r)
 		}

--- a/src/runtime/cgocall.go
+++ b/src/runtime/cgocall.go
@@ -796,6 +796,9 @@ func cgoCheckResult(val any) {
 
 	ep := efaceOf(&val)
 	t := ep._type
+	if t == nil {
+		return
+	}
 	cgoCheckArg(t, ep.data, !t.IsDirectIface(), false, cgoResultFail)
 }
 


### PR DESCRIPTION
When using `any` as param or return type of an exported
function, we currently have the error `unrecognized Go
type any`. `any` is an alias of `interface{}` which is
already supported.

This would avoid such change: https://github.com/php/frankenphp/pull/1976

Fixes #76340