### PR TITLE
builtin: update new documentation for Go 1.26 expression syntax

### DIFF
--- a/src/builtin/builtin.go
+++ b/src/builtin/builtin.go
@@ -224,16 +224,14 @@ func max[T cmp.Ordered](x T, y ...T) T
 // min will return NaN.
 func min[T cmp.Ordered](x T, y ...T) T
 
-// The new built-in function creates a new, initialized variable and
+// The new built-in function allocates a new, initialized variable and
 // returns a pointer to it. It accepts a single argument, which may be
-// either a type or an expression.
-//
-// If the argument is a type T, then new(T) allocates a variable of type T
-// initialized to its zero value.
-//
-// If the argument is an expression x, then new(x) allocates a variable of
-// the type of x initialized to the value of x. If that value is an untyped
-// constant, it is first implicitly converted to its default type.
+// either a type or an expression. If the argument is a type T, then
+// new(T) allocates a variable of type T initialized to its zero value.
+// Otherwise, the argument is an expression and new(x) allocates a
+// variable of the type of x initialized to the value of x. If that value
+// is an untyped constant, it is first implicitly converted to its default
+// type.
 func new(TypeOrValue) *Type
 
 // The complex built-in function constructs a complex value from two

--- a/src/builtin/builtin.go
+++ b/src/builtin/builtin.go
@@ -134,6 +134,10 @@ type FloatType float32
 // stand-in for either complex type: complex64 or complex128.
 type ComplexType complex64
 
+// TypeOrValue is here for the purposes of documentation only. It is a stand-in
+// for either a type or an expression.
+type TypeOrValue int
+
 // The append built-in function appends elements to the end of a slice. If
 // it has sufficient capacity, the destination is resliced to accommodate the
 // new elements. If it does not, a new underlying array will be allocated.
@@ -229,13 +233,8 @@ func min[T cmp.Ordered](x T, y ...T) T
 //
 // If the argument is an expression x, then new(x) allocates a variable of
 // the type of x initialized to the value of x. If that value is an untyped
-// constant, it is first implicitly converted to its default type; if it is
-// an untyped boolean value, it is first implicitly converted to type bool.
-//
-// For example, new(int) and new(123) each return a pointer to a new
-// variable of type int. The value of the first variable is 0, and the value
-// of the second is 123.
-func new(Type) *Type
+// constant, it is first implicitly converted to its default type.
+func new(TypeOrValue) *Type
 
 // The complex built-in function constructs a complex value from two
 // floating-point values. The real and imaginary parts must be of the same

--- a/src/builtin/builtin.go
+++ b/src/builtin/builtin.go
@@ -122,6 +122,10 @@ type Type int
 // invocation.
 type Type1 int
 
+// TypeOrExpr is here for the purposes of documentation only. It is a stand-in
+// for either a Go type or an expression.
+type TypeOrExpr int
+
 // IntegerType is here for the purposes of documentation only. It is a stand-in
 // for any integer type: int, uint, int8 etc.
 type IntegerType int
@@ -133,10 +137,6 @@ type FloatType float32
 // ComplexType is here for the purposes of documentation only. It is a
 // stand-in for either complex type: complex64 or complex128.
 type ComplexType complex64
-
-// TypeOrValue is here for the purposes of documentation only. It is a stand-in
-// for either a type or an expression.
-type TypeOrValue int
 
 // The append built-in function appends elements to the end of a slice. If
 // it has sufficient capacity, the destination is resliced to accommodate the
@@ -224,15 +224,16 @@ func max[T cmp.Ordered](x T, y ...T) T
 // min will return NaN.
 func min[T cmp.Ordered](x T, y ...T) T
 
-// The new built-in function allocates a new, initialized variable and
-// returns a pointer to it. It accepts a single argument, which may be
-// either a type or an expression. If the argument is a type T, then
-// new(T) allocates a variable of type T initialized to its zero value.
-// Otherwise, the argument is an expression and new(x) allocates a
-// variable of the type of x initialized to the value of x. If that value
-// is an untyped constant, it is first implicitly converted to its default
-// type.
-func new(TypeOrValue) *Type
+// The built-in function new creates a new, initialized variable and returns
+// a pointer to it. It accepts a single argument, which may be either a type
+// or an expression.
+//
+// If the argument is a type T, then new(T) allocates a variable of type T
+// initialized to its zero value.
+//
+// If the argument is an expression x, then new(x) allocates a variable of
+// the type of x initialized to the value of x.
+func new(TypeOrExpr) *Type
 
 // The complex built-in function constructs a complex value from two
 // floating-point values. The real and imaginary parts must be of the same

--- a/src/builtin/builtin.go
+++ b/src/builtin/builtin.go
@@ -220,9 +220,21 @@ func max[T cmp.Ordered](x T, y ...T) T
 // min will return NaN.
 func min[T cmp.Ordered](x T, y ...T) T
 
-// The new built-in function allocates memory. The first argument is a type,
-// not a value, and the value returned is a pointer to a newly
-// allocated zero value of that type.
+// The new built-in function creates a new, initialized variable and
+// returns a pointer to it. It accepts a single argument, which may be
+// either a type or an expression.
+//
+// If the argument is a type T, then new(T) allocates a variable of type T
+// initialized to its zero value.
+//
+// If the argument is an expression x, then new(x) allocates a variable of
+// the type of x initialized to the value of x. If that value is an untyped
+// constant, it is first implicitly converted to its default type; if it is
+// an untyped boolean value, it is first implicitly converted to type bool.
+//
+// For example, new(int) and new(123) each return a pointer to a new
+// variable of type int. The value of the first variable is 0, and the value
+// of the second is 123.
 func new(Type) *Type
 
 // The complex built-in function constructs a complex value from two


### PR DESCRIPTION
The built-in new function now accepts an expression as its
operand, not just a type. Update the doc comment to reflect this
change introduced in Go 1.26.

The documentation now describes both behaviors:
  new(T) allocates a zero value of type T
  new(expr) allocates with the expression value as initial value

Fixes #77584