### PR TITLE
cmd/go: add -static flag for simplified static builds

### DIFF
--- a/src/cmd/go/internal/cfg/cfg.go
+++ b/src/cmd/go/internal/cfg/cfg.go
@@ -88,6 +88,7 @@ var (
 	BuildPGO               string                  // -pgo flag
 	BuildPkgdir            string                  // -pkgdir flag
 	BuildRace              bool                    // -race flag
+	BuildStatic            bool                    // -static flag
 	BuildToolexec          []string                // -toolexec flag
 	BuildToolchainName     string
 	BuildToolchainCompiler func() string

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -189,6 +189,10 @@ and test commands:
 		install and load all packages from dir instead of the usual locations.
 		For example, when building with a non-standard configuration,
 		use -pkgdir to keep generated packages in a separate location.
+	-static
+		produce a statically linked binary.
+		When CGO is not required by the package, this sets CGO_ENABLED=0.
+		When CGO is required, this adds -extldflags "-static" to the linker flags.
 	-tags tag,list
 		a comma-separated list of additional build tags to consider satisfied
 		during the build. For more information about build tags, see
@@ -350,6 +354,7 @@ func AddBuildFlags(cmd *base.Command, mask BuildFlagMask) {
 	cmd.Flag.StringVar(&cfg.BuildPGO, "pgo", "auto", "")
 	cmd.Flag.StringVar(&cfg.BuildPkgdir, "pkgdir", "", "")
 	cmd.Flag.BoolVar(&cfg.BuildRace, "race", false, "")
+	cmd.Flag.BoolVar(&cfg.BuildStatic, "static", false, "")
 	cmd.Flag.Var((*tagsFlag)(&cfg.BuildContext.BuildTags), "tags", "")
 	cmd.Flag.Var((*base.StringsFlag)(&cfg.BuildToolexec), "toolexec", "")
 	cmd.Flag.BoolVar(&cfg.BuildTrimpath, "trimpath", false, "")

--- a/src/cmd/go/internal/work/init.go
+++ b/src/cmd/go/internal/work/init.go
@@ -60,6 +60,7 @@ func BuildInit(ld *modload.Loader) {
 	modload.Init(ld)
 	instrumentInit()
 	buildModeInit()
+	staticInit()
 	initCompilerConcurrencyPool()
 	cfgChangedEnv = makeCfgChangedEnv()
 
@@ -210,6 +211,24 @@ func instrumentInit() {
 	}
 	cfg.BuildContext.InstallSuffix += mode
 	cfg.BuildContext.ToolTags = append(cfg.BuildContext.ToolTags, mode)
+}
+
+func staticInit() {
+	if !cfg.BuildStatic {
+		return
+	}
+	// When -static is set, produce a statically linked binary.
+	//
+	// If the user explicitly requested CGO (CGO_ENABLED=1), keep it enabled
+	// and pass -extldflags "-static" to the external linker.
+	// Otherwise, disable CGO to produce a pure Go static binary.
+	if v := cfg.Getenv("CGO_ENABLED"); v == "1" {
+		// User explicitly enabled CGO; use external linker with -static.
+		forcedLdflags = append(forcedLdflags, `-extldflags=-static`)
+	} else {
+		// Disable CGO for a fully static pure-Go binary.
+		cfg.BuildContext.CgoEnabled = false
+	}
 }
 
 func buildModeInit() {


### PR DESCRIPTION
When `-static` is passed, the build produces a statically linked binary without having to remember `CGO_ENABLED=0` or the `-extldflags` incantation.

If CGO is explicitly enabled (`CGO_ENABLED=1`), it keeps cgo and passes `-extldflags=-static` to the linker. Otherwise it just disables cgo for a pure Go static binary.

Updates #26492