### PR TITLE
cmd/internal/quoted: apply TestComments in tests

### DIFF
--- a/src/cmd/internal/quoted/quoted_test.go
+++ b/src/cmd/internal/quoted/quoted_test.go
@@ -13,28 +13,28 @@ import (
 func TestSplit(t *testing.T) {
 	for _, test := range []struct {
 		name    string
-		value   string
+		in      string
 		want    []string
 		wantErr string
 	}{
-		{name: "empty", value: "", want: nil},
-		{name: "space", value: " ", want: nil},
-		{name: "one", value: "a", want: []string{"a"}},
-		{name: "leading_space", value: " a", want: []string{"a"}},
-		{name: "trailing_space", value: "a ", want: []string{"a"}},
-		{name: "two", value: "a b", want: []string{"a", "b"}},
-		{name: "two_multi_space", value: "a  b", want: []string{"a", "b"}},
-		{name: "two_tab", value: "a\tb", want: []string{"a", "b"}},
-		{name: "two_newline", value: "a\nb", want: []string{"a", "b"}},
-		{name: "quote_single", value: `'a b'`, want: []string{"a b"}},
-		{name: "quote_double", value: `"a b"`, want: []string{"a b"}},
-		{name: "quote_both", value: `'a '"b "`, want: []string{"a ", "b "}},
-		{name: "quote_contains", value: `'a "'"'b"`, want: []string{`a "`, `'b`}},
-		{name: "escape", value: `\'`, want: []string{`\'`}},
-		{name: "quote_unclosed", value: `'a`, wantErr: "unterminated ' string"},
+		{name: "empty", in: "", want: nil},
+		{name: "space", in: " ", want: nil},
+		{name: "one", in: "a", want: []string{"a"}},
+		{name: "leading_space", in: " a", want: []string{"a"}},
+		{name: "trailing_space", in: "a ", want: []string{"a"}},
+		{name: "two", in: "a b", want: []string{"a", "b"}},
+		{name: "two_multi_space", in: "a  b", want: []string{"a", "b"}},
+		{name: "two_tab", in: "a\tb", want: []string{"a", "b"}},
+		{name: "two_newline", in: "a\nb", want: []string{"a", "b"}},
+		{name: "quote_single", in: `'a b'`, want: []string{"a b"}},
+		{name: "quote_double", in: `"a b"`, want: []string{"a b"}},
+		{name: "quote_both", in: `'a '"b "`, want: []string{"a ", "b "}},
+		{name: "quote_contains", in: `'a "'"'b"`, want: []string{`a "`, `'b`}},
+		{name: "escape", in: `\'`, want: []string{`\'`}},
+		{name: "quote_unclosed", in: `'a`, wantErr: "unterminated ' string"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := Split(test.value)
+			got, err := Split(test.in)
 			if err != nil {
 				if test.wantErr == "" {
 					t.Fatalf("unexpected error: %v", err)
@@ -47,7 +47,7 @@ func TestSplit(t *testing.T) {
 				t.Fatalf("unexpected success; wanted error containing %q", test.wantErr)
 			}
 			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("got %q; want %q", got, test.want)
+				t.Errorf("Split(%q) = %q, want %q", test.in, got, test.want)
 			}
 		})
 	}
@@ -56,19 +56,19 @@ func TestSplit(t *testing.T) {
 func TestJoin(t *testing.T) {
 	for _, test := range []struct {
 		name          string
-		args          []string
+		in            []string
 		want, wantErr string
 	}{
-		{name: "empty", args: nil, want: ""},
-		{name: "one", args: []string{"a"}, want: "a"},
-		{name: "two", args: []string{"a", "b"}, want: "a b"},
-		{name: "space", args: []string{"a ", "b"}, want: "'a ' b"},
-		{name: "newline", args: []string{"a\n", "b"}, want: "'a\n' b"},
-		{name: "quote", args: []string{`'a `, "b"}, want: `"'a " b`},
-		{name: "unquoteable", args: []string{`'"`}, wantErr: "contains both single and double quotes and cannot be quoted"},
+		{name: "empty", in: nil, want: ""},
+		{name: "one", in: []string{"a"}, want: "a"},
+		{name: "two", in: []string{"a", "b"}, want: "a b"},
+		{name: "space", in: []string{"a ", "b"}, want: "'a ' b"},
+		{name: "newline", in: []string{"a\n", "b"}, want: "'a\n' b"},
+		{name: "quote", in: []string{`'a `, "b"}, want: `"'a " b`},
+		{name: "unquoteable", in: []string{`'"`}, wantErr: "contains both single and double quotes and cannot be quoted"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := Join(test.args)
+			got, err := Join(test.in)
 			if err != nil {
 				if test.wantErr == "" {
 					t.Fatalf("unexpected error: %v", err)
@@ -81,7 +81,7 @@ func TestJoin(t *testing.T) {
 				t.Fatalf("unexpected success; wanted error containing %q", test.wantErr)
 			}
 			if got != test.want {
-				t.Errorf("got %s; want %s", got, test.want)
+				t.Errorf("Join(%v) = %s, want %s", test.in, got, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
It seems there is a bit of inconsistency in the formatting/output of the failure messages of the tests.
As an example, tests like directive_test.go are using the failure messages as described in https://go.dev/wiki/TestComments#got-before-want.
But some other tests, like the ones in quoted_test.go are using the (not recommended) approach of:
"got %v, want %v"

This PR tries to follow the failure message recommendation described in https://go.dev/wiki/TestComments:

- Adding the tested function at the beginning.
- Changing the input parameter name to in.

So, as an example, this is a before/after for the two tests I changed:

Split:
- Before: "got ["a"]; want ["a "]"
- After: "Split("a") = ["a"], want ["a "]"

Join:
- "got a; want ab"
- "Join([a]) = a, want ab"