### PR TITLE
runtime: add a runtime.wasiOnIdle function

### DIFF
--- a/src/runtime/lock_wasip1.go
+++ b/src/runtime/lock_wasip1.go
@@ -105,8 +105,16 @@ func notetsleepg(n *note, ns int64) bool {
 	}
 }
 
+var onIdle = func() bool {
+	return false
+}
+
+func wasiOnIdle(callback func() bool) {
+	onIdle = callback
+}
+
 func beforeIdle(int64, int64) (*g, bool) {
-	return nil, false
+	return nil, onIdle()
 }
 
 func checkTimeouts() {}


### PR DESCRIPTION
This small patch provides a mechanism for bridging the Go scheduler
with WASIp3's concurrency model.

Note that I'm fairly new to Go and very open to feedback and
alternative approaches.  Please consider this as much an RFC as it is
a PR.

Background

Both the js and wasip1 target OSes define a runtime.beforeIdle
function, called by the scheduler if and when no goroutines are
runnable.  In the case of js, the Go scheduler yields to the JS event
loop to await any async events it might produce.  In the case of
wasip1 (and all other OSes), beforeIdle does nothing since that
platform has neither an event loop nor async events.

However, WASIp3 (due to be released early next year) _does_ support
concurrency and asynchronous I/O [1] in which case it's useful for the
Go scheduler to yield to the host once all goroutines have gone idle,
just like it does for JS.

Motivation

This patch is intended as a baby step towards full GOOS=wasip3
support.  Unlike GOOS=wasip1, where blocking I/O operations block
_all_ goroutines, GOOS=wasip3 can support asynchronous I/O operations
which cooperate with the Go scheduler, only blocking the goroutine
doing the call and allowing any others to continue running.
Internally, each such operation may either complete immediately
without blocking or return a waitable handle representing a pending
event.  We can associate a channel with that waitable, to be written
to once the host delivers the corresponding event.  The calling
goroutine reads from that channel before returning a value.

In order to support the above, each exported function needs to be able
to wait for all goroutines to reach an idle state, collect any
accumulated waitable handles, and return control to the host until one
or more events are ready.  runtime.wasiOnIdle provides that capability
by accepting a callback to be run by runtime.beforeIdle.

Once GOOS=wasip3 has been fully implemented, the above can be handled
internally by the compiler and runtime.  As a first step, though, I've
created a bindings generator [2] which generates import and export
glue code from the IDL in which the WASIp3 interfaces are defined.
That glue code handles bridging Go's scheduler to the WASIp3 host
event loop.  It's able to do this using standard goroutines and
channels, with no special integration with the Go scheduler _except_
for runtime.wasiOnIdle, hence this patch.

Note that wasiOnIdle is private since it's not intended for general
use; the glue code mentioned above uses go:linkname to access it.
This use of go:linkname is a temporary measure while we experiment
with WASIp3 support outside of the runtime.  The eventual goal is to
encapsulate the host<->scheduler interaction entirely within the Go
runtime.

Concurrent imports and exports

WASIp3 is based on the WebAssembly Component Model [3], which includes
an IDL (WebAssembly Interface Types, or WIT) and an ABI for expressing
high-level types, functions, and interfaces which can be used to
represent both traditional OS features (e.g. filesystem and network
access) and high-level features such as HTTP request handlers and
database connections.  WIT can also be used to represent custom,
application specific APIs and then build components which either
implement or consume those APIs, analogous to how shared libraries
work on native OSes.

Consequently, GOOS=wasip3 will ideally support creating both
"executable"-style applications with a single func main entrypoint and
also "library"-style components with one or more custom entrypoints
and imports.  Fortunately, Go already has go:wasmexport and
go:wasmimport directives to support this.  The wit-bindgen-go project
mentioned above builds upon those directives to support exporting and
importing _concurrent_ functions which may suspend and resume as
necessary (e.g. due to I/O) prior to producing a result.
Hypothetically, this support could be integrated into the compiler if
there's interest.

[1] https://github.com/WebAssembly/component-model/blob/main/design/mvp/Concurrency.md
[2] https://github.com/bytecodealliance/wit-bindgen/tree/main/crates/go
[3] https://github.com/WebAssembly/component-model