### PR TITLE
runtime/secret: clarify Enabled() semantics

### DIFF
--- a/src/runtime/secret/secret.go
+++ b/src/runtime/secret/secret.go
@@ -25,8 +25,8 @@ import (
 //     Do itself.
 //
 // Limitations:
-//   - Currently only supported on linux/amd64 and linux/arm64.  On unsupported
-//     platforms, Do will invoke f directly.
+//   - Currently only supported on linux/amd64 and linux/arm64. 
+//     On unsupported platforms, Do will invoke f directly.
 //   - Protection does not extend to any global variables written by f.
 //   - Protection does not extend to any new goroutines made by f.
 //   - If f calls runtime.Goexit, erasure can be delayed by defers
@@ -108,7 +108,8 @@ func doHelper(f func()) (p any) {
 	return
 }
 
-// Enabled reports whether [Do] appears anywhere on the call stack.
+// Enabled returns true if [Do] appears anywhere on the call stack
+// and the platform is supported (see [Do] for details).
 func Enabled() bool {
 	return count() > 0
 }


### PR DESCRIPTION
The old wording may be interpreted to mean that it returns true whether the platform is supported or not, as long as Do is on the call stack.

Updates #21865