### PR TITLE
cmd/compile: use the correct const when flagging indirect map elem types

### DIFF
--- a/src/cmd/compile/internal/reflectdata/map.go
+++ b/src/cmd/compile/internal/reflectdata/map.go
@@ -295,7 +295,7 @@ func writeMapType(t *types.Type, lsym *obj.LSym, c rttype.Cursor) {
 	if t.Key().Size() > abi.MapMaxKeyBytes {
 		flags |= abi.MapIndirectKey
 	}
-	if t.Elem().Size() > abi.MapMaxKeyBytes {
+	if t.Elem().Size() > abi.MapMaxElemBytes {
 		flags |= abi.MapIndirectElem
 	}
 	c.Field("Flags").WriteUint32(flags)


### PR DESCRIPTION
Currently both MapMaxKeyBytes and MapMaxElemBytes are 128 so there's no
functional change.