### PR TITLE
net/http: reject Origin headers containing userinfo in CrossOriginProtection

### DIFF
--- a/src/net/http/csrf.go
+++ b/src/net/http/csrf.go
@@ -158,13 +158,20 @@ func (c *CrossOriginProtection) Check(req *Request) error {
 		return nil
 	}
 
-	if o, err := url.Parse(origin); err == nil && o.Host == req.Host {
+	if o, err := url.Parse(origin); err == nil && o.User == nil && o.Host == req.Host {
 		// The Origin header matches the Host header. Note that the Host header
 		// doesn't include the scheme, so we don't know if this might be an
 		// HTTP→HTTPS cross-origin request. We fail open, since all modern
 		// browsers support Sec-Fetch-Site since 2023, and running an older
 		// browser makes a clear security trade-off already. Sites can mitigate
 		// this with HTTP Strict Transport Security (HSTS).
+		//
+		// We also reject any Origin containing userinfo (e.g., "http://user@host").
+		// RFC 6454 §6.2 explicitly excludes userinfo from the Origin serialization,
+		// so a well-formed Origin header never carries userinfo. url.Parse strips
+		// userinfo from Host but preserves it in the User field, so without the
+		// o.User == nil guard an attacker could send "Origin: http://attacker@victim.com"
+		// and have o.Host == "victim.com" pass the check.
 		return nil
 	}
 

--- a/src/net/http/csrf_test.go
+++ b/src/net/http/csrf_test.go
@@ -45,6 +45,14 @@ func TestCrossOriginProtectionSecFetchSite(t *testing.T) {
 		{"no header with mismatched origin", "POST", "", "https://attacker.example", http.StatusForbidden},
 		{"no header with null origin", "POST", "", "null", http.StatusForbidden},
 
+		// RFC 6454 §6.2: userinfo is not part of the Origin serialization.
+		// url.Parse("http://attacker@example.com").Host == "example.com", so
+		// without an explicit userinfo check the host comparison passes and the
+		// CSRF protection is bypassed.
+		{"userinfo bypass attempt (http)", "POST", "", "http://attacker@example.com", http.StatusForbidden},
+		{"userinfo bypass attempt (https)", "POST", "", "https://evil@example.com", http.StatusForbidden},
+		{"userinfo with password bypass attempt", "POST", "", "https://evil:pass@example.com", http.StatusForbidden},
+
 		{"GET allowed", "GET", "cross-site", "", http.StatusOK},
 		{"HEAD allowed", "HEAD", "cross-site", "", http.StatusOK},
 		{"OPTIONS allowed", "OPTIONS", "cross-site", "", http.StatusOK},


### PR DESCRIPTION
CrossOriginProtection.Check uses url.Parse to extract the hostname
from the Origin request header and then compares it to req.Host:

    if o, err := url.Parse(origin); err == nil &&
        o.Host == req.Host {

However, url.Parse strips userinfo from Host into the separate
User field. An Origin header like

    Origin: http://evil@victim.com

parses with o.Host == "victim.com" and o.User != nil. The check
passes because o.Host matches req.Host, bypassing CSRF protection.

RFC 6454 section 6.2 explicitly excludes userinfo from the
serialized origin, so no conforming browser ever includes it.
However, non-browser HTTP clients (API consumers, mobile apps,
scripts) can set arbitrary headers. Any Go HTTP handler relying
on CrossOriginProtection is vulnerable to CSRF from such clients.

The fix adds o.User == nil to the condition:

    if o, err := url.Parse(origin); err == nil &&
        o.User == nil && o.Host == req.Host {

This rejects any Origin containing userinfo, which is correct
per RFC 6454.

Added test cases for Origin headers with userinfo (single user,
user with password) — all now correctly return 403.

Fixes #78563