### PR TITLE
cmd/dist: detect import cycles instead of deadlocking

### DIFF
--- a/src/cmd/dist/build.go
+++ b/src/cmd/dist/build.go
@@ -678,6 +678,31 @@ var gentab = []struct {
 var installed = make(map[string]chan struct{})
 var installedMu sync.Mutex
 
+// waitingOn tracks which package each installing package is currently blocked
+// on, forming an implicit import stack. Before blocking on a dependency, we
+// walk this chain to check whether the dependency is already waiting on us
+// (directly or transitively). This is the concurrent equivalent of the import
+// stack approach used by cmd/go to detect import cycles.
+var waitingOn = make(map[string]string)
+
+// checkImportCycle checks whether pkg waiting on dep would create an import
+// cycle by walking the waitingOn chain from dep. If the chain leads back to
+// pkg, it returns a string describing the cycle (e.g. "A -> B -> A").
+// If no cycle is found, it returns the empty string.
+// Must be called with installedMu held.
+func checkImportCycle(pkg, dep string) string {
+	stk := []string{pkg, dep}
+	for p := dep; p != pkg; {
+		next, ok := waitingOn[p]
+		if !ok {
+			return ""
+		}
+		stk = append(stk, next)
+		p = next
+	}
+	return strings.Join(stk, " -> ")
+}
+
 func install(dir string) {
 	<-startInstall(dir)
 }
@@ -890,7 +915,19 @@ func runInstall(pkg string, ch chan struct{}) {
 		startInstall(dep)
 	}
 	for _, dep := range importMap {
+		installedMu.Lock()
+		if cycle := checkImportCycle(pkg, dep); cycle != "" {
+			installedMu.Unlock()
+			fatalf("import cycle: %s", cycle)
+		}
+		waitingOn[pkg] = dep
+		installedMu.Unlock()
+
 		install(dep)
+
+		installedMu.Lock()
+		delete(waitingOn, pkg)
+		installedMu.Unlock()
 	}
 
 	if goos != gohostos || goarch != gohostarch {


### PR DESCRIPTION
Previously, if there was an import cycle in the packages being built
(e.g., package A imports B and B imports A), the build would deadlock
with "all goroutines are asleep - deadlock!" because each package's
goroutine would block waiting for the other to complete.

Now we detect import cycles before blocking on each dependency by
tracking an "install stack" of which package is waiting on which.
Before waiting for a dependency, we walk the stack to check if that
dependency is already waiting on us. When a cycle is detected, we
report it with a clear message like "import cycle: A -> B -> A".

Tested:
- Self-import cycle detection (go/ast imports go/ast)
- Indirect import cycle detection (go/token imports go/ast creates
  cycle through go/ast -> go/token -> go/ast)
- Normal builds complete successfully
- all.bash passes

Fixes #76439