### PR TITLE
os: allow direntries to have zero inodes on Linux

### DIFF
--- a/src/os/dir_unix.go
+++ b/src/os/dir_unix.go
@@ -112,7 +112,8 @@ func (f *File) readdir(n int, mode readdirMode) (names []string, dirents []DirEn
 		// or might expose a remote file system which does not have the concept
 		// of inodes. Therefore, we cannot make the assumption that it is safe
 		// to skip entries with zero inodes.
-		if ino == 0 && runtime.GOOS != "wasip1" {
+		// Some Linux filesystems (old XFS, FUSE) can return valid files with zero inodes.
+		if ino == 0 && runtime.GOOS != "linux" && runtime.GOOS != "wasip1" {
 			continue
 		}
 		const namoff = uint64(unsafe.Offsetof(syscall.Dirent{}.Name))

--- a/src/syscall/dirent.go
+++ b/src/syscall/dirent.go
@@ -73,8 +73,8 @@ func ParseDirent(buf []byte, max int, names []string) (consumed int, count int, 
 			break
 		}
 		// See src/os/dir_unix.go for the reason why this condition is
-		// excluded on wasip1.
-		if ino == 0 && runtime.GOOS != "wasip1" { // File absent in directory.
+		// excluded on wasip1 and linux.
+		if ino == 0 && runtime.GOOS != "linux" && runtime.GOOS != "wasip1" { // File absent in directory.
 			continue
 		}
 		const namoff = uint64(unsafe.Offsetof(Dirent{}.Name))


### PR DESCRIPTION
Some Linux filesystems have been known to return valid enties with
zero inodes. This new behavior also puts Go in agreement with recent
glibc.

Fixes #76428