### PR TITLE
syscall: document Sendfile semantics

### DIFF
--- a/src/syscall/syscall_unix.go
+++ b/src/syscall/syscall_unix.go
@@ -530,12 +530,12 @@ func Socketpair(domain, typ, proto int) (fd [2]int, err error) {
 // On Linux, if offset is nil, Sendfile uses and updates the current file
 // position of infd. If offset is non-nil, the current file position is
 // unchanged, and the offset pointer is updated to reflect the bytes written.
+// A non-nil error typically implies that no bytes were written.
 //
-// On BSD-derived systems (including macOS), the offset argument is not
-// updated by the system call; the caller must manually update the offset
-// using the number of bytes written. These systems may also return a
-// non-zero byte count together with an error (for example, EAGAIN).
-// On Linux, a non-nil error typically implies that no bytes were written.
+// On BSD-derived systems (including macOS), if offset is nil, Sendfile panics.
+// The offset argument is not updated by the system call; the caller must manually
+// update the offset using the number of bytes written. These systems may
+// return a non-zero byte count together with an error (for example, EAGAIN).
 //
 // For precise semantics, see the system documentation (e.g., man 2 sendfile).
 func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err error) {

--- a/src/syscall/syscall_unix.go
+++ b/src/syscall/syscall_unix.go
@@ -522,6 +522,22 @@ func Socketpair(domain, typ, proto int) (fd [2]int, err error) {
 	return
 }
 
+// Sendfile copies up to count bytes from file descriptor infd to file descriptor outfd.
+//
+// It wraps the sendfile system call. The behavior varies by operating system,
+// particularly regarding the offset argument and how partial writes are reported.
+//
+// On Linux, if offset is nil, Sendfile uses and updates the current file
+// position of infd. If offset is non-nil, the current file position is
+// unchanged, and the offset pointer is updated to reflect the bytes written.
+//
+// On BSD-derived systems (including macOS), the offset argument is not
+// updated by the system call; the caller must manually update the offset
+// using the number of bytes written. These systems may also return a
+// non-zero byte count together with an error (for example, EAGAIN).
+// On Linux, a non-nil error typically implies that no bytes were written.
+//
+// For precise semantics, see the system documentation (e.g., man 2 sendfile).
 func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err error) {
 	if race.Enabled {
 		race.ReleaseMerge(unsafe.Pointer(&ioSync))


### PR DESCRIPTION
syscall.Sendfile behavior differs significantly between operating 
systems.

Document the platform-specific behavior for the offset argument and
partial write reporting on Linux versus BSD-derived systems.

Fixes #64044