### PR TITLE
all: replace calls to errors.As with errors.AsType

### DIFF
--- a/src/cmd/go/internal/modcmd/vendor.go
+++ b/src/cmd/go/internal/modcmd/vendor.go
@@ -310,12 +310,10 @@ func vendorPkg(s *modload.State, vdir, pkg string) {
 	// TODO(#42504): Find a better way to avoid errors from ImportDir. We'll
 	// need to figure this out when we switch to PackagesAndErrors as per the
 	// TODO above.
-	var multiplePackageError *build.MultiplePackageError
-	var noGoError *build.NoGoError
 	if err != nil {
-		if errors.As(err, &noGoError) {
+		if _, ok := errors.AsType[*build.NoGoError](err); ok {
 			return // No source files in this package are built. Skip embeds in ignored files.
-		} else if !errors.As(err, &multiplePackageError) { // multiplePackageErrors are OK, but others are not.
+		} else if _, ok := errors.AsType[*build.MultiplePackageError](err); !ok { // multiplePackageErrors are OK, but others are not.
 			base.Fatalf("internal error: failed to find embedded files of %s: %v\n", pkg, err)
 		}
 	}

--- a/src/debug/elf/file_test.go
+++ b/src/debug/elf/file_test.go
@@ -1635,8 +1635,7 @@ func TestOpenEmptyFile(t *testing.T) {
 		t.Fatal("Open on empty file: got nil error, want non-nil")
 	}
 
-	var formatErr *FormatError
-	if !errors.As(err, &formatErr) {
+	if _, ok := errors.AsType[*FormatError](err); !ok {
 		t.Errorf("Open on empty file: got %T (%v), want *FormatError", err, err)
 	}
 }
@@ -1659,8 +1658,7 @@ func TestNewFileShortReader(t *testing.T) {
 				t.Fatal("NewFile with short data: got nil error, want non-nil")
 			}
 
-			var formatErr *FormatError
-			if !errors.As(err, &formatErr) {
+			if _, ok := errors.AsType[*FormatError](err); !ok {
 				t.Errorf("NewFile with short data: got %T (%v), want *FormatError", err, err)
 			}
 		})

--- a/src/encoding/asn1/asn1_test.go
+++ b/src/encoding/asn1/asn1_test.go
@@ -1241,7 +1241,7 @@ func TestParsingMemoryConsumption(t *testing.T) {
 		Value    []byte
 	}
 	_, err := Unmarshal(derBomb, &out)
-	if !errors.As(err, &SyntaxError{}) {
+	if _, ok := errors.AsType[*SyntaxError](err); !ok {
 		t.Fatalf("Incorrect error result: want (%v), but got (%v) instead", &SyntaxError{}, err)
 	}
 


### PR DESCRIPTION
This is a follow-up for CL 708495.

Updates #51945