### PR TITLE
net: make SplitHostPort alloc-free in more cases

### DIFF
--- a/src/cmd/compile/internal/test/inl_test.go
+++ b/src/cmd/compile/internal/test/inl_test.go
@@ -185,6 +185,7 @@ func TestIntendedInlining(t *testing.T) {
 		},
 		"net": {
 			"(*UDPConn).ReadFromUDP",
+			"SplitHostPort",
 		},
 		"sync": {
 			// Both OnceFunc and its returned closure need to be inlinable so

--- a/src/net/ip_test.go
+++ b/src/net/ip_test.go
@@ -644,6 +644,43 @@ func TestSplitHostPort(t *testing.T) {
 	}
 }
 
+func TestSplitHostPortDoesNotAllocateForNilCheckCallers(t *testing.T) {
+	for _, tt := range []struct {
+		hostPort string
+		wantErr  bool
+	}{
+		{"localhost:80", false},
+		{"localhost%lo0:80", false},
+		{"127.0.0.1:80", false},
+		{"[::1%lo0]:80", false},
+		{"localhost", true},       // missing port in address
+		{"::1", true},             // too many colons in address
+		{"[foo:bar]", true},       // missing port in address
+		{"[:", true},              // missing ']' in address
+		{"[::1]x", true},          // ']' not followed by a colon
+		{"[foo]:[bar]:baz", true}, // too many colons in address
+		{"foo[bar]:baz", true},    // unexpected '[' in address
+		{"foo]bar:baz", true},     // unexpected ']' in address
+	} {
+		// By design, the following function only uses SplitHostPort's error
+		// result in nil checks.
+		f := func() {
+			_, _, err := SplitHostPort(tt.hostPort)
+			switch {
+			case err != nil && !tt.wantErr:
+				t.Fatalf("SplitHostPort(%q) fails, but should succeed", tt.hostPort)
+			case err == nil && tt.wantErr:
+				t.Fatalf("SplitHostPort(%q) succeeds, but should fail", tt.hostPort)
+			}
+		}
+		allocs := int(testing.AllocsPerRun(5, f))
+		const wantAllocs = 0
+		if allocs > wantAllocs {
+			t.Errorf("SplitHostPort(%q): allocs=%d, want %d", tt.hostPort, allocs, wantAllocs)
+		}
+	}
+}
+
 func TestJoinHostPort(t *testing.T) {
 	for _, tt := range []struct {
 		host     string

--- a/src/net/ipsock.go
+++ b/src/net/ipsock.go
@@ -163,12 +163,24 @@ func ipv6only(addr IPAddr) bool {
 // See func Dial for a description of the hostport parameter, and host
 // and port results.
 func SplitHostPort(hostport string) (host, port string, err error) {
+	// This implementation is inlineable and saves one heap allocation
+	// in case callers use the error result only in nil checks.
+	host, port, addrErr := splitHostPortNoAlloc(hostport)
+	if (addrErr != AddrError{}) {
+		return host, port, &addrErr
+	}
+	return host, port, nil
+}
+
+// Note: A zero AddrError result indicates success;
+// conversely, a nonzero AddrError result indicates failure.
+func splitHostPortNoAlloc(hostport string) (host, port string, err AddrError) {
 	const (
 		missingPort   = "missing port in address"
 		tooManyColons = "too many colons in address"
 	)
-	addrErr := func(addr, why string) (host, port string, err error) {
-		return "", "", &AddrError{Err: why, Addr: addr}
+	addrErr := func(addr, why string) (host, port string, err AddrError) {
+		return "", "", AddrError{Err: why, Addr: addr}
 	}
 	j, k := 0, 0
 
@@ -214,7 +226,7 @@ func SplitHostPort(hostport string) (host, port string, err error) {
 	}
 
 	port = hostport[i+1:]
-	return host, port, nil
+	return host, port, AddrError{}
 }
 
 func splitHostZone(s string) (host, zone string) {


### PR DESCRIPTION
Because SplitHostPort is not inlineable, its error result cannot benefit
from mid-stack inlining and must be moved to the heap. However, callers
of SplitHostPort that only use its error result in nil checks are pretty
typical, and their performance needlessly suffers from the resulting
allocation.
    
Drawing inspiration from CL 734440, this CL refactors SplitHostPort to
an inlineable wrapper around a function that returns, not an error, but
the concrete type of SplitHostPort's error result. Consequently, that
error result can stay on the stack in cases where callers only use it in
nil checks, and SplitHostPort is now allocation-free for such callers.
    
To clarify: the goal of this CL is to make SplitHostPort
allocation-free, not simply in non-error cases, but also in error cases
in which the error result is only used in nil checks.