### PR TITLE
cmd/compile/internal/ssagen: fix typo GrtCallerSP -> GetCallerSP

### DIFF
--- a/src/cmd/compile/internal/ssagen/intrinsics.go
+++ b/src/cmd/compile/internal/ssagen/intrinsics.go
@@ -2170,7 +2170,7 @@ func findIntrinsic(sym *types.Sym) intrinsicBuilder {
 
 	fn := sym.Name
 	if ssa.IntrinsicsDisable {
-		if pkg == "internal/runtime/sys" && (fn == "GetCallerPC" || fn == "GrtCallerSP" || fn == "GetClosurePtr") ||
+		if pkg == "internal/runtime/sys" && (fn == "GetCallerPC" || fn == "GetCallerSP" || fn == "GetClosurePtr") ||
 			pkg == simdPackage {
 			// These runtime functions don't have definitions, must be intrinsics.
 		} else {


### PR DESCRIPTION
Fix a typo in findIntrinsic function where "GrtCallerSP" should be
"GetCallerSP". This typo was in the condition checking for runtime
intrinsic functions that don't have definitions.

Fixes #77432
