### PR TITLE
debug/elf: return FormatError on UnexpectedEOF

### DIFF
--- a/src/debug/elf/file.go
+++ b/src/debug/elf/file.go
@@ -289,7 +289,11 @@ func NewFile(r io.ReaderAt) (*File, error) {
 	sr := io.NewSectionReader(r, 0, 1<<63-1)
 	// Read and decode ELF identifier
 	var ident [16]uint8
-	if _, err := r.ReadAt(ident[0:], 0); err != nil {
+	n, err := r.ReadAt(ident[0:], 0)
+	if err != nil {
+		if err == io.EOF {
+			err = &FormatError{int64(n), io.ErrUnexpectedEOF.Error(), ident[0:n]}
+		}
 		return nil, err
 	}
 	if ident[0] != '\x7f' || ident[1] != 'E' || ident[2] != 'L' || ident[3] != 'F' {

--- a/src/debug/elf/file.go
+++ b/src/debug/elf/file.go
@@ -245,6 +245,9 @@ func (e *FormatError) Error() string {
 	return msg
 }
 
+// A [*FormatError] is a target error if the base message matches the target.Error string
+func (e *FormatError) Is(target error) bool { return e.msg == target.Error() }
+
 // Open opens the named file using [os.Open] and prepares it for use as an ELF binary.
 func Open(name string) (*File, error) {
 	f, err := os.Open(name)

--- a/src/debug/elf/file_test.go
+++ b/src/debug/elf/file_test.go
@@ -1585,6 +1585,21 @@ func TestIssue59208(t *testing.T) {
 	}
 }
 
+// Issue #76338
+func TestUnexpectedEOF(t *testing.T) {
+	const testdata = "testdata/empty"
+	wantedVal := io.ErrUnexpectedEOF
+	var wantedType *FormatError
+
+	_, err := Open(testdata)
+	if !errors.As(err, &wantedType) {
+		t.Errorf("did not receive a FormatError, instead: %#v", err)
+	}
+	if !errors.Is(err, wantedVal) {
+		t.Errorf("did not get an io.ErrUnexpectedEOF, instead: %#v", err)
+	}
+}
+
 func BenchmarkSymbols64(b *testing.B) {
 	const testdata = "testdata/gcc-amd64-linux-exec"
 	f, err := Open(testdata)


### PR DESCRIPTION
Return a FormatError if io.EOF is unexpectedly encountered
while parsing an ELF.

The resulting error will be identified as io.ErrUnexpectedEOF
by errors.Is

Fixes #76338