### PR TITLE
crypto/cipher: add one-time pad encrypt and decrypt

### DIFF
--- a/src/crypto/cipher/otp.go
+++ b/src/crypto/cipher/otp.go
@@ -1,0 +1,30 @@
+package cipher
+
+import "crypto/rand"
+
+func KeyGen(message string) []byte {
+	key := make([]byte, len(message))
+
+	_, err := rand.Read(key)
+	if err != nil {
+		panic(err)
+	}
+	return key
+}
+
+func OTPEncrypt(message string) (encrypted, key []byte) {
+	encrypted = make([]byte, len(message))
+	key = KeyGen(message)
+	for i := 0; i < len(message); i++ {
+		encrypted[i] = message[i] ^ key[i]
+	}
+	return
+}
+
+func OTPDecrypt(encrypted, key []byte) []byte {
+	decrypted := make([]byte, len(encrypted))
+	for i := 0; i < len(encrypted); i++ {
+		decrypted[i] = encrypted[i] ^ key[i]
+	}
+	return decrypted
+}

--- a/src/crypto/cipher/otp_test.go
+++ b/src/crypto/cipher/otp_test.go
@@ -1,0 +1,16 @@
+package cipher
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestOTP(t *testing.T) {
+	msg := []byte("Hello OTP!")
+	ciphertext, key := OTPEncrypt(string(msg))
+	decrypted := OTPDecrypt(ciphertext, key)
+
+	if !bytes.Equal([]byte(decrypted), msg) {
+		t.Errorf("Decrypted message does not match original")
+	}
+}


### PR DESCRIPTION
Adds a One-Time Pad (OTP) implementation to crypto/cipher.

OTP is a type of encryption that is provably secure
information-theoretically when used correctly. It
requires a key that is the same length as the message
and used only once.

This package provides the following:

- OTPEncrypt and OTPDecrypt functions for encryption
  and decryption of byte slices.
- KeyGen function for generating cryptographically
  secure random keys of the appropriate length.
- A simple unit test (otp_test.go) that verifies
  encryption and decryption works correctly.

Note: OTP is not intended to be used in real-life practice
as it has highly limited capabilities and can only be used once
for the safest encryption, making it highly inefficient.





