### PR TITLE
slices: document backing array behavior in package doc

### DIFF
--- a/src/slices/slices.go
+++ b/src/slices/slices.go
@@ -3,6 +3,9 @@
 // license that can be found in the LICENSE file.
 
 // Package slices defines various functions useful with slices of any type.
+//
+// Unless otherwise documented, functions that modify and return a slice
+// may reuse the backing array of the input slice.
 package slices
 
 import (

--- a/src/slices/slices.go
+++ b/src/slices/slices.go
@@ -3,6 +3,9 @@
 // license that can be found in the LICENSE file.
 
 // Package slices defines various functions useful with slices of any type.
+//
+// Unless otherwise documented, functions may reuse the backing array
+// of the input slice.
 package slices
 
 import (


### PR DESCRIPTION
Several functions in the slices package may reuse the backing
array of their input slice unless otherwise documented.

Add a short note to the package documentation so callers know
not to assume a new backing array is allocated.

Fixes #60142