### PR TITLE
cmd/compile: add missing usemethod checks for reflect method iterators

### DIFF
--- a/src/cmd/link/internal/ld/deadcode_test.go
+++ b/src/cmd/link/internal/ld/deadcode_test.go
@@ -29,6 +29,7 @@ func TestDeadcode(t *testing.T) {
 		{"ifacemethod4", nil, []string{"main.T.M"}},
 		{"ifacemethod5", []string{"main.S.M"}, nil},
 		{"ifacemethod6", []string{"main.S.M"}, []string{"main.S.N"}},
+		{"methods_by_name", []string{"main.T.M"}, nil},
 		{"structof_funcof", []string{"main.S.M"}, []string{"main.S.N"}},
 		{"globalmap", []string{"main.small", "main.effect"},
 			[]string{"main.large"}},

--- a/src/cmd/link/internal/ld/testdata/deadcode/methods_by_name.go
+++ b/src/cmd/link/internal/ld/testdata/deadcode/methods_by_name.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"iter"
+	"reflect"
+)
+
+type T int
+
+func (T) M() { println("M called") }
+
+func main() {
+	v := reflect.ValueOf(T(0))
+	t := v.Type()
+	tv := reflect.ValueOf(t)
+	ms := tv.MethodByName("Methods")
+	it := ms.Call(nil)[0]
+	for m := range it.Interface().(iter.Seq[reflect.Method]) {
+		m.Func.Call([]reflect.Value{v})
+	}
+}


### PR DESCRIPTION
Required for dead-code elimination.

Fixes #77222
