### PR TITLE
cmd:  added service init to the go command line ,This Will allow developers to have a common directory structure for their backend services

### DIFF
--- a/src/cmd/go/internal/base/service.go
+++ b/src/cmd/go/internal/base/service.go
@@ -1,0 +1,115 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package base
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// CreateServiceScaffold creates the scaffolding of a minimal backend service.
+// creates api/, cmd/, internal/, pkg/ directories and a main.go file in cmd
+// This will allow deveopers to have a common structure for backend services.
+func CreateServiceScaffold(serviceName string) {
+	//get current directory
+	currentDir, err := os.Getwd()
+	if err != nil {
+		Fatalf("could not get current directory: %v", err)
+	}
+
+	//create service directory
+	serviceDir := filepath.Join(currentDir, serviceName)
+	err = os.Mkdir(serviceDir, 0755)
+	if err != nil {
+		Fatalf("could not create service directory: %v", err)
+	}
+
+	//create a directory cmd and a main.go file inside it
+	cmdDir := filepath.Join(serviceDir, "cmd")
+	err = os.Mkdir(cmdDir, 0755)
+	if err != nil {
+		Fatalf("could not create cmd directory: %v", err)
+	}
+	//create main.go file
+	mainFilePath := filepath.Join(cmdDir, "main.go")
+	mainFileContent := `package main
+import "net/http"
+func main() {
+	http.ListenAndServe(":8080", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Go is great!"))
+	}))
+}`
+	err = os.WriteFile(mainFilePath, []byte(mainFileContent), 0644)
+	if err != nil {
+		Fatalf("could not create main.go file: %v", err)
+	}
+
+	// run go mod init
+	cmd := exec.Command("go", "mod", "init", serviceName)
+	cmd.Dir = serviceDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		Fatalf("could not initialize go module: %v\n%s", err, output)
+	}
+	// create a pkg directory and create a sample package file
+	pkgDir := filepath.Join(serviceDir, "pkg")
+	err = os.Mkdir(pkgDir, 0755)
+	if err != nil {
+		Fatalf("could not create pkg directory: %v", err)
+	}
+	samplePkgFilePath := filepath.Join(pkgDir, "sample.go")
+	samplePkgContent := `//package pkg is for all shared packages
+package pkg 
+	`
+	err = os.WriteFile(samplePkgFilePath, []byte(samplePkgContent), 0644)
+	if err != nil {
+		Fatalf("could not create sample package file: %v", err)
+	}
+	//create api directory and create api.go file
+	apiDir := filepath.Join(serviceDir, "api")
+	err = os.Mkdir(apiDir, 0755)
+	if err != nil {
+		Fatalf("could not create api directory: %v", err)
+	}
+	apiFilePath := filepath.Join(apiDir, "api.go")
+	apiFileContent := `// package api contains API definitions
+package api 
+	`
+	err = os.WriteFile(apiFilePath, []byte(apiFileContent), 0644)
+	if err != nil {
+		Fatalf("could not create api.go file: %v", err)
+	}
+	//create an internal directory and create a service.go file
+	internalDir := filepath.Join(serviceDir, "internal")
+	err = os.Mkdir(internalDir, 0755)
+	if err != nil {
+		Fatalf("could not create internal directory: %v", err)
+	}
+	serviceFilePath := filepath.Join(internalDir, "service.go")
+	serviceFileContent := `// package internal contains internal service logic
+package internal 
+	`
+	err = os.WriteFile(serviceFilePath, []byte(serviceFileContent), 0644)
+	if err != nil {
+		Fatalf("could not create service.go file: %v", err)
+	}
+	//create model directory and create a model.go file inside inyternal
+	modelDir := filepath.Join(internalDir, "model")
+	err = os.Mkdir(modelDir, 0755)
+	if err != nil {
+		Fatalf("could not create model directory: %v", err)
+	}
+	modelFilePath := filepath.Join(modelDir, "model.go")
+	modelFileContent := `// package model contains data models
+package model 
+	`
+	err = os.WriteFile(modelFilePath, []byte(modelFileContent), 0644)
+	if err != nil {
+		Fatalf("could not create model.go file: %v", err)
+	}
+
+	println("Service scaffolding created successfully at", serviceDir)
+}

--- a/src/cmd/go/internal/service/service.go
+++ b/src/cmd/go/internal/service/service.go
@@ -1,0 +1,54 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package service implements the “go service” command.
+package service
+
+import (
+	"cmd/internal/telemetry/counter"
+	"context"
+
+	"cmd/go/internal/base"
+)
+
+var CmdService = &base.Command{
+	Run:         createServiceScafflod,
+	UsageLine:   "go service [init] [service-name]",
+	Short:       "create backend service scaffolding",
+	CustomFlags: true,
+	Long: `
+	Service init creates the scaffolding of a minimal backend service with the given service name.`,
+}
+
+// Return whether tool can be expected in the gccgo tool directory.
+// Other binaries could be in the same directory so don't
+// show those with the 'go tool' command.
+func isGccgoTool(tool string) bool {
+	switch tool {
+	case "cgo", "fix", "cover", "godoc", "vet":
+		return true
+	}
+	return false
+}
+
+// createServiceScafflod creates the service scaffolding
+func createServiceScafflod(ctx context.Context, cmd *base.Command, args []string) {
+	if len(args) == 0 {
+		counter.Inc("go/subcommand:service")
+		return
+	}
+	commandOption := args[0]
+	switch commandOption {
+	case "init":
+		if len(args) < 2 {
+			base.Fatalf("service init requires a service name")
+		}
+		serviceName := args[1]
+		base.CreateServiceScaffold(serviceName)
+		counter.Inc("go/subcommand:service-init")
+		return
+	default:
+		base.Fatalf("unknown service subcommand: %s", commandOption)
+	}
+}

--- a/src/cmd/go/main.go
+++ b/src/cmd/go/main.go
@@ -33,6 +33,7 @@ import (
 	"cmd/go/internal/modget"
 	"cmd/go/internal/modload"
 	"cmd/go/internal/run"
+	"cmd/go/internal/service"
 	"cmd/go/internal/telemetrycmd"
 	"cmd/go/internal/telemetrystats"
 	"cmd/go/internal/test"
@@ -66,6 +67,7 @@ func init() {
 		telemetrycmd.CmdTelemetry,
 		test.CmdTest,
 		tool.CmdTool,
+		service.CmdService,
 		version.CmdVersion,
 		vet.CmdVet,
 


### PR DESCRIPTION
This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**
Added service init to the go command line tool.This will allow users to create a service scaffolding .This would be really helpful for all developers to have a common folder structure across projects for easy navigation and understanding.