### PR TITLE
debug/macho: return FormatError for truncated or empty files

### DIFF
--- a/src/debug/macho/file.go
+++ b/src/debug/macho/file.go
@@ -234,7 +234,7 @@ func NewFile(r io.ReaderAt) (*File, error) {
 	// Magic32 and Magic64 differ only in the bottom bit.
 	var ident [4]byte
 	if _, err := r.ReadAt(ident[0:], 0); err != nil {
-		return nil, err
+		return nil, &FormatError{0, "cannot read Mach-O identifier", err}
 	}
 	be := binary.BigEndian.Uint32(ident[0:])
 	le := binary.LittleEndian.Uint32(ident[0:])
@@ -251,7 +251,7 @@ func NewFile(r io.ReaderAt) (*File, error) {
 
 	// Read entire file header.
 	if err := binary.Read(sr, f.ByteOrder, &f.FileHeader); err != nil {
-		return nil, err
+		return nil, &FormatError{0, "cannot read Mach-O header", err}
 	}
 
 	// Then load commands.

--- a/src/debug/macho/file_test.go
+++ b/src/debug/macho/file_test.go
@@ -6,8 +6,11 @@ package macho
 
 import (
 	"bytes"
+	"errors"
 	"internal/obscuretestdata"
 	"io"
+	"os"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"testing"
@@ -449,5 +452,47 @@ func TestOpenBadDysymCmd(t *testing.T) {
 	_, err := openObscured("testdata/gcc-amd64-darwin-exec-with-bad-dysym.base64")
 	if err == nil {
 		t.Fatal("openObscured did not fail when opening a file with an invalid dynamic symbol table command")
+	}
+}
+
+func TestOpenEmptyFile(t *testing.T) {
+	name := filepath.Join(t.TempDir(), "empty")
+	if err := os.WriteFile(name, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Open(name)
+	if err == nil {
+		t.Fatal("Open on empty file: got nil error, want non-nil")
+	}
+
+	var formatErr *FormatError
+	if !errors.As(err, &formatErr) {
+		t.Errorf("Open on empty file: got %T (%v), want *FormatError", err, err)
+	}
+}
+
+func TestNewFileShortReader(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{"empty", []byte{}},
+		{"one byte", []byte{0xfe}},
+		{"three bytes", []byte{0xfe, 0xed, 0xfa}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewFile(bytes.NewReader(tt.data))
+			if err == nil {
+				t.Fatal("NewFile with short data: got nil error, want non-nil")
+			}
+
+			var formatErr *FormatError
+			if !errors.As(err, &formatErr) {
+				t.Errorf("NewFile with short data: got %T (%v), want *FormatError", err, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
When `macho.NewFile` encounters `io.EOF` or `io.ErrUnexpectedEOF` while
reading the Mach-O identifier or file header, wrap the error in a
`*FormatError` instead of returning the bare error. This allows callers
to reliably use `errors.As(err, &formatErr)` to distinguish malformed
Mach-O files from actual I/O errors.

Previously, opening an empty or truncated file returned bare `io.EOF`
or `io.ErrUnexpectedEOF`, which callers checking for `*FormatError`
would miss.

This is the `debug/macho` equivalent of CL 736600 which fixed the same
issue in `debug/elf`.

Updates #76338