### PR TITLE
cmd/link: propagate Mach-O section alignment to symbol in loadmacho

### DIFF
--- a/src/cmd/link/internal/loadmacho/ldmacho.go
+++ b/src/cmd/link/internal/loadmacho/ldmacho.go
@@ -570,6 +570,9 @@ func Load(l *loader.Loader, arch *sys.Arch, localSymVersion int, f *bio.Reader, 
 			bld.SetData(dat[sect.addr-c.seg.vmaddr:][:sect.size])
 		}
 		bld.SetSize(int64(len(bld.Data())))
+		if sect.align != 0 {
+			bld.SetAlign(1 << sect.align)
+		}
 
 		if sect.segname == "__TEXT" {
 			if sect.name == "__text" {


### PR DESCRIPTION
The Mach-O object file loader reads the section alignment from the
section header into ldMachoSect.align, but never calls SetAlign on
the symbol builder when converting sections to linker symbols. This
causes all Mach-O .syso sections to fall back to Funcalign (16 bytes
on ARM64) regardless of the alignment declared in the section header.

For .syso files containing C-compiled code with ADRP instructions on
ARM64, the lack of page alignment (4096 bytes) leads to incorrect
PC-relative address computation and runtime crashes.

The ELF loader already correctly propagates section alignment via
sb.SetAlign (ldelf.go:543). Apply the same treatment to the Mach-O
loader. Note that Mach-O stores alignment as log2 (e.g. 12 for 4096),
so we use 1 << sect.align.

Fixes #78192