### PR TITLE
errors: fix errors.Join single unwrappable errors

### DIFF
--- a/src/errors/join.go
+++ b/src/errors/join.go
@@ -29,9 +29,7 @@ func Join(errs ...error) error {
 	}
 	if n == 1 {
 		for _, err := range errs {
-			if _, ok := err.(interface {
-				Unwrap() []error
-			}); ok {
+			if _, ok := err.(*joinError); ok {
 				return err
 			}
 		}

--- a/src/errors/join_test.go
+++ b/src/errors/join_test.go
@@ -104,3 +104,24 @@ func BenchmarkJoin(b *testing.B) {
 		})
 	}
 }
+
+func TestJoin_returns_wrapped_error(t *testing.T) {
+	x := CustomUnwrappableError{errors.ErrUnsupported}
+	if errors.Join(x) == error(x) { // Actually this comparison panics.
+		t.Errorf("Join(x) returns x, expected to return a wrapped error")
+	}
+}
+
+type CustomUnwrappableError []error
+
+func (c CustomUnwrappableError) Error() (s string) {
+	for i, err := range c {
+		if i > 0 {
+			s += "\n"
+		}
+		s += err.Error()
+	}
+	return s
+}
+
+func (c CustomUnwrappableError) Unwrap() []error { return c }


### PR DESCRIPTION
Fixes #76961 mismatch between the new behavior and the function documentation.