### PR TITLE
net/http: clarify influence of go.mod version on ServeMux behavior

### DIFF
--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -2554,9 +2554,16 @@ func RedirectHandler(url string, code int) Handler {
 // # Compatibility
 //
 // The pattern syntax and matching behavior of ServeMux changed significantly
-// in Go 1.22. To restore the old behavior, set the GODEBUG environment variable
-// to "httpmuxgo121=1". This setting is read once, at program startup; changes
-// during execution will be ignored.
+// in Go 1.22. 
+//
+// The new behavior is determined by the Go version in the go.mod file. 
+// If the go.mod file specifies Go 1.22 or later, the new patterns and 
+// matching rules are used. If it specifies an earlier version, the 1.21 
+// behavior is maintained for compatibility.
+//
+// To manually restore the old behavior regardless of the go.mod version, 
+// set the GODEBUG environment variable to "httpmuxgo121=1". This setting 
+// is read once, at program startup; changes during execution will be ignored.
 //
 // The backwards-incompatible changes include:
 //   - Wildcards are just ordinary literal path segments in 1.21.


### PR DESCRIPTION
Added a note about the importance of the specified `go.mod` version.

When using go `1.25` with a `1.20` specified in the `go.mod` file I had non
obvious issues with getting the new path behavior(since `1.22`) to work.

I do recognize that https://go.dev/doc/modules/gomod-ref#go-notes specifies
that gowill refuse to use "future" features but as the interface is the same
there are no compiler errors. As it took me quite some time to catch it would be
great to have a note about this as well in the docs.