### PR TITLE
cmd/go: honor -fullpath for compiler diagnostics

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -179,6 +179,8 @@
 //		arguments to pass on each gccgo compiler/linker invocation.
 //	-gcflags '[pattern=]arg list'
 //		arguments to pass on each go tool compile invocation.
+//	-fullpath
+//		show full file names in error messages.
 //	-installsuffix suffix
 //		a suffix to use in the name of the package installation directory,
 //		in order to keep output separate from default builds.

--- a/src/cmd/go/internal/cfg/cfg.go
+++ b/src/cmd/go/internal/cfg/cfg.go
@@ -81,6 +81,7 @@ var (
 	BuildCover             bool                    // -cover flag
 	BuildCoverMode         string                  // -covermode flag
 	BuildCoverPkg          []string                // -coverpkg flag
+	BuildFullpath          bool                    // -fullpath flag
 	BuildJSON              bool                    // -json flag
 	BuildN                 bool                    // -n flag
 	BuildO                 string                  // -o flag

--- a/src/cmd/go/internal/load/pkg.go
+++ b/src/cmd/go/internal/load/pkg.go
@@ -308,7 +308,9 @@ func (p *Package) setLoadPackageDataError(err error, path string, stk *ImportSta
 		isScanErr = true // For stack push/pop below.
 
 		scanPos := scanErr[0].Pos
-		scanPos.Filename = base.ShortPath(scanPos.Filename)
+		if !cfg.BuildFullpath {
+			scanPos.Filename = base.ShortPath(scanPos.Filename)
+		}
 		pos = scanPos.String()
 		err = errors.New(scanErr[0].Msg)
 	}
@@ -507,7 +509,9 @@ func (p *PackageError) setPos(posList []token.Position) {
 		return
 	}
 	pos := posList[0]
-	pos.Filename = base.ShortPath(pos.Filename)
+	if !cfg.BuildFullpath {
+		pos.Filename = base.ShortPath(pos.Filename)
+	}
 	p.Pos = pos.String()
 }
 

--- a/src/cmd/go/internal/test/testflag.go
+++ b/src/cmd/go/internal/test/testflag.go
@@ -55,7 +55,6 @@ func init() {
 	cf.StringVar(&testCPUProfile, "cpuprofile", "", "")
 	cf.BoolVar(&testFailFast, "failfast", false, "")
 	cf.StringVar(&testFuzz, "fuzz", "", "")
-	cf.Bool("fullpath", false, "")
 	cf.StringVar(&testList, "list", "", "")
 	cf.StringVar(&testMemProfile, "memprofile", "", "")
 	cf.String("memprofilerate", "", "")

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -135,6 +135,8 @@ and test commands:
 		arguments to pass on each gccgo compiler/linker invocation.
 	-gcflags '[pattern=]arg list'
 		arguments to pass on each go tool compile invocation.
+	-fullpath
+		show full file names in error messages.
 	-installsuffix suffix
 		a suffix to use in the name of the package installation directory,
 		in order to keep output separate from default builds.
@@ -323,6 +325,7 @@ func AddBuildFlags(cmd *base.Command, mask BuildFlagMask) {
 	cmd.Flag.Var(buildCompiler{}, "compiler", "")
 	cmd.Flag.StringVar(&cfg.BuildBuildmode, "buildmode", "default", "")
 	cmd.Flag.Var((*buildvcsFlag)(&cfg.BuildBuildvcs), "buildvcs", "")
+	cmd.Flag.BoolVar(&cfg.BuildFullpath, "fullpath", false, "")
 	cmd.Flag.Var(&load.BuildGcflags, "gcflags", "")
 	cmd.Flag.Var(&load.BuildGccgoflags, "gccgoflags", "")
 	if mask&OmitModFlag == 0 {

--- a/src/cmd/go/internal/work/shell.go
+++ b/src/cmd/go/internal/work/shell.go
@@ -495,12 +495,14 @@ func (sh *Shell) reportCmd(desc, dir string, cmdOut []byte, cmdErr error) error 
 		// prefixes, the only way to find them is to look.
 		// This doesn't always produce a relative path --
 		// /foo is shorter than ../../.., for example.
-		if reldir := base.ShortPath(dir); reldir != dir {
-			out = replacePrefix(out, dir, reldir)
-			if filepath.Separator == '\\' {
-				// Don't know why, sometimes this comes out with slashes, not backslashes.
-				wdir := strings.ReplaceAll(dir, "\\", "/")
-				out = replacePrefix(out, wdir, reldir)
+		if !cfg.BuildFullpath {
+			if reldir := base.ShortPath(dir); reldir != dir {
+				out = replacePrefix(out, dir, reldir)
+				if filepath.Separator == '\\' {
+					// Don't know why, sometimes this comes out with slashes, not backslashes.
+					wdir := strings.ReplaceAll(dir, "\\", "/")
+					out = replacePrefix(out, wdir, reldir)
+				}
 			}
 		}
 		dirP := filepath.Dir(dir)

--- a/src/cmd/go/testdata/script/build_fullpath.txt
+++ b/src/cmd/go/testdata/script/build_fullpath.txt
@@ -1,0 +1,17 @@
+[short] skip
+
+# Test go build without -fullpath.
+! go build ./y/...
+stderr '^y[/\\]y.go:3:9: undefined: mistake$'
+
+# Test go build with -fullpath.
+! go build -fullpath ./y/...
+stderr '^'$WORK'[/\\]gopath[/\\]src[/\\]y[/\\]y.go:3:9: undefined: mistake$'
+! stderr '^y[/\\]y.go:3:9: undefined: mistake$'
+
+-- go.mod --
+module example
+-- y/y.go --
+package y
+
+var _ = mistake

--- a/src/cmd/go/testdata/script/build_fullpath.txt
+++ b/src/cmd/go/testdata/script/build_fullpath.txt
@@ -2,12 +2,12 @@
 
 # Test go build without -fullpath.
 ! go build ./y/...
-stderr '^y[/\\]y.go:3:9: undefined: mistake$'
+stderr '^y'${/}y.go':3:9: undefined: mistake$'
 
 # Test go build with -fullpath.
 ! go build -fullpath ./y/...
-stderr '^'$WORK'[/\\]gopath[/\\]src[/\\]y[/\\]y.go:3:9: undefined: mistake$'
-! stderr '^y[/\\]y.go:3:9: undefined: mistake$'
+stderr '^'$WORK${/}gopath${/}src${/}y${/}y.go':3:9: undefined: mistake$'
+! stderr '^y'${/}y.go':3:9: undefined: mistake$'
 
 -- go.mod --
 module example


### PR DESCRIPTION
Promote -fullpath into shared cmd/go build flag handling so it affects
cmd/go error formatting as well as forwarded test binary output.
When -fullpath is set avoid shortening file names in command output
and package-load errors. add script coverage for compiler diagnostics
with "go test -C ... -fullpath".
Fixes #60451