### PR TITLE
os/user: return UnknownUserError for ERROR_NONE_MAPPED on Windows

### DIFF
--- a/src/internal/syscall/windows/syscall_windows.go
+++ b/src/internal/syscall/windows/syscall_windows.go
@@ -44,6 +44,7 @@ const (
 	ERROR_IO_INCOMPLETE          syscall.Errno = 996
 	ERROR_NO_TOKEN               syscall.Errno = 1008
 	ERROR_NO_UNICODE_TRANSLATION syscall.Errno = 1113
+	ERROR_NONE_MAPPED            syscall.Errno = 1332
 	ERROR_CANT_ACCESS_FILE       syscall.Errno = 1920
 )
 

--- a/src/os/user/lookup_windows.go
+++ b/src/os/user/lookup_windows.go
@@ -173,6 +173,9 @@ func findHomeDirInRegistry(uid string) (dir string, e error) {
 func lookupGroupName(groupname string) (string, error) {
 	sid, _, t, e := syscall.LookupSID("", groupname)
 	if e != nil {
+		if errors.Is(e, windows.ERROR_NONE_MAPPED) {
+			return "", UnknownGroupError(groupname)
+		}
 		return "", e
 	}
 	if !isValidGroupAccountType(t) {
@@ -454,6 +457,9 @@ func newUserFromSid(usid *syscall.SID) (*User, error) {
 func lookupUser(username string) (*User, error) {
 	sid, _, t, e := syscall.LookupSID("", username)
 	if e != nil {
+		if errors.Is(e, windows.ERROR_NONE_MAPPED) {
+			return nil, UnknownUserError(username)
+		}
 		return nil, e
 	}
 	if !isValidUserAccountType(sid, t) {

--- a/src/os/user/user_test.go
+++ b/src/os/user/user_test.go
@@ -5,6 +5,7 @@
 package user
 
 import (
+	"errors"
 	"os"
 	"slices"
 	"testing"
@@ -90,6 +91,40 @@ func TestLookup(t *testing.T) {
 		t.Fatalf("Lookup: %v", err)
 	}
 	compare(t, want, got)
+}
+
+func TestLookupNonexistent(t *testing.T) {
+	checkUser(t)
+
+	const username = "nonexistent_user_does_not_exist_12345"
+	_, err := Lookup(username)
+	if err == nil {
+		t.Fatalf("Lookup(%q): expected error, got nil", username)
+	}
+	var unknown UnknownUserError
+	if !errors.As(err, &unknown) {
+		t.Fatalf("Lookup(%q): expected UnknownUserError, got %T: %v", username, err, err)
+	}
+	if string(unknown) != username {
+		t.Errorf("Lookup(%q): UnknownUserError = %q, want %q", username, string(unknown), username)
+	}
+}
+
+func TestLookupGroupNonexistent(t *testing.T) {
+	checkGroup(t)
+
+	const groupname = "nonexistent_group_does_not_exist_12345"
+	_, err := LookupGroup(groupname)
+	if err == nil {
+		t.Fatalf("LookupGroup(%q): expected error, got nil", groupname)
+	}
+	var unknown UnknownGroupError
+	if !errors.As(err, &unknown) {
+		t.Fatalf("LookupGroup(%q): expected UnknownGroupError, got %T: %v", groupname, err, err)
+	}
+	if string(unknown) != groupname {
+		t.Errorf("LookupGroup(%q): UnknownGroupError = %q, want %q", groupname, string(unknown), groupname)
+	}
 }
 
 func TestLookupId(t *testing.T) {


### PR DESCRIPTION
When `user.Lookup` is called with a nonexistent user on Windows,
`LookupAccountName` returns `ERROR_NONE_MAPPED` (error code 1332).
Currently this raw Windows error propagates to the caller, but the
documentation says `Lookup` should return `UnknownUserError`.

This change checks for `ERROR_NONE_MAPPED` in both `lookupUser` and
`lookupGroupName`, returning `UnknownUserError` and `UnknownGroupError`
respectively.

Fixes #73595