### PR TITLE
runtime: revert entry point on freebsd/arm64

### DIFF
--- a/src/runtime/rt0_freebsd_arm64.s
+++ b/src/runtime/rt0_freebsd_arm64.s
@@ -9,7 +9,7 @@
 TEXT _rt0_arm64_freebsd(SB),NOSPLIT,$0
 	ADD	$8, R0, R1	// argv (use R0 while it's still the pointer)
 	MOVD	0(R0), R0	// argc
-	JMP runtime·rt0_go(SB)
+	JMP	runtime·rt0_go(SB)
 
 // When building with -buildmode=c-shared, this symbol is called when the shared
 // library is loaded.

--- a/src/runtime/rt0_freebsd_arm64.s
+++ b/src/runtime/rt0_freebsd_arm64.s
@@ -4,9 +4,12 @@
 
 #include "textflag.h"
 
-// On FreeBSD argc/argv are passed in R0, not RSP
+// FreeBSD passes a pointer to the argument block in R0, not RSP,
+// so _rt0_arm64 cannot be used.
 TEXT _rt0_arm64_freebsd(SB),NOSPLIT,$0
-	JMP	_rt0_arm64(SB)
+	ADD	$8, R0, R1	// argv (use R0 while it's still the pointer)
+	MOVD	0(R0), R0	// argc
+	JMP runtime·rt0_go(SB)
 
 // When building with -buildmode=c-shared, this symbol is called when the shared
 // library is loaded.


### PR DESCRIPTION
CL 706175 unified some arm64 entry points. However, the entry point for
freebsd/arm64 is incorrect and builds now fail. This change reverts the
freebsd/arm64 entry point and adds additional context for the future.

Fixes #76958