### PR TITLE
runtime: support c-archive and c-shared on freebsd/arm and freebsd/arm64

### DIFF
--- a/src/cmd/dist/test.go
+++ b/src/cmd/dist/test.go
@@ -1760,7 +1760,7 @@ func buildModeSupported(compiler, buildmode, goos, goarch string) bool {
 				return false
 			}
 		case "freebsd":
-			return goarch == "amd64"
+			return goarch == "amd64" || goarch == "arm" || goarch == "arm64"
 		}
 		return false
 
@@ -1768,7 +1768,7 @@ func buildModeSupported(compiler, buildmode, goos, goarch string) bool {
 		switch platform {
 		case "linux/amd64", "linux/arm", "linux/arm64", "linux/loong64", "linux/386", "linux/ppc64le", "linux/riscv64", "linux/s390x",
 			"android/amd64", "android/arm", "android/arm64", "android/386",
-			"freebsd/amd64",
+			"freebsd/amd64", "freebsd/arm", "freebsd/arm64",
 			"darwin/amd64", "darwin/arm64",
 			"windows/amd64", "windows/386", "windows/arm64",
 			"wasip1/wasm":

--- a/src/cmd/dist/test.go
+++ b/src/cmd/dist/test.go
@@ -1758,7 +1758,7 @@ func buildModeSupported(compiler, buildmode, goos, goarch string) bool {
 				return false
 			}
 		case "freebsd":
-			return goarch == "amd64"
+			return goarch == "amd64" || goarch == "arm" || goarch == "arm64"
 		}
 		return false
 
@@ -1766,7 +1766,7 @@ func buildModeSupported(compiler, buildmode, goos, goarch string) bool {
 		switch platform {
 		case "linux/amd64", "linux/arm", "linux/arm64", "linux/loong64", "linux/386", "linux/ppc64", "linux/ppc64le", "linux/riscv64", "linux/s390x",
 			"android/amd64", "android/arm", "android/arm64", "android/386",
-			"freebsd/amd64",
+			"freebsd/amd64", "freebsd/arm", "freebsd/arm64",
 			"darwin/amd64", "darwin/arm64",
 			"windows/amd64", "windows/386", "windows/arm64",
 			"wasip1/wasm":

--- a/src/internal/platform/supported.go
+++ b/src/internal/platform/supported.go
@@ -158,7 +158,7 @@ func BuildModeSupported(compiler, buildmode, goos, goarch string) bool {
 				return false
 			}
 		case "freebsd":
-			return goarch == "amd64"
+			return goarch == "amd64" || goarch == "arm" || goarch == "arm64"
 		}
 		return false
 
@@ -166,7 +166,7 @@ func BuildModeSupported(compiler, buildmode, goos, goarch string) bool {
 		switch platform {
 		case "linux/amd64", "linux/arm", "linux/arm64", "linux/loong64", "linux/386", "linux/ppc64le", "linux/riscv64", "linux/s390x",
 			"android/amd64", "android/arm", "android/arm64", "android/386",
-			"freebsd/amd64",
+			"freebsd/amd64", "freebsd/arm", "freebsd/arm64",
 			"darwin/amd64", "darwin/arm64",
 			"windows/amd64", "windows/386", "windows/arm64",
 			"wasip1/wasm":

--- a/src/internal/platform/supported.go
+++ b/src/internal/platform/supported.go
@@ -156,7 +156,7 @@ func BuildModeSupported(compiler, buildmode, goos, goarch string) bool {
 				return false
 			}
 		case "freebsd":
-			return goarch == "amd64"
+			return goarch == "amd64" || goarch == "arm" || goarch == "arm64"
 		}
 		return false
 
@@ -164,7 +164,7 @@ func BuildModeSupported(compiler, buildmode, goos, goarch string) bool {
 		switch platform {
 		case "linux/amd64", "linux/arm", "linux/arm64", "linux/loong64", "linux/386", "linux/ppc64", "linux/ppc64le", "linux/riscv64", "linux/s390x",
 			"android/amd64", "android/arm", "android/arm64", "android/386",
-			"freebsd/amd64",
+			"freebsd/amd64", "freebsd/arm", "freebsd/arm64",
 			"darwin/amd64", "darwin/arm64",
 			"windows/amd64", "windows/386", "windows/arm64",
 			"wasip1/wasm":

--- a/src/runtime/cgo/gcc_freebsd_sigaction.c
+++ b/src/runtime/cgo/gcc_freebsd_sigaction.c
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build freebsd && amd64
+//go:build freebsd && (amd64 || arm || arm64)
 
 #include <errno.h>
 #include <stddef.h>
@@ -14,7 +14,7 @@
 
 // go_sigaction_t is a C version of the sigactiont struct from
 // os_freebsd.go.  This definition — and its conversion to and from struct
-// sigaction — are specific to freebsd/amd64.
+// sigaction — are specific to freebsd/amd64, freebsd/arm, and freebsd/arm64.
 typedef struct {
         uint32_t __bits[_SIG_WORDS];
 } go_sigset_t;

--- a/src/runtime/cgo/sigaction.go
+++ b/src/runtime/cgo/sigaction.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (linux && (386 || amd64 || arm64 || loong64 || ppc64le)) || (freebsd && amd64)
+//go:build (linux && (386 || amd64 || arm64 || loong64 || ppc64le)) || (freebsd && (amd64 || arm || arm64))
 
 package cgo
 

--- a/src/runtime/cgo/sigaction.go
+++ b/src/runtime/cgo/sigaction.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (linux && (386 || amd64 || arm64 || loong64 || ppc64 || ppc64le || riscv64)) || (freebsd && amd64)
+//go:build (linux && (386 || amd64 || arm64 || loong64 || ppc64 || ppc64le || riscv64)) || (freebsd && (amd64 || arm || arm64))
 
 package cgo
 

--- a/src/runtime/cgo_sigaction.go
+++ b/src/runtime/cgo_sigaction.go
@@ -6,7 +6,7 @@
 // Also used on linux/386 to clear the SA_RESTORER flag
 // when using cgo; see issue #75253.
 
-//go:build (linux && (386 || amd64 || arm64 || loong64 || ppc64le)) || (freebsd && amd64)
+//go:build (linux && (386 || amd64 || arm64 || loong64 || ppc64le)) || (freebsd && (amd64 || arm || arm64))
 
 package runtime
 

--- a/src/runtime/cgo_sigaction.go
+++ b/src/runtime/cgo_sigaction.go
@@ -6,7 +6,7 @@
 // Also used on linux/386 to clear the SA_RESTORER flag
 // when using cgo; see issue #75253.
 
-//go:build (linux && (386 || amd64 || arm64 || loong64 || ppc64 || ppc64le || riscv64)) || (freebsd && amd64)
+//go:build (linux && (386 || amd64 || arm64 || loong64 || ppc64 || ppc64le || riscv64)) || (freebsd && (amd64 || arm || arm64))
 
 package runtime
 

--- a/src/runtime/sigaction.go
+++ b/src/runtime/sigaction.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (linux && !386 && !amd64 && !arm64 && !loong64 && !ppc64le) || (freebsd && !amd64)
+//go:build (linux && !386 && !amd64 && !arm64 && !loong64 && !ppc64le) || (freebsd && !amd64 && !arm && !arm64)
 
 package runtime
 

--- a/src/runtime/sigaction.go
+++ b/src/runtime/sigaction.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (linux && !386 && !amd64 && !arm64 && !loong64 && !ppc64 && !ppc64le && !riscv64) || (freebsd && !amd64)
+//go:build (linux && !386 && !amd64 && !arm64 && !loong64 && !ppc64 && !ppc64le && !riscv64) || (freebsd && !amd64 && !arm && !arm64)
 
 package runtime
 

--- a/src/runtime/sys_freebsd_arm.s
+++ b/src/runtime/sys_freebsd_arm.s
@@ -232,6 +232,20 @@ TEXT runtime·asmSigaction(SB),NOSPLIT|NOFRAME,$0
 	MOVW	R0, ret+12(FP)
 	RET
 
+// Call the function stored in _cgo_sigaction using the GCC calling convention.
+TEXT runtime·callCgoSigaction(SB),NOSPLIT,$0
+	MOVW	sig+0(FP), R0
+	MOVW	new+4(FP), R1
+	MOVW	old+8(FP), R2
+	MOVW	_cgo_sigaction(SB), R11
+	MOVW	R13, R4
+	SUB	$24, R13
+	BIC	$0x7, R13 // alignment for ELF ABI
+	BL	(R11)
+	MOVW	R4, R13
+	MOVW	R0, ret+12(FP)
+	RET
+
 TEXT runtime·sigtramp(SB),NOSPLIT|TOPFRAME,$0
 	// Reserve space for callee-save registers and arguments.
 	MOVM.DB.W [R4-R11], (R13)

--- a/src/runtime/sys_freebsd_arm64.s
+++ b/src/runtime/sys_freebsd_arm64.s
@@ -266,6 +266,18 @@ ok:
 	MOVW	R0, ret+24(FP)
 	RET
 
+// Call the function stored in _cgo_sigaction using the GCC calling convention.
+TEXT runtime·callCgoSigaction(SB),NOSPLIT,$0
+	MOVD	sig+0(FP), R0
+	MOVD	new+8(FP), R1
+	MOVD	old+16(FP), R2
+	MOVD	_cgo_sigaction(SB), R3
+	SUB	$16, RSP		// reserve 16 bytes for sp-8 where fp may be saved.
+	BL	R3
+	ADD	$16, RSP
+	MOVW	R0, ret+24(FP)
+	RET
+
 // func sigfwd(fn uintptr, sig uint32, info *siginfo, ctx unsafe.Pointer)
 TEXT runtime·sigfwd(SB),NOSPLIT,$0-32
 	MOVW	sig+8(FP), R0


### PR DESCRIPTION
This PR adds support for c-archive and c-shared on freebsd/arm and
freebsd/arm64.

Fixes #44084