### PR TITLE
cmd/compile: avoid stack temporary for struct literal assignment to addressable targets

### DIFF
--- a/src/cmd/compile/internal/test/bench_test.go
+++ b/src/cmd/compile/internal/test/bench_test.go
@@ -180,6 +180,233 @@ func BenchmarkSimplifyNegDiv(b *testing.B) {
 
 var globbool bool
 
+// --- Struct literal assignment benchmarks ---
+
+// benchStruct is a large-ish struct (8 fields, 104 bytes on 64-bit)
+// used to benchmark struct literal assignment codegen.
+type benchStruct struct {
+	A int
+	B string
+	C float64
+	D int64
+	E bool
+	F string
+	G int
+	H string
+}
+
+var benchStructSink benchStruct
+
+// Nested/embedded struct types for benchmarking.
+type benchInner struct {
+	X int
+	Y string
+}
+
+type benchNested struct {
+	I benchInner
+	Z float64
+	W string
+}
+
+type benchEmbedded struct {
+	benchInner
+	Z float64
+	W string
+}
+
+
+// --- noinline helper functions for benchmarks ---
+
+//go:noinline
+func slAssignLiteral(s []benchStruct, idx int, a int, b string, c float64, d int64, e bool, f string, g int, h string) {
+	s[idx] = benchStruct{A: a, B: b, C: c, D: d, E: e, F: f, G: g, H: h}
+}
+
+//go:noinline
+func slAssignFieldByField(s []benchStruct, idx int, a int, b string, c float64, d int64, e bool, f string, g int, h string) {
+	s[idx].A = a
+	s[idx].B = b
+	s[idx].C = c
+	s[idx].D = d
+	s[idx].E = e
+	s[idx].F = f
+	s[idx].G = g
+	s[idx].H = h
+}
+
+//go:noinline
+func slAssignGlobal(a int, b string, c float64, d int64, e bool, f string, g int, h string) {
+	benchStructSink = benchStruct{A: a, B: b, C: c, D: d, E: e, F: f, G: g, H: h}
+}
+
+//go:noinline
+func slAssignPtr(p *benchStruct, a int, b string, c float64, d int64, e bool, f string, g int, h string) {
+	*p = benchStruct{A: a, B: b, C: c, D: d, E: e, F: f, G: g, H: h}
+}
+
+//go:noinline
+func slAssignNested(s []benchNested, idx int, x int, y string, z float64, w string) {
+	s[idx] = benchNested{I: benchInner{X: x, Y: y}, Z: z, W: w}
+}
+
+//go:noinline
+func slAssignEmbedded(s []benchEmbedded, idx int, x int, y string, z float64, w string) {
+	s[idx] = benchEmbedded{benchInner: benchInner{X: x, Y: y}, Z: z, W: w}
+}
+
+//go:noinline
+func slGetInt() int { return 42 }
+
+//go:noinline
+func slGetString() string { return "hello" }
+
+//go:noinline
+func slAssignFuncCall(s []benchStruct, idx int, c float64, d int64, e bool, g int) {
+	s[idx] = benchStruct{
+		A: slGetInt(), B: slGetString(), C: c, D: d,
+		E: e, F: slGetString(), G: g, H: slGetString(),
+	}
+}
+
+var slGlobalInt int = 99
+
+//go:noinline
+func slAssignAlias(s []benchStruct, idx int, b string, c float64, d int64) {
+	// RHS reads a global (slGlobalInt) — may alias with destination,
+	// so the compiler must use a stack temporary (not optimized).
+	s[idx] = benchStruct{A: slGlobalInt, B: b, C: c, D: d, E: true, F: b, G: 7, H: b}
+}
+
+//go:noinline
+func slAssignPartial(s []benchStruct, idx int, a int) {
+	// Only one field set — zero + one store.
+	s[idx] = benchStruct{A: a}
+}
+
+//go:noinline
+func slAssignPartialHalf(s []benchStruct, idx int, a int, b string, c float64, d int64) {
+	// Half the fields set — zero + four stores.
+	s[idx] = benchStruct{A: a, B: b, C: c, D: d}
+}
+
+//go:noinline
+func slAssignZeroValue(s []benchStruct, idx int) {
+	// Zero-value literal — just zero the destination.
+	s[idx] = benchStruct{}
+}
+
+//go:noinline
+func slAssignLHSAlias(s []benchStruct, idx int, a int, c float64, d int64) {
+	// RHS reads directly from the destination slice element.
+	// exprSafeForDirectStore rejects these (field access through slice index),
+	// so the compiler falls back to the stack temporary path.
+	s[idx] = benchStruct{A: a, B: s[idx].B, C: c, D: d, E: s[idx].E, F: s[idx].F, G: s[idx].G, H: s[idx].H}
+}
+
+//go:noinline
+func slAssignNestedPartial(s []benchNested, idx int, x int, z float64, w string) {
+	// Outer fully set, inner benchInner partial (only X, not Y).
+	// Optimization fires but must zero destination first (compLitAllFieldsSet).
+	s[idx] = benchNested{I: benchInner{X: x}, Z: z, W: w}
+}
+
+//go:noinline
+func slAssignRHSGrowsSlice(s *[]benchStruct, idx int, b string, c float64, d int64) {
+	// RHS lambda grows the slice via append.
+	// The order pass extracts the call to an autotemp, so the
+	// optimization fires (direct stores, no stack temporary).
+	(*s)[idx] = benchStruct{A: func() int { *s = append(*s, benchStruct{}); return 42 }(), B: b, C: c, D: d, E: true, F: b, G: 7, H: b}
+}
+
+// BenchmarkStructLitAssign measures the performance impact of struct literal
+// assignment codegen. When the compiler decomposes struct literals into direct
+// field stores (avoiding DUFFZERO+DUFFCOPY via a stack temporary), this should
+// match or beat field-by-field assignment.
+func BenchmarkStructLitAssign(b *testing.B) {
+	s := make([]benchStruct, 64)
+	str1 := fmt.Sprintf("%s", "hello")
+	str2 := fmt.Sprintf("%s", "world")
+	str3 := fmt.Sprintf("%s", "test!")
+
+	b.Run("SliceLiteral", func(b *testing.B) {
+		for b.Loop() {
+			slAssignLiteral(s, 0, 42, str1, 3.14, 100, true, str2, 7, str3)
+		}
+	})
+	b.Run("SliceFieldByField", func(b *testing.B) {
+		for b.Loop() {
+			slAssignFieldByField(s, 0, 42, str1, 3.14, 100, true, str2, 7, str3)
+		}
+	})
+	b.Run("Global", func(b *testing.B) {
+		for b.Loop() {
+			slAssignGlobal(42, str1, 3.14, 100, true, str2, 7, str3)
+		}
+	})
+	b.Run("PtrDeref", func(b *testing.B) {
+		p := &s[0]
+		for b.Loop() {
+			slAssignPtr(p, 42, str1, 3.14, 100, true, str2, 7, str3)
+		}
+	})
+	b.Run("Nested", func(b *testing.B) {
+		ns := make([]benchNested, 64)
+		for b.Loop() {
+			slAssignNested(ns, 0, 42, str1, 3.14, str2)
+		}
+	})
+	b.Run("Embedded", func(b *testing.B) {
+		es := make([]benchEmbedded, 64)
+		for b.Loop() {
+			slAssignEmbedded(es, 0, 42, str1, 3.14, str2)
+		}
+	})
+	b.Run("FuncCallRHS", func(b *testing.B) {
+		for b.Loop() {
+			slAssignFuncCall(s, 0, 3.14, 100, true, 7)
+		}
+	})
+	b.Run("AliasRHS", func(b *testing.B) {
+		for b.Loop() {
+			slAssignAlias(s, 0, str1, 3.14, 100)
+		}
+	})
+	b.Run("PartialOne", func(b *testing.B) {
+		for b.Loop() {
+			slAssignPartial(s, 0, 42)
+		}
+	})
+	b.Run("PartialHalf", func(b *testing.B) {
+		for b.Loop() {
+			slAssignPartialHalf(s, 0, 42, str1, 3.14, 100)
+		}
+	})
+	b.Run("ZeroValue", func(b *testing.B) {
+		for b.Loop() {
+			slAssignZeroValue(s, 0)
+		}
+	})
+	b.Run("LHSAlias", func(b *testing.B) {
+		for b.Loop() {
+			slAssignLHSAlias(s, 0, 42, 3.14, 100)
+		}
+	})
+	b.Run("NestedPartial", func(b *testing.B) {
+		ns := make([]benchNested, 64)
+		for b.Loop() {
+			slAssignNestedPartial(ns, 0, 42, 3.14, str1)
+		}
+	})
+	b.Run("RHSGrowsSlice", func(b *testing.B) {
+		ms := make([]benchStruct, 1, 1024)
+		for b.Loop() {
+			ms = ms[:1]
+			slAssignRHSGrowsSlice(&ms, 0, str1, 3.14, 100)
+		}
+	})
+}
+
 // containsRight compares strs[i] == str (slice element on left).
 //
 //go:noinline

--- a/src/cmd/compile/internal/walk/complit.go
+++ b/src/cmd/compile/internal/walk/complit.go
@@ -566,7 +566,7 @@ func anylit(n ir.Node, var_ ir.Node, init *ir.Nodes) {
 			components = int64(t.NumFields())
 		}
 		// initialization of an array or struct with unspecified components (missing fields or arrays)
-		if isSimpleName(var_) || int64(len(n.List)) < components {
+		if isSimpleName(var_) || int64(len(n.List)) < components || !compLitAllFieldsSet(n) {
 			appendWalkStmt(init, ir.NewAssignStmt(base.Pos, var_, nil))
 		}
 
@@ -597,19 +597,8 @@ func oaslit(n *ir.AssignStmt, init *ir.Nodes) bool {
 		// not a special composite literal assignment
 		return false
 	}
-	if !isSimpleName(n.X) {
-		// not a special composite literal assignment
-		return false
-	}
-	x := n.X.(*ir.Name)
 	if !types.Identical(n.X.Type(), n.Y.Type()) {
 		// not a special composite literal assignment
-		return false
-	}
-	if x.Addrtaken() {
-		// If x is address-taken, the RHS may (implicitly) uses LHS.
-		// Not safe to do a special composite literal assignment
-		// (which may expand to multiple assignments).
 		return false
 	}
 
@@ -617,15 +606,183 @@ func oaslit(n *ir.AssignStmt, init *ir.Nodes) bool {
 	default:
 		// not a special composite literal assignment
 		return false
-
 	case ir.OSTRUCTLIT, ir.OARRAYLIT, ir.OSLICELIT, ir.OMAPLIT:
+	}
+
+	// Case 1: LHS is a simple stack-local name (original path).
+	if isSimpleName(n.X) {
+		x := n.X.(*ir.Name)
+		if x.Addrtaken() {
+			// If x is address-taken, the RHS may (implicitly) uses LHS.
+			// Not safe to do a special composite literal assignment
+			// (which may expand to multiple assignments).
+			return false
+		}
 		if ir.Any(n.Y, func(y ir.Node) bool { return ir.Uses(y, x) }) {
 			// not safe to do a special composite literal assignment if RHS uses LHS.
 			return false
 		}
 		anylit(n.Y, n.X, init)
+		return true
 	}
 
+	// Case 2: LHS is an addressable non-name (slice index, array index,
+	// pointer deref, global, struct field through pointer, etc.).
+	// We decompose the struct/array literal into direct field stores
+	// through a pointer to the destination, avoiding a stack temporary
+	// and the associated SSA Zero + Move/Copy operations.
+	return oaslitAddr(n, init)
+}
+
+// oaslitAddr decomposes a composite literal assignment to an addressable
+// non-name target into direct stores through a pointer.
+//
+// For a fully-initialized literal, s[i] = S{A: a, B: b} becomes:
+//
+//	ptr := &s[i]      // bounds check happens once here
+//	(*ptr).A = a
+//	(*ptr).B = b
+//
+// For a partially-initialized literal, s[i] = S{A: a} becomes:
+//
+//	ptr := &s[i]
+//	*ptr = S{}        // zero the destination directly
+//	(*ptr).A = a
+//
+// In both cases this avoids creating a stack temporary. Without this
+// optimization the compiler would emit a Zero of the temp, fill fields
+// into the temp, then emit a Move (or wbMove for pointer-containing
+// types) to copy the temp to the destination. The direct path
+// eliminates the copy entirely; for partial initialization it zeroes
+// the destination in-place instead of zeroing a temp.
+//
+// Safety requirements:
+//   - Only struct/array literals (not slice/map which need runtime calls).
+//   - All RHS values must not alias with the destination. We conservatively
+//     require every RHS value to be a stack-local non-addrtaken name or a
+//     constant, which cannot alias with any addressable destination.
+func oaslitAddr(n *ir.AssignStmt, init *ir.Nodes) bool {
+	// Only decompose struct and array literals. Slice and map literals
+	// involve heap allocation / runtime calls and can't be decomposed
+	// into simple field stores.
+	if n.Y.Op() != ir.OSTRUCTLIT && n.Y.Op() != ir.OARRAYLIT {
+		return false
+	}
+
+	// The LHS must be addressable so we can take its address once.
+	if !ir.IsAddressable(n.X) {
+		return false
+	}
+
+	lit := n.Y.(*ir.CompLitExpr)
+
+	// Ensure no RHS value can alias with the destination. We accept
+	// only constants, nil, and stack-local non-addrtaken names
+	// (parameters, local variables). This guarantees that writing to
+	// the destination field-by-field cannot corrupt any RHS value
+	// that hasn't been read yet. For partial initialization, the
+	// destination is zeroed first (by anylit), so aliasing with a
+	// RHS value would cause that value to read zeroes instead of
+	// original data — still wrong. The same check covers both cases.
+	if !compLitFieldsSafe(lit) {
+		return false
+	}
+
+	// Take the address of the destination once. For slice/array
+	// indexing this evaluates the index and performs the bounds check
+	// exactly once.
+	addr := typecheck.NodAddr(n.X)
+	addr = typecheck.Expr(addr).(*ir.AddrExpr)
+
+	ptr := typecheck.TempAt(base.Pos, ir.CurFunc, addr.Type())
+	appendWalkStmt(init, ir.NewAssignStmt(base.Pos, ptr, addr))
+
+	// Dereference the pointer to use as the destination for anylit.
+	// This mirrors the pattern used in anylit's OPTRLIT case.
+	deref := ir.NewStarExpr(base.Pos, ptr)
+	deref = typecheck.AssignExpr(deref).(*ir.StarExpr)
+
+	anylit(n.Y, deref, init)
+	return true
+}
+
+// compLitFieldsSafe reports whether every field/element value in the
+// composite literal is safe from aliasing with an arbitrary addressable
+// destination. A value is safe if it is a constant, nil, or a stack-local
+// non-addrtaken name (e.g., function parameter), since such values cannot
+// alias with heap, global, or indirectly-addressed memory.
+func compLitFieldsSafe(lit *ir.CompLitExpr) bool {
+	for _, elem := range lit.List {
+		var val ir.Node
+		switch elem.Op() {
+		case ir.OSTRUCTKEY:
+			val = elem.(*ir.StructKeyExpr).Value
+		case ir.OKEY:
+			val = elem.(*ir.KeyExpr).Value
+		default:
+			val = elem
+		}
+		if !exprSafeForDirectStore(val) {
+			return false
+		}
+	}
+	return true
+}
+
+// exprSafeForDirectStore reports whether n is safe to use as a RHS value
+// when decomposing a composite literal assignment into field-by-field stores.
+// Safe expressions cannot alias with any addressable destination.
+func exprSafeForDirectStore(n ir.Node) bool {
+	switch n.Op() {
+	case ir.OLITERAL, ir.ONIL:
+		return true
+	case ir.ONAME:
+		name := n.(*ir.Name)
+		if name.Class == ir.PFUNC {
+			return true
+		}
+		return name.OnStack() && !name.Addrtaken()
+	case ir.OCONV, ir.OCONVNOP:
+		return exprSafeForDirectStore(n.(*ir.ConvExpr).X)
+	case ir.OSTRUCTLIT, ir.OARRAYLIT:
+		return compLitFieldsSafe(n.(*ir.CompLitExpr))
+	}
+	return false
+}
+
+// compLitAllFieldsSet reports whether the composite literal n and all
+// nested struct/array literals recursively have all fields/elements
+// specified. This is used to determine whether zeroing the destination
+// can be skipped: if any nested literal is partial, the destination
+// must be zeroed first since fixedlit only stores the specified fields.
+func compLitAllFieldsSet(n *ir.CompLitExpr) bool {
+	t := n.Type()
+	var components int64
+	if n.Op() == ir.OARRAYLIT {
+		components = t.NumElem()
+	} else {
+		components = int64(t.NumFields())
+	}
+	if int64(len(n.List)) < components {
+		return false
+	}
+	for _, elem := range n.List {
+		var val ir.Node
+		switch elem.Op() {
+		case ir.OSTRUCTKEY:
+			val = elem.(*ir.StructKeyExpr).Value
+		case ir.OKEY:
+			val = elem.(*ir.KeyExpr).Value
+		default:
+			val = elem
+		}
+		switch val.Op() {
+		case ir.OSTRUCTLIT, ir.OARRAYLIT:
+			if !compLitAllFieldsSet(val.(*ir.CompLitExpr)) {
+				return false
+			}
+		}
+	}
 	return true
 }
 

--- a/test/codegen/struct_literal_assign.go
+++ b/test/codegen/struct_literal_assign.go
@@ -1,0 +1,241 @@
+// asmcheck
+
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Test that fully-initialized struct literal assignments do not generate
+// unnecessary zeroing and copying via a stack temporary. When every field is
+// set in the literal, the compiler should write fields directly to the
+// destination without zeroing or copying an intermediate.
+
+package codegen
+
+type BigStruct struct {
+	A int
+	B string
+	C float64
+	D int64
+	E bool
+	F string
+	G int
+	H string
+}
+
+var bsSink BigStruct
+var bsSlice = make([]BigStruct, 16)
+var bsIdx int
+
+// --- Basic LHS variants (optimized) ---
+
+// Slice index LHS
+func AssignFullLiteralToSlice(a int, b string, c float64, d int64, e bool, f string, g int, h string) {
+	// 386:-"DUFFZERO"
+	// 386:-"DUFFCOPY"
+	// 386:-"runtime.wbMove"
+	bsSlice[bsIdx] = BigStruct{
+		A: a, B: b, C: c, D: d, E: e, F: f, G: g, H: h,
+	}
+}
+
+// Global variable LHS
+func AssignFullLiteralToGlobal(a int, b string, c float64, d int64, e bool, f string, g int, h string) {
+	// 386:-"DUFFZERO"
+	// 386:-"DUFFCOPY"
+	// 386:-"runtime.wbMove"
+	bsSink = BigStruct{
+		A: a, B: b, C: c, D: d, E: e, F: f, G: g, H: h,
+	}
+}
+
+// Pointer dereference LHS
+func AssignFullLiteralToDeref(p *BigStruct, a int, b string, c float64, d int64, e bool, f string, g int, h string) {
+	// 386:-"DUFFZERO"
+	// 386:-"DUFFCOPY"
+	// 386:-"runtime.wbMove"
+	*p = BigStruct{
+		A: a, B: b, C: c, D: d, E: e, F: f, G: g, H: h,
+	}
+}
+
+type OuterNamed struct {
+	Inner BigStruct
+	X     int
+}
+
+// Struct field through pointer LHS
+func AssignFullLiteralToFieldViaPtr(o *OuterNamed, a int, b string, c float64, d int64, e bool, f string, g int, h string) {
+	// 386:-"DUFFZERO"
+	// 386:-"DUFFCOPY"
+	// 386:-"runtime.wbMove"
+	o.Inner = BigStruct{
+		A: a, B: b, C: c, D: d, E: e, F: f, G: g, H: h,
+	}
+}
+
+// Local variable LHS — not affected by the addressable-target optimization
+// (locals go through the existing isSimpleName path in oaslit).
+func AssignFullLiteralToLocal(a int, b string, c float64, d int64, e bool, f string, g int, h string) BigStruct {
+	x := BigStruct{
+		A: a, B: b, C: c, D: d, E: e, F: f, G: g, H: h,
+	}
+	return x
+}
+
+// --- Nested struct literal ---
+
+type InnerSmall struct {
+	X int
+	Y string
+}
+
+type OuterWithInner struct {
+	I InnerSmall
+	Z float64
+	W string
+}
+
+var owSlice = make([]OuterWithInner, 16)
+
+// Nested struct literal with all fields set
+func AssignNestedLiteralToSlice(x int, y string, z float64, w string) {
+	// 386:-"DUFFZERO"
+	// 386:-"DUFFCOPY"
+	// 386:-"runtime.wbMove"
+	owSlice[0] = OuterWithInner{
+		I: InnerSmall{X: x, Y: y},
+		Z: z,
+		W: w,
+	}
+}
+
+// Nested struct literal to global
+func AssignNestedLiteralToGlobal(x int, y string, z float64, w string) {
+	// 386:-"DUFFZERO"
+	// 386:-"DUFFCOPY"
+	// 386:-"runtime.wbMove"
+	bsNested = OuterWithInner{
+		I: InnerSmall{X: x, Y: y},
+		Z: z,
+		W: w,
+	}
+}
+
+var bsNested OuterWithInner
+
+// --- Anonymous/embedded fields ---
+
+type EmbedBase struct {
+	X int
+	Y string
+}
+
+type WithEmbed struct {
+	EmbedBase
+	Z float64
+	W string
+}
+
+var weSlice = make([]WithEmbed, 16)
+
+// Anonymous embedded struct, all fields set
+func AssignEmbeddedLiteralToSlice(x int, y string, z float64, w string) {
+	// 386:-"DUFFZERO"
+	// 386:-"DUFFCOPY"
+	// 386:-"runtime.wbMove"
+	weSlice[0] = WithEmbed{
+		EmbedBase: EmbedBase{X: x, Y: y},
+		Z:         z,
+		W:         w,
+	}
+}
+
+// Multiple levels of embedding
+type DeepBase struct {
+	A int
+	B string
+}
+
+type MidEmbed struct {
+	DeepBase
+	C float64
+}
+
+type DeepEmbed struct {
+	MidEmbed
+	D string
+}
+
+var deSlice = make([]DeepEmbed, 16)
+
+func AssignDeepEmbeddedLiteralToSlice(a int, b string, c float64, d string) {
+	// 386:-"DUFFZERO"
+	// 386:-"DUFFCOPY"
+	// 386:-"runtime.wbMove"
+	deSlice[0] = DeepEmbed{
+		MidEmbed: MidEmbed{
+			DeepBase: DeepBase{A: a, B: b},
+			C:        c,
+		},
+		D: d,
+	}
+}
+
+// --- Function call results in RHS ---
+
+//go:noinline
+func bsGetInt() int { return 42 }
+
+//go:noinline
+func bsGetString() string { return "hello" }
+
+// Function call results are placed into autotemps by the order pass,
+// so they should be safe for the optimization.
+func AssignFuncCallResultToSlice(c float64, d int64, e bool, g int) {
+	// 386:-"DUFFZERO"
+	// 386:-"DUFFCOPY"
+	// 386:-"runtime.wbMove"
+	bsSlice[0] = BigStruct{
+		A: bsGetInt(), B: bsGetString(), C: c, D: d,
+		E: e, F: bsGetString(), G: g, H: bsGetString(),
+	}
+}
+
+// --- Type conversion in RHS ---
+
+func AssignWithConvToSlice(a int32, b string, c float64, d int64, e bool, f string, g int, h string) {
+	// 386:-"DUFFZERO"
+	// 386:-"DUFFCOPY"
+	// 386:-"runtime.wbMove"
+	bsSlice[0] = BigStruct{
+		A: int(a), B: b, C: c, D: d, E: e, F: f, G: g, H: h,
+	}
+}
+
+// --- RHS function call that grows the LHS slice ---
+
+// Function call in RHS that grows the destination slice via append.
+// The order pass extracts the call to an autotemp before the assignment,
+// so the optimization can fire safely.
+func AssignRHSGrowsSlice(s []BigStruct, b string, c float64, d int64, e bool, f string, g int, h string) {
+	// 386:-"DUFFZERO"
+	// 386:-"DUFFCOPY"
+	// 386:-"runtime.wbMove"
+	s[0] = BigStruct{
+		A: func() int { s = append(s, BigStruct{}); return 99 }(),
+		B: b, C: c, D: d, E: e, F: f, G: g, H: h,
+	}
+}
+
+// --- RHS aliases LHS (must NOT be optimized) ---
+
+func AssignRHSAliasesLHS(a int, c float64, d int64, e bool, g int) {
+	// RHS reads from the same slice element being written.
+	// The optimization must NOT fire — exprSafeForDirectStore rejects
+	// slice index field accesses. The compiler falls back to the
+	// stack temporary path to avoid corrupting RHS values.
+	bsSlice[bsIdx] = BigStruct{
+		A: a, B: bsSlice[bsIdx].B, C: c, D: d,
+		E: e, F: bsSlice[bsIdx].F, G: g, H: bsSlice[bsIdx].H,
+	}
+}

--- a/test/complit3.go
+++ b/test/complit3.go
@@ -1,0 +1,92 @@
+// run
+
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Test that struct literal assignment to slice elements works correctly
+// when the RHS contains function calls that grow the LHS slice.
+// The order pass evaluates the LHS index after extracting RHS side effects,
+// so the slice is already grown when the index is evaluated at runtime.
+
+package main
+
+type S struct {
+	A int
+	B string
+	C float64
+	D int64
+	E bool
+	F string
+	G int
+	H string
+}
+
+//go:noinline
+func growSlice(sp *[]S) int {
+	*sp = append(*sp, S{})
+	return 99
+}
+
+func main() {
+	testLocalClosure()
+	testNoinlineGrow()
+}
+
+func testLocalClosure() {
+	// s starts empty (len=0). The closure in the RHS grows it to len=1
+	// via append before returning. The order pass extracts the closure
+	// call, so by the time s[0] is evaluated, len(s)==1.
+	s := []S{}
+	s[0] = S{
+		A: func() int { s = append(s, S{}); return 42 }(),
+		B: "hello",
+		C: 3.14,
+		D: 100,
+		E: true,
+		F: "world",
+		G: 7,
+		H: "test",
+	}
+	if s[0].A != 42 {
+		panic("testLocalClosure: s[0].A != 42")
+	}
+	if s[0].B != "hello" {
+		panic("testLocalClosure: s[0].B != hello")
+	}
+	if s[0].G != 7 {
+		panic("testLocalClosure: s[0].G != 7")
+	}
+	if len(s) != 1 {
+		panic("testLocalClosure: len(s) != 1")
+	}
+}
+
+func testNoinlineGrow() {
+	// s starts empty. growSlice appends a zero S{} and returns 99.
+	// The order pass extracts the call to an autotemp, so s has
+	// len=1 by the time s[0] is evaluated.
+	s := make([]S, 0)
+	s[0] = S{
+		A: growSlice(&s),
+		B: "hello",
+		C: 3.14,
+		D: 100,
+		E: true,
+		F: "world",
+		G: 7,
+		H: "test",
+	}
+	if s[0].A != 99 {
+		panic("testNoinlineGrow: s[0].A != 99")
+	}
+	if s[0].B != "hello" {
+		panic("testNoinlineGrow: s[0].B != hello")
+	}
+	if s[0].H != "test" {
+		panic("testNoinlineGrow: s[0].H != test")
+	}
+	if len(s) != 1 {
+		panic("testNoinlineGrow: len(s) != 1")
+	}
+}


### PR DESCRIPTION
When assigning a struct/array literal to a non-local addressable target
(slice index, global, pointer deref, struct field through pointer), the
compiler previously created a stack temporary, zeroed it, filled fields,
then bulk-copied to the destination. This was because oaslit() required
LHS to be isSimpleName() (stack-local variable).

Extend oaslit with oaslitAddr, which takes the address of the destination
once and decomposes the literal into direct field stores through that
pointer. For partially-initialized literals, the destination is zeroed
in-place before filling fields, eliminating the bulk copy entirely.

Safety is ensured by compLitFieldsSafe/exprSafeForDirectStore, which
conservatively accept only constants, nil, and stack-local non-addrtaken
names as RHS values -- these cannot alias with any addressable destination.
When nested struct literals are partially initialized, compLitAllFieldsSet
detects this and ensures the destination is zeroed before field stores.

Benchmark results (arm64, Apple M1 Max):

                                 |  baseline   |           optimized            |
                                 |   sec/op    |   sec/op     vs base           |
StructLitAssign/SliceLiteral       8.91n +/- 1%    4.57n +/- 2%  -48.75% (p=0.000)
StructLitAssign/Global             8.04n +/- 1%    3.97n +/- 1%  -50.55% (p=0.000)
StructLitAssign/PtrDeref           8.22n +/- 0%    3.84n +/- 1%  -53.37% (p=0.000)
StructLitAssign/Nested             3.99n +/- 1%    2.93n +/- 2%  -26.62% (p=0.000)
StructLitAssign/Embedded           4.01n +/- 1%    2.91n +/- 1%  -27.32% (p=0.000)
StructLitAssign/FuncCallRHS        9.17n +/- 1%    5.62n +/- 1%  -38.75% (p=0.000)
StructLitAssign/PartialHalf        5.79n +/- 1%    4.12n +/- 1%  -28.74% (p=0.000)
StructLitAssign/AliasRHS           7.93n +/- 1%    7.94n +/- 2%       ~ (no regression)

Test plan:
- go test cmd/compile/... -count=1 -- all pass
- go test cmd/internal/testdir -run Test -count=1 -- asmcheck tests pass
- ./all.bash -- all pass (only pre-existing TestFortran failure due to local gfortran arch mismatch)
- Benchmarks with benchstat -count=8 -benchtime=5s show 27-53% improvement, no regressions

Fixes #78597