### PR TITLE
sync: modernize examples using newer ranged for loops

### DIFF
--- a/src/sync/example_test.go
+++ b/src/sync/example_test.go
@@ -66,13 +66,13 @@ func ExampleOnce() {
 		fmt.Println("Only once")
 	}
 	done := make(chan bool)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			once.Do(onceBody)
 			done <- true
 		}()
 	}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		<-done
 	}
 	// Output:
@@ -84,14 +84,14 @@ func ExampleOnce() {
 func ExampleOnceValue() {
 	once := sync.OnceValue(func() int {
 		sum := 0
-		for i := 0; i < 1000; i++ {
+		for i := range 1000 {
 			sum += i
 		}
 		fmt.Println("Computed once:", sum)
 		return sum
 	})
 	done := make(chan bool)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			const want = 499500
 			got := once()
@@ -101,7 +101,7 @@ func ExampleOnceValue() {
 			done <- true
 		}()
 	}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		<-done
 	}
 	// Output:
@@ -115,7 +115,7 @@ func ExampleOnceValues() {
 		return os.ReadFile("example_test.go")
 	})
 	done := make(chan bool)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			data, err := once()
 			if err != nil {
@@ -125,7 +125,7 @@ func ExampleOnceValues() {
 			done <- true
 		}()
 	}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		<-done
 	}
 	// Output:


### PR DESCRIPTION
The examples in sync package currently use the traditional
for loop pattern.

These examples are modernized using the ranged for loops.