### PR TITLE
time: fix typo in comment

### DIFF
--- a/src/time/time.go
+++ b/src/time/time.go
@@ -1279,7 +1279,7 @@ func daysBefore(m Month) int {
 	// which is:
 	//	0  31  61  92 122 153 183 214 245 275 306 336 367
 	// This is almost exactly 367/12×(m-1) except for the
-	// occasonal off-by-one suggesting there may be an
+	// occasional off-by-one suggesting there may be an
 	// integer approximation of the form (a×m + b)/c.
 	// A brute force search over small a, b, c finds that
 	// (214×m - 211) / 7 computes the function perfectly.


### PR DESCRIPTION
Correct "occasonal" to "occasional"
