### PR TITLE
crypto/x509/pkix: avoid quadratic string concatenation in RDNSequence.String

### DIFF
--- a/src/crypto/x509/pkix/pkix.go
+++ b/src/crypto/x509/pkix/pkix.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 )
 
@@ -38,15 +39,15 @@ var attributeTypeNames = map[string]string{
 // String returns a string representation of the sequence r,
 // roughly following the RFC 2253 Distinguished Names syntax.
 func (r RDNSequence) String() string {
-	s := ""
+	var buf strings.Builder
 	for i := 0; i < len(r); i++ {
 		rdn := r[len(r)-1-i]
 		if i > 0 {
-			s += ","
+			buf.WriteByte(',')
 		}
 		for j, tv := range rdn {
 			if j > 0 {
-				s += "+"
+				buf.WriteByte('+')
 			}
 
 			oidString := tv.Type.String()
@@ -54,7 +55,9 @@ func (r RDNSequence) String() string {
 			if !ok {
 				derBytes, err := asn1.Marshal(tv.Value)
 				if err == nil {
-					s += oidString + "=#" + hex.EncodeToString(derBytes)
+					buf.WriteString(oidString)
+					buf.WriteString("=#")
+					buf.WriteString(hex.EncodeToString(derBytes))
 					continue // No value escaping necessary.
 				}
 
@@ -85,11 +88,13 @@ func (r RDNSequence) String() string {
 				}
 			}
 
-			s += typeName + "=" + string(escaped)
+			buf.WriteString(typeName)
+			buf.WriteByte('=')
+			buf.WriteString(string(escaped))
 		}
 	}
 
-	return s
+	return buf.String()
 }
 
 type RelativeDistinguishedNameSET []AttributeTypeAndValue


### PR DESCRIPTION
RDNSequence.String builds its result using repeated s += ... inside
nested loops, leading to O(N²) time and memory complexity.
A certificate with many Subject or Issuer RDN entries can therefore
cause excessive CPU and memory usage when String is called.

Switch to strings.Builder to construct the output, reducing complexity
to O(N) without changing behavior.

This follows the same approach used to fix CVE-2025-61729
(HostnameError.Error), which addressed the same quadratic concatenation
pattern.