### PR TITLE
internal/syscall/windows: add lpBytesReturned to DeviceIoControl call

### DIFF
--- a/src/internal/syscall/windows/at_windows.go
+++ b/src/internal/syscall/windows/at_windows.go
@@ -585,6 +585,7 @@ func symlinkat(oldname string, newdirfd syscall.Handle, newname string, flags Sy
 	namebuf := rdbbuf[bufferSize:]
 	copy(namebuf, unsafe.String((*byte)(unsafe.Pointer(&oldnameu16[0])), 2*len(oldnameu16)))
 
+	var bytesReturned uint32
 	err = syscall.DeviceIoControl(
 		h,
 		FSCTL_SET_REPARSE_POINT,
@@ -592,7 +593,7 @@ func symlinkat(oldname string, newdirfd syscall.Handle, newname string, flags Sy
 		uint32(len(rdbbuf)),
 		nil,
 		0,
-		nil,
+		&bytesReturned,
 		nil)
 	if err != nil {
 		// Creating the symlink has failed, so try to remove the file.


### PR DESCRIPTION
According to https://learn.microsoft.com/en-us/windows/win32/api/ioapiset/nf-ioapiset-deviceiocontrol,
if lpOverlapped is NULL, then lpBytesReturned cannot be NULL.
Even when an operation returns no output data and lpOutBuffer is NULL,
DeviceIoControl makes use of lpBytesReturned. After such an operation,
the value of lpBytesReturned is meaningless.

This trivial change should help us avoid potential issues in the future.