### PR TITLE
os: update examples to use errors.Is instead of deprecated helpers

### DIFF
--- a/src/os/example_test.go
+++ b/src/os/example_test.go
@@ -246,7 +246,7 @@ func ExampleWriteFile() {
 
 func ExampleMkdir() {
 	err := os.Mkdir("testdir", 0750)
-	if err != nil && !os.IsExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrExist) {
 		log.Fatal(err)
 	}
 	err = os.WriteFile("testdir/testfile.txt", []byte("Hello, Gophers!"), 0660)
@@ -365,7 +365,7 @@ func ExampleUserConfigDir() {
 		configPath = filepath.Join(dir, "ExampleUserConfigDir", "example.conf")
 		var err error
 		origConfig, err = os.ReadFile(configPath)
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			// The user has a config file but we couldn't read it.
 			// Report the error instead of ignoring their configuration.
 			log.Fatal(err)


### PR DESCRIPTION
The os.IsExist and os.IsNotExist functions predate errors.Is
and their documentation recommends using
errors.Is(err, fs.ErrExist) and errors.Is(err, fs.ErrNotExist)
in new code.

Update ExampleMkdir and ExampleUserConfigDir to follow this
recommendation.

Fixes #77643