### PR TITLE
internal/strconv: adds support for yes/no in ParseBool

### DIFF
--- a/src/internal/strconv/atob.go
+++ b/src/internal/strconv/atob.go
@@ -9,9 +9,9 @@ package strconv
 // Any other value returns an error.
 func ParseBool(str string) (bool, error) {
 	switch str {
-	case "1", "t", "T", "true", "TRUE", "True":
+	case "1", "t", "T", "true", "TRUE", "True", "yes", "YES", "Yes":
 		return true, nil
-	case "0", "f", "F", "false", "FALSE", "False":
+	case "0", "f", "F", "false", "FALSE", "False", "no", "NO", "No":
 		return false, nil
 	}
 	return false, ErrSyntax


### PR DESCRIPTION
strconv: accept "yes" and "no" in ParseBool

ParseBool now treats the strings "yes" and "no" (case-insensitive) as valid boolean representations, returning true and false respectively.

preserves backwards compatibility since no existing keyword is removed.

this was necessary because many a times, at my day job, we get input data with yes/no labelled info. earlier had to create wrappers over strconv.ParseBool just to parse yes/no correctly.
