### PR TITLE
internal/profile: fix error message casing for function ID not found

### DIFF
--- a/src/internal/profile/encode.go
+++ b/src/internal/profile/encode.go
@@ -232,7 +232,7 @@ func (p *Profile) postDecode() error {
 			if id := ln.functionIDX; id != 0 {
 				l.Line[i].Function = functions[id]
 				if l.Line[i].Function == nil {
-					return fmt.Errorf("Function ID %d not found", id)
+					return fmt.Errorf("function ID %d not found", id)
 				}
 				l.Line[i].functionIDX = 0
 			}


### PR DESCRIPTION
Go convention: error messages should not be capitalized 