### PR TITLE
cmd/cover: exclude commented-out code from coverage instrumentation

### DIFF
--- a/src/cmd/cover/cover.go
+++ b/src/cmd/cover/cover.go
@@ -287,7 +287,7 @@ func (f *File) codeRanges(start, end token.Pos) []Range {
 	)
 
 	// Create a temporary File for scanning this block.
-	// We use a separate FileSet because we're scanning a slice of the
+	// We use a separate file because we're scanning a slice of the
 	// original source, so positions in scanFile are relative to the
 	// block start, not the original file.
 	scanFile := token.NewFileSet().AddFile("", -1, len(src))

--- a/src/cmd/cover/cover.go
+++ b/src/cmd/cover/cover.go
@@ -950,8 +950,7 @@ func (f *File) addCounters(pos, insertPos, blockEnd token.Pos, list []ast.Stmt, 
 			// Create counters only for executable code ranges.
 			// Merge back ranges that fall inside a statement to avoid
 			// inserting counters inside multi-line constructs (e.g. const blocks).
-			ranges := mergeRangesWithinStatements(f.codeRanges(pos, end), list[:last])
-			for i, r := range ranges {
+			for i, r := range mergeRangesWithinStatements(f.codeRanges(pos, end), list[:last]) {
 				// Insert counter at the beginning of the code range
 				insertOffset := f.offset(r.pos)
 				// For the first range, use the original insertPos if it's before the range

--- a/src/cmd/cover/cover.go
+++ b/src/cmd/cover/cover.go
@@ -316,8 +316,9 @@ func (f *File) codeRanges(start, end token.Pos) []Range {
 		}
 
 		// Skip braces and automatic semicolons: braces are block
-		// delimiters, not executable code. The scanner also inserts
-		// automatic semicolons (lit == "\n") after }, ), ], etc.
+		// delimiters, not executable code. The Go spec
+		// (https://go.dev/ref/spec#Semicolons) requires the scanner
+		// to insert semicolons (with lit == "\n") after }, ), ], etc.
 		// These are always on lines already marked by real tokens,
 		// except for lone "}" lines. Skipping both prevents a lone
 		// "}" from being treated as a separate code range, which
@@ -385,6 +386,9 @@ func insideStatement(pos token.Pos, stmts []ast.Stmt) bool {
 	for _, s := range stmts {
 		if s.Pos() < pos && pos < s.End() {
 			return true
+		}
+		if s.Pos() >= pos {
+			break // stmts are in source order; the rest are past pos.
 		}
 	}
 	return false

--- a/src/cmd/cover/cover_test.go
+++ b/src/cmd/cover/cover_test.go
@@ -739,6 +739,11 @@ func coverRanges(t *testing.T, src []byte) []lineRange {
 		var packed int
 		fmt.Sscanf(m[3], "0x%x", &packed)
 		endCol := (packed >> 16) & 0xFFFF
+		startCol := packed & 0xFFFF
+		// Skip zero-width ranges (comment-only or empty blocks).
+		if startLine == endLine && startCol == endCol {
+			continue
+		}
 		// The range [start, end) is half-open. When endCol==1, the
 		// range reaches the beginning of endLine but includes no
 		// content on it, so the last covered line is endLine-1.

--- a/src/cmd/cover/cover_test.go
+++ b/src/cmd/cover/cover_test.go
@@ -671,10 +671,10 @@ func parseBrackets(src []byte) ([]byte, []lineRange) {
 	)
 	i := 0
 	for i < len(src) {
-		if strings.HasPrefix(string(src[i:]), open) {
+		if bytes.HasPrefix(src[i:], []byte(open)) {
 			stack = append(stack, len(cleaned))
 			i += len(open)
-		} else if strings.HasPrefix(string(src[i:]), close) {
+		} else if bytes.HasPrefix(src[i:], []byte(close)) {
 			if len(stack) == 0 {
 				panic("unmatched close bracket at offset " + strconv.Itoa(i))
 			}

--- a/src/cmd/cover/testdata/html/html.golden
+++ b/src/cmd/cover/testdata/html/html.golden
@@ -1,6 +1,6 @@
 // START f
-func f() <span class="cov8" title="1">{
-	ch := make(chan int)
+func f() {
+	<span class="cov8" title="1">ch := make(chan int)
 	select </span>{
 	case &lt;-ch:<span class="cov0" title="0"></span>
 	default:<span class="cov8" title="1"></span>
@@ -9,10 +9,10 @@ func f() <span class="cov8" title="1">{
 
 // END f
 // START g
-func g() <span class="cov8" title="1">{
-	if false </span><span class="cov0" title="0">{
-		fmt.Printf("Hello")
-	}</span>
+func g() {
+	<span class="cov8" title="1">if false </span>{
+		<span class="cov0" title="0">fmt.Printf("Hello")
+</span>	}
 }
 
 // END g

--- a/src/cmd/cover/testdata/ranges/ranges.go
+++ b/src/cmd/cover/testdata/ranges/ranges.go
@@ -1,0 +1,98 @@
+package main
+
+import "fmt"
+
+func main() {
+«	fmt.Println("Start")
+	x := 42
+»
+	// This is a regular comment
+«	y := 0
+	fmt.Println("After comment")
+»
+	// Multiple comment lines
+	// fmt.Println("commented code")
+	// TODO: implement this later
+
+«	fmt.Println("After multiple comments")
+»
+	/* block comment */
+
+«	fmt.Println("After block comment")
+	z := 0
+»
+	«if x > 0 {»
+«		y = x * 2
+»	} else {
+«		y = x - 2
+»	}
+
+«	z = 5
+»
+	/* Multiline block
+	comment spanning
+	several lines */
+
+«	z1 := 0
+»
+«	z1 = 1 /* inline comment
+»	spanning lines
+«	end */ z1 = 2
+»
+«	z1 = 3; /* // */ z1 = 4
+»
+«	z1 = 5 /* //
+»	//
+«	// */ z1 = 6
+»
+	/*
+«	*/ z1 = 7 /*
+»	*/
+
+«	z1 = 8/*
+»	*/ /* comment
+«	*/z1 = 9
+»
+«	/* before */ z1 = 10
+	/* before */ z1 = 10 /* after */
+	             z1 = 10 /* after */
+»
+«	fmt.Printf("Result: %d\n", z)
+	fmt.Printf("Result: %d\n", z1)
+»
+«	s := `This is a multi-line raw string
+	// fake comment on line 2
+	/* and fake comment on line 3 */
+	and other`
+»
+«	s = `another multiline string
+	` // another trap
+»
+«	fmt.Printf("%s", s)
+»
+	// More comments to exclude
+	// for i := 0; i < 10; i++ {
+	//   fmt.Printf("Loop %d", i)
+	// }
+
+«	fmt.Printf("Result: %d\n", y)»
+	// end comment
+}
+
+«func empty() {
+
+}»
+
+func singleBlock() {
+«	fmt.Printf("ResultSomething")
+»}
+
+«func justComment() {
+	// comment
+}»
+
+«func justMultilineComment() {
+	/* comment
+	again
+	until here */
+}»

--- a/src/cmd/cover/testdata/ranges/ranges.go
+++ b/src/cmd/cover/testdata/ranges/ranges.go
@@ -96,3 +96,12 @@ func singleBlock() {
 	again
 	until here */
 }»
+
+func constBlock() {
+«	const (
+		A = 1
+
+		B = 2
+	)
+	fmt.Printf("A=%d B=%d", A, B)
+»}

--- a/src/cmd/cover/testdata/ranges/ranges.go
+++ b/src/cmd/cover/testdata/ranges/ranges.go
@@ -79,23 +79,23 @@ func main() {
 	// end comment
 }
 
-«func empty() {
+func empty() {
 
-}»
+}
 
 func singleBlock() {
 «	fmt.Printf("ResultSomething")
 »}
 
-«func justComment() {
+func justComment() {
 	// comment
-}»
+}
 
-«func justMultilineComment() {
+func justMultilineComment() {
 	/* comment
 	again
 	until here */
-}»
+}
 
 func constBlock() {
 «	const (
@@ -104,4 +104,11 @@ func constBlock() {
 		B = 2
 	)
 	fmt.Printf("A=%d B=%d", A, B)
+»}
+
+func compositeLit() {
+«	m := map[string]int{
+		"a": 1,
+»	}
+«	fmt.Println(m)
 »}


### PR DESCRIPTION
Add logic to exclude purely commented lines from coverage instrumentation.

When instrumenting Go code for coverage, the cover tool now identifies
and excludes lines that contain only comments from coverage blocks.
This prevents commented-out code from being reported as "uncovered"
in coverage reports, which can be misleading.

The implementation adds a splitBlockByComments function that parses
source code character by character to identify segments containing
executable code versus segments containing only comments. The
addCounters function now uses this to create coverage counters only
for segments that contain actual executable code.

The parser correctly handles:
- Single-line comments (//)
- Multi-line comments (/* */)
- String literals containing comment-like sequences
- Raw string literals with fake comments
- Mixed lines with both code and comments

This improves the accuracy of coverage reports by ensuring that
commented-out code, TODOs, and documentation comments don't inflate
the count of uncovered lines.

Fixes #22545
