### PR TITLE
cmd/compile: allow generic function values in composite literals

### DIFF
--- a/test/fixedbugs/issue77245.go
+++ b/test/fixedbugs/issue77245.go
@@ -1,0 +1,14 @@
+// compile
+
+package p
+
+type S struct{ f func(int) }
+
+func g[T any](T) {}
+
+func _() {
+	var s S
+	s.f = g      // ok
+	_ = S{f: g}  // should be ok; was rejected
+	_ = s
+}


### PR DESCRIPTION
Allow generic function values to be used in composite literals.

This fixes a case where assigning a generic function value inside a
composite literal was incorrectly rejected.

This change is mirrored in go/types via go generate go/types.

Fixes [#77245](https://go.dev/issue/77245)
