### PR TITLE
crypto/tls: enhanced session resumption ticket age check

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -978,6 +978,10 @@ func (c *Config) ticketKeyFromBytes(b [32]byte) (key ticketKey) {
 // ticket, and the lifetime we set for all tickets we send.
 const maxSessionTicketLifetime = 7 * 24 * time.Hour
 
+// Maximum allowed mismatch between the stated age of a ticket and the server-observed one. 
+// See https://datatracker.ietf.org/doc/html/rfc8446#section-8.3
+const maxSessionTicketSkewAllowance = 10 * time.Second
+
 // Clone returns a shallow clone of c or nil if c is nil. It is safe to clone a [Config] that is
 // being used concurrently by a TLS client or server.
 func (c *Config) Clone() *Config {

--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -997,6 +997,10 @@ func (c *Config) ticketKeyFromBytes(b [32]byte) (key ticketKey) {
 // ticket, and the lifetime we set for all tickets we send.
 const maxSessionTicketLifetime = 7 * 24 * time.Hour
 
+// Maximum allowed mismatch between the stated age of a ticket and the server-observed one. 
+// See https://datatracker.ietf.org/doc/html/rfc8446#section-8.3
+const maxSessionTicketSkewAllowance = 10 * time.Second
+
 // Clone returns a shallow clone of c or nil if c is nil. It is safe to clone a
 // [Config] that is being used concurrently by a TLS client or server.
 //

--- a/src/crypto/tls/handshake_messages_test.go
+++ b/src/crypto/tls/handshake_messages_test.go
@@ -421,9 +421,9 @@ func (*SessionState) Generate(rand *rand.Rand, size int) reflect.Value {
 		s.alpnProtocol = string(randomBytes(rand.Intn(10), rand))
 	}
 	if isTLS13 {
+		s.ageAdd = uint32(rand.Int63() & math.MaxUint32)
 		if s.isClient {
 			s.useBy = uint64(rand.Int63())
-			s.ageAdd = uint32(rand.Int63() & math.MaxUint32)
 		}
 	} else {
 		s.curveID = CurveID(rand.Intn(30000) + 1)

--- a/src/crypto/tls/handshake_messages_test.go
+++ b/src/crypto/tls/handshake_messages_test.go
@@ -413,9 +413,9 @@ func (*SessionState) Generate(rand *rand.Rand, size int) reflect.Value {
 		s.alpnProtocol = string(randomBytes(rand.Intn(10), rand))
 	}
 	if isTLS13 {
+		s.ageAdd = uint32(rand.Int63() & math.MaxUint32)
 		if s.isClient {
 			s.useBy = uint64(rand.Int63())
-			s.ageAdd = uint32(rand.Int63() & math.MaxUint32)
 		}
 	} else {
 		s.curveID = CurveID(rand.Intn(30000) + 1)

--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -347,7 +347,8 @@ func (hs *serverHandshakeStateTLS13) checkForResumption() error {
 		}
 
 		createdAt := time.Unix(int64(sessionState.createdAt), 0)
-		if c.config.time().Sub(createdAt) > maxSessionTicketLifetime {
+		serverAge := c.config.time().Sub(createdAt)
+		if serverAge > maxSessionTicketLifetime || serverAge < -maxSessionTicketLifetime {
 			continue
 		}
 
@@ -380,12 +381,6 @@ func (hs *serverHandshakeStateTLS13) checkForResumption() error {
 			continue
 		}
 
-		if c.quic != nil && c.quic.enableSessionEvents {
-			if err := c.quicResumeSession(sessionState); err != nil {
-				return err
-			}
-		}
-
 		hs.earlySecret = tls13.NewEarlySecret(hs.suite.hash.New, sessionState.secret)
 		binderKey := hs.earlySecret.ResumptionBinderKey()
 		// Clone the transcript in case a HelloRetryRequest was recorded.
@@ -406,17 +401,8 @@ func (hs *serverHandshakeStateTLS13) checkForResumption() error {
 			return errors.New("tls: invalid PSK binder")
 		}
 
-		if c.quic != nil && hs.clientHello.earlyData && i == 0 &&
-			sessionState.EarlyData && sessionState.cipherSuite == hs.suite.id &&
-			sessionState.alpnProtocol == c.clientProtocol {
-			hs.earlyData = true
-
-			transcript := hs.suite.hash.New()
-			if err := transcriptMsg(hs.clientHello, transcript); err != nil {
-				return err
-			}
-			earlyTrafficSecret := hs.earlySecret.ClientEarlyTrafficSecret(transcript)
-			if err := c.quicSetReadSecret(QUICEncryptionLevelEarly, hs.suite.id, earlyTrafficSecret); err != nil {
+		if c.quic != nil && c.quic.enableSessionEvents {
+			if err := c.quicResumeSession(sessionState); err != nil {
 				return err
 			}
 		}
@@ -430,6 +416,33 @@ func (hs *serverHandshakeStateTLS13) checkForResumption() error {
 		hs.hello.selectedIdentityPresent = true
 		hs.hello.selectedIdentity = uint16(i)
 		hs.usingPSK = true
+
+		if !hs.clientHello.earlyData || !sessionState.EarlyData || i != 0 {
+			return nil
+		}
+
+		clientAge := time.Duration(identity.obfuscatedTicketAge-sessionState.ageAdd) * time.Millisecond
+		if ageDiff := serverAge - clientAge; ageDiff > maxSessionTicketSkewAllowance || ageDiff < -maxSessionTicketSkewAllowance {
+			return nil
+		}
+
+		if sessionState.cipherSuite != hs.suite.id || sessionState.alpnProtocol != c.clientProtocol {
+			return nil
+		}
+
+		hs.earlyData = true
+
+		earlyTranscript := hs.suite.hash.New()
+		if err := transcriptMsg(hs.clientHello, earlyTranscript); err != nil {
+			return err
+		}
+
+		earlyTrafficSecret := hs.earlySecret.ClientEarlyTrafficSecret(earlyTranscript)
+		if c.quic != nil {
+			if err := c.quicSetReadSecret(QUICEncryptionLevelEarly, hs.suite.id, earlyTrafficSecret); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 
@@ -987,6 +1000,15 @@ func (c *Conn) sendSessionTicket(earlyData bool, extra [][]byte) error {
 	state.secret = psk
 	state.EarlyData = earlyData
 	state.Extra = extra
+
+	// ticket_age_add is a random 32-bit value.
+	// See RFC 8446, section 4.6.1
+	ageAdd := make([]byte, 4)
+	if _, err := c.config.rand().Read(ageAdd); err != nil {
+		return err
+	}
+	state.ageAdd = byteorder.LEUint32(ageAdd)
+
 	if c.config.WrapSession != nil {
 		var err error
 		m.label, err = c.config.WrapSession(c.connectionStateLocked(), state)
@@ -1005,15 +1027,7 @@ func (c *Conn) sendSessionTicket(earlyData bool, extra [][]byte) error {
 		}
 	}
 	m.lifetime = uint32(maxSessionTicketLifetime / time.Second)
-
-	// ticket_age_add is a random 32-bit value. See RFC 8446, section 4.6.1
-	// The value is not stored anywhere; we never need to check the ticket age
-	// because 0-RTT is not supported.
-	ageAdd := make([]byte, 4)
-	if _, err := c.config.rand().Read(ageAdd); err != nil {
-		return err
-	}
-	m.ageAdd = byteorder.LEUint32(ageAdd)
+	m.ageAdd = state.ageAdd
 
 	if earlyData {
 		// RFC 9001, Section 4.6.1


### PR DESCRIPTION
Reject tickets created in the future time.

Add the 0-RTT client ticket age check described in RFC 8446 Section 8.3.