### PR TITLE
cmd/go: fix toolchain escape via PATH in covermode

### DIFF
--- a/src/cmd/go/internal/work/cover.go
+++ b/src/cmd/go/internal/work/cover.go
@@ -24,7 +24,8 @@ import (
 func (b *Builder) CovData(a *Action, cmdargs ...any) ([]byte, error) {
 	cmdline := str.StringList(cmdargs...)
 	args := append([]string{}, cfg.BuildToolexec...)
-	args = append(args, "go", "tool", "covdata")
+	goBin := filepath.Join(cfg.GOROOTbin, "go"+cfg.ExeSuffix)
+	args = append(args, goBin, "tool", "covdata")
 	args = append(args, cmdline...)
 	return b.Shell(a).runOut(a.Objdir, nil, args)
 }


### PR DESCRIPTION
When a user has a local Go installation of 1.25.5 but their go.mod
specifies 1.26.0, running a test command with coverage flags like
go test -covermode=count -coverpkg=./... ./... triggers the
GOTOOLCHAIN auto-switch mechanism to use the newer toolchain.

However, b.CovData uses the hardcoded 'go' command to invoke the
builtin tool covdata. Because GOTOOLCHAIN does not modify the system
PATH, exec.LookPath resolves this hardcoded 'go' to the host's older
Go version (e.g., 1.25.5).

Since covdata is a builtin tool built and run dynamically by the go
command, invoking the older go binary to handle the new toolchain's
files causes a fatal mismatch. The build fails with an error like:
compile: version "go1.26.0" does not match go tool version "go1.25.5..."

This CL fixes the issue by replacing the hardcoded 'go' with the
absolute path to the current toolchain's go executable, ensuring the
correct toolchain context is maintained and preventing PATH escape.