### PR TITLE
cmd/go: document go mod vendor omission of non-Go dirs

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -1446,6 +1446,9 @@
 // Vendor resets the main module's vendor directory to include all packages
 // needed to build and test all the main module's packages.
 // It does not include test code for vendored packages.
+// It copies package source files and files matched by //go:embed patterns,
+// not complete source trees, so directories that do not contain Go package
+// files are omitted unless they are needed for an embed pattern.
 //
 // The -v flag causes vendor to print the names of vendored
 // modules and packages to standard error.

--- a/src/cmd/go/internal/modcmd/vendor.go
+++ b/src/cmd/go/internal/modcmd/vendor.go
@@ -37,6 +37,9 @@ var cmdVendor = &base.Command{
 Vendor resets the main module's vendor directory to include all packages
 needed to build and test all the main module's packages.
 It does not include test code for vendored packages.
+It copies package source files and files matched by //go:embed patterns,
+not complete source trees, so directories that do not contain Go package
+files are omitted unless they are needed for an embed pattern.
 
 The -v flag causes vendor to print the names of vendored
 modules and packages to standard error.

--- a/src/cmd/go/testdata/script/mod_vendor_issue57529.txt
+++ b/src/cmd/go/testdata/script/mod_vendor_issue57529.txt
@@ -1,0 +1,46 @@
+[!cgo] skip 'test verifies vendoring behavior for cgo includes in subdirectories'
+
+# Regression test for golang.org/issue/57529:
+# 'go mod vendor' copies package files, not complete source trees,
+# so a subdirectory with no Go package files is omitted.
+
+go build -mod=mod ./...
+go mod vendor
+! exists vendor/example.com/dep/subdir/dep.h
+! go build -mod=vendor ./...
+
+-- go.mod --
+module example.com/main
+
+go 1.17
+
+require example.com/dep v0.1.0
+
+replace example.com/dep v0.1.0 => ./dep
+-- main.go --
+package main
+
+import "example.com/dep"
+
+func main() {
+	println(dep.F())
+}
+-- dep/go.mod --
+module example.com/dep
+
+go 1.17
+-- dep/dep.go --
+package dep
+
+/*
+#include "subdir/dep.h"
+*/
+import "C"
+
+func F() int {
+	return int(C.dep())
+}
+-- dep/subdir/dep.h --
+static inline int dep(void) {
+	return 42;
+}


### PR DESCRIPTION
Document that go mod vendor copies package source files and files matched by //go:embed patterns, not complete source trees.

This clarifies that directories without Go package files are omitted unless they are needed by an embed pattern.

Issue 57529 reported a surprising behavior where vendoring a dependency could omit non-Go subdirectories that are still needed by cgo includes. That behavior is current and intentional given how vendoring works today, but the command documentation did not say it clearly.

Fixes #57529