### PR TITLE
net: eliminate bounds checks in hasUpperCase

### DIFF
--- a/src/net/parse.go
+++ b/src/net/parse.go
@@ -182,7 +182,7 @@ func xtoi2(s string, e byte) (byte, bool) {
 
 // hasUpperCase tells whether the given string contains at least one upper-case.
 func hasUpperCase(s string) bool {
-	for i := range s {
+	for i := range len(s) {
 		if 'A' <= s[i] && s[i] <= 'Z' {
 			return true
 		}


### PR DESCRIPTION
Function hasUpperCase accesses its parameter's bytes while iterating
over its runes. This approach muddles intent and causes an unnecessary
bounds check.

This CL makes hasUpperCase iterate over its parameter's bytes instead.

Updates #76354
