### PR TITLE
src/unsafe: add comment on alignment assumptions for misaligned accesses

### DIFF
--- a/src/unsafe/unsafe.go
+++ b/src/unsafe/unsafe.go
@@ -83,6 +83,9 @@ type IntegerType int
 //
 // It is valid both to add and to subtract offsets from a pointer in this way.
 // It is also valid to use &^ to round pointers, usually for alignment.
+// When converting the result to a pointer value p of some type *T and dereferencing,
+// p must be appropriately aligned for T. The compiler assumes
+// uintptr(p) % unsafe.Alignof(*p) == 0 for any dereference *p.
 // In all cases, the result must continue to point into the original allocated object.
 //
 // Unlike in C, it is not valid to advance a pointer just beyond the end of

--- a/src/unsafe/unsafe.go
+++ b/src/unsafe/unsafe.go
@@ -83,9 +83,9 @@ type IntegerType int
 //
 // It is valid both to add and to subtract offsets from a pointer in this way.
 // It is also valid to use &^ to round pointers, usually for alignment.
-// When converting the result to a pointer value p of some type *T and dereferencing,
+// When converting the result to a pointer value p of some type *T,
 // p must be appropriately aligned for T. The compiler assumes
-// uintptr(p) % unsafe.Alignof(*p) == 0 for any dereference *p.
+// uintptr(p) % unsafe.Alignof(*p) == 0 for any dereference p.
 // In all cases, the result must continue to point into the original allocated object.
 //
 // Unlike in C, it is not valid to advance a pointer just beyond the end of


### PR DESCRIPTION
Aims to clarify the assumptions the compiler makes on misaligned accesses wrt unsafe code.

Following conversations with Alex Vlasov and https://github.com/golang/go/issues/76919#issuecomment-3675508605 
It seems that the compiler always assumes that pointers are aligned to their types.

Also see #37298