### PR TITLE
cmd/link: add more clang driver flags when testing flag

### DIFF
--- a/src/cmd/link/internal/ld/lib.go
+++ b/src/cmd/link/internal/ld/lib.go
@@ -2242,7 +2242,7 @@ func trimLinkerArgv(argv []string) []string {
 		"-resource-dir",
 		"-rtlib",
 		"--rtlib",
-		"-stdlib"
+		"-stdlib",
 		"--stdlib",
 		"-unwindlib",
 		"--unwindlib",

--- a/src/cmd/link/internal/ld/lib.go
+++ b/src/cmd/link/internal/ld/lib.go
@@ -2220,9 +2220,11 @@ func trimLinkerArgv(argv []string) []string {
 		"-target",
 		"--target",
 		"-resource-dir",
-		"-stdlib",
+		"-rtlib",
 		"--rtlib",
+		"-stdlib",
 		"--stdlib",
+		"-unwindlib",
 		"--unwindlib",
 	}
 	prefixesToKeep := []string{
@@ -2238,9 +2240,11 @@ func trimLinkerArgv(argv []string) []string {
 		"-target",
 		"--target",
 		"-resource-dir",
-		"-stdlib"
+		"-rtlib",
 		"--rtlib",
+		"-stdlib"
 		"--stdlib",
+		"-unwindlib",
 		"--unwindlib",
 	}
 

--- a/src/cmd/link/internal/ld/lib.go
+++ b/src/cmd/link/internal/ld/lib.go
@@ -2215,6 +2215,7 @@ func trimLinkerArgv(argv []string) []string {
 	}
 	flagsWithNextArgKeep := []string{
 		"-B",
+		"-L",
 		"-arch",
 		"-isysroot",
 		"--sysroot",

--- a/src/cmd/link/internal/ld/lib.go
+++ b/src/cmd/link/internal/ld/lib.go
@@ -2208,7 +2208,6 @@ func trimLinkerArgv(argv []string) []string {
 	flagsWithNextArgSkip := []string{
 		"-F",
 		"-l",
-		"-L",
 		"-framework",
 		"-Wl,-framework",
 		"-Wl,-rpath",
@@ -2220,8 +2219,15 @@ func trimLinkerArgv(argv []string) []string {
 		"--sysroot",
 		"-target",
 		"--target",
+		"-resource-dir",
+		"-stdlib",
+		"--rtlib",
+		"--stdlib",
+		"--unwindlib",
 	}
 	prefixesToKeep := []string{
+		"-B",
+		"-L",
 		"-f",
 		"-m",
 		"-p",
@@ -2231,6 +2237,11 @@ func trimLinkerArgv(argv []string) []string {
 		"--sysroot",
 		"-target",
 		"--target",
+		"-resource-dir",
+		"-stdlib"
+		"--rtlib",
+		"--stdlib",
+		"--unwindlib",
 	}
 
 	var flags []string

--- a/src/cmd/link/internal/ld/lib.go
+++ b/src/cmd/link/internal/ld/lib.go
@@ -2214,6 +2214,7 @@ func trimLinkerArgv(argv []string) []string {
 		"-Wl,-undefined",
 	}
 	flagsWithNextArgKeep := []string{
+		"-B",
 		"-arch",
 		"-isysroot",
 		"--sysroot",


### PR DESCRIPTION
This changes does 2 things:

- Move `-L` to `prefixesToKeep` since it allows providing a custom
default libs search path.

- Allow various flags that impact the behaviour of the clang driver.

The latter allows for LLVM only toolchains to be compatible with
linkerFlagSupported checks.

The end goal of this PR is to allow fully hermetic toolchains,
especially pure LLVM ones, to be used to cross-compile CGO.

Fixes #76825 