### PR TITLE
archive/tar: reset Size to 0 for header-only types in WriteHeader

### DIFF
--- a/src/archive/tar/writer.go
+++ b/src/archive/tar/writer.go
@@ -83,6 +83,11 @@ func (tw *Writer) WriteHeader(hdr *Header) error {
 		}
 	}
 
+	// Header-only types have no data section, so force Size to 0.
+	if isHeaderOnlyType(tw.hdr.Typeflag) {
+		tw.hdr.Size = 0
+	}
+
 	// Round ModTime and ignore AccessTime and ChangeTime unless
 	// the format is explicitly chosen.
 	// This ensures nominal usage of WriteHeader (without specifying the format)


### PR DESCRIPTION
When writing a header-only type (TypeLink, TypeSymlink, TypeChar,
TypeBlock, TypeDir, TypeFifo) with a non-zero Size, the resulting
archive is corrupt because the header claims data follows but none
is written.

Reset Size to 0 for header-only types before encoding the header.

Fixes #76468