### PR TITLE
context: fix doc for WithDeadlineCause and WithTimeoutCause

### DIFF
--- a/src/context/context.go
+++ b/src/context/context.go
@@ -24,10 +24,11 @@
 // child and its children until the parent is canceled. The go vet tool
 // checks that CancelFuncs are used on all control-flow paths.
 //
-// The [WithCancelCause], [WithDeadlineCause], and [WithTimeoutCause] functions
-// return a [CancelCauseFunc], which takes an error and records it as
-// the cancellation cause. Calling [Cause] on the canceled context
-// or any of its children retrieves the cause. If no cause is specified,
+// The [WithCancelCause] function returns a [CancelCauseFunc], which takes an
+// error and records it as the cancellation cause. [WithDeadlineCause] and
+// [WithTimeoutCause] also accept a cause, which is set when the deadline or
+// timeout expires. Calling [Cause] on the canceled context or any of its
+// children retrieves the cause. If no cause is specified,
 // Cause(ctx) returns the same value as ctx.Err().
 //
 // Programs that use Contexts should follow these rules to keep interfaces


### PR DESCRIPTION
## Summary
- The package doc incorrectly stated that `WithCancelCause`, `WithDeadlineCause`, and `WithTimeoutCause` all return a `CancelCauseFunc`
- Only `WithCancelCause` returns `CancelCauseFunc`. `WithDeadlineCause` and `WithTimeoutCause` accept the cause as a parameter and return a plain `CancelFunc`
- Updated the wording to accurately describe each function's behavior

Fixes #77478

🤖 Generated with [Claude Code](https://claude.com/claude-code)