### PR TITLE
unicode: remove variation selectors from IsGraphic and IsPrint 

### DIFF
--- a/src/unicode/graphic.go
+++ b/src/unicode/graphic.go
@@ -39,6 +39,9 @@ func IsGraphic(r rune) bool {
 	if uint32(r) <= MaxLatin1 {
 		return properties[uint8(r)]&pg != 0
 	}
+	if Is(Variation_Selector, r) {
+		return false
+	}
 	return In(r, GraphicRanges...)
 }
 
@@ -50,6 +53,9 @@ func IsGraphic(r rune) bool {
 func IsPrint(r rune) bool {
 	if uint32(r) <= MaxLatin1 {
 		return properties[uint8(r)]&pp != 0
+	}
+	if Is(Variation_Selector, r) {
+		return false
 	}
 	return In(r, PrintRanges...)
 }

--- a/src/unicode/graphic_test.go
+++ b/src/unicode/graphic_test.go
@@ -101,6 +101,50 @@ func TestIsPunctLatin1(t *testing.T) {
 	}
 }
 
+func TestIsGraphicVariationSelector(t *testing.T) {
+	// Variation selectors are invisible and should return false for IsGraphic.
+	for _, r16 := range Variation_Selector.R16 {
+		for r := rune(r16.Lo); r <= rune(r16.Hi); r += rune(r16.Stride) {
+			got := IsGraphic(r)
+			want := false
+			if got != want {
+				t.Errorf("%U incorrect: got %t; want %t", r, got, want)
+			}
+		}
+	}
+	for _, r32 := range Variation_Selector.R32 {
+		for r := rune(r32.Lo); r <= rune(r32.Hi); r += rune(r32.Stride) {
+			got := IsGraphic(r)
+			want := false
+			if got != want {
+				t.Errorf("%U incorrect: got %t; want %t", r, got, want)
+			}
+		}
+	}
+}
+
+func TestIsPrintVariationSelector(t *testing.T) {
+	// Variation selectors are invisible and should return false for IsPrint.
+	for _, r16 := range Variation_Selector.R16 {
+		for r := rune(r16.Lo); r <= rune(r16.Hi); r += rune(r16.Stride) {
+			got := IsPrint(r)
+			want := false
+			if got != want {
+				t.Errorf("%U incorrect: got %t; want %t", r, got, want)
+			}
+		}
+	}
+	for _, r32 := range Variation_Selector.R32 {
+		for r := rune(r32.Lo); r <= rune(r32.Hi); r += rune(r32.Stride) {
+			got := IsPrint(r)
+			want := false
+			if got != want {
+				t.Errorf("%U incorrect: got %t; want %t", r, got, want)
+			}
+		}
+	}
+}
+
 func TestIsSpaceLatin1(t *testing.T) {
 	for i := rune(0); i <= MaxLatin1; i++ {
 		got := IsSpace(i)


### PR DESCRIPTION
IsGraphic and IsPrint return true for Variation Selectors, which are invisible.

This just adds a check to not include those, and a test to verify.

Fixes #73673