### PR TITLE
internal/syscall/windows: correct some enums and syscall signatures

### DIFF
--- a/src/internal/syscall/windows/at_windows_test.go
+++ b/src/internal/syscall/windows/at_windows_test.go
@@ -131,7 +131,7 @@ func makeFileNotReadable(t *testing.T, name string) {
 			Inheritance:       windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
 			Trustee: windows.TRUSTEE{
 				TrusteeForm: windows.TRUSTEE_IS_SID,
-				Name:        (*uint16)(unsafe.Pointer(sid)),
+				Name:        (uintptr)(unsafe.Pointer(sid)),
 			},
 		}
 	}
@@ -142,7 +142,7 @@ func makeFileNotReadable(t *testing.T, name string) {
 		entryForSid(everyoneSID),
 	}
 
-	var oldAcl, newAcl syscall.Handle
+	var oldAcl, newAcl *windows.ACL
 	if err := windows.SetEntriesInAcl(
 		uint32(len(entries)),
 		&entries[0],
@@ -160,7 +160,7 @@ func makeFileNotReadable(t *testing.T, name string) {
 		nil,
 		nil,
 		newAcl,
-		0,
+		nil,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/src/internal/syscall/windows/syscall_windows.go
+++ b/src/internal/syscall/windows/syscall_windows.go
@@ -581,5 +581,5 @@ type FILE_MODE_INFORMATION struct {
 //sys	RtlIsDosDeviceName_U(name *uint16) (ret uint32) = ntdll.RtlIsDosDeviceName_U
 //sys   NtQueryInformationFile(handle syscall.Handle, iosb *IO_STATUS_BLOCK, inBuffer unsafe.Pointer, inBufferLen uint32, class uint32) (ntstatus error) = ntdll.NtQueryInformationFile
 
-//sys	SetEntriesInAcl(countExplicitEntries uint32, explicitEntries *EXPLICIT_ACCESS, oldACL syscall.Handle, newACL *syscall.Handle) (ret error) =  advapi32.SetEntriesInAclW
-//sys	SetNamedSecurityInfo(objectName string, objectType int32, securityInformation uint32, owner *syscall.SID, group *syscall.SID, dacl syscall.Handle, sacl syscall.Handle) (ret error) = advapi32.SetNamedSecurityInfoW
+//sys	SetEntriesInAcl(countExplicitEntries uint32, explicitEntries *EXPLICIT_ACCESS, oldACL *ACL, newACL **ACL) (ret error) =  advapi32.SetEntriesInAclW
+//sys	SetNamedSecurityInfo(objectName string, objectType uint32, securityInformation uint32, owner *syscall.SID, group *syscall.SID, dacl *ACL, sacl *ACL) (ret error) = advapi32.SetNamedSecurityInfoW

--- a/src/internal/syscall/windows/types_windows.go
+++ b/src/internal/syscall/windows/types_windows.go
@@ -305,38 +305,38 @@ const ValidFileFlagsMask = O_FILE_FLAG_OPEN_REPARSE_POINT |
 // https://msdn.microsoft.com/en-us/library/windows/desktop/aa379636.aspx
 type TRUSTEE struct {
 	MultipleTrustee          *TRUSTEE
-	MultipleTrusteeOperation int32
-	TrusteeForm              int32
-	TrusteeType              int32
-	Name                     *uint16
+	MultipleTrusteeOperation uint32
+	TrusteeForm              uint32
+	TrusteeType              uint32
+	Name                     uintptr
 }
 
 // https://msdn.microsoft.com/en-us/library/windows/desktop/aa379638.aspx
 const (
-	TRUSTEE_IS_SID = iota
-	TRUSTEE_IS_NAME
-	TRUSTEE_BAD_FORM
-	TRUSTEE_IS_OBJECTS_AND_SID
-	TRUSTEE_IS_OBJECTS_AND_NAME
+	TRUSTEE_IS_SID              = 0x0
+	TRUSTEE_IS_NAME             = 0x1
+	TRUSTEE_BAD_FORM            = 0x2
+	TRUSTEE_IS_OBJECTS_AND_SID  = 0x3
+	TRUSTEE_IS_OBJECTS_AND_NAME = 0x4
 )
 
 // https://msdn.microsoft.com/en-us/library/windows/desktop/aa446627.aspx
 type EXPLICIT_ACCESS struct {
 	AccessPermissions uint32
-	AccessMode        int32
+	AccessMode        uint32
 	Inheritance       uint32
 	Trustee           TRUSTEE
 }
 
 // https://msdn.microsoft.com/en-us/library/windows/desktop/aa374899.aspx
 const (
-	NOT_USED_ACCESS = iota
-	GRANT_ACCESS
-	SET_ACCESS
-	DENY_ACCESS
-	REVOKE_ACCESS
-	SET_AUDIT_SUCCESS
-	SET_AUDIT_FAILURE
+	NOT_USED_ACCESS   = 0x0
+	GRANT_ACCESS      = 0x1
+	SET_ACCESS        = 0x2
+	DENY_ACCESS       = 0x3
+	REVOKE_ACCESS     = 0x4
+	SET_AUDIT_SUCCESS = 0x5
+	SET_AUDIT_FAILURE = 0x6
 )
 
 // https://msdn.microsoft.com/en-us/library/windows/desktop/aa446627.aspx
@@ -351,20 +351,20 @@ const (
 
 // https://msdn.microsoft.com/en-us/library/windows/desktop/aa379593.aspx
 const (
-	SE_UNKNOWN_OBJECT_TYPE = iota
-	SE_FILE_OBJECT
-	SE_SERVICE
-	SE_PRINTER
-	SE_REGISTRY_KEY
-	SE_LMSHARE
-	SE_KERNEL_OBJECT
-	SE_WINDOW_OBJECT
-	SE_DS_OBJECT
-	SE_DS_OBJECT_ALL
-	SE_PROVIDER_DEFINED_OBJECT
-	SE_WMIGUID_OBJECT
-	SE_REGISTRY_WOW64_32KEY
-	SE_REGISTRY_WOW64_64KEY
+	SE_UNKNOWN_OBJECT_TYPE     = 0x0
+	SE_FILE_OBJECT             = 0x1
+	SE_SERVICE                 = 0x2
+	SE_PRINTER                 = 0x3
+	SE_REGISTRY_KEY            = 0x4
+	SE_LMSHARE                 = 0x5
+	SE_KERNEL_OBJECT           = 0x6
+	SE_WINDOW_OBJECT           = 0x7
+	SE_DS_OBJECT               = 0x8
+	SE_DS_OBJECT_ALL           = 0x9
+	SE_PROVIDER_DEFINED_OBJECT = 0xa
+	SE_WMIGUID_OBJECT          = 0xb
+	SE_REGISTRY_WOW64_32KEY    = 0xc
+	SE_REGISTRY_WOW64_64KEY    = 0xd
 )
 
 // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/23e75ca3-98fd-4396-84e5-86cd9d40d343

--- a/src/internal/syscall/windows/zsyscall_windows.go
+++ b/src/internal/syscall/windows/zsyscall_windows.go
@@ -238,15 +238,15 @@ func RevertToSelf() (err error) {
 	return
 }
 
-func SetEntriesInAcl(countExplicitEntries uint32, explicitEntries *EXPLICIT_ACCESS, oldACL syscall.Handle, newACL *syscall.Handle) (ret error) {
-	r0, _, _ := syscall.SyscallN(procSetEntriesInAclW.Addr(), uintptr(countExplicitEntries), uintptr(unsafe.Pointer(explicitEntries)), uintptr(oldACL), uintptr(unsafe.Pointer(newACL)))
+func SetEntriesInAcl(countExplicitEntries uint32, explicitEntries *EXPLICIT_ACCESS, oldACL *ACL, newACL **ACL) (ret error) {
+	r0, _, _ := syscall.SyscallN(procSetEntriesInAclW.Addr(), uintptr(countExplicitEntries), uintptr(unsafe.Pointer(explicitEntries)), uintptr(unsafe.Pointer(oldACL)), uintptr(unsafe.Pointer(newACL)))
 	if r0 != 0 {
 		ret = syscall.Errno(r0)
 	}
 	return
 }
 
-func SetNamedSecurityInfo(objectName string, objectType int32, securityInformation uint32, owner *syscall.SID, group *syscall.SID, dacl syscall.Handle, sacl syscall.Handle) (ret error) {
+func SetNamedSecurityInfo(objectName string, objectType uint32, securityInformation uint32, owner *syscall.SID, group *syscall.SID, dacl *ACL, sacl *ACL) (ret error) {
 	var _p0 *uint16
 	_p0, ret = syscall.UTF16PtrFromString(objectName)
 	if ret != nil {
@@ -255,8 +255,8 @@ func SetNamedSecurityInfo(objectName string, objectType int32, securityInformati
 	return _SetNamedSecurityInfo(_p0, objectType, securityInformation, owner, group, dacl, sacl)
 }
 
-func _SetNamedSecurityInfo(objectName *uint16, objectType int32, securityInformation uint32, owner *syscall.SID, group *syscall.SID, dacl syscall.Handle, sacl syscall.Handle) (ret error) {
-	r0, _, _ := syscall.SyscallN(procSetNamedSecurityInfoW.Addr(), uintptr(unsafe.Pointer(objectName)), uintptr(objectType), uintptr(securityInformation), uintptr(unsafe.Pointer(owner)), uintptr(unsafe.Pointer(group)), uintptr(dacl), uintptr(sacl))
+func _SetNamedSecurityInfo(objectName *uint16, objectType uint32, securityInformation uint32, owner *syscall.SID, group *syscall.SID, dacl *ACL, sacl *ACL) (ret error) {
+	r0, _, _ := syscall.SyscallN(procSetNamedSecurityInfoW.Addr(), uintptr(unsafe.Pointer(objectName)), uintptr(objectType), uintptr(securityInformation), uintptr(unsafe.Pointer(owner)), uintptr(unsafe.Pointer(group)), uintptr(unsafe.Pointer(dacl)), uintptr(unsafe.Pointer(sacl)))
 	if r0 != 0 {
 		ret = syscall.Errno(r0)
 	}


### PR DESCRIPTION
This CL corrects code submitted in CL 741040.

Fixes #77402