### PR TITLE
crypto/x509: avoid false wildcard matches for 2-label exclusions

### DIFF
--- a/src/crypto/x509/name_constraints_test.go
+++ b/src/crypto/x509/name_constraints_test.go
@@ -1674,6 +1674,22 @@ var nameConstraintsTests = []nameConstraintsTest{
 			sans: []string{"dns:*.example.com"},
 		},
 	},
+	// #90: a two-label excluded constraint doesn't exclude unrelated wildcards
+	{
+		roots: []constraintsSpec{
+			{
+				bad: []string{"dns:blocked.example"},
+			},
+		},
+		intermediates: [][]constraintsSpec{
+			{
+				{},
+			},
+		},
+		leaf: leafSpec{
+			sans: []string{"dns:*.service.example"},
+		},
+	},
 }
 
 func makeConstraintsCACert(constraints constraintsSpec, name string, key *ecdsa.PrivateKey, parent *Certificate, parentKey *ecdsa.PrivateKey) (*Certificate, error) {

--- a/src/crypto/x509/verify.go
+++ b/src/crypto/x509/verify.go
@@ -546,7 +546,7 @@ func matchDomainConstraint(domain, constraint string, excluded bool, reversedDom
 		return false, nil
 	}
 
-	if excluded && wildcardDomain && len(domainLabels) > 1 && len(constraintLabels) > 1 {
+	if excluded && wildcardDomain && len(domainLabels) > 1 && len(constraintLabels) > 2 {
 		domainLabels = domainLabels[:len(domainLabels)-1]
 		constraintLabels = constraintLabels[:len(constraintLabels)-1]
 	}

--- a/src/crypto/x509/verify_test.go
+++ b/src/crypto/x509/verify_test.go
@@ -1417,6 +1417,52 @@ func TestNameConstraints(t *testing.T) {
 	}
 }
 
+func TestExcludedWildcardNameConstraints(t *testing.T) {
+	tests := []struct {
+		name        string
+		domain      string
+		constraint  string
+		shouldMatch bool
+	}{
+		{
+			name:        "excluded subdomain matches wildcard parent",
+			domain:      "*.example.com",
+			constraint:  "foo.example.com",
+			shouldMatch: true,
+		},
+		{
+			name:        "excluded parent domain matches wildcard",
+			domain:      "*.example.com",
+			constraint:  "example.com",
+			shouldMatch: true,
+		},
+		{
+			name:        "excluded unrelated two-label domain does not match wildcard",
+			domain:      "*.service.example",
+			constraint:  "blocked.example",
+			shouldMatch: false,
+		},
+		{
+			name:        "excluded single-label domain does not match wildcard",
+			domain:      "*.service.example",
+			constraint:  "internal",
+			shouldMatch: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			match, err := matchDomainConstraint(tc.domain, tc.constraint, true, map[string][]string{}, map[string][]string{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if match != tc.shouldMatch {
+				t.Fatalf("matchDomainConstraint(%q, %q, excluded=true) = %v, want %v", tc.domain, tc.constraint, match, tc.shouldMatch)
+			}
+		})
+	}
+}
+
 const selfSignedWithCommonName = `-----BEGIN CERTIFICATE-----
 MIIDCjCCAfKgAwIBAgIBADANBgkqhkiG9w0BAQsFADAaMQswCQYDVQQKEwJjYTEL
 MAkGA1UEAxMCY2EwHhcNMTYwODI4MTcwOTE4WhcNMjEwODI3MTcwOTE4WjAcMQsw


### PR DESCRIPTION
When evaluating excluded DNS name constraints against wildcard SANs,
matchDomainConstraint trims one label from both names so that excluded
subdomains like `foo.example.com` correctly preclude `*.example.com`.

That trimming was also applied to two-label constraints. For a
constraint like `blocked.example`, trimming reduces it to `example`, which
can incorrectly match unrelated wildcard names.

Only apply the wildcard/excluded trimming path when the excluded
constraint has more than two labels.

This change adds regression coverage for the wildcard-matching behavior
in `TestExcludedWildcardNameConstraints` and adds a chain-level case in
`TestConstraintCases`.

Updates #76935
Updates #77323