### PR TITLE
context: fix outdated documentation

### DIFF
--- a/src/context/context.go
+++ b/src/context/context.go
@@ -25,8 +25,9 @@
 // checks that CancelFuncs are used on all control-flow paths.
 //
 // The [WithCancelCause], [WithDeadlineCause], and [WithTimeoutCause] functions
-// return a [CancelCauseFunc], which takes an error and records it as
-// the cancellation cause. Calling [Cause] on the canceled context
+// return a [CancelCauseFunc], which takes an error and records it as the cancellattion cause.
+// [WithDeadlineCause] and [WithTimeoutCause] take a cause to use after the deadline has elapsed.
+// Calling [Cause] on the canceled context
 // or any of its children retrieves the cause. If no cause is specified,
 // Cause(ctx) returns the same value as ctx.Err().
 //

--- a/src/context/context.go
+++ b/src/context/context.go
@@ -24,10 +24,10 @@
 // child and its children until the parent is canceled. The go vet tool
 // checks that CancelFuncs are used on all control-flow paths.
 //
+/// A context may be canceled with a cause, where the cause is an error
+// describing the reason for cancellation in more detail.
 // The [WithCancelCause], [WithDeadlineCause], and [WithTimeoutCause] functions
-// return a [CancelCauseFunc], which takes an error and records it as the cancellattion cause.
-// [WithDeadlineCause] and [WithTimeoutCause] take a cause to use after the deadline has elapsed.
-// Calling [Cause] on the canceled context
+// set the cause for a canceled context. Calling [Cause] on the canceled context
 // or any of its children retrieves the cause. If no cause is specified,
 // Cause(ctx) returns the same value as ctx.Err().
 //


### PR DESCRIPTION
context: fix outdated documentation for With*Cause

This change modifies the documentation provided for "context" package in
the standard library. The documentation provided was outdated but now
has been fixed.

Fixes #77478