### PR TITLE
os: update examples to use errors.Is instead of os.IsExist/IsNotExist

### DIFF
--- a/src/os/example_test.go
+++ b/src/os/example_test.go
@@ -246,7 +246,7 @@ func ExampleWriteFile() {
 
 func ExampleMkdir() {
 	err := os.Mkdir("testdir", 0750)
-	if err != nil && !os.IsExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrExist) {
 		log.Fatal(err)
 	}
 	err = os.WriteFile("testdir/testfile.txt", []byte("Hello, Gophers!"), 0660)
@@ -365,7 +365,7 @@ func ExampleUserConfigDir() {
 		configPath = filepath.Join(dir, "ExampleUserConfigDir", "example.conf")
 		var err error
 		origConfig, err = os.ReadFile(configPath)
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			// The user has a config file but we couldn't read it.
 			// Report the error instead of ignoring their configuration.
 			log.Fatal(err)


### PR DESCRIPTION
## Summary

Updated two example functions in `src/os/example_test.go` to use the modern `errors.Is(err, fs.ErrExist)` and `errors.Is(err, fs.ErrNotExist)` instead of the deprecated `os.IsExist(err)` and `os.IsNotExist(err)`.

## Changes

- `ExampleMkdir()`: Changed `!os.IsExist(err)` to `!errors.Is(err, fs.ErrExist)`
- `ExampleUserConfigDir()`: Changed `!os.IsNotExist(err)` to `!errors.Is(err, fs.ErrNotExist)`

The `errors` and `io/fs` packages were already imported in the file.

Fixes #77643