### PR TITLE
runtime/cgo: avoid unused parameter warning

### DIFF
--- a/src/runtime/cgo/gcc_clearenv.c
+++ b/src/runtime/cgo/gcc_clearenv.c
@@ -10,7 +10,7 @@
 
 /* Stub for calling clearenv */
 void
-x_cgo_clearenv(void **_unused)
+x_cgo_clearenv(void **env __attribute__((unused)))
 {
 	_cgo_tsan_acquire();
 	clearenv();


### PR DESCRIPTION
Annotate the unused parameter with `__attribute__((unused))` to avoid
build failures in environments that treat unused parameters as errors.

We see this when using `rules_go`:
```
@@rules_go+//:stdlib
builder failed: error executing GoStdlib command (from stdlib rule target @@rules_go+//:stdlib) bazel-out/linux_host_platform-opt-exec-ST-f2d1f3f5d18d/bin/external/rules_go++go_sdk+main___download_0/builder_reset/builder stdlib -sdk external/rules_go++go_sdk+main___download_0 -goroot ... (remaining 16 arguments skipped)
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
stderr:
# runtime/cgo
gcc_clearenv.c:13:23: error: unused parameter '_unused' [-Werror,-Wunused-parameter]
stdlib: error running subcommand external/rules_go++go_sdk+main___download_0/bin/go: exit status 1
```

This matches the style used in `src/runtime/cgo/gcc_libinit.c` since
dc2ae2886fbcd2297d2a0ea67a5d220ae2c74152 which fixed an identical issue.
