### PR TITLE
go/printer: nameSize += 1 instead of nameSize = 1

### DIFF
--- a/src/go/printer/nodes.go
+++ b/src/go/printer/nodes.go
@@ -479,7 +479,7 @@ func (p *printer) isOneLineFieldList(list []*ast.Field) bool {
 	const maxSize = 30 // adjust as appropriate, this is an approximate value
 	namesSize := identListSize(f.Names, maxSize)
 	if namesSize > 0 {
-		namesSize = 1 // blank between names and types
+		namesSize += 1 // blank between names and types
 	}
 	typeSize := p.nodeSize(f.Type, maxSize)
 	return namesSize+typeSize <= maxSize

--- a/src/go/printer/printer_test.go
+++ b/src/go/printer/printer_test.go
@@ -848,6 +848,31 @@ func TestSourcePosNewline(t *testing.T) {
 	}
 }
 
+func TestOneLineFieldListNamesSize(t *testing.T) {
+	const src = `package p
+
+type T struct{ FieldNameThatExceedsMaxSize28 int }
+`
+	// 28 (name size) + 1 (whitespace) + 3 (typeSize) == 32
+	// 32 > 30; so the struct should be formatted across multiple lines.
+	const want = "package p\n\ntype T struct {\n\tFieldNameThatExceedsMaxSize28 int\n}\n"
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "", src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := (&Config{Mode: TabIndent, Tabwidth: 8}).Fprint(&buf, fset, f); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
 // TestEmptyDecl tests that empty decls for const, var, import are printed with
 // valid syntax e.g "var ()" instead of just "var", which is invalid and cannot
 // be parsed.


### PR DESCRIPTION
Fixes #78544 