### PR TITLE
internal/filepathlite: move Windows-specific method

### DIFF
--- a/src/internal/filepathlite/path.go
+++ b/src/internal/filepathlite/path.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"internal/stringslite"
 	"io/fs"
-	"slices"
 )
 
 var errInvalidPath = errors.New("invalid path")
@@ -47,11 +46,6 @@ func (b *lazybuf) append(c byte) {
 	}
 	b.buf[b.w] = c
 	b.w++
-}
-
-func (b *lazybuf) prepend(prefix ...byte) {
-	b.buf = slices.Insert(b.buf, 0, prefix...)
-	b.w += len(prefix)
 }
 
 func (b *lazybuf) string() string {

--- a/src/internal/filepathlite/path_windows.go
+++ b/src/internal/filepathlite/path_windows.go
@@ -8,6 +8,7 @@ import (
 	"internal/bytealg"
 	"internal/stringslite"
 	"internal/syscall/windows"
+	"slices"
 	"syscall"
 )
 
@@ -323,4 +324,9 @@ func postClean(out *lazybuf) {
 	if len(out.buf) >= 3 && IsPathSeparator(out.buf[0]) && out.buf[1] == '?' && out.buf[2] == '?' {
 		out.prepend(Separator, '.')
 	}
+}
+
+func (b *lazybuf) prepend(prefix ...byte) {
+	b.buf = slices.Insert(b.buf, 0, prefix...)
+	b.w += len(prefix)
 }


### PR DESCRIPTION
Method (*lazybuf).prepend is only used on GOOS=windows. Accordingly,
this CL moves that method's declaration from path.go (which contains no
build constraints) to path_windows.go.