### PR TITLE
debug/elf: document errors returned by Open

### DIFF
--- a/src/debug/elf/file.go
+++ b/src/debug/elf/file.go
@@ -230,6 +230,7 @@ type Symbol struct {
  * ELF reader
  */
 
+// FormatError is returned if the data does not have the correct format for an ELF.
 type FormatError struct {
 	off int64
 	msg string

--- a/src/debug/elf/file.go
+++ b/src/debug/elf/file.go
@@ -247,6 +247,9 @@ func (e *FormatError) Error() string {
 }
 
 // Open opens the named file using [os.Open] and prepares it for use as an ELF binary.
+//
+// Will return [*FormatError] if the file does not have the correct format for an ELF or
+// [*os.PathError] if an error is encountered opening or reading the file.
 func Open(name string) (*File, error) {
 	f, err := os.Open(name)
 	if err != nil {


### PR DESCRIPTION
Add documentation for FormatError analog to debug/machos and extend
documentation of Open to detail errors returned.

Updates #76338.