### PR TITLE
internal/trace: fix recorder.Write return value for header-only buffers

### DIFF
--- a/src/runtime/trace/recorder.go
+++ b/src/runtime/trace/recorder.go
@@ -39,7 +39,7 @@ func (w *recorder) Write(b []byte) (n int, err error) {
 		w.headerReceived = true
 	}
 	if len(b) == n {
-		return 0, nil
+		return n, nil
 	}
 	ba, nb, err := readBatch(b[n:]) // Every write from the runtime is guaranteed to be a complete batch.
 	if err != nil {


### PR DESCRIPTION
Fix issue #77083 