### PR TITLE
internal/bytealg: add MTE-safe IndexByte implementation for ARM64 iOS

### DIFF
--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -435,6 +435,93 @@ func TestIndexByteSmall(t *testing.T) {
 	}
 }
 
+// TestIndexByteSIMDPaths tests edge cases for SIMD implementations of IndexByte,
+// specifically targeting the different code paths: unaligned prefix, 32-byte chunks,
+// 16-byte chunks, and scalar tail handling. This is particularly relevant for
+// ARM64 MTE-safe implementations.
+func TestIndexByteSIMDPaths(t *testing.T) {
+	// Test various sizes that exercise different SIMD code paths
+	sizes := []int{
+		0, 1, 2, 7, 8, 15, 16, 17, 31, 32, 33, 47, 48, 49,
+		63, 64, 65, 95, 96, 97, 127, 128, 129, 255, 256, 257,
+	}
+
+	for _, size := range sizes {
+		b := make([]byte, size)
+		// Fill with non-target byte
+		for i := range b {
+			b[i] = 'a'
+		}
+
+		// Test 1: Target byte not present
+		if got := IndexByte(b, 'x'); got != -1 {
+			t.Errorf("IndexByte(size=%d, no match) = %d; want -1", size, got)
+		}
+
+		// Test 2: Target byte at each position
+		for pos := 0; pos < size; pos++ {
+			b[pos] = 'x'
+			if got := IndexByte(b, 'x'); got != pos {
+				t.Errorf("IndexByte(size=%d, pos=%d) = %d; want %d", size, pos, got, pos)
+			}
+			b[pos] = 'a'
+		}
+	}
+}
+
+// TestIndexByteUnaligned tests IndexByte with slices starting at various
+// alignments. This tests the unaligned prefix handling in SIMD implementations.
+func TestIndexByteUnaligned(t *testing.T) {
+	// Create a large buffer and test slices at different offsets
+	const bufSize = 512
+	buf := make([]byte, bufSize)
+	for i := range buf {
+		buf[i] = 'a'
+	}
+
+	// Test with different starting offsets (0 to 63 to cover 32-byte alignment cases)
+	for offset := 0; offset < 64 && offset < bufSize; offset++ {
+		// Test with different lengths from this offset
+		for length := 1; length <= bufSize-offset && length <= 256; length++ {
+			slice := buf[offset : offset+length]
+
+			// Reset slice
+			for i := range slice {
+				slice[i] = 'a'
+			}
+
+			// Test: no match
+			if got := IndexByte(slice, 'x'); got != -1 {
+				t.Errorf("IndexByte(offset=%d, len=%d, no match) = %d; want -1", offset, length, got)
+			}
+
+			// Test: match at first position
+			slice[0] = 'x'
+			if got := IndexByte(slice, 'x'); got != 0 {
+				t.Errorf("IndexByte(offset=%d, len=%d, pos=0) = %d; want 0", offset, length, got)
+			}
+			slice[0] = 'a'
+
+			// Test: match at last position
+			slice[length-1] = 'x'
+			if got := IndexByte(slice, 'x'); got != length-1 {
+				t.Errorf("IndexByte(offset=%d, len=%d, pos=%d) = %d; want %d", offset, length, length-1, got, length-1)
+			}
+			slice[length-1] = 'a'
+
+			// Test: match in middle (if length > 2)
+			if length > 2 {
+				mid := length / 2
+				slice[mid] = 'x'
+				if got := IndexByte(slice, 'x'); got != mid {
+					t.Errorf("IndexByte(offset=%d, len=%d, pos=%d) = %d; want %d", offset, length, mid, got, mid)
+				}
+				slice[mid] = 'a'
+			}
+		}
+	}
+}
+
 func TestIndexRune(t *testing.T) {
 	tests := []struct {
 		in   string

--- a/src/internal/bytealg/indexbyte_arm64.s
+++ b/src/internal/bytealg/indexbyte_arm64.s
@@ -4,6 +4,152 @@
 
 #include "textflag.h"
 
+#ifdef GOOS_ios
+// func IndexByte(b []byte, c byte) int
+// input:
+//   R0: b ptr
+//   R1: b len
+//   R2: b cap (unused)
+//   R3: c byte to search
+// return
+//   R0: result
+TEXT ·IndexByte<ABIInternal>(SB),NOSPLIT,$0-40
+	MOVD	R3, R2
+	B	·IndexByteString<ABIInternal>(SB)
+
+// func IndexByteString(s string, c byte) int
+// input:
+//   R0: s ptr
+//   R1: s len
+//   R2: c byte to search
+// return
+//   R0: result
+TEXT ·IndexByteString<ABIInternal>(SB),NOSPLIT,$0-32
+	// MTE-safe implementation: never reads before start or beyond end.
+	// For each 32-byte chunk we calculate a 64-bit syndrome value,
+	// with two bits per byte. Bit 0 is set if the relevant byte
+	// matched the requested character. Counting trailing zeros
+	// identifies which byte matched.
+
+	CBZ	R1, fail
+	MOVD	R0, R11          // Save original pointer
+	ADD	R0, R1, R4       // R4 = end pointer
+
+	// Setup SIMD constants
+	// Magic constant 0x40100401 allows us to identify which lane matches.
+	// 0x40100401 = ((1<<0) + (4<<8) + (16<<16) + (64<<24))
+	VMOV	R2, V0.B16       // Broadcast search byte to all lanes
+	MOVD	$0x40100401, R5
+	VMOV	R5, V5.S4
+
+	// Check alignment - process unaligned prefix byte-by-byte
+	// This avoids reading before the string start (MTE violation)
+	ANDS	$0x1f, R0, R9
+	BEQ	aligned_start
+
+unaligned_loop:
+	MOVBU	(R0), R5
+	CMP	R2, R5
+	BEQ	found_scalar
+	ADD	$1, R0
+	CMP	R0, R4
+	BEQ	fail
+	TST	$0x1f, R0
+	BNE	unaligned_loop
+
+aligned_start:
+	// Check if we have at least 32 bytes remaining BEFORE loading
+	SUB	R0, R4, R5       // R5 = remaining bytes
+	CMP	$32, R5
+	BLO	tail16_check
+
+loop32:
+	// Load 32 aligned bytes - safe because we verified 32+ bytes remain
+	VLD1.P	32(R0), [V1.B16, V2.B16]
+
+	// Compare both vectors against search byte
+	VCMEQ	V0.B16, V1.B16, V3.B16
+	VCMEQ	V0.B16, V2.B16, V4.B16
+
+	// Quick check: any matches in either vector?
+	VORR	V4.B16, V3.B16, V6.B16
+	VADDP	V6.D2, V6.D2, V6.D2
+	VMOV	V6.D[0], R6
+	CBNZ	R6, found32
+
+	// Check bounds BEFORE next iteration
+	SUB	R0, R4, R5
+	CMP	$32, R5
+	BHS	loop32
+
+tail16_check:
+	// Try 16-byte chunks if available
+	CMP	$16, R5
+	BLO	tail_scalar
+
+loop16:
+	// Load 16 aligned bytes
+	VLD1.P	16(R0), [V1.B16]
+
+	VCMEQ	V0.B16, V1.B16, V3.B16
+	VAND	V5.B16, V3.B16, V3.B16
+	VADDP	V3.B16, V3.B16, V3.B16  // 128->64
+	VADDP	V3.B16, V3.B16, V3.B16  // 64->32
+	VMOV	V3.S[0], R6
+	CBNZ	R6, found16
+
+	// Check bounds BEFORE next iteration
+	SUB	R0, R4, R5
+	CMP	$16, R5
+	BHS	loop16
+
+tail_scalar:
+	// Handle remaining bytes one at a time (always safe)
+	CMP	R0, R4
+	BEQ	fail
+
+tail_loop:
+	MOVBU	(R0), R5
+	CMP	R2, R5
+	BEQ	found_scalar
+	ADD	$1, R0
+	CMP	R0, R4
+	BNE	tail_loop
+	B	fail
+
+found32:
+	// Calculate full syndrome for precise position
+	VAND	V5.B16, V3.B16, V3.B16
+	VAND	V5.B16, V4.B16, V4.B16
+	VADDP	V4.B16, V3.B16, V6.B16  // 256->128
+	VADDP	V6.B16, V6.B16, V6.B16  // 128->64
+	VMOV	V6.D[0], R6
+
+	RBIT	R6, R6
+	SUB	$32, R0, R0      // Compensate post-increment
+	CLZ	R6, R6
+	ADD	R6>>1, R0, R0    // R6 is twice the byte offset
+	SUB	R11, R0, R0
+	RET
+
+found16:
+	RBIT	R6, R6
+	SUB	$16, R0, R0      // Compensate post-increment
+	CLZ	R6, R6
+	ADD	R6>>1, R0, R0    // R6 is twice the byte offset
+	SUB	R11, R0, R0
+	RET
+
+found_scalar:
+	SUB	R11, R0, R0
+	RET
+
+fail:
+	MOVD	$-1, R0
+	RET
+
+#else
+
 // func IndexByte(b []byte, c byte) int
 // input:
 //   R0: b ptr
@@ -143,3 +289,5 @@ tail:
 fail:
 	MOVD	$-1, R0
 	RET
+
+#endif

--- a/src/runtime/export_test.go
+++ b/src/runtime/export_test.go
@@ -228,6 +228,15 @@ func GostringW(w []uint16) (s string) {
 	return
 }
 
+// Findnull is an entry point for testing findnull.
+// It returns the index of the first NUL byte in a NUL-terminated byte slice.
+func Findnull(s []byte) int {
+	if len(s) == 0 {
+		return 0
+	}
+	return findnull(&s[0])
+}
+
 var Open = open
 var Close = closefd
 var Read = read

--- a/src/runtime/string.go
+++ b/src/runtime/string.go
@@ -493,7 +493,7 @@ func findnull(s *byte) int {
 	// Avoid IndexByteString on Plan 9 because it uses SSE instructions
 	// on x86 machines, and those are classified as floating point instructions,
 	// which are illegal in a note handler.
-	if GOOS == "plan9" {
+	if GOOS == "plan9" || GOOS == "ios" {
 		p := (*[maxAlloc/2 - 1]byte)(unsafe.Pointer(s))
 		l := 0
 		for p[l] != 0 {

--- a/src/runtime/string_test.go
+++ b/src/runtime/string_test.go
@@ -214,6 +214,57 @@ func TestStringW(t *testing.T) {
 	}
 }
 
+// TestFindnull tests the findnull function which finds the index of the
+// first NUL byte in a NUL-terminated byte slice. This tests the byte-by-byte
+// fallback path used on Plan 9 and iOS
+func TestFindnull(t *testing.T) {
+	// Test various sizes that might exercise different code paths
+	sizes := []int{
+		0, 1, 2, 7, 8, 15, 16, 17, 31, 32, 33, 47, 48, 49,
+		63, 64, 65, 127, 128, 129, 255, 256, 257, 1023, 1024, 1025,
+	}
+
+	for _, size := range sizes {
+		// Create a NUL-terminated byte slice
+		b := make([]byte, size+1) // +1 for NUL terminator
+		for i := 0; i < size; i++ {
+			b[i] = 'a'
+		}
+		b[size] = 0
+
+		got := runtime.Findnull(b)
+		if got != size {
+			t.Errorf("Findnull(size=%d) = %d; want %d", size, got, size)
+		}
+	}
+
+	// Test with NUL at various positions
+	for _, total := range []int{64, 128, 256} {
+		for pos := 0; pos < total; pos++ {
+			b := make([]byte, total+1)
+			for i := 0; i < total; i++ {
+				b[i] = 'a'
+			}
+			b[pos] = 0 // Place NUL at position pos
+			b[total] = 0
+
+			got := runtime.Findnull(b)
+			if got != pos {
+				t.Errorf("Findnull(total=%d, nul_at=%d) = %d; want %d", total, pos, got, pos)
+			}
+
+			// Restore for next iteration
+			b[pos] = 'a'
+		}
+	}
+
+	// Test empty slice (nil pointer behavior)
+	got := runtime.Findnull(nil)
+	if got != 0 {
+		t.Errorf("Findnull(nil) = %d; want 0", got)
+	}
+}
+
 func TestLargeStringConcat(t *testing.T) {
 	output := runTestProg(t, "testprog", "stringconcat")
 	want := "panic: " + strings.Repeat("0", 1<<10) + strings.Repeat("1", 1<<10) +

--- a/src/strings/strings_test.go
+++ b/src/strings/strings_test.go
@@ -266,6 +266,100 @@ func TestLastIndexByte(t *testing.T) {
 	}
 }
 
+// TestIndexByteSIMDPaths tests edge cases for SIMD implementations of IndexByte,
+// specifically targeting the different code paths: unaligned prefix, 32-byte chunks,
+// 16-byte chunks, and scalar tail handling. This is particularly relevant for
+// ARM64 MTE-safe implementations.
+func TestIndexByteSIMDPaths(t *testing.T) {
+	// Test various sizes that exercise different SIMD code paths
+	sizes := []int{
+		0, 1, 2, 7, 8, 15, 16, 17, 31, 32, 33, 47, 48, 49,
+		63, 64, 65, 95, 96, 97, 127, 128, 129, 255, 256, 257,
+	}
+
+	for _, size := range sizes {
+		// Create a string of the given size
+		b := make([]byte, size)
+		for i := range b {
+			b[i] = 'a'
+		}
+		s := string(b)
+
+		// Test 1: Target byte not present
+		if got := IndexByte(s, 'x'); got != -1 {
+			t.Errorf("IndexByte(size=%d, no match) = %d; want -1", size, got)
+		}
+
+		// Test 2: Target byte at each position
+		for pos := 0; pos < size; pos++ {
+			b[pos] = 'x'
+			s = string(b)
+			if got := IndexByte(s, 'x'); got != pos {
+				t.Errorf("IndexByte(size=%d, pos=%d) = %d; want %d", size, pos, got, pos)
+			}
+			b[pos] = 'a'
+		}
+	}
+}
+
+// TestIndexByteStringUnaligned tests IndexByte with strings created from
+// slices at various alignments. This tests the unaligned prefix handling
+// in SIMD implementations.
+func TestIndexByteStringUnaligned(t *testing.T) {
+	// Create a large buffer and test strings at different offsets
+	const bufSize = 512
+	buf := make([]byte, bufSize)
+	for i := range buf {
+		buf[i] = 'a'
+	}
+
+	// Test with different starting offsets (0 to 63 to cover 32-byte alignment cases)
+	for offset := 0; offset < 64 && offset < bufSize; offset++ {
+		// Test with different lengths from this offset
+		for length := 1; length <= bufSize-offset && length <= 256; length++ {
+			slice := buf[offset : offset+length]
+
+			// Reset slice
+			for i := range slice {
+				slice[i] = 'a'
+			}
+			s := string(slice)
+
+			// Test: no match
+			if got := IndexByte(s, 'x'); got != -1 {
+				t.Errorf("IndexByte(offset=%d, len=%d, no match) = %d; want -1", offset, length, got)
+			}
+
+			// Test: match at first position
+			slice[0] = 'x'
+			s = string(slice)
+			if got := IndexByte(s, 'x'); got != 0 {
+				t.Errorf("IndexByte(offset=%d, len=%d, pos=0) = %d; want 0", offset, length, got)
+			}
+			slice[0] = 'a'
+
+			// Test: match at last position
+			slice[length-1] = 'x'
+			s = string(slice)
+			if got := IndexByte(s, 'x'); got != length-1 {
+				t.Errorf("IndexByte(offset=%d, len=%d, pos=%d) = %d; want %d", offset, length, length-1, got, length-1)
+			}
+			slice[length-1] = 'a'
+
+			// Test: match in middle (if length > 2)
+			if length > 2 {
+				mid := length / 2
+				slice[mid] = 'x'
+				s = string(slice)
+				if got := IndexByte(s, 'x'); got != mid {
+					t.Errorf("IndexByte(offset=%d, len=%d, pos=%d) = %d; want %d", offset, length, mid, got, mid)
+				}
+				slice[mid] = 'a'
+			}
+		}
+	}
+}
+
 func simpleIndex(s, sep string) int {
 	n := len(sep)
 	for i := n; i <= len(s); i++ {


### PR DESCRIPTION
Add optimized ARM64 implementation of IndexByte and IndexByteString for iOS that never reads before string start or beyond end, making it MTE-safe.

Also extend the findnull fallback to iOS since it
may use ARM64 with restrictions similar to Plan 9.

Includes comprehensive tests for different SIMD code paths and alignments.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.