### PR TITLE
archive/zip: set ZIP64 version in Local File Header for large entries

### DIFF
--- a/src/archive/zip/writer.go
+++ b/src/archive/zip/writer.go
@@ -115,11 +115,11 @@ func (w *Writer) SetOffset(n int64) {
 }
 
 // writeZip64LFH writes the Local File Header (LFH) version field for ZIP64
-// entries to ensure consistency with the Central Directory. The LFH is written
-// before the file data when the final size is unknown, so it uses version 20.
-// After the data is written, if the entry exceeds 4GB, the Central Directory
-// uses version 45. This method seeks back to each ZIP64 entry's LFH and updates
-// the version to 45.
+// entries to ensure consistency with the Central Directory. The LFH is 
+// written before the file data when the final size is unknown, so it uses 
+// version 20. After the data is written, if the entry exceeds 4GB, the 
+// Central Directory uses version 45. This method seeks back to each ZIP64 
+// entry's LFH and updates the version to 45.
 func (w *Writer) writeZip64LFH() error {
 	if w.ws == nil {
 		return nil
@@ -179,8 +179,9 @@ func (w *Writer) Close() error {
 	}
 	w.closed = true
 
-	// write Local File Header versions for ZIP64 entries to ensure consistency
-	// with the Central Directory. This is required by strict ZIP readers.
+	// write Local File Header versions for ZIP64 entries to ensure 
+	// consistency with the Central Directory. This is required by strict 
+	// ZIP readers.
 	if err := w.writeZip64LFH(); err != nil {
 		return err
 	}

--- a/src/archive/zip/writer_test.go
+++ b/src/archive/zip/writer_test.go
@@ -672,8 +672,8 @@ func TestIssue61875(t *testing.T) {
 	}
 }
 
-// TestZip64LFHVersion tests that the Local File Header version is written to 45
-// for ZIP64 entries to match the Central Directory version.
+// TestZip64LFHVersion tests that the Local File Header version is written 
+// to 45 for ZIP64 entries to match the Central Directory version.
 func TestZip64LFHVersion(t *testing.T) {
 	buf := new(bytes.Buffer)
 	w := NewWriter(buf)

--- a/src/archive/zip/writer_test.go
+++ b/src/archive/zip/writer_test.go
@@ -672,7 +672,7 @@ func TestIssue61875(t *testing.T) {
 	}
 }
 
-// TestZip64LFHVersion tests that the Local File Header version is written 
+// TestZip64LFHVersion tests that the Local File Header version is written
 // to 45 for ZIP64 entries to match the Central Directory version.
 func TestZip64LFHVersion(t *testing.T) {
 	buf := new(bytes.Buffer)

--- a/src/archive/zip/writer_test.go
+++ b/src/archive/zip/writer_test.go
@@ -671,3 +671,39 @@ func TestIssue61875(t *testing.T) {
 		t.Errorf("expected error, got nil")
 	}
 }
+
+// TestZip64LFHVersion tests that the Local File Header version is written to 45
+// for ZIP64 entries to match the Central Directory version.
+func TestZip64LFHVersion(t *testing.T) {
+	buf := new(bytes.Buffer)
+	w := NewWriter(buf)
+	fh := &FileHeader{
+		Name:               "large_file.bin",
+		Method:             Store,
+		CRC32:              0x12345678,
+		CompressedSize64:   uint32max + 1,
+		UncompressedSize64: uint32max + 1,
+	}
+	if _, err := w.CreateRaw(fh); err != nil {
+		t.Fatalf("CreateRaw failed: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+	data := buf.Bytes()
+	// Find Local File Header (signature 0x04034b50)
+	lfhIdx := bytes.Index(data, []byte{0x50, 0x4b, 0x03, 0x04})
+	if lfhIdx == -1 {
+		t.Fatal("local file header not found")
+	}
+	lfhVersion := binary.LittleEndian.Uint16(data[lfhIdx+4 : lfhIdx+6])
+	// Find Central Directory Header (signature 0x02014b50)
+	cdIdx := bytes.Index(data, []byte{0x50, 0x4b, 0x01, 0x02})
+	if cdIdx == -1 {
+		t.Fatal("central directory header not found")
+	}
+	cdVersion := binary.LittleEndian.Uint16(data[cdIdx+6 : cdIdx+8])
+	if lfhVersion != 45 || cdVersion != 45 {
+		t.Errorf("version mismatch: LFH=%d, CD=%d, want both 45", lfhVersion, cdVersion)
+	}
+}


### PR DESCRIPTION
When creating ZIP64 entries via CreateRaw, set ReaderVersion to 45 (ZIP64 version 4.5) upfront since the file sizes are known at creation time. This ensures the Local File Header version matches the Central Directory version for ZIP64 entries.

Fixes #77060