### PR TITLE
bytes: remove unused indexBytePortable

### DIFF
--- a/src/bytes/bytes.go
+++ b/src/bytes/bytes.go
@@ -98,15 +98,6 @@ func IndexByte(b []byte, c byte) int {
 	return bytealg.IndexByte(b, c)
 }
 
-func indexBytePortable(s []byte, c byte) int {
-	for i, b := range s {
-		if b == c {
-			return i
-		}
-	}
-	return -1
-}
-
 // LastIndex returns the index of the last instance of sep in s, or -1 if sep is not present in s.
 func LastIndex(s, sep []byte) int {
 	n := len(sep)

--- a/src/bytes/bytes_test.go
+++ b/src/bytes/bytes_test.go
@@ -323,10 +323,6 @@ func TestIndexByte(t *testing.T) {
 		if pos != tt.i {
 			t.Errorf(`IndexByte(%q, '%c') = %v`, tt.a, b, pos)
 		}
-		posp := IndexBytePortable(a, b)
-		if posp != tt.i {
-			t.Errorf(`indexBytePortable(%q, '%c') = %v`, tt.a, b, posp)
-		}
 	}
 }
 
@@ -617,8 +613,18 @@ func BenchmarkIndexByte(b *testing.B) {
 	benchBytes(b, indexSizes, bmIndexByte(IndexByte))
 }
 
+// indexBytePortable use as the baseline for performance comparisons.
+func indexBytePortable(s []byte, c byte) int {
+	for i, b := range s {
+		if b == c {
+			return i
+		}
+	}
+	return -1
+}
+
 func BenchmarkIndexBytePortable(b *testing.B) {
-	benchBytes(b, indexSizes, bmIndexByte(IndexBytePortable))
+	benchBytes(b, indexSizes, bmIndexByte(indexBytePortable))
 }
 
 func bmIndexByte(index func([]byte, byte) int) func(b *testing.B, n int) {

--- a/src/bytes/export_test.go
+++ b/src/bytes/export_test.go
@@ -1,8 +1,0 @@
-// Copyright 2009 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
-package bytes
-
-// Export func for testing
-var IndexBytePortable = indexBytePortable

--- a/src/cmd/go/testdata/script/list_test.txt
+++ b/src/cmd/go/testdata/script/list_test.txt
@@ -4,18 +4,18 @@
 
 [compiler:gccgo] skip 'gccgo does not have standard packages'
 
-go list -test -deps bytes
-stdout '^bytes.test$' # test main
-stdout '^bytes$' # real bytes
-stdout '^bytes \[bytes.test\]$' # test copy of bytes
-stdout 'testing \[bytes.test\]$' # test copy of testing
+go list -test -deps strings
+stdout '^strings.test$' # test main
+stdout '^strings$' # real strings
+stdout '^strings \[strings.test\]$' # test copy of strings
+stdout 'testing \[strings.test\]$' # test copy of testing
 ! stdout ^testing$ # should not have real testing
 
-go list -test bytes
-stdout '^bytes.test$' # test main
-stdout '^bytes$' # real bytes
-stdout '^bytes \[bytes.test\]$' # test copy of bytes
-! stdout '^testing \[bytes.test\]$' # should not have test copy of testing
+go list -test strings
+stdout '^strings.test$' # test main
+stdout '^strings$' # real strings
+stdout '^strings \[strings.test\]$' # test copy of strings
+! stdout '^testing \[strings.test\]$' # should not have test copy of testing
 ! stdout '^testing$' # should not have real testing
 
 go list -test cmd/buildid cmd/gofmt


### PR DESCRIPTION
The function "indexBytePortable" is no longer in use, and we have an
identical one in "internal/bytealg".

Remove this function and related tests.