### PR TITLE
net: permit WriteMsgUnix to connected SOCK_DGRAM sockets

### DIFF
--- a/src/net/unixsock_posix.go
+++ b/src/net/unixsock_posix.go
@@ -141,7 +141,7 @@ func (c *UnixConn) writeTo(b []byte, addr *UnixAddr) (int, error) {
 }
 
 func (c *UnixConn) writeMsg(b, oob []byte, addr *UnixAddr) (n, oobn int, err error) {
-	if c.fd.sotype == syscall.SOCK_DGRAM && c.fd.isConnected {
+	if c.fd.sotype == syscall.SOCK_DGRAM && c.fd.isConnected && addr != nil {
 		return 0, 0, ErrWriteToConnected
 	}
 	var sa syscall.Sockaddr


### PR DESCRIPTION
The sendmsg function works on connected SOCK_DGRAM sockets if no address is specified,
the check in writeMsg is too strict. This change is analogous to #9807
