### PR TITLE
runtime: unified the calculate for max objects per span

### DIFF
--- a/src/runtime/heapdump.go
+++ b/src/runtime/heapdump.go
@@ -480,7 +480,7 @@ func dumproots() {
 
 // Bit vector of free marks.
 // Needs to be as big as the largest number of objects per span.
-var freemark [pageSize / 8]bool
+var freemark [gc.MaxObjsPerSpan]bool
 
 func dumpobjs() {
 	// To protect mheap_.allspans.


### PR DESCRIPTION
the freemark is used for mark the status for one span's slots. 
the size can be simplify by directly use the predefined constant 
of gc.MaxObjsPerSpan
