### PR TITLE
runtime: truncate trace strings before inserting into trace map

### DIFF
--- a/src/runtime/trace/annotation_test.go
+++ b/src/runtime/trace/annotation_test.go
@@ -8,8 +8,21 @@ import (
 	"context"
 	"io"
 	. "runtime/trace"
+	"strings"
 	"testing"
 )
+
+func TestStartRegionLongString(t *testing.T) {
+	// Regression test: a region name longer than the trace region
+	// allocator's block size (~64KB) used to crash with
+	// "traceRegion: alloc too large" because traceStringTable.put
+	// inserted the full string into the trace map before truncation.
+	Start(io.Discard)
+	defer Stop()
+
+	big := strings.Repeat("x", 70_000)
+	StartRegion(context.Background(), big).End()
+}
 
 func BenchmarkStartRegion(b *testing.B) {
 	b.ReportAllocs()

--- a/src/runtime/tracestring.go
+++ b/src/runtime/tracestring.go
@@ -25,6 +25,11 @@ type traceStringTable struct {
 
 // put adds a string to the table, emits it, and returns a unique ID for it.
 func (t *traceStringTable) put(gen uintptr, s string) uint64 {
+	// Truncate the string now to avoid wasting space in the
+	// traceMap and to stay within traceRegionAlloc's block size limit.
+	if len(s) > tracev2.MaxEventTrailerDataSize {
+		s = s[:tracev2.MaxEventTrailerDataSize]
+	}
 	// Put the string in the table.
 	ss := stringStructOf(&s)
 	id, added := t.tab.put(ss.str, uintptr(ss.len))


### PR DESCRIPTION
traceStringTable.put inserted the full user-supplied string into the
trace map, then only truncated it to MaxEventTrailerDataSize (1024
bytes) when writing to the trace buffer. If the string exceeded the
traceRegionAlloc block size (~64KB), this caused a fatal
"traceRegion: alloc too large" crash.

Move the truncation to the top of put, before the map insertion, so
that the map key, map entry, and written output are all consistent
and bounded.

The existing truncation in writeString is retained: the emit method
also calls writeString without going through the map, so writeString
still needs its own guard.

TestStartRegionLongString reproduces the crash before the fix.

Observed in production at CockroachDB: Stopper.RunTask passes
singleflight keys (up to ~450KB) as trace region names via
trace.StartRegion. See:

https://github.com/cockroachdb/cockroach/pull/166669 for context
on the trigger.