### PR TITLE
cmd/compile: unwrap OCONVIFACE in staticinit for OAS2

### DIFF
--- a/src/cmd/compile/internal/staticinit/sched.go
+++ b/src/cmd/compile/internal/staticinit/sched.go
@@ -114,7 +114,7 @@ func (s *Schedule) tryStaticInit(n ir.Node) bool {
 		// "var a, b = f()" that needs type conversion, which is not static.
 		n := n.(*ir.AssignListStmt)
 		for _, rhs := range n.Rhs {
-			for rhs.Op() == ir.OCONVNOP {
+			for rhs.Op() == ir.OCONVNOP || rhs.Op() == ir.OCONVIFACE {
 				rhs = rhs.(*ir.ConvExpr).X
 			}
 			if name, ok := rhs.(*ir.Name); !ok || !name.AutoTemp() {

--- a/test/fixedbugs/issue78016.go
+++ b/test/fixedbugs/issue78016.go
@@ -1,0 +1,13 @@
+// compile
+
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+var a, b, c interface{} = func() (_, _, _ int) { return 1, 2, 3 }()
+
+func main() {
+	println(a.(int), b.(int), c.(int))
+}


### PR DESCRIPTION
Static initialization only expected OCONVNOP wrappings.
Unwrap OCONVIFACE too, since it occurs when multiple return values
of an OAS2FUNC are implicitly converted to an interface.

Fixes #78016
