### PR TITLE
net/url: allow commas in hostnames for mongodb urls

### DIFF
--- a/src/net/url/url.go
+++ b/src/net/url/url.go
@@ -615,6 +615,13 @@ func parseHost(scheme, host string) (string, error) {
 				// continue to permit it for postgres:// URLs only.
 				// https://go.dev/issue/75223
 				i = lastColon
+			} else if scheme == "mongodb" || scheme == "mongodb+srv" {
+				// In a MongoDB connection URI, commas are used to separate
+				// multiple host addresses when connecting to a replica set or a sharded cluster.
+				// https://www.mongodb.com/docs/manual/reference/connection-string-formats/
+				// Example:
+				// mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017
+				i = lastColon
 			} else if urlstrictcolons.Value() == "0" {
 				urlstrictcolons.IncNonDefault()
 				i = lastColon

--- a/src/net/url/url_test.go
+++ b/src/net/url/url_test.go
@@ -627,6 +627,27 @@ var urltests = []URLTest{
 		},
 		"postgresql://host1:1,host2:2,host3:3",
 	},
+	// Mongodb URLs can include a comma-separated list of host:post hosts.
+	{
+		"mongodb://user:password@host1:1,host2:2,host3:3",
+		&URL{
+			Scheme: "mongodb",
+			User:   UserPassword("user", "password"),
+			Host:   "host1:1,host2:2,host3:3",
+			Path:   "",
+		},
+		"",
+	},
+	{
+		"mongodb+srv://user:password@host1:1,host2:2,host3:3",
+		&URL{
+			Scheme: "mongodb+srv",
+			User:   UserPassword("user", "password"),
+			Host:   "host1:1,host2:2,host3:3",
+			Path:   "",
+		},
+		"",
+	},
 }
 
 // more useful string for debugging than fmt's struct printer


### PR DESCRIPTION
A valid MongoDB URL can contain commas 
to include multiple host:port pairs.
The current parseHost function splits the port 
starting from the first colon (:),
but for MongoDB URLs that contain multiple host:port pairs, 
it needs to split from the last colon (:).

Fixes #78077 

