### PR TITLE
os: fix Chtimes timestamp overflow for dates outside 1677-2262

### DIFF
--- a/src/os/file_posix.go
+++ b/src/os/file_posix.go
@@ -190,7 +190,10 @@ func chtimesUtimes(atime, mtime time.Time) [2]syscall.Timespec {
 		if t.IsZero() {
 			utimes[i] = syscall.Timespec{Sec: _UTIME_OMIT, Nsec: _UTIME_OMIT}
 		} else {
-			utimes[i] = syscall.NsecToTimespec(t.UnixNano())
+			// Use time.Unix() and time.Nanosecond() separately
+			// instead of time.UnixNano() to avoid int64 overflow
+			// for dates before year 1677 or after 2262. See #75542.
+			utimes[i] = syscall.SecNsecToTimespec(t.Unix(), int64(t.Nanosecond()))
 		}
 	}
 	set(0, atime)

--- a/src/os/os_test.go
+++ b/src/os/os_test.go
@@ -1579,6 +1579,53 @@ func TestChtimesToUnixZero(t *testing.T) {
 	}
 }
 
+func TestChtimesExtremeDates(t *testing.T) {
+	t.Parallel()
+
+	file := newFile(t)
+	fn := file.Name()
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test dates outside the range of time.UnixNano (~1677-2262).
+	// These timestamps overflow int64 when converted to nanoseconds,
+	// which previously caused Chtimes to set corrupted timestamps.
+	// See #75542.
+	tests := []struct {
+		name string
+		time time.Time
+	}{
+		{"year 1000", time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+		{"year 1600", time.Date(1600, time.January, 1, 0, 0, 0, 0, time.UTC)},
+		{"year 3000", time.Date(3000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+		{"year 2300", time.Date(2300, time.June, 15, 12, 0, 0, 0, time.UTC)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := Chtimes(fn, tt.time, tt.time); err != nil {
+				// Some filesystems don't support timestamps outside a limited range.
+				t.Skipf("Chtimes failed for %v (filesystem may not support this date range): %v", tt.time, err)
+			}
+
+			st, err := Stat(fn)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// The filesystem may truncate to second precision,
+			// so compare only up to seconds.
+			got := st.ModTime().Unix()
+			want := tt.time.Unix()
+			if got != want {
+				t.Errorf("ModTime = %v (unix %d), want %v (unix %d)",
+					st.ModTime(), got, tt.time, want)
+			}
+		})
+	}
+}
+
 func TestFileChdir(t *testing.T) {
 	wd, err := Getwd()
 	if err != nil {

--- a/src/os/root_windows.go
+++ b/src/os/root_windows.go
@@ -351,6 +351,24 @@ func removedirat(dirfd syscall.Handle, name string) error {
 	return windows.Deleteat(dirfd, name, windows.FILE_DIRECTORY_FILE)
 }
 
+// timeToFiletime converts a time.Time to a syscall.Filetime without
+// using time.UnixNano(), which overflows int64 for dates before 1677
+// or after 2262. See #75542.
+func timeToFiletime(t time.Time) syscall.Filetime {
+	// Windows FILETIME is 100-nanosecond intervals since January 1, 1601.
+	// Compute seconds and nanoseconds separately to avoid int64 overflow.
+	sec := t.Unix()
+	nsec := int64(t.Nanosecond())
+	// Convert to 100-nanosecond ticks since Unix epoch.
+	ticks := sec*1e7 + nsec/100
+	// Shift epoch from 1970 to 1601 (difference is 11644473600 seconds = 116444736000000000 ticks).
+	ticks += 116444736000000000
+	return syscall.Filetime{
+		LowDateTime:  uint32(ticks & 0xffffffff),
+		HighDateTime: uint32(ticks >> 32 & 0xffffffff),
+	}
+}
+
 func chtimesat(dirfd syscall.Handle, name string, atime time.Time, mtime time.Time) error {
 	h, err := windows.Openat(dirfd, name, syscall.O_CLOEXEC|windows.O_NOFOLLOW_ANY|windows.O_WRITE_ATTRS, 0)
 	if err == syscall.ELOOP || err == syscall.ENOTDIR {
@@ -365,10 +383,12 @@ func chtimesat(dirfd syscall.Handle, name string, atime time.Time, mtime time.Ti
 	a := syscall.Filetime{}
 	w := syscall.Filetime{}
 	if !atime.IsZero() {
-		a = syscall.NsecToFiletime(atime.UnixNano())
+		// Use timeToFiletime instead of UnixNano() to avoid
+		// int64 overflow for extreme timestamps. See #75542.
+		a = timeToFiletime(atime)
 	}
 	if !mtime.IsZero() {
-		w = syscall.NsecToFiletime(mtime.UnixNano())
+		w = timeToFiletime(mtime)
 	}
 	return syscall.SetFileTime(h, nil, &a, &w)
 }

--- a/src/syscall/syscall_windows.go
+++ b/src/syscall/syscall_windows.go
@@ -726,6 +726,20 @@ func Utimes(path string, tv []Timeval) (err error) {
 // This matches the value in os/file_windows.go.
 const _UTIME_OMIT = -1
 
+// timespecToFiletime converts a Timespec to a Filetime without computing
+// Sec * 1e9 which can overflow int64 for extreme timestamps. See #75542.
+func timespecToFiletime(ts Timespec) Filetime {
+	// Windows FILETIME is 100-nanosecond intervals since January 1, 1601.
+	// Compute from Sec and Nsec separately to avoid int64 overflow.
+	ticks := ts.Sec*1e7 + ts.Nsec/100
+	// Shift epoch from 1970 to 1601.
+	ticks += 116444736000000000
+	return Filetime{
+		LowDateTime:  uint32(ticks & 0xffffffff),
+		HighDateTime: uint32(ticks >> 32 & 0xffffffff),
+	}
+}
+
 func UtimesNano(path string, ts []Timespec) (err error) {
 	if len(ts) != 2 {
 		return EINVAL
@@ -744,10 +758,10 @@ func UtimesNano(path string, ts []Timespec) (err error) {
 	a := Filetime{}
 	w := Filetime{}
 	if ts[0].Nsec != _UTIME_OMIT {
-		a = NsecToFiletime(TimespecToNsec(ts[0]))
+		a = timespecToFiletime(ts[0])
 	}
 	if ts[1].Nsec != _UTIME_OMIT {
-		w = NsecToFiletime(TimespecToNsec(ts[1]))
+		w = timespecToFiletime(ts[1])
 	}
 	return SetFileTime(h, nil, &a, &w)
 }
@@ -1182,6 +1196,14 @@ func NsecToTimespec(nsec int64) (ts Timespec) {
 	ts.Sec = nsec / 1e9
 	ts.Nsec = nsec % 1e9
 	return
+}
+
+// SecNsecToTimespec converts separate seconds and nanoseconds values
+// into a [Timespec]. This avoids the int64 overflow that can occur
+// when using [NsecToTimespec] with very large or very small timestamps,
+// since it does not require computing seconds * 1e9.
+func SecNsecToTimespec(sec int64, nsec int64) Timespec {
+	return Timespec{Sec: sec, Nsec: nsec}
 }
 
 // TODO(brainman): fix all needed for net

--- a/src/syscall/timestruct.go
+++ b/src/syscall/timestruct.go
@@ -20,6 +20,14 @@ func NsecToTimespec(nsec int64) Timespec {
 	return setTimespec(sec, nsec)
 }
 
+// SecNsecToTimespec converts separate seconds and nanoseconds values
+// into a [Timespec]. This avoids the int64 overflow that can occur
+// when using [NsecToTimespec] with very large or very small timestamps,
+// since it does not require computing seconds * 1e9.
+func SecNsecToTimespec(sec int64, nsec int64) Timespec {
+	return setTimespec(sec, nsec)
+}
+
 // TimevalToNsec returns the time stored in tv as nanoseconds.
 func TimevalToNsec(tv Timeval) int64 { return tv.Nano() }
 


### PR DESCRIPTION
os.Chtimes used time.Time.UnixNano() to convert timestamps to syscall
timespecs, which overflows int64 for dates before ~1677 or after ~2262.
This corrupts timestamps on filesystems that support wider date ranges
(ext4, NTFS, APFS, etc.).

Changes:
- Add syscall.SecNsecToTimespec(sec, nsec int64) that takes separate
  seconds and nanoseconds, avoiding the seconds * 1e9 overflow inherent
  in NsecToTimespec
- Use SecNsecToTimespec(t.Unix(), int64(t.Nanosecond())) in
  os.chtimesUtimes instead of NsecToTimespec(t.UnixNano())
- Fix the same overflow in Windows codepaths (syscall.UtimesNano and
  os.chtimesat) by computing FILETIME ticks from seconds and
  nanoseconds separately
- Add TestChtimesExtremeDates covering years 1000, 1600, 2300, and 3000

Fixes #75542