### PR TITLE
go/token: replace map with array for looking up keywords

### DIFF
--- a/src/cmd/compile/internal/syntax/scanner.go
+++ b/src/cmd/compile/internal/syntax/scanner.go
@@ -381,10 +381,7 @@ func (s *scanner) ident() {
 	// possibly a keyword
 	lit := s.segment()
 	if len(lit) >= 2 {
-		// tok := keywordMap[hash(lit)]
-		// tok := keywords[keywordsIndex(lit)]
-		tok := keywordRuntimeMap[string(lit)]
-		if tok != 0 && tokStrFast(tok) == string(lit) {
+		if tok := keywordMap[hash(lit)]; tok != 0 && tokStrFast(tok) == string(lit) {
 			s.nlsemi = contains(1<<_Break|1<<_Continue|1<<_Fallthrough|1<<_Return, tok)
 			s.tok = tok
 			return
@@ -425,47 +422,15 @@ func hash(s []byte) uint {
 }
 
 var keywordMap [1 << 6]token // size must be power of two
-var keywordRuntimeMap = make(map[string]token)
-var keywords [256]Token
-
-// keywordsIndex maps an identifier to an index in keywords array.
-func keywordsIndex(maybeKeyword []byte) uint8 {
-	if len(maybeKeyword) <= 3 {
-		return maybeKeyword[0]
-	}
-	// This hash was adjusted by hand. Finding the working combinations
-	// for this hash is quite straightforward, even when restricting all
-	// operations to power-of-two multiplications and addition/subtractions
-	// for performance reasons since multiplication of an integer by a power-of-two
-	// can be optimized to a bitshift which is faster on some architectures.
-	//
-	// Here is a list of hashes that also works for current keyword set:
-	// h = v0 + v1*2 + v2*4 + v3*8
-	// h = v0 + v1*4 + v2*8 + v3
-	// h = v0 + v1*2 + (v2+v3)*2
-	// h = v0*4 + v1*2 + v2*2 + v3*2
-	// h = v0*4 + v1*2 + v2*v3
-	v0 := maybeKeyword[0]
-	v1 := maybeKeyword[1]
-	v2 := maybeKeyword[2]
-	v3 := maybeKeyword[3]
-	h := v0 + v1*8 + v2 - v3
-	return h
-}
 
 func init() {
 	// populate keywordMap
 	for tok := _Break; tok <= _Var; tok++ {
-		kws := tok.String()
-		kw := []byte(kws)
-		i := keywordsIndex(kw)
-		h := hash(kw)
-		if keywordMap[h] != 0 || keywords[i] != 0 {
+		h := hash([]byte(tok.String()))
+		if keywordMap[h] != 0 {
 			panic("imperfect hash")
 		}
-		keywords[i] = tok
 		keywordMap[h] = tok
-		keywordRuntimeMap[kws] = tok
 	}
 }
 

--- a/src/go/token/token.go
+++ b/src/go/token/token.go
@@ -290,11 +290,25 @@ func init() {
 // keywordsIndex maps an identifier to an index in keywords array.
 func keywordsIndex(maybeKeyword string) uint8 {
 	if len(maybeKeyword) <= 3 {
+		// If adding a 2 or 3 letter keyword that starts with `i`(if),`f`(for) or `g`(go)
+		// you'd need to add logic to this if statement to differentiate between them.
 		if len(maybeKeyword) == 0 {
 			return 0
 		}
 		return maybeKeyword[0]
 	}
+	// This hash was adjusted by hand. Finding the working combinations
+	// for this hash is quite straightforward, even when restricting all
+	// operations to power-of-two multiplications and addition/subtractions
+	// for performance reasons since multiplication of an integer by a power-of-two
+	// can be optimized to a bitshift which is faster on some architectures.
+	//
+	// Here is a list of hashes that also works for current keyword set:
+	// h = v0 + v1*2 + v2*4 + v3*8
+	// h = v0 + v1*4 + v2*8 + v3
+	// h = v0 + v1*2 + (v2+v3)*2
+	// h = v0*4 + v1*2 + v2*2 + v3*2
+	// h = v0*4 + v1*2 + v2*v3
 	v0 := maybeKeyword[0]
 	v1 := maybeKeyword[1]
 	v2 := maybeKeyword[2]

--- a/src/go/token/token.go
+++ b/src/go/token/token.go
@@ -282,9 +282,14 @@ func (op Token) Precedence() int {
 // hash is a perfect hash function for keywords.
 // It assumes that s has at least length 2.
 func hash(s string) uint {
+	// If you get collisions on adding a keyword you'll need to
+	// process more bytes of the identifier since this'll indicate
+	// two keywords share the same first two bytes.
+	// Best course of action is incrementing keyword map size or tuning the hash operations.
 	return (uint(s[0])<<4 ^ uint(s[1]) + uint(len(s))) & uint(len(keywordMap)-1)
 }
 
+// keywordMap is a perfect map taken from src/cmd/compile/internal/syntax/scanner.go
 var keywordMap [1 << 6]Token // size must be power of two
 
 func init() {

--- a/src/go/token/token.go
+++ b/src/go/token/token.go
@@ -280,16 +280,11 @@ func (op Token) Precedence() int {
 }
 
 // hash is a perfect hash function for keywords.
-// It assumes that s has at least length 2.
+// It assumes that s has at least length 2. taken from src/cmd/compile/internal/syntax/scanner.go
 func hash(s string) uint {
-	// If you get collisions on adding a keyword you'll need to
-	// process more bytes of the identifier since this'll indicate
-	// two keywords share the same first two bytes.
-	// Best course of action is incrementing keyword map size or tuning the hash operations.
 	return (uint(s[0])<<4 ^ uint(s[1]) + uint(len(s))) & uint(len(keywordMap)-1)
 }
 
-// keywordMap is a perfect map taken from src/cmd/compile/internal/syntax/scanner.go
 var keywordMap [1 << 6]Token // size must be power of two
 
 func init() {


### PR DESCRIPTION
array access has considerable less overhead than map access 
thus yielding benefits in performance and package initialization 
cost.

goos: linux
goarch: amd64
pkg: cmd/compile/internal/syntax
cpu: 12th Gen Intel(R) Core(TM) i5-12400F
                                 │   map.rej    │             syntax.rej             │
                                 │    sec/op    │   sec/op     vs base               │
ParseStdLib/longest_10_files-12    101.21m ± 3%   97.20m ± 2%  -3.96% (p=0.000 n=20) 
ParseStdLib/shortest_10_files-12    14.42µ ± 2%   13.39µ ± 1%  -7.14% (p=0.000 n=20)
geomean                             1.208m        1.141m       -5.56% 
