### PR TITLE
Fix #78006: include type arguments in instantiated type cycle errors

### DIFF
--- a/src/cmd/compile/internal/types2/decl.go
+++ b/src/cmd/compile/internal/types2/decl.go
@@ -10,7 +10,34 @@ import (
 	"go/constant"
 	. "internal/types/errors"
 	"slices"
+	"strings" // Added
 )
+
+// objTypeName returns the (possibly qualified) name of obj,
+// including type arguments if obj is an instantiated TypeName.
+// The qualifier function is used to qualify package names.
+func objTypeName(obj Object, qualifier func(*Package) string) string {
+	// Use obj.Name() for non-TypeName objects or non-instantiated TypeNames.
+	// For instantiated TypeNames, format as Name[Args].
+	if tname, ok := obj.(*TypeName); ok {
+		if named, ok := tname.Type().(*Named); ok && named.TypeArgs() != nil {
+			var b strings.Builder
+			b.WriteString(packagePrefix(obj.Pkg(), qualifier))
+			b.WriteString(obj.Name()) // Base name
+			b.WriteByte('[')
+			for i, targ := range named.TypeArgs().list() {
+				if i > 0 {
+					b.WriteString(", ")
+				}
+				// TypeString is expected to be available in this package.
+				b.WriteString(TypeString(targ, qualifier))
+			}
+			b.WriteByte(']')
+			return b.String()
+		}
+	}
+	return packagePrefix(obj.Pkg(), qualifier) + obj.Name()
+}
 
 func (check *Checker) declare(scope *Scope, id *syntax.Name, obj Object, pos syntax.Pos) {
 	// spec: "The blank identifier, represented by the underscore
@@ -39,7 +66,7 @@ func pathString(path []Object) string {
 		if i > 0 {
 			s += "->"
 		}
-		s += p.Name()
+		s += objTypeName(p, nil) // Use objTypeName
 	}
 	return s
 }
@@ -210,7 +237,7 @@ loop:
 	}
 
 	if check.conf.Trace {
-		check.trace(obj.Pos(), "## cycle detected: objPath = %s->%s (len = %d)", pathString(cycle), obj.Name(), len(cycle))
+		check.trace(obj.Pos(), "## cycle detected: objPath = %s->%s (len = %d)", pathString(cycle), objTypeName(obj, nil), len(cycle)) // Use objTypeName
 		if tparCycle {
 			check.trace(obj.Pos(), "## cycle contains: generic type in a type parameter list")
 		} else {
@@ -255,7 +282,7 @@ func (check *Checker) cycleError(cycle []Object, start int) {
 	// may refer to imported types. See go.dev/issue/50788.
 	// TODO(gri) This functionality is used elsewhere. Factor it out.
 	name := func(obj Object) string {
-		return packagePrefix(obj.Pkg(), check.qualifier) + obj.Name()
+		return objTypeName(obj, check.qualifier) // Use objTypeName
 	}
 
 	// If obj is a type alias, mark it as valid (not broken) in order to avoid follow-on errors.


### PR DESCRIPTION
## More Context
This PR addresses issue #78006 by enhancing the clarity of cycle error messages for instantiated generic types in the Go compiler. Previously, when a declaration cycle involved a generic type instantiated with specific arguments (e.g., `MyType[int]`), the compiler's error message would only display the generic type's base name ("MyType"), omitting the crucial type arguments. This made it challenging to identify the exact recursive type causing the error.

The core problem lies in the `pathString` function and the local `name` helper within `src/cmd/compile/internal/types2/decl.go`. These functions, responsible for constructing cycle error messages, did not leverage the full type-formatting capabilities available in `src/cmd/compile/internal/types2/typestring.go`. Consequently, when processing an `Object` representing an instantiated generic `TypeName`, `obj.Name()` only returned the base name, ignoring the associated type arguments. This PR rectifies this by integrating the detailed type representation from `typestring.go` into the error reporting in `decl.go`.

## Test Plan

To verify this fix, the following test cases should be considered:

### Test Case 1: Simple Instantiated Generic Type Cycle
*   **Scenario:** Create a Go program with a declaration cycle involving a straightforward instantiated generic type.
    *   *Example:*
        ```go
        package p
        type A[T any] B[T]
        type B[T any] A[T]
        var _ A[int]
        ```
*   **Expected Result:** The compiler error message for the cycle should explicitly include the type arguments, e.g., "A[int] refers to B[int] -> A[int]".

### Test Case 2: Complex Instantiated Generic Type Cycle
*   **Scenario:** Introduce a more intricate declaration cycle involving multiple instantiated generic types or nested generic types.
    *   *Example:*
        ```go
        package p
        type C[X any] D[X, int]
        type D[Y, Z any] C[Y]
        var _ C[string]
        ```
*   **Expected Result:** The compiler error message should accurately reflect all instantiated generic types with their specific arguments throughout the cycle path.

### Test Case 3: Non-Generic Type Cycle (No Change Expected)
*   **Scenario:** Create a Go program with a declaration cycle that does *not* involve any generic types.
    *   *Example:*
        ```go
        package p
        type E F
        type F E
        var _ E
        ```
*   **Expected Result:** The compiler error message should remain unchanged, confirming that this PR does not inadvertently affect error reporting for non-generic cycles.

### Test Case 4: Cycle Involving Imported Generic Types
*   **Scenario:** Define a generic type and a cycle involving it in one package. In a separate package, import and instantiate this generic type, forming a cycle.
*   **Expected Result:** The error message should correctly qualify the imported generic type with its package name and include its type arguments.

---
Fixes #78006

## Summary
This PR addresses issue #78006 by ensuring that cycle error messages for instantiated generic types include their type arguments. Previously, these error messages would only show the generic type's name, making it difficult to pinpoint the exact recursive type causing the error. By including the type arguments, the error messages become more informative and actionable.

## Changes
- `src/cmd/compile/internal/types2/decl.go`: 
  - Added a new helper function `objTypeName` that formats `Object`s, specifically `TypeName` objects that are instances of generic types, to include their type arguments (e.g., `Type[Arg1, Arg2]`).
  - Modified `pathString` to utilize `objTypeName` for formatting objects in the cycle path.
  - Modified the `name` helper function within `cycleError` to also use `objTypeName` when constructing error messages for declaration cycles.
