### PR TITLE
syscall: fix incorrect defer usage in acquireForkLock

### DIFF
--- a/src/syscall/forkpipe2.go
+++ b/src/syscall/forkpipe2.go
@@ -38,12 +38,12 @@ func hasWaitingReaders(rw *sync.RWMutex) bool
 // at the first fork and unlocked when there are no more forks.
 func acquireForkLock() {
 	forkingLock.Lock()
-	defer forkingLock.Unlock()
 
 	if forking == 0 {
 		// There is no current write lock on ForkLock.
 		ForkLock.Lock()
 		forking++
+		forkingLock.Unlock()
 		return
 	}
 
@@ -77,6 +77,7 @@ func acquireForkLock() {
 	}
 
 	forking++
+	forkingLock.Unlock()
 }
 
 // releaseForkLock releases the conceptual write lock on ForkLock


### PR DESCRIPTION
The defer forkingLock.Unlock() at the start of acquireForkLock was problematic because:

1. When forking == 0, the function returns early (line 47), but the deferred Unlock() would still execute, which is correct behavior.

2. However, when hasWaitingReaders returns true, the function manually unlocks (line 65) and then re-locks (line 70) forkingLock. At the end of this path, the deferred Unlock() would execute again, causing a double unlock on forkingLock.

This fix replaces defer with explicit Unlock() calls at both exit points to ensure the lock is released exactly once per execution path.

Change-Id: Ic513c749dd71ddaf9146d51f4b63dc4be40e86ed

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
