### PR TITLE
syscall: replace panic with error return in Accept4 on FreeBSD

### DIFF
--- a/src/syscall/syscall_freebsd.go
+++ b/src/syscall/syscall_freebsd.go
@@ -109,7 +109,8 @@ func Accept4(fd, flags int) (nfd int, sa Sockaddr, err error) {
 		return
 	}
 	if len > SizeofSockaddrAny {
-		panic("RawSockaddrAny too small")
+		Close(nfd)
+		return 0, nil, EINVAL
 	}
 	sa, err = anyToSockaddr(&rsa)
 	if err != nil {


### PR DESCRIPTION
The Accept4 function on FreeBSD uses panic when the returned address length exceeds SizeofSockaddrAny. This is inconsistent with Go's error handling philosophy and can crash the entire program.

This commit replaces the panic with proper error handling: closing the accepted file descriptor and returning EINVAL error, which allows callers to handle the exceptional case gracefully.

Changes:
- Close the newly accepted fd before returning error
- Return EINVAL instead of panicking
- Maintain consistency with other error handling in the same function

If this approach is acceptable, similar changes can be applied to other platforms (NetBSD, OpenBSD, DragonflyBSD, Linux, Solaris).

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
