### PR TITLE
internal/runtime/gc/scan: fix calls for retpoline compatibility

### DIFF
--- a/src/internal/runtime/gc/scan/scan_amd64.s
+++ b/src/internal/runtime/gc/scan/scan_amd64.s
@@ -12,7 +12,8 @@ TEXT ·ExpandAVX512(SB), NOSPLIT, $0-24
 
 	// Call the expander for this size class
 	LEAQ ·gcExpandersAVX512(SB), BX
-	CALL (BX)(CX*8)
+	MOVQ (BX)(CX*8), R11
+	CALL R11
 
 	MOVQ unpacked+16(FP), DI // Expanded output bitmap pointer
 	VMOVDQU64 Z1, 0(DI)
@@ -25,7 +26,8 @@ TEXT ·scanSpanPackedAVX512(SB), NOSPLIT, $256-44
 	MOVQ objMarks+16(FP), AX
 	MOVQ sizeClass+24(FP), CX
 	LEAQ ·gcExpandersAVX512(SB), BX
-	CALL (BX)(CX*8)
+	MOVQ (BX)(CX*8), R11
+	CALL R11
 
 	// Z3+Z4 = Load the pointer mask
 	MOVQ ptrMask+32(FP), AX

--- a/src/internal/runtime/startlinetest/func_amd64.s
+++ b/src/internal/runtime/startlinetest/func_amd64.s
@@ -24,5 +24,6 @@ TEXT	·AsmFunc<ABIInternal>(SB),NOSPLIT,$8-0
 	NO_LOCAL_POINTERS
 	MOVQ	$0, AX // wantInlined
 	MOVQ	·CallerStartLine(SB), DX
-	CALL	(DX)
+	MOVQ	(DX), BX
+	CALL	BX
 	RET


### PR DESCRIPTION
The assembler's retpoline pass for Spectre mitigations did not recognize
several indirect CALL instructions, causing assembly failures with:

\# internal/runtime/gc/scan
asm: non-retpoline-compatible: 00005 (/path_to_go/src/internal/runtime/gc/scan/scan_amd64.s:15) CALL    (BX)(CX*8)
asm: non-retpoline-compatible: 00015 (/path_to_go/src/internal/runtime/gc/scan/scan_amd64.s:28) CALL    (BX)(CX*8)
asm: assembly failed
\# internal/runtime/startlinetest
asm: non-retpoline-compatible: 00005 (/path_to_go/src/internal/runtime/startlinetest/func_amd64.s:27)   CALL    (DX)
asm: assembly failed

Adapt the calls in func_amd64.s and scan_amd64.s to allow the assembler to
correctly apply retpolines and fix the build with Spectre mitigations
enabled.

I'm not certain about the syntax or the exact registers (e.g. `R11`), but
`go tool dist test` passes on target. There's probably a better approach.

Commits are split in case this needs backporting, since paths are different
on <1.26.

Fixes #77420