### PR TITLE
crypto/tls: fix CurvePreferences comment

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -807,7 +807,7 @@ type Config struct {
 	// or use the GODEBUG=tlsmlkem=0 environment variable.
 	//
 	// From Go 1.26, the default includes the [SecP256r1MLKEM768] and
-	// [SecP256r1MLKEM768] hybrid post-quantum key exchanges, too. To disable
+	// [SecP384r1MLKEM1024] hybrid post-quantum key exchanges, too. To disable
 	// them, set CurvePreferences explicitly or use either the
 	// GODEBUG=tlsmlkem=0 or the GODEBUG=tlssecpmlkem=0 environment variable.
 	CurvePreferences []CurveID


### PR DESCRIPTION
SecP256r1MLKEM768 appeared twice while the second should have been
SecP384r1MLKEM1024.