### PR TITLE
runtime: handle ENOTSUP/ENOSYS from poll_oneoff in netpoll_wasip1

### DIFF
--- a/src/runtime/netpoll_wasip1.go
+++ b/src/runtime/netpoll_wasip1.go
@@ -33,7 +33,11 @@ import "unsafe"
 // Since poll_oneoff is similar to poll(2), the implementation here was derived
 // from netpoll_aix.go.
 
-const _EINTR = 27
+const (
+	_EINTR   = 27
+	_ENOSYS  = 52
+	_ENOTSUP = 58
+)
 
 var (
 	evts []event
@@ -211,17 +215,21 @@ retry:
 	var nevents size
 	errno := poll_oneoff(&pollsubs[0], &evts[0], uint32(len(pollsubs)), &nevents)
 	if errno != 0 {
-		if errno != _EINTR {
-			println("errno=", errno, " len(pollsubs)=", len(pollsubs))
-			throw("poll_oneoff failed")
+		if errno == _EINTR {
+			// If a timed sleep was interrupted, just return to
+			// recalculate how long we should sleep now.
+			if delay > 0 {
+				unlock(&mtx)
+				return gList{}, 0
+			}
+			goto retry
 		}
-		// If a timed sleep was interrupted, just return to
-		// recalculate how long we should sleep now.
-		if delay > 0 {
+		if errno == _ENOSYS || errno == _ENOTSUP {
 			unlock(&mtx)
 			return gList{}, 0
 		}
-		goto retry
+		println("errno=", errno, " len(pollsubs)=", len(pollsubs))
+		throw("poll_oneoff failed")
 	}
 
 	var toRun gList


### PR DESCRIPTION
Some WASM host runtimes export poll_oneoff but return ENOTSUP or ENOSYS rather than implementing it, because they're event-driven and blocking the WASM thread would deadlock their worker. This caused a fatal crash during GC cycles in any wasip1 plugin that transitively imports fmt or os — which is nearly everything.

The fix treats ENOTSUP (58) and ENOSYS (52) the same way as returning zero events, which is always safe when there are no real FD subscriptions and harmless otherwise since the scheduler will re-poll on the next GC cycle. This mirrors what netpoll_fake.go already does for the js/wasm target.

Fix for the issue #78513