### PR TITLE
fix(crypto/internal/fips140): force heap allocation for ARM temporaries

### DIFF
--- a/src/crypto/internal/fips140/bigmod/nat.go
+++ b/src/crypto/internal/fips140/bigmod/nat.go
@@ -784,12 +784,7 @@ func (x *Nat) montgomeryMul(a *Nat, b *Nat, m *Modulus) *Nat {
 
 	switch n {
 	default:
-		// Attempt to use a stack-allocated backing array.
-		T := make([]uint, 0, preallocLimbs*2)
-		if cap(T) < n*2 {
-			T = make([]uint, 0, n*2)
-		}
-		T = T[:n*2]
+		T := makeWideLimbs(n)
 
 		// This loop implements Word-by-Word Montgomery Multiplication, as
 		// described in Algorithm 4 (Fig. 3) of "Efficient Software
@@ -935,12 +930,7 @@ func (x *Nat) Mul(y *Nat, m *Modulus) *Nat {
 
 	switch n {
 	default:
-		// Attempt to use a stack-allocated backing array.
-		T := make([]uint, 0, preallocLimbs*2)
-		if cap(T) < n*2 {
-			T = make([]uint, 0, n*2)
-		}
-		T = T[:n*2]
+		T := makeWideLimbs(n)
 
 		// T = x * y
 		for i := 0; i < n; i++ {

--- a/src/crypto/internal/fips140/bigmod/temp_limbs.go
+++ b/src/crypto/internal/fips140/bigmod/temp_limbs.go
@@ -1,0 +1,16 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !arm
+
+package bigmod
+
+func makeWideLimbs(n int) []uint {
+	// Attempt to use a stack-allocated backing array.
+	T := make([]uint, 0, preallocLimbs*2)
+	if cap(T) < n*2 {
+		T = make([]uint, 0, n*2)
+	}
+	return T[:n*2]
+}

--- a/src/crypto/internal/fips140/bigmod/temp_limbs_arm.go
+++ b/src/crypto/internal/fips140/bigmod/temp_limbs_arm.go
@@ -1,0 +1,16 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build arm
+
+package bigmod
+
+// Returning the slice from a non-inlined helper forces the backing array to
+// outlive this stack frame, which avoids arm compiler/runtime miscompilations
+// seen when the generic Montgomery temporaries are stack allocated.
+//
+//go:noinline
+func makeWideLimbs(n int) []uint {
+	return make([]uint, n*2)
+}

--- a/src/crypto/internal/fips140/bigmod/temp_limbs_arm_test.go
+++ b/src/crypto/internal/fips140/bigmod/temp_limbs_arm_test.go
@@ -1,0 +1,18 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build arm
+
+package bigmod
+
+import "testing"
+
+func TestMakeWideLimbsAllocatesOnArm(t *testing.T) {
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = makeWideLimbs(128)
+	})
+	if allocs < 1 {
+		t.Fatalf("makeWideLimbs(128) allocations = %v, want at least 1", allocs)
+	}
+}


### PR DESCRIPTION
Ensures 8-byte alignment on ARMv7 by forcing heap allocation for bigmod
buffers, preventing SIGSEGV in addMulVVW. This is necessary because
stack-allocated slices may not meet the alignment requirements of
specific ARM assembly instructions.

Fixes #78271