### PR TITLE
encoding/xml: validate element and attribute names in Encoder

### DIFF
--- a/src/encoding/xml/marshal.go
+++ b/src/encoding/xml/marshal.go
@@ -733,6 +733,9 @@ func (p *printer) writeStart(start *StartElement) error {
 	if start.Name.Local == "" {
 		return fmt.Errorf("xml: start tag with no name")
 	}
+	if !isNameString(start.Name.Local) {
+		return fmt.Errorf("xml: start tag with invalid name: %s", start.Name.Local)
+	}
 
 	p.tags = append(p.tags, start.Name)
 	p.markPrefix()
@@ -753,9 +756,16 @@ func (p *printer) writeStart(start *StartElement) error {
 		if name.Local == "" {
 			continue
 		}
+		if !isNameString(name.Local) {
+			return fmt.Errorf("xml: attribute with invalid name: %s", name.Local)
+		}
 		p.WriteByte(' ')
 		if name.Space != "" {
-			p.WriteString(p.createAttrPrefix(name.Space))
+			prefix := p.createAttrPrefix(name.Space)
+			if !isNameString(prefix) {
+				return fmt.Errorf("xml: attribute prefix with invalid name: %s", prefix)
+			}
+			p.WriteString(prefix)
 			p.WriteByte(':')
 		}
 		p.WriteString(name.Local)
@@ -770,6 +780,9 @@ func (p *printer) writeStart(start *StartElement) error {
 func (p *printer) writeEnd(name Name) error {
 	if name.Local == "" {
 		return fmt.Errorf("xml: end tag with no name")
+	}
+	if !isNameString(name.Local) {
+		return fmt.Errorf("xml: end tag with invalid name: %s", name.Local)
 	}
 	if len(p.tags) == 0 || p.tags[len(p.tags)-1].Local == "" {
 		return fmt.Errorf("xml: end tag </%s> without start tag", name.Local)

--- a/src/encoding/xml/marshal_test.go
+++ b/src/encoding/xml/marshal_test.go
@@ -2588,3 +2588,77 @@ func TestClose(t *testing.T) {
 		})
 	}
 }
+
+func TestEncodeTokenInvalidNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		token Token
+	}{
+		{
+			name:  "start element with angle bracket in name",
+			token: StartElement{Name: Name{Local: `div><script>alert(1)</script><div`}},
+		},
+		{
+			name:  "start element with quote in name",
+			token: StartElement{Name: Name{Local: `x" onclick="alert(1)`}},
+		},
+		{
+			name:  "start element with space in name",
+			token: StartElement{Name: Name{Local: "has space"}},
+		},
+		{
+			name:  "start element with ampersand in name",
+			token: StartElement{Name: Name{Local: "a&b"}},
+		},
+		{
+			name: "start element with invalid attribute name",
+			token: StartElement{
+				Name: Name{Local: "div"},
+				Attr: []Attr{{Name: Name{Local: `x"><injected y="`}, Value: "val"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			enc := NewEncoder(&buf)
+
+			err := enc.EncodeToken(tt.token)
+			if err == nil {
+				t.Errorf("EncodeToken(%#v) succeeded, want error for invalid XML name", tt.token)
+				t.Logf("produced output: %s", buf.String())
+			}
+		})
+	}
+}
+
+func TestMarshalInvalidXMLName(t *testing.T) {
+	type Item struct {
+		XMLName Name
+		Value   string `xml:",chardata"`
+	}
+
+	tests := []struct {
+		name  string
+		input Item
+	}{
+		{
+			name:  "element name with script injection",
+			input: Item{XMLName: Name{Local: `x"><script>alert(1)</script><y`}, Value: "data"},
+		},
+		{
+			name:  "element name with angle brackets",
+			input: Item{XMLName: Name{Local: "foo>bar"}, Value: "data"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Marshal(tt.input)
+			if err == nil {
+				t.Errorf("Marshal with invalid XMLName.Local=%q succeeded, want error", tt.input.XMLName.Local)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The xml.Encoder and xml.Marshal functions write element and attribute
names directly to the output without validation. If an application
passes attacker-controlled strings as Name.Local (via XMLName fields,
EncodeElement, or EncodeToken), the output contains unescaped XML
special characters, enabling XML injection.

This is inconsistent with the existing validation for ProcInst
targets (which calls isNameString at marshal.go:240) and the
escaping of namespace values (which calls EscapeString).

A crafted Name.Local value can inject arbitrary XML elements:

    item := struct {
        XMLName xml.Name
        Value   string
    }{
        XMLName: xml.Name{Local: "x\"><script>..."},
        Value:   "safe",
    }
    out, _ := xml.Marshal(item)
    // Produces: <x"><script>...>safe</x"><script>...>

This affects Marshal, MarshalIndent, EncodeToken, and
EncodeElement when Name.Local is attacker-controlled.

Attribute names are equally affected via EncodeToken with
StartElement containing crafted Attr Name.Local values.

The fix adds isNameString validation to writeStart (for both
element and attribute names) and writeEnd, matching the
validation already applied to ProcInst targets. Invalid names
now return an error instead of producing malformed XML.

Added TestEncodeTokenInvalidNames and TestMarshalInvalidXMLName.