### PR TITLE
runtime/metrics: fix panic in Read with empty slice

### DIFF
--- a/src/runtime/metrics/description_test.go
+++ b/src/runtime/metrics/description_test.go
@@ -156,3 +156,10 @@ func TestDocs(t *testing.T) {
 		fmt.Fprintf(os.Stderr, "go test -generate: doc.go already up-to-date\n")
 	}
 }
+
+func TestReadEmptySlice(t *testing.T) {
+	// Test that Read does not panic when given an empty slice.
+	// This should be a no-op.
+	metrics.Read(nil)
+	metrics.Read([]metrics.Sample{})
+}

--- a/src/runtime/metrics/sample.go
+++ b/src/runtime/metrics/sample.go
@@ -43,5 +43,8 @@ func runtime_readMetrics(unsafe.Pointer, int, int)
 // Sample values with names not appearing in [All] will have their Value populated
 // as KindBad to indicate that the name is unknown.
 func Read(m []Sample) {
+	if len(m) == 0 {
+		return
+	}
 	runtime_readMetrics(unsafe.Pointer(&m[0]), len(m), cap(m))
 }


### PR DESCRIPTION
Calling Read with a nil or empty slice previously caused a panic with
"index out of range" because the function unconditionally accessed the
first element of the slice (via &m[0]) to pass the pointer to the
runtime.

This change adds a check for len(m) == 0 to return early, preventing
the panic when no samples are provided.

Fixes #77231