### PR TITLE
runtime: speed up cheaprand and cheaprand64

### DIFF
--- a/src/runtime/export_test.go
+++ b/src/runtime/export_test.go
@@ -273,6 +273,10 @@ func CountPagesInUse() (pagesInUse, counted uintptr) {
 	return
 }
 
+func Blocksampled(cycles, rate int64) bool { return blocksampled(cycles, rate) }
+
+func Cheaprand() uint32         { return cheaprand() }
+func Cheaprand64() int64        { return cheaprand64() }
 func Fastrand() uint32          { return uint32(rand()) }
 func Fastrand64() uint64        { return rand() }
 func Fastrandn(n uint32) uint32 { return randn(n) }

--- a/src/runtime/lock_spinbit.go
+++ b/src/runtime/lock_spinbit.go
@@ -327,16 +327,8 @@ func unlock2(l *mutex) {
 // mutexSampleContention returns whether the current mutex operation should
 // report any contention it discovers.
 func mutexSampleContention() bool {
-	if rate := int64(atomic.Load64(&mutexprofilerate)); rate <= 0 {
-		return false
-	} else {
-		// TODO: have SetMutexProfileFraction do the clamping
-		rate32 := uint32(rate)
-		if int64(rate32) != rate {
-			rate32 = ^uint32(0)
-		}
-		return cheaprandn(rate32) == 0
-	}
+	rate := atomic.Load64(&mutexprofilerate)
+	return rate > 0 && cheaprandu64()%rate == 0
 }
 
 // unlock2Wake updates the list of Ms waiting on l, waking an M if necessary.

--- a/src/runtime/mprof.go
+++ b/src/runtime/mprof.go
@@ -696,8 +696,8 @@ func (prof *mLockProfile) recordUnlock(cycles int64) {
 		if cycles == 0 {
 			return
 		}
-		prevScore := uint64(cheaprand64()) % uint64(prev)
-		thisScore := uint64(cheaprand64()) % uint64(cycles)
+		prevScore := cheaprandu64() % uint64(prev)
+		thisScore := cheaprandu64() % uint64(cycles)
 		if prevScore > thisScore {
 			prof.cyclesLost += cycles
 			return

--- a/src/runtime/mprof_test.go
+++ b/src/runtime/mprof_test.go
@@ -1,0 +1,16 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package runtime_test
+
+import (
+	. "runtime"
+	"testing"
+)
+
+func BenchmarkBlocksampled(b *testing.B) {
+	for b.Loop() {
+		Blocksampled(42, 1337)
+	}
+}

--- a/src/runtime/rand_test.go
+++ b/src/runtime/rand_test.go
@@ -22,6 +22,18 @@ func TestReadRandom(t *testing.T) {
 	}
 }
 
+func BenchmarkCheaprand(b *testing.B) {
+	for b.Loop() {
+		Cheaprand()
+	}
+}
+
+func BenchmarkCheaprand64(b *testing.B) {
+	for b.Loop() {
+		Cheaprand64()
+	}
+}
+
 func BenchmarkFastrand(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {

--- a/src/runtime/runtime2.go
+++ b/src/runtime/runtime2.go
@@ -715,8 +715,9 @@ type m struct {
 
 	mOS
 
-	chacha8   chacha8rand.State
-	cheaprand uint64
+	chacha8     chacha8rand.State
+	cheaprand   uint32
+	cheaprand64 uint64
 
 	// Up to 10 locks held by this m, maintained by the lock ranking code.
 	locksHeldLen int


### PR DESCRIPTION
The current cheaprand performs 128-bit multiplication on 64-bit numbers
and truncate the result to 32 bits, which is inefficient.

A 32-bit specific implementation is more performant because it performs
64-bit multiplication on 32-bit numbers instead.

The current cheaprand64 involves two cheaprand calls.
Implementing it as 64-bit wyrand is significantly faster.

Since cheaprand64 discards one bit, I have preserved this behavior.
The underlying uint64 function is made available as cheaprandu64.

               │    old      │                new           │
               │   sec/op    │   sec/op     vs base         │
Cheaprand-8      1.358n ± 0%   1.218n ± 0%  -10.31% (n=100)
Cheaprand64-8    2.424n ± 0%   1.391n ± 0%  -42.62% (n=100)
Blocksampled-8   8.347n ± 0%   2.022n ± 0%  -75.78% (n=100)

Fixes #77149