### PR TITLE
all: test: remove unneeded loop variables

### DIFF
--- a/src/cmd/api/api_test.go
+++ b/src/cmd/api/api_test.go
@@ -232,7 +232,6 @@ var warmupCache = sync.OnceFunc(func() {
 	// Warm up the import cache in parallel.
 	var wg sync.WaitGroup
 	for _, context := range contexts {
-		context := context
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/src/cmd/api/main_test.go
+++ b/src/cmd/api/main_test.go
@@ -121,7 +121,6 @@ func Check(t *testing.T) {
 	walkers := make([]*Walker, len(contexts))
 	var wg sync.WaitGroup
 	for i, context := range contexts {
-		i, context := i, context
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/src/cmd/cgo/internal/testerrors/errors_test.go
+++ b/src/cmd/cgo/internal/testerrors/errors_test.go
@@ -152,7 +152,6 @@ func TestToleratesOptimizationFlag(t *testing.T) {
 		"",
 		"-O",
 	} {
-		cflags := cflags
 		t.Run(cflags, func(t *testing.T) {
 			testenv.MustHaveGoBuild(t)
 			testenv.MustHaveCGO(t)

--- a/src/cmd/cgo/internal/testsanitizers/asan_test.go
+++ b/src/cmd/cgo/internal/testsanitizers/asan_test.go
@@ -48,7 +48,6 @@ func TestASAN(t *testing.T) {
 		{src: "arena_fail.go", memoryAccessError: "use-after-poison", errorLocation: "arena_fail.go:26", experiments: []string{"arenas"}},
 	}
 	for _, tc := range cases {
-		tc := tc
 		name := strings.TrimSuffix(tc.src, ".go")
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/src/cmd/cgo/internal/testsanitizers/cshared_test.go
+++ b/src/cmd/cgo/internal/testsanitizers/cshared_test.go
@@ -54,7 +54,6 @@ func TestShared(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		name := strings.TrimSuffix(tc.src, ".go")
 		//The memory sanitizer tests require support for the -msan option.
 		if tc.sanitizer == "memory" && !platform.MSanSupported(GOOS, GOARCH) {

--- a/src/cmd/cgo/internal/testsanitizers/libfuzzer_test.go
+++ b/src/cmd/cgo/internal/testsanitizers/libfuzzer_test.go
@@ -43,7 +43,6 @@ func TestLibFuzzer(t *testing.T) {
 		{goSrc: "libfuzzer2.go", cSrc: "libfuzzer2.c", expectedError: "panic: found it"},
 	}
 	for _, tc := range cases {
-		tc := tc
 		name := strings.TrimSuffix(tc.goSrc, ".go")
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/src/cmd/cgo/internal/testsanitizers/msan_test.go
+++ b/src/cmd/cgo/internal/testsanitizers/msan_test.go
@@ -62,7 +62,6 @@ func TestMSAN(t *testing.T) {
 		{src: "arena_fail.go", wantErr: true, experiments: []string{"arenas"}},
 	}
 	for _, tc := range cases {
-		tc := tc
 		name := strings.TrimSuffix(tc.src, ".go")
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/src/cmd/cgo/internal/testsanitizers/tsan_test.go
+++ b/src/cmd/cgo/internal/testsanitizers/tsan_test.go
@@ -59,7 +59,6 @@ func TestTSAN(t *testing.T) {
 		{src: "tsan_tracebackctxt", needsRuntime: true}, // Subdirectory
 	}
 	for _, tc := range cases {
-		tc := tc
 		name := strings.TrimSuffix(tc.src, ".go")
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/src/cmd/cgo/internal/teststdio/stdio_test.go
+++ b/src/cmd/cgo/internal/teststdio/stdio_test.go
@@ -56,7 +56,6 @@ func TestTestRun(t *testing.T) {
 		"fib.go",
 		"hello.go",
 	} {
-		file := file
 		wantFile := strings.Replace(file, ".go", ".out", 1)
 		t.Run(file, func(t *testing.T) {
 			cmd := exec.Command(testenv.GoToolPath(t), "run", file)

--- a/src/cmd/compile/internal/test/reproduciblebuilds_test.go
+++ b/src/cmd/compile/internal/test/reproduciblebuilds_test.go
@@ -26,7 +26,6 @@ func TestReproducibleBuilds(t *testing.T) {
 	}
 	t.Parallel()
 	for _, test := range tests {
-		test := test
 		t.Run(test, func(t *testing.T) {
 			t.Parallel()
 			var want []byte

--- a/src/cmd/compile/internal/test/ssa_test.go
+++ b/src/cmd/compile/internal/test/ssa_test.go
@@ -163,7 +163,6 @@ func TestCode(t *testing.T) {
 
 		// Now we have a test binary. Run it with all the tests as subtests of this one.
 		for _, test := range tests {
-			test := test
 			if flag == ",softfloat" && !test.usesFloat {
 				// No point in running the soft float version if the test doesn't use floats.
 				continue

--- a/src/cmd/compile/internal/types2/api_test.go
+++ b/src/cmd/compile/internal/types2/api_test.go
@@ -2599,7 +2599,6 @@ func fn() {
 	})
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			if got := len(idents[test.name]); got != 1 {
 				t.Fatalf("found %d identifiers named %s, want 1", got, test.name)

--- a/src/cmd/compile/internal/types2/sizes_test.go
+++ b/src/cmd/compile/internal/types2/sizes_test.go
@@ -184,7 +184,6 @@ func main() {
 func TestGCSizes(t *testing.T) {
 	types2.DefPredeclaredTestFuncs()
 	for _, tc := range gcSizesTests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			conf := types2.Config{Importer: defaultImporter(), Sizes: types2.SizesFor("gc", "amd64")}

--- a/src/cmd/compile/internal/types2/stdlib_test.go
+++ b/src/cmd/compile/internal/types2/stdlib_test.go
@@ -59,8 +59,6 @@ func TestStdlib(t *testing.T) {
 	var wg sync.WaitGroup
 
 	for dir := range dirFiles {
-		dir := dir
-
 		cpulimit <- struct{}{}
 		wg.Add(1)
 		go func() {

--- a/src/cmd/go/internal/modfetch/coderepo_test.go
+++ b/src/cmd/go/internal/modfetch/coderepo_test.go
@@ -819,7 +819,6 @@ func TestCodeRepoVersions(t *testing.T) {
 	testenv.MustHaveExternalNetwork(t)
 	fetcher := NewFetcher()
 	for _, tt := range codeRepoVersionsTests {
-		tt := tt
 		t.Run(strings.ReplaceAll(tt.path, "/", "_"), func(t *testing.T) {
 			if strings.Contains(tt.path, "gopkg.in") {
 				testenv.SkipFlaky(t, 54503)

--- a/src/cmd/go/script_test.go
+++ b/src/cmd/go/script_test.go
@@ -107,7 +107,6 @@ func TestScript(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, file := range files {
-		file := file
 		name := strings.TrimSuffix(filepath.Base(file), ".txt")
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/src/cmd/link/dwarf_test.go
+++ b/src/cmd/link/dwarf_test.go
@@ -32,7 +32,6 @@ func testDWARF(t *testing.T, buildmode string, expectDWARF bool, env ...string) 
 	t.Parallel()
 
 	for _, prog := range []string{"testprog", "testprogcgo"} {
-		prog := prog
 		expectDWARF := expectDWARF
 		if runtime.GOOS == "aix" && prog == "testprogcgo" {
 			extld := os.Getenv("CC")

--- a/src/cmd/link/internal/ld/deadcode_test.go
+++ b/src/cmd/link/internal/ld/deadcode_test.go
@@ -34,7 +34,6 @@ func TestDeadcode(t *testing.T) {
 			[]string{"main.large"}},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.src, func(t *testing.T) {
 			t.Parallel()
 			src := filepath.Join("testdata", "deadcode", test.src+".go")

--- a/src/cmd/link/internal/ld/dwarf_test.go
+++ b/src/cmd/link/internal/ld/dwarf_test.go
@@ -408,7 +408,6 @@ func main() {}
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -473,7 +472,6 @@ func main() {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -555,7 +553,6 @@ func main() {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1984,7 +1981,6 @@ func TestZeroSizedVariable(t *testing.T) {
 	// See go.dev/issues/54615.
 
 	for _, opt := range []string{NoOpt, DefaultOpt} {
-		opt := opt
 		t.Run(opt, func(t *testing.T) {
 			_, ex := gobuildAndExamine(t, zeroSizedVarProg, opt)
 

--- a/src/cmd/link/internal/ld/ld_test.go
+++ b/src/cmd/link/internal/ld/ld_test.go
@@ -354,7 +354,6 @@ func main() {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			tempDir := t.TempDir()

--- a/src/cmd/link/link_test.go
+++ b/src/cmd/link/link_test.go
@@ -1715,7 +1715,6 @@ func TestCheckLinkname(t *testing.T) {
 		{"badlinkname.go", true},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.src, func(t *testing.T) {
 			t.Parallel()
 			src := "./testdata/linkname/" + test.src


### PR DESCRIPTION
This CL follows from the abandoned CL 722961.

Alan Donovan asked if modernize would catch these changes; it does in part.

Here is how modernize was used:
1. Build the Go compiler from latest master
2. Clone x/tools and build modernize with the newest compiler
3. Then, do:

    PATH=PATH_TO_BIN:$PATH go list ./... | xargs env PATH=PATH_TO_BIN:$PATH GOMOD=off MODERNIZE -forvar -fix -test -debug fpstv

4. For assurance, move into a package directory (i.e, cmd), and redo Step 3.

From the obtained result, it seems modernize did not remove the loop variable when:
- the range notation was not used
- the loop variable was not directly under the for directive.

Which does happens here:

    # git ls-files | xargs -I {} perl -nE 'print "$ARGV:$.:$_" if /\s+(\w+) := \1$/' {} | grep _test
    [...]
    cmd/compile/internal/types2/api_test.go:2423:                   i := i
    md/go/internal/modload/query_test.go:182:              tt := tt
    md/go/internal/web/url_test.go:17:             tc := tc
    cmd/go/internal/web/url_test.go:49:             tc := tc
    cmd/internal/par/queue_test.go:54:              i := i
    runtime/syscall_windows_test.go:781:            arglen := arglen

Link: https://go-review.googlesource.com/c/go/+/722961/comments/e8d47866_fc399fa1
Co-authored-by: Plamerdi Makela <plamerdi447@gmail.com>
Fixes #76411 