### PR TITLE
crypto/tls: add identity freshness on server resumption

### DIFF
--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -47,7 +47,7 @@ type serverHandshakeStateTLS13 struct {
 	clientHello     *clientHelloMsg
 	hello           *serverHelloMsg
 	sentDummyCCS    bool
-	usingPSK        bool
+	sessionState    *SessionState
 	earlyData       bool
 	suite           *cipherSuiteTLS13
 	cert            *Certificate
@@ -429,7 +429,11 @@ pskIdentityLoop:
 
 		hs.hello.selectedIdentityPresent = true
 		hs.hello.selectedIdentity = uint16(i)
-		hs.usingPSK = true
+
+		hs.sessionState = sessionState
+		if c.quic != nil {
+			c.quic.sessionState = sessionState
+		}
 		return nil
 	}
 
@@ -475,7 +479,7 @@ func (hs *serverHandshakeStateTLS13) pickCertificate() error {
 	c := hs.c
 
 	// Only one of PSK and certificates are used at a time.
-	if hs.usingPSK {
+	if hs.sessionState != nil {
 		return nil
 	}
 
@@ -815,19 +819,15 @@ func (hs *serverHandshakeStateTLS13) sendServerParameters() error {
 	return nil
 }
 
-func (hs *serverHandshakeStateTLS13) requestClientCert() bool {
-	return hs.c.config.ClientAuth >= RequestClientCert && !hs.usingPSK
-}
-
 func (hs *serverHandshakeStateTLS13) sendServerCertificate() error {
 	c := hs.c
 
 	// Only one of PSK and certificates are used at a time.
-	if hs.usingPSK {
+	if hs.sessionState != nil {
 		return nil
 	}
 
-	if hs.requestClientCert() {
+	if c.config.ClientAuth != NoClientCert {
 		// Request a client certificate
 		certReq := new(certificateRequestMsgTLS13)
 		certReq.ocspStapling = true
@@ -926,7 +926,7 @@ func (hs *serverHandshakeStateTLS13) sendServerFinished() error {
 	// If we did not request client certificates, at this point we can
 	// precompute the client finished and roll the transcript forward to send
 	// session tickets in our first flight.
-	if !hs.requestClientCert() {
+	if hs.c.config.ClientAuth == NoClientCert || hs.sessionState != nil {
 		if err := hs.sendSessionTickets(); err != nil {
 			return err
 		}
@@ -965,10 +965,10 @@ func (hs *serverHandshakeStateTLS13) sendSessionTickets() error {
 	if !hs.shouldSendSessionTickets() {
 		return nil
 	}
-	return c.sendSessionTicket(false, nil)
+	return c.sendSessionTicket(hs.sessionState, false, nil)
 }
 
-func (c *Conn) sendSessionTicket(earlyData bool, extra [][]byte) error {
+func (c *Conn) sendSessionTicket(sessionState *SessionState, earlyData bool, extra [][]byte) error {
 	suite := cipherSuiteTLS13ByID(c.cipherSuite)
 	if suite == nil {
 		return errors.New("tls: internal error: unknown cipher suite")
@@ -981,6 +981,11 @@ func (c *Conn) sendSessionTicket(earlyData bool, extra [][]byte) error {
 	m := new(newSessionTicketMsgTLS13)
 
 	state := c.sessionState()
+	if c.config.ClientAuth != NoClientCert && sessionState != nil {
+		// If this is re-wrapping an old authentication state,
+		// then keep the original time it was created.
+		state.createdAt = sessionState.createdAt
+	}
 	state.secret = psk
 	state.EarlyData = earlyData
 	state.Extra = extra
@@ -1027,7 +1032,7 @@ func (c *Conn) sendSessionTicket(earlyData bool, extra [][]byte) error {
 func (hs *serverHandshakeStateTLS13) readClientCertificate() error {
 	c := hs.c
 
-	if !hs.requestClientCert() {
+	if c.config.ClientAuth == NoClientCert || hs.sessionState != nil {
 		// Make sure the connection is still being verified whether or not
 		// the server requested a client certificate.
 		if c.config.VerifyConnection != nil {

--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -48,7 +48,7 @@ type serverHandshakeStateTLS13 struct {
 	clientHello     *clientHelloMsg
 	hello           *serverHelloMsg
 	sentDummyCCS    bool
-	usingPSK        bool
+	sessionState    *SessionState
 	earlyData       bool
 	suite           *cipherSuiteTLS13
 	cert            *Certificate
@@ -429,7 +429,11 @@ func (hs *serverHandshakeStateTLS13) checkForResumption() error {
 
 		hs.hello.selectedIdentityPresent = true
 		hs.hello.selectedIdentity = uint16(i)
-		hs.usingPSK = true
+
+		hs.sessionState = sessionState
+		if c.quic != nil {
+			c.quic.sessionState = sessionState
+		}
 		return nil
 	}
 
@@ -475,7 +479,7 @@ func (hs *serverHandshakeStateTLS13) pickCertificate() error {
 	c := hs.c
 
 	// Only one of PSK and certificates are used at a time.
-	if hs.usingPSK {
+	if hs.sessionState != nil {
 		return nil
 	}
 
@@ -818,19 +822,15 @@ func (hs *serverHandshakeStateTLS13) sendServerParameters() error {
 	return nil
 }
 
-func (hs *serverHandshakeStateTLS13) requestClientCert() bool {
-	return hs.c.config.ClientAuth >= RequestClientCert && !hs.usingPSK
-}
-
 func (hs *serverHandshakeStateTLS13) sendServerCertificate() error {
 	c := hs.c
 
 	// Only one of PSK and certificates are used at a time.
-	if hs.usingPSK {
+	if hs.sessionState != nil {
 		return nil
 	}
 
-	if hs.requestClientCert() {
+	if c.config.ClientAuth != NoClientCert {
 		// Request a client certificate
 		certReq := new(certificateRequestMsgTLS13)
 		certReq.ocspStapling = true
@@ -929,7 +929,7 @@ func (hs *serverHandshakeStateTLS13) sendServerFinished() error {
 	// If we did not request client certificates, at this point we can
 	// precompute the client finished and roll the transcript forward to send
 	// session tickets in our first flight.
-	if !hs.requestClientCert() {
+	if hs.c.config.ClientAuth == NoClientCert || hs.sessionState != nil {
 		if err := hs.sendSessionTickets(); err != nil {
 			return err
 		}
@@ -968,10 +968,10 @@ func (hs *serverHandshakeStateTLS13) sendSessionTickets() error {
 	if !hs.shouldSendSessionTickets() {
 		return nil
 	}
-	return c.sendSessionTicket(false, nil)
+	return c.sendSessionTicket(hs.sessionState, false, nil)
 }
 
-func (c *Conn) sendSessionTicket(earlyData bool, extra [][]byte) error {
+func (c *Conn) sendSessionTicket(sessionState *SessionState, earlyData bool, extra [][]byte) error {
 	suite := cipherSuiteTLS13ByID(c.cipherSuite)
 	if suite == nil {
 		return errors.New("tls: internal error: unknown cipher suite")
@@ -984,6 +984,11 @@ func (c *Conn) sendSessionTicket(earlyData bool, extra [][]byte) error {
 	m := new(newSessionTicketMsgTLS13)
 
 	state := c.sessionState()
+	if c.config.ClientAuth != NoClientCert && sessionState != nil {
+		// If this is re-wrapping an old authentication state,
+		// then keep the original time it was created.
+		state.createdAt = sessionState.createdAt
+	}
 	state.secret = psk
 	state.EarlyData = earlyData
 	state.Extra = extra
@@ -1030,7 +1035,7 @@ func (c *Conn) sendSessionTicket(earlyData bool, extra [][]byte) error {
 func (hs *serverHandshakeStateTLS13) readClientCertificate() error {
 	c := hs.c
 
-	if !hs.requestClientCert() {
+	if c.config.ClientAuth == NoClientCert || hs.sessionState != nil {
 		// Make sure the connection is still being verified whether or not
 		// the server requested a client certificate.
 		if c.config.VerifyConnection != nil {

--- a/src/crypto/tls/quic.go
+++ b/src/crypto/tls/quic.go
@@ -176,6 +176,8 @@ type quicState struct {
 	transportParams []byte // to send to the peer
 
 	enableSessionEvents bool
+
+	sessionState *SessionState
 }
 
 // QUICClient returns a new TLS client side connection using QUICTransport as the
@@ -334,7 +336,10 @@ func (q *QUICConn) SendSessionTicket(opts QUICSessionTicketOptions) error {
 		return quicError(errors.New("tls: SendSessionTicket called multiple times"))
 	}
 	q.sessionTicketSent = true
-	return quicError(c.sendSessionTicket(opts.EarlyData, opts.Extra))
+
+	sessionState := q.conn.quic.sessionState
+	q.conn.quic.sessionState = nil
+	return quicError(c.sendSessionTicket(sessionState, opts.EarlyData, opts.Extra))
 }
 
 // StoreSession stores a session previously received in a QUICStoreSession event

--- a/src/crypto/tls/quic.go
+++ b/src/crypto/tls/quic.go
@@ -180,6 +180,7 @@ type quicState struct {
 	transportParams []byte // to send to the peer
 
 	enableSessionEvents bool
+	sessionState        *SessionState
 	clientHelloInfoConn net.Conn
 }
 
@@ -334,7 +335,10 @@ func (q *QUICConn) SendSessionTicket(opts QUICSessionTicketOptions) error {
 		return quicError(errors.New("tls: SendSessionTicket called multiple times"))
 	}
 	q.sessionTicketSent = true
-	return quicError(c.sendSessionTicket(opts.EarlyData, opts.Extra))
+
+	sessionState := q.conn.quic.sessionState
+	q.conn.quic.sessionState = nil
+	return quicError(c.sendSessionTicket(sessionState, opts.EarlyData, opts.Extra))
 }
 
 // StoreSession stores a session previously received in a QUICStoreSession event


### PR DESCRIPTION
TLS 1.3's forward security would issue new session tickets with a new createdAt for a resumed connection.

This will cause client identity re-verification to be delay indefinitely.

Now the createdAt property of such tickets will be inherited.

This feature is designed to periodically check and ensure that the client still holds the private key.

Fixes #77294 