### PR TITLE
slog: use time.Time.AppendFormat to write value

### DIFF
--- a/src/log/slog/value.go
+++ b/src/log/slog/value.go
@@ -470,7 +470,7 @@ func (v Value) append(dst []byte) []byte {
 	case KindDuration:
 		return append(dst, v.duration().String()...)
 	case KindTime:
-		return append(dst, v.time().String()...)
+		return v.time().AppendFormat(dst, "2006-01-02 15:04:05.999999999 -0700 MST")
 	case KindGroup:
 		return fmt.Append(dst, v.group())
 	case KindAny, KindLogValuer:


### PR DESCRIPTION
Avoid allocating a string by using the append method on time.Time.
