### PR TITLE
runtime: delete deadcode in mheap

### DIFF
--- a/src/runtime/mheap.go
+++ b/src/runtime/mheap.go
@@ -524,15 +524,6 @@ func (s *mspan) base() uintptr {
 	return s.startAddr
 }
 
-func (s *mspan) layout() (size, n, total uintptr) {
-	total = s.npages << gc.PageShift
-	size = s.elemsize
-	if size > 0 {
-		n = total / size
-	}
-	return
-}
-
 // recordspan adds a newly allocated span to h.allspans.
 //
 // This only happens the first time a span is allocated from


### PR DESCRIPTION
this method seems implements for the old span's memory layout,
and is not suitable for the new implements.