### PR TITLE
cmd/link: allow -no family of flags for testing compiler flag

### DIFF
--- a/src/cmd/link/internal/ld/lib.go
+++ b/src/cmd/link/internal/ld/lib.go
@@ -2248,6 +2248,7 @@ func trimLinkerArgv(argv []string) []string {
 		"--stdlib",
 		"-unwindlib",
 		"--unwindlib",
+		"-nostdlib++",
 	}
 
 	var flags []string

--- a/src/cmd/link/internal/ld/lib.go
+++ b/src/cmd/link/internal/ld/lib.go
@@ -2249,6 +2249,12 @@ func trimLinkerArgv(argv []string) []string {
 		"-unwindlib",
 		"--unwindlib",
 		"-nostdlib++",
+		"-nostdlib",
+		"-nodefaultlibs",
+		"-nostartfiles",
+		"-nostdinc++",
+		"-nostdinc",
+		"-nobuiltininc",
 	}
 
 	var flags []string


### PR DESCRIPTION
This changes modifies Go to allow the -nostdlib++ flag to the list of
allowed flags to be passed to the c compiler invocation when testing flags
in cmd/link.

It is similar to #76858 and complements #76825.

This is needed for hermetic c only toolchains where -nostdlib++ is passed
transitively.

Given prior discussions about security considerations when adding flags to
the whitelist, this particular one may be particularly safe to whitelist.
