### PR TITLE
regexp/syntax: extract maxRepeat constant and document nested repetition limit

### DIFF
--- a/src/regexp/syntax/doc.go
+++ b/src/regexp/syntax/doc.go
@@ -51,6 +51,9 @@ Repetitions:
 Implementation restriction: The counting forms x{n,m}, x{n,}, and x{n}
 reject forms that create a minimum or maximum repetition count above 1000.
 Unlimited repetitions are not subject to this restriction.
+For nested repetitions, the product of the repetition counts must not
+exceed 1000. For example, x{10}{10} (product 100) is valid,
+but x{10}{101} (product 1010) is not.
 
 Grouping:
 

--- a/src/regexp/syntax/parse.go
+++ b/src/regexp/syntax/parse.go
@@ -433,12 +433,16 @@ func (p *parser) repeat(op Op, min, max int, before, after, lastRepeat string) (
 	p.stack[n-1] = re
 	p.checkLimits(re)
 
-	if op == OpRepeat && (min >= 2 || max >= 2) && !repeatIsValid(re, 1000) {
+	if op == OpRepeat && (min >= 2 || max >= 2) && !repeatIsValid(re, maxRepeat) {
 		return "", &Error{ErrInvalidRepeatSize, before[:len(before)-len(after)]}
 	}
 
 	return after, nil
 }
+
+// maxRepeat is the maximum count allowed in any single repetition x{n,m}.
+// The product of all nested repetition counts must also not exceed this limit.
+const maxRepeat = 1000
 
 // repeatIsValid reports whether the repetition re is valid.
 // Valid means that the combination of the top-level repetition
@@ -1000,7 +1004,7 @@ func parse(s string, flags Flags) (_ *Regexp, err error) {
 				t = t[1:]
 				break
 			}
-			if min < 0 || min > 1000 || max > 1000 || max >= 0 && min > max {
+			if min < 0 || min > maxRepeat || max > maxRepeat || max >= 0 && min > max {
 				// Numbers were too big, or max is present and min > max.
 				return nil, &Error{ErrInvalidRepeatSize, before[:len(before)-len(after)]}
 			}

--- a/src/regexp/syntax/parse_test.go
+++ b/src/regexp/syntax/parse_test.go
@@ -214,6 +214,7 @@ var parseTests = []parseTest{
 	// Valid repetitions.
 	{`((((((((((x{2}){2}){2}){2}){2}){2}){2}){2}){2}))`, ``},
 	{`((((((((((x{1}){2}){2}){2}){2}){2}){2}){2}){2}){2})`, ``},
+	{`(?:[a-z]{4}){0,250}`, ``},  // nested repeat product 4*250 = 1000, at the limit
 
 	// Valid nesting.
 	{strings.Repeat("(", 999) + strings.Repeat(")", 999), ``},
@@ -500,6 +501,7 @@ var invalidRegexps = []string{
 	`a{100000}`,  // too much repetition
 	`a{100000,}`, // too much repetition
 	"((((((((((x{2}){2}){2}){2}){2}){2}){2}){2}){2}){2})",    // too much repetition
+	`(?:[a-z]{4}){0,251}`,                                      // nested repeat product 4*251 > 1000
 	strings.Repeat("(", 1000) + strings.Repeat(")", 1000),    // too deep
 	strings.Repeat("(?:", 1000) + strings.Repeat(")*", 1000), // too deep
 	"(" + strings.Repeat("(xx?)", 1000) + "){1000}",          // too long


### PR DESCRIPTION
The repeat count limit of 1000 was hardcoded as a magic number in
multiple places. Extract it into a named constant `maxRepeat` for clarity.

Additionally, the documentation stated that repeat counts above 1000
are rejected, but did not mention that nested repetitions have their
counts multiplied. For example, `(?:[a-z]{4}){0,251}` is rejected
because the product 4*251=1004 exceeds 1000, even though neither
individual count does. Document this behavior.

Add test cases for the exact boundary: `{4}{250}` (product 1000, valid)
and `{4}{251}` (product 1004, invalid).

Fixes #78222