### PR TITLE
runtime/amd64: use ABIInternal convention in cgocallbackg

### DIFF
--- a/src/runtime/asm_amd64.s
+++ b/src/runtime/asm_amd64.s
@@ -1105,25 +1105,23 @@ havem:
 	// will seamlessly trace back into the earlier calls.
 	MOVQ	m_curg(BX), SI
 	MOVQ	SI, g(CX)
+	MOVQ	SI, R14 // set the g register
 	MOVQ	(g_sched+gobuf_sp)(SI), DI  // prepare stack as DI
 	MOVQ	(g_sched+gobuf_pc)(SI), BX
 	MOVQ	BX, -8(DI)  // "push" return PC on the g stack
 	// Gather our arguments into registers.
-	MOVQ	fn+0(FP), BX
-	MOVQ	frame+8(FP), CX
-	MOVQ	ctxt+16(FP), DX
+	MOVQ	fn+0(FP), AX
+	MOVQ	frame+8(FP), BX
+	MOVQ	ctxt+16(FP), CX
 	// Compute the size of the frame, including return PC and, if
 	// GOEXPERIMENT=framepointer, the saved base pointer
-	LEAQ	fn+0(FP), AX
-	SUBQ	SP, AX   // AX is our actual frame size
-	SUBQ	AX, DI   // Allocate the same frame size on the g stack
+	LEAQ	fn+0(FP), R8
+	SUBQ	SP, R8   // R8 is our actual frame size
+	SUBQ	R8, DI   // Allocate the same frame size on the g stack
 	MOVQ	DI, SP
 
-	MOVQ	BX, 0(SP)
-	MOVQ	CX, 8(SP)
-	MOVQ	DX, 16(SP)
-	MOVQ	$runtime·cgocallbackg(SB), AX
-	CALL	AX	// indirect call to bypass nosplit check. We're on a different stack now.
+	MOVQ	$runtime·cgocallbackg<ABIInternal>(SB), DX
+	CALL	DX	// indirect call to bypass nosplit check. We're on a different stack now.
 
 	// Compute the size of the frame again. FP and SP have
 	// completely different values here than they did above,


### PR DESCRIPTION
When an unpinned Go pointer is passed from Go to C,

    # cat -n main.c
         1  #include <stdio.h>
         2  #include "parse.h"
         3
         4  int main(void) {
         5          GoMap m = GoFoo();
         6          (void)m;
         7          return 0;
         8  }

    # cat -n callbackErr.go
         1  package main
         2
         3  import (
         4          "C"
         5  )
         6
         7  //export GoFoo
         8  func GoFoo() map[int]int {
         9          return map[int]int{0: 1,}
        10  }
        11
        12  func main() {
        13  }

    # go build -buildmode=c-shared -o callbackErr.so callbackErr.go
    # gcc -o main main.c callbackErr.so -Wl,-rpath,'$ORIGIN'
    # ./main

The program errors out as expected.

    [...]
    goroutine 17 [running, locked to thread]:
    panic({0x73b3380a0180?, 0x1dd6df238060?})
            /usr/lib/go/src/runtime/panic.go:879 +0x16f
    runtime.cgoCheckArg(0x73b3380a1400, 0x1dd6df2cc060, 0x0?, 0x0, 0x1)
            /usr/lib/go/src/runtime/cgocall.go:659 +0x499
    runtime.cgoCheckResult({0x73b3380a1400, 0x1dd6df2cc060})
            /usr/lib/go/src/runtime/cgocall.go:829 +0x45
    _cgoexp_35a35dd190e3_GoFoo(0x7ffebc378ba0)
            /mnt/tmp/callbackErr.go:8 +0x6f
    runtime.cgocallbackg1(0x73b338003000, 0x7ffebc378ba0, 0x0)
            /usr/lib/go/src/runtime/cgocall.go:466 +0x2e5
    runtime.cgocallbackg(0x73b338003000, 0x7ffebc378ba0, 0x0)
            /usr/lib/go/src/runtime/cgocall.go:362 +0x132
    runtime.cgocallbackg(0x73b338003000, 0x7ffebc378ba0, 0x0)
            <autogenerated>:1 +0x2b
    runtime.cgocallback(0x0, 0x0, 0x0)
            /usr/lib/go/src/runtime/asm_amd64.s:1160 +0xcd
    runtime.goexit({})
            /usr/lib/go/src/runtime/asm_amd64.s:1771 +0x1

The resulting stack trace shows an autogenerated frame:the Go Assembly cgocallbackg uses the ABI0 convention, and got wrapped by the linker into a frame compatible with the ABIInternal convention.

Load the cgocallbackg arguments into the registers expected by the ABIInternal convention. Use the ABIInternal convention at call site.

    goroutine 17 [running, locked to thread]:
    panic({0x7a27b84a0cb8?, 0x2c83846a0000?})
            /mnt/go/src/runtime/panic.go:878 +0x159
    runtime.cgoCheckArg(0x7a27b849b528, 0x2c8384692000, 0x0?, 0x0, 0x1)
            /mnt/go/src/runtime/cgocall.go:667 +0x499
    runtime.cgoCheckResult({0x7a27b849b528, 0x2c8384692000})
            /mnt/go/src/runtime/cgocall.go:837 +0x45
    _cgoexp_35a35dd190e3_GoFoo(0x7ffca436fd40)
            /mnt/tmp/callbackErr.go:8 +0x6f
    runtime.cgocallbackg1(0x7a27b83fecc0, 0x7ffca436fd40, 0x0)
            /mnt/go/src/runtime/cgocall.go:474 +0x2f5
    runtime.cgocallbackg(0x7a27b83fecc0, 0x7ffca436fd40, 0x0)
            /mnt/go/src/runtime/cgocall.go:362 +0x12e
    runtime.cgocallback(0x0, 0x0, 0x0)
            /mnt/go/src/runtime/asm_amd64.s:1124 +0xc2
    runtime.goexit({})
            /mnt/go/src/runtime/asm_amd64.s:1735 +0x1