### PR TITLE
cmd/compile: prevent pointer shaping of array pointer shape types

### DIFF
--- a/src/cmd/compile/internal/noder/reader.go
+++ b/src/cmd/compile/internal/noder/reader.go
@@ -941,6 +941,16 @@ func shapify(targ *types.Type, basic bool) *types.Type {
 	if pointerShaping && !targ.Elem().IsShape() && targ.Elem().HasShape() {
 		return targ
 	}
+	// Another exception is when targ is a pointer shape type whose element
+	// is an array (e.g., go.shape.*[1]uint8). This happens when a shaped
+	// pointer type from an outer generic function is used to instantiate an
+	// inner generic function with a basic constraint. Pointer-shaping would
+	// change the element type (e.g., *[1]uint8 -> *uint8), losing the array
+	// type needed for slice operations.
+	// See issue #78297.
+	if pointerShaping && targ.IsShape() && targ.Elem().IsArray() {
+		return targ
+	}
 	under := targ.Underlying()
 	if pointerShaping {
 		under = types.NewPtr(types.Types[types.TUINT8])

--- a/src/cmd/compile/testdata/script/issue78297.txt
+++ b/src/cmd/compile/testdata/script/issue78297.txt
@@ -1,0 +1,65 @@
+go build main.go
+! stdout .
+! stderr .
+
+go build variants.go
+! stdout .
+! stderr .
+
+go build normalshaping.go
+! stdout .
+! stderr .
+
+-- main.go --
+package main
+
+func Z[U any]() (z U) { return }
+
+func F[T ~*[1]byte]() {
+	_ = Z[T]()[:]
+}
+
+var _ = F[*[1]byte]
+
+func main() {}
+
+-- variants.go --
+package main
+
+func identity[U any]() (z U) { return }
+
+func sliceArrayPtr2[T ~*[2]byte]() {
+	_ = identity[T]()[:]
+}
+
+func sliceArrayPtrInt[T ~*[1]int]() {
+	_ = identity[T]()[:]
+}
+
+func sliceArrayPtrLarge[T ~*[100]byte]() {
+	_ = identity[T]()[:]
+}
+
+var _ = sliceArrayPtr2[*[2]byte]
+var _ = sliceArrayPtrInt[*[1]int]
+var _ = sliceArrayPtrLarge[*[100]byte]
+
+func main() {}
+
+-- normalshaping.go --
+package main
+
+func echo[U any]() (z U) { return }
+
+func usePtr[T ~*int]() {
+	_ = echo[T]()
+}
+
+func useBasic[T ~int]() {
+	_ = echo[T]()
+}
+
+var _ = usePtr[*int]
+var _ = useBasic[int]
+
+func main() {}


### PR DESCRIPTION
CL 704095 added an exception in shapify to prevent pointer shaping of
`*[]go.shape.T`, which would lose the original type by converting it to
`*go.shape.uint8`.

However, there is another edge case when the type argument is itself
already a shape type (e.g., go.shape.*[1]uint8). This happens when a
shaped pointer type from an outer generic function is used to
instantiate an inner generic function with a basic interface constraint.
In this case, pointer shaping converts `go.shape.*[1]uint8` to
`go.shape.*uint8`, losing the array element type. Subsequent slice
operations then fail with "bad ptr to array in slice" because uint8 is
not an array type.

This commit adds an exception to skip pointer shaping when the type
argument is a pointer shape type whose element is an array, preserving
the array type information needed for slice operations.

Fixes #78297