### PR TITLE
doc/go1.26: document ServeMux trailing slash redirect status change

### DIFF
--- a/doc/next/6-stdlib/99-minor/net/http/77741.md
+++ b/doc/next/6-stdlib/99-minor/net/http/77741.md
@@ -1,0 +1,2 @@
+The ServeMux trailing slash redirect now uses HTTP status 307
+(Temporary Redirect) instead of 301 (Moved Permanently).

--- a/src/cmd/vendor/golang.org/x/tools/go/analysis/passes/modernize/doc.go
+++ b/src/cmd/vendor/golang.org/x/tools/go/analysis/passes/modernize/doc.go
@@ -91,6 +91,8 @@ The any analyzer suggests replacing uses of the empty interface type,
 `interface{}`, with the `any` alias, which was introduced in Go 1.18.
 This is a purely stylistic change that makes code more readable.
 
+Note: the -any flag enables only this analyzer; it does not enable all analyzers.
+
 # Analyzer errorsastype
 
 errorsastype: replace errors.As with errors.AsType[T]

--- a/src/cmd/vendor/golang.org/x/tools/go/analysis/passes/modernize/doc.go
+++ b/src/cmd/vendor/golang.org/x/tools/go/analysis/passes/modernize/doc.go
@@ -91,8 +91,6 @@ The any analyzer suggests replacing uses of the empty interface type,
 `interface{}`, with the `any` alias, which was introduced in Go 1.18.
 This is a purely stylistic change that makes code more readable.
 
-Note: the -any flag enables only this analyzer; it does not enable all analyzers.
-
 # Analyzer errorsastype
 
 errorsastype: replace errors.As with errors.AsType[T]


### PR DESCRIPTION
This CL documents a behavior change in net/http ServeMux
introduced in Go 1.26.

In Go 1.25, trailing slash redirects returned HTTP 301.
In Go 1.26, they now return HTTP 307.

This change is not currently mentioned in the Go 1.26
release notes under net/http.

Verified behavior:

go version go1.25.7 windows/amd64
→ trailing slash redirect returns 301

go version go1.26.0 windows/amd64
→ trailing slash redirect returns 307

Fixes #77741