### PR TITLE
simd/archsimd: switch from gopkg.in/yaml.v3 to go.yaml.in/yaml/v3

### DIFF
--- a/src/simd/archsimd/_gen/go.mod
+++ b/src/simd/archsimd/_gen/go.mod
@@ -3,6 +3,6 @@ module simd/archsimd/_gen
 go 1.24
 
 require (
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/arch v0.20.0
-	gopkg.in/yaml.v3 v3.0.1
 )

--- a/src/simd/archsimd/_gen/go.sum
+++ b/src/simd/archsimd/_gen/go.sum
@@ -1,6 +1,4 @@
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/arch v0.20.0 h1:dx1zTU0MAE98U+TQ8BLl7XsJbgze2WnNKF/8tGp/Q6c=
 golang.org/x/arch v0.20.0/go.mod h1:bdwinDaKcfZUGpH09BB7ZmOfhalA8lQdzl62l8gGWsk=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/simd/archsimd/_gen/simdgen/main.go
+++ b/src/simd/archsimd/_gen/simdgen/main.go
@@ -94,7 +94,7 @@ import (
 
 	"simd/archsimd/_gen/unify"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 var (

--- a/src/simd/archsimd/_gen/simdgen/xed.go
+++ b/src/simd/archsimd/_gen/simdgen/xed.go
@@ -16,8 +16,8 @@ import (
 
 	"simd/archsimd/_gen/unify"
 
+	"go.yaml.in/yaml/v3"
 	"golang.org/x/arch/x86/xeddata"
-	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/src/simd/archsimd/_gen/unify/trace.go
+++ b/src/simd/archsimd/_gen/unify/trace.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // debugDotInHTML, if true, includes dot code for all graphs in the HTML. Useful

--- a/src/simd/archsimd/_gen/unify/unify_test.go
+++ b/src/simd/archsimd/_gen/unify/unify_test.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestUnify(t *testing.T) {

--- a/src/simd/archsimd/_gen/unify/yaml.go
+++ b/src/simd/archsimd/_gen/unify/yaml.go
@@ -14,7 +14,7 @@ import (
 	"regexp"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // ReadOpts provides options to [Read] and related functions. The zero value is

--- a/src/simd/archsimd/_gen/unify/yaml_test.go
+++ b/src/simd/archsimd/_gen/unify/yaml_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func mustParse(expr string) Closure {


### PR DESCRIPTION
gopkg.in/yaml.v3 is unmaintained, ref https://github.com/yaml/go-yaml#project-status

Upgrade to 3.0.4 while at it.

- 3.0.1..3.0.2 diff (3.0.1 are identical): https://gist.github.com/scop/6ec72debf62a9603cff9dc97e6814ddd
- changes after that as usual from https://github.com/yaml/go-yaml/tags