### PR TITLE
internal/stringslite: use bytealg.MakeNoZero in Clone

### DIFF
--- a/src/internal/stringslite/strings.go
+++ b/src/internal/stringslite/strings.go
@@ -116,7 +116,7 @@ func Clone(s string) string {
 	if len(s) == 0 {
 		return ""
 	}
-	b := make([]byte, len(s))
+	b := bytealg.MakeNoZero(len(s))
 	copy(b, s)
 	return unsafe.String(&b[0], len(b))
 }

--- a/src/strings/clone_test.go
+++ b/src/strings/clone_test.go
@@ -39,7 +39,7 @@ func TestClone(t *testing.T) {
 func BenchmarkClone(b *testing.B) {
 	var str = strings.Repeat("a", 42)
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		stringSink = strings.Clone(str)
+	for b.Loop() {
+		strings.Clone(str)
 	}
 }


### PR DESCRIPTION
CL 456336 introduced bytealg.MakeNoZero and leveraged it, for better
performance, in many places of the strings package, but omitted to do so
in Clone.

This CL remedies that omission and also opportunistically
modernizes BenchmarkClone by adopting B.Loop.

Here are some benchmark results:

goos: darwin
goarch: arm64
pkg: strings
cpu: Apple M4
         │     old     │                 new                 │
         │   sec/op    │   sec/op     vs base                │
Clone-10   19.79n ± 0%   17.45n ± 0%  -11.82% (p=0.000 n=20)

         │    old     │              new               │
         │    B/op    │    B/op     vs base            │
Clone-10   48.00 ± 0%   48.00 ± 0%  ~ (p=1.000 n=20) ¹
¹ all samples are equal

         │    old     │              new               │
         │ allocs/op  │ allocs/op   vs base            │
Clone-10   1.000 ± 0%   1.000 ± 0%  ~ (p=1.000 n=20) ¹
¹ all samples are equal
