### PR TITLE
cmd/go: document -p flag in go help testflag

### DIFF
--- a/doc/next/6-stdlib/99-minor/net/http/77741.md
+++ b/doc/next/6-stdlib/99-minor/net/http/77741.md
@@ -1,0 +1,2 @@
+The ServeMux trailing slash redirect now uses HTTP status 307
+(Temporary Redirect) instead of 301 (Moved Permanently).

--- a/src/cmd/go/internal/test/test.go
+++ b/src/cmd/go/internal/test/test.go
@@ -310,6 +310,11 @@ control the execution of any test:
 	    in parallel as well, according to the setting of the -p flag
 	    (see 'go help build').
 
+	-p n
+		The number of packages that can be run in parallel.
+		The default is GOMAXPROCS, normally the number of CPUs available.
+		See 'go help build' for more details.
+
 	-run regexp
 	    Run only those tests, examples, and fuzz tests matching the regular
 	    expression. For tests, the regular expression is split by unbracketed

--- a/src/cmd/vendor/golang.org/x/tools/go/analysis/passes/modernize/doc.go
+++ b/src/cmd/vendor/golang.org/x/tools/go/analysis/passes/modernize/doc.go
@@ -91,6 +91,8 @@ The any analyzer suggests replacing uses of the empty interface type,
 `interface{}`, with the `any` alias, which was introduced in Go 1.18.
 This is a purely stylistic change that makes code more readable.
 
+Note: the -any flag enables only this analyzer; it does not enable all analyzers.
+
 # Analyzer errorsastype
 
 errorsastype: replace errors.As with errors.AsType[T]


### PR DESCRIPTION
The -p flag controls the number of packages that can be
tested in parallel by `go test`.

Although the flag is documented in `go help build`,
it is not explicitly documented in `go help testflag`.

This change adds documentation for -p to improve
discoverability and consistency with other test flags.

Fixes #77746.