### PR TITLE
Add package comment to crypto/fips140

### DIFF
--- a/src/crypto/fips140/fips140.go
+++ b/src/crypto/fips140/fips140.go
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Package fips140 provides access to the FIPS 140-3 validation status of the
+// cryptographic module, including the Enabled and Version functions.
+//
+// For more information, see https://go.dev/doc/security/fips140.
 package fips140
 
 import (


### PR DESCRIPTION
Fixes #77879. Adds a package comment to the crypto/fips140 package that was missing documentation.