### PR TITLE
cmd/compile/internal/ssa: enable unalign memory access optimization on riscv64

### DIFF
--- a/src/cmd/compile/internal/ssa/config.go
+++ b/src/cmd/compile/internal/ssa/config.go
@@ -352,6 +352,7 @@ func NewConfig(arch string, types Types, ctxt *obj.Link, optimize, softfloat boo
 		c.floatParamRegs = paramFloatRegRISCV64
 		c.FPReg = framepointerRegRISCV64
 		c.hasGReg = true
+		c.unalignedOK = true
 	case "wasm":
 		c.PtrSize = 8
 		c.RegSize = 8


### PR DESCRIPTION
This PR enables unaligned memory access optimization for RISC-V 64, allowing memcombine to function properly.

Zicclsm is an extension that enables support for misaligned loads and stores, and it is mandatory for RVA20U64, RVA22U64, and RVA23U64 (see https://github.com/riscv/riscv-profiles/blob/main/src/profiles.adoc and https://github.com/riscv/riscv-profiles/blob/main/src/rva23-profile.adoc).