### PR TITLE
cmd/internal/obj/arm: set spadj in arm32 tailcall

### DIFF
--- a/src/cmd/internal/obj/arm/obj5.go
+++ b/src/cmd/internal/obj/arm/obj5.go
@@ -387,12 +387,18 @@ func preprocess(ctxt *obj.Link, cursym *obj.LSym, newprog obj.ProgAlloc) {
 
 			// If there are instructions following
 			// this ARET, they come from a branch
-			// with the same stackframe, so no spadj.
+			// with the same stackframe, so spadj should
+			// sum to 0.
 
 			if retSym != nil || retReg != REGLINK { // retjmp
 				p.To.Reg = REGLINK
+				// If ARET is a tail-call, the frame pop
+				// and jump are in separate instructions
+				// and spadj is needed.
+				p.Spadj = -autosize
 				q2 = obj.Appendp(p, newprog)
 				q2.As = AB
+				q2.Spadj = +autosize
 				if retSym != nil {
 					q2.To.Type = obj.TYPE_BRANCH
 					q2.To.Sym = retSym


### PR DESCRIPTION
In the normal case spadj is not needed because ARET handles the frame pop
and return in a single instruction. However, if the ARET is a tailcall then
there will be a second instruction where the pcsp stack depth is
incorrect.

Fixes #78021
