### PR TITLE
log/slog: use B.Loop to simplify the code

### DIFF
--- a/src/log/slog/handler_test.go
+++ b/src/log/slog/handler_test.go
@@ -760,9 +760,8 @@ func TestWriteTimeRFC3339(t *testing.T) {
 
 func BenchmarkWriteTime(b *testing.B) {
 	tm := time.Date(2022, 3, 4, 5, 6, 7, 823456789, time.Local)
-	b.ResetTimer()
 	var buf []byte
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		buf = appendRFC3339Millis(buf[:0], tm)
 	}
 }

--- a/src/log/slog/json_handler_test.go
+++ b/src/log/slog/json_handler_test.go
@@ -214,8 +214,7 @@ func BenchmarkJSONHandler(b *testing.B) {
 				String("traceID", "2039232309232309"),
 				String("URL", "https://pkg.go.dev/golang.org/x/log/slog"))
 			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				l.LogAttrs(ctx, LevelInfo, "this is a typical log message",
 					String("module", "github.com/google/go-cmp"),
 					String("version", "v1.23.4"),
@@ -276,8 +275,7 @@ func BenchmarkPreformatting(b *testing.B) {
 		b.Run(bench.name, func(b *testing.B) {
 			l := New(NewJSONHandler(bench.wc, nil)).With(bench.attrs...)
 			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				l.LogAttrs(ctx, LevelInfo, "this is a typical log message",
 					String("module", "github.com/google/go-cmp"),
 					String("version", "v1.23.4"),

--- a/src/log/slog/level_test.go
+++ b/src/log/slog/level_test.go
@@ -230,7 +230,6 @@ func BenchmarkLevelString(b *testing.B) {
 		LevelDebug,
 		LevelDebug - 2,
 	}
-	b.ResetTimer()
 	for b.Loop() {
 		for _, level := range levels {
 			_ = level.String()

--- a/src/log/slog/value_access_benchmark_test.go
+++ b/src/log/slog/value_access_benchmark_test.go
@@ -100,8 +100,7 @@ func BenchmarkDispatch(b *testing.B) {
 
 	b.Run("Visit", func(b *testing.B) {
 		v := &setVisitor{}
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			for _, kv := range vs {
 				kv.Visit(v)
 			}

--- a/src/log/slog/value_test.go
+++ b/src/log/slog/value_test.go
@@ -289,9 +289,8 @@ func BenchmarkUnsafeStrings(b *testing.B) {
 	for i := range src {
 		src[i] = StringValue(fmt.Sprintf("string#%d", i))
 	}
-	b.ResetTimer()
 	var d string
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		copy(dst, src)
 		for _, a := range dst {
 			d = a.String()


### PR DESCRIPTION
Simplify the code and remove some unnecessary calls of ResetTimer.

Updates #61515
