### PR TITLE
runtime: add explicit lower bounds check to decoderune

### DIFF
--- a/src/cmd/compile/internal/walk/range.go
+++ b/src/cmd/compile/internal/walk/range.go
@@ -348,6 +348,8 @@ func walkRange(nrange *ir.RangeStmt) ir.Node {
 		// } else {
 		// hv2, hv1 = decoderune(ha, hv1)
 		fn := typecheck.LookupRuntime("decoderune")
+		// decoderune expects a uint, but hv1 is an int.
+		// This is safe because hv1 is always >= 0.
 		call := mkcall1(fn, fn.Type().ResultsTuple(), &nif.Else, ha, hv1)
 		a := ir.NewAssignListStmt(base.Pos, ir.OAS2, []ir.Node{hv2, hv1}, []ir.Node{call})
 		nif.Else.Append(a)

--- a/src/runtime/utf8.go
+++ b/src/runtime/utf8.go
@@ -57,10 +57,10 @@ func countrunes(s string) int {
 // If the string appears to be incomplete or decoding problems
 // are encountered (runeerror, k + 1) is returned to ensure
 // progress when decoderune is used to iterate over a string.
-func decoderune(s string, k int) (r rune, pos int) {
+func decoderune(s string, k uint) (r rune, pos uint) {
 	pos = k
 
-	if k >= len(s) {
+	if k >= uint(len(s)) {
 		return runeError, k + 1
 	}
 


### PR DESCRIPTION
decoderune is only called by generated code, so we can guarantee that
it's non-negative. This allows eliminating the automatic bounds check in
it.

To make this work, we need to expand the existing optimization to uints.
This generally enables BCE for cases like this:
```go
func test(list []int, idx uint64) int {
        if idx >= uint64(len(list)) {
                return 0
        }

        list1 := list[idx:]
        return list1[0]
}
```