### PR TITLE
fmt: fix %q verb documentation to say "rune literal"

### DIFF
--- a/src/fmt/doc.go
+++ b/src/fmt/doc.go
@@ -43,7 +43,7 @@ Integer:
 	%d	base 10
 	%o	base 8
 	%O	base 8 with 0o prefix
-	%q	a single-quoted character literal safely escaped with Go syntax.
+	%q	a single-quoted rune literal safely escaped with Go syntax.
 	%x	base 16, with lower-case letters for a-f
 	%X	base 16, with upper-case letters for A-F
 	%U	Unicode format: U+1234; same as "U+%04X"


### PR DESCRIPTION
The Go specification uses the term "rune literal" (not "character
literal") for single-quoted literals like 'a'. The %q verb
documentation in the fmt package uses the outdated term "character
literal". This change updates it to use the correct Go terminology.

As noted by @adonovan in #78486, %q works with rune and byte types
but not general int types (which is enforced by go vet since
Go 1.26).

Fixes #78486