### PR TITLE
runtime: set up TLS for g on linux/arm64

### DIFF
--- a/src/runtime/asm_arm64.s
+++ b/src/runtime/asm_arm64.s
@@ -136,8 +136,15 @@ TEXT runtime·rt0_go(SB),NOSPLIT|TOPFRAME,$0
 	SUB	$16, RSP		// reserve 16 bytes for sp-8 where fp may be saved.
 	BL	(R12)
 	ADD	$16, RSP
+	B	nosettls
 
 nocgo:
+#ifdef GOOS_linux
+	MOVD	$runtime·m0+m_tls(SB), R0
+	MSR_R0_TPIDR
+#endif
+
+nosettls:
 	BL	runtime·save_g(SB)
 	// update stackguard after _cgo_init
 	MOVD	(g_stack+stack_lo)(g), R0

--- a/src/runtime/signal_arm64_test.go
+++ b/src/runtime/signal_arm64_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux && arm64
+
+package runtime_test
+
+import (
+	"internal/testenv"
+	"testing"
+	"time"
+)
+
+// TestR28ClobberSIGURG verifies that sigtramp recovers g from TLS when
+// R28 is clobbered on the main thread. The child clobbers R28 and calls
+// tgkill(SIGURG) in the same instruction sequence, guaranteeing the signal
+// arrives while R28 holds a garbage value.
+func TestR28ClobberSIGURG(t *testing.T) {
+	testenv.MustHaveGoBuild(t)
+	exe, err := buildTestProg(t, "testprog")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := testenv.CleanCmdEnv(testenv.Command(t, exe, "R28ClobberSIGURG"))
+	cmd.WaitDelay = 5 * time.Second
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("crashed: sigtramp likely used clobbered R28:\n%s\n%v", out, err)
+	}
+}
+
+// TestR28ClobberSIGURGClone is the same test on a newly cloned thread,
+// verifying that clone sets up TLS for g recovery.
+func TestR28ClobberSIGURGClone(t *testing.T) {
+	testenv.MustHaveGoBuild(t)
+	exe, err := buildTestProg(t, "testprog")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := testenv.CleanCmdEnv(testenv.Command(t, exe, "R28ClobberSIGURGClone"))
+	cmd.WaitDelay = 5 * time.Second
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("crashed: TLS not set up on cloned thread:\n%s\n%v", out, err)
+	}
+}

--- a/src/runtime/sys_linux_arm64.s
+++ b/src/runtime/sys_linux_arm64.s
@@ -465,12 +465,10 @@ TEXT runtime·sigtramp(SB),NOSPLIT|TOPFRAME,$176
 	// where g is not set.
 	// first save R0, because runtime·load_g will clobber it
 	MOVW	R0, 8(RSP)
-	MOVBU	runtime·iscgo(SB), R0
-	CBZ	R0, 2(PC)
 	BL	runtime·load_g(SB)
-
 	// Restore signum to R0.
 	MOVW	8(RSP), R0
+
 	// R1 and R2 already contain info and ctx, respectively.
 	MOVD	$runtime·sigtrampgo<ABIInternal>(SB), R3
 	BL	(R3)
@@ -682,6 +680,21 @@ TEXT runtime·clone(SB),NOSPLIT|NOFRAME,$0
 	MOVD	$1234, R10
 	MOVD	R10, -32(R1)
 
+	// Clear unused clone args.
+	MOVD	$0, R2	// parent_tidptr
+	MOVD	$0, R3	// tls
+	MOVD	$0, R4	// child_tidptr
+
+	// If mp and gp are set, set up CLONE_SETTLS for the child thread.
+	MOVD	mp+16(FP), R10
+	CMP	$0, R10
+	BEQ	notls
+	CMP	$0, R11
+	BEQ	notls
+	ADD	$m_tls, R10, R3	// &mp.tls[0]
+	ORR	$0x00080000, R0	// CLONE_SETTLS
+notls:
+
 	MOVD	$SYS_clone, R8
 	SVC
 
@@ -716,12 +729,10 @@ good:
 
 	MOVD	R0, m_procid(R10)
 
-	// TODO: setup TLS.
-
 	// In child, set up new stack
 	MOVD	R10, g_m(R11)
 	MOVD	R11, g
-	//CALL	runtime·stackcheck(SB)
+	BL	runtime·save_g(SB)
 
 nog:
 	// Call fn

--- a/src/runtime/testdata/testprog/r28clobber_arm64.go
+++ b/src/runtime/testdata/testprog/r28clobber_arm64.go
@@ -1,0 +1,44 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux && arm64
+
+package main
+
+import (
+	"os"
+	"runtime"
+	"sync"
+	"syscall"
+)
+
+func init() {
+	register("R28ClobberSIGURG", R28ClobberSIGURG)
+	register("R28ClobberSIGURGClone", R28ClobberSIGURGClone)
+}
+
+// Declared in r28clobber_arm64.s
+func r28DirtyLoop(tid, pid int, sig, iters int32)
+
+func R28ClobberSIGURG() {
+	runtime.LockOSThread()
+	r28DirtyLoop(syscall.Gettid(), syscall.Getpid(), int32(syscall.SIGURG), 100)
+	os.Exit(0)
+}
+
+func R28ClobberSIGURGClone() {
+	// Lock the main thread so the new goroutine must run on a fresh OS thread.
+	runtime.LockOSThread()
+	runtime.GOMAXPROCS(2)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		runtime.LockOSThread()
+		r28DirtyLoop(syscall.Gettid(), syscall.Getpid(), int32(syscall.SIGURG), 100)
+	}()
+	wg.Wait()
+	os.Exit(0)
+}

--- a/src/runtime/testdata/testprog/r28clobber_arm64.s
+++ b/src/runtime/testdata/testprog/r28clobber_arm64.s
@@ -1,0 +1,30 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "textflag.h"
+
+// func r28DirtyLoop(tid, pid int, sig, iters int32)
+TEXT ·r28DirtyLoop(SB), NOSPLIT, $16-24
+	MOVD R19, 16(RSP)
+	MOVD g, R19                // save g
+	MOVD $0xDEADBEEF, g        // clobber R28
+loop:
+	// tgkill(pid, tid, sig)
+	MOVD pid+8(FP), R0
+	MOVD tid+0(FP), R1
+	MOVW sig+16(FP), R2
+	MOVD $131, R8
+	SVC $0
+	WORD $0xD5033FDF            // ISB
+
+	MOVW iters+20(FP), R7
+	SUBW $1, R7
+	MOVW R7, iters+20(FP)
+
+	WORD $0xD5033FDF            // ISB
+
+	CBNZW R7, loop
+	MOVD R19, g                // restore g
+	MOVD 16(RSP), R19
+	RET

--- a/src/runtime/tls_arm64.h
+++ b/src/runtime/tls_arm64.h
@@ -11,6 +11,7 @@
 #endif
 #ifdef TLS_linux
 #define MRS_TPIDR_R0 WORD $0xd53bd040 // MRS TPIDR_EL0, R0
+#define MSR_R0_TPIDR WORD $0xd51bd040 // MSR TPIDR_EL0, R0
 #endif
 
 #ifdef GOOS_darwin

--- a/src/runtime/tls_arm64.s
+++ b/src/runtime/tls_arm64.s
@@ -12,8 +12,10 @@ TEXT runtime·load_g(SB),NOSPLIT,$0
 #ifndef GOOS_darwin
 #ifndef GOOS_openbsd
 #ifndef GOOS_windows
+#ifndef GOOS_linux
 	MOVB	runtime·iscgo(SB), R0
 	CBZ	R0, nocgo
+#endif
 #endif
 #endif
 #endif
@@ -33,8 +35,10 @@ TEXT runtime·save_g(SB),NOSPLIT,$0
 #ifndef GOOS_darwin
 #ifndef GOOS_openbsd
 #ifndef GOOS_windows
+#ifndef GOOS_linux
 	MOVB	runtime·iscgo(SB), R0
 	CBZ	R0, nocgo
+#endif
 #endif
 #endif
 #endif


### PR DESCRIPTION
Fixes SIGSEGV in sigtramp when SIGURG arrives while non-Go code (e.g. linked via .syso) has clobbered the g register.

Fixes #78621

