### PR TITLE
cmd/compile: emit epilogue_begin in DWARF line info

### DIFF
--- a/src/cmd/internal/obj/arm64/obj7.go
+++ b/src/cmd/internal/obj/arm64/obj7.go
@@ -706,6 +706,7 @@ func preprocess(ctxt *obj.Link, cursym *obj.LSym, newprog obj.ProgAlloc) {
 				retReg = REGLINK
 			}
 			p.To = obj.Addr{}
+			p.Pos = p.Pos.WithXlogue(src.PosEpilogueBegin)
 			aoffset := c.autosize
 			if c.cursym.Func().Text.Mark&LEAF != 0 {
 				if aoffset != 0 {

--- a/src/cmd/internal/obj/dwarf.go
+++ b/src/cmd/internal/obj/dwarf.go
@@ -22,7 +22,7 @@ const (
 	LINE_BASE   = -4
 	LINE_RANGE  = 10
 	PC_RANGE    = (255 - OPCODE_BASE) / LINE_RANGE
-	OPCODE_BASE = 11
+	OPCODE_BASE = 13
 )
 
 // generateDebugLinesSymbol fills the debug lines symbol of a given function.
@@ -51,9 +51,13 @@ func (ctxt *Link) generateDebugLinesSymbol(s, lines *LSym) {
 	var lastpc int64 // last PC written to line table, not last PC in func
 	fileIndex := 1
 	prologue, wrotePrologue := false, false
+	epilogue := false
 	// Walk the progs, generating the DWARF table.
 	for p := s.Func().Text; p != nil; p = p.Link {
 		prologue = prologue || (p.Pos.Xlogue() == src.PosPrologueEnd)
+		if p.Pos.Xlogue() == src.PosEpilogueBegin {
+			epilogue = true
+		}
 		// If we're not at a real instruction, keep looping!
 		if p.Pos.Line() == 0 || (p.Link != nil && p.Link.Pc == p.Pc) {
 			continue
@@ -73,6 +77,11 @@ func (ctxt *Link) generateDebugLinesSymbol(s, lines *LSym) {
 		if prologue && !wrotePrologue {
 			dctxt.AddUint8(lines, uint8(dwarf.DW_LNS_set_prologue_end))
 			wrotePrologue = true
+			wrote = true
+		}
+		if epilogue {
+			dctxt.AddUint8(lines, uint8(dwarf.DW_LNS_set_epilogue_begin))
+			epilogue = false
 			wrote = true
 		}
 		if stmt != newStmt {

--- a/src/cmd/internal/obj/loong64/obj.go
+++ b/src/cmd/internal/obj/loong64/obj.go
@@ -366,6 +366,7 @@ func preprocess(ctxt *obj.Link, cursym *obj.LSym, newprog obj.ProgAlloc) {
 			p.To.Name = obj.NAME_NONE // clear fields as we may modify p to other instruction
 			p.To.Sym = nil
 			p.To.Reg = obj.REG_NONE
+			p.Pos = p.Pos.WithXlogue(src.PosEpilogueBegin)
 
 			if c.cursym.Func().Text.Mark&LEAF != 0 {
 				if autosize == 0 {

--- a/src/cmd/internal/obj/ppc64/obj9.go
+++ b/src/cmd/internal/obj/ppc64/obj9.go
@@ -982,6 +982,7 @@ func preprocess(ctxt *obj.Link, cursym *obj.LSym, newprog obj.ProgAlloc) {
 				p.Link = x
 				p = x
 			}
+			p.Pos = p.Pos.WithXlogue(src.PosEpilogueBegin)
 
 			if c.cursym.Func().Text.Mark&LEAF != 0 {
 				if autosize == 0 {

--- a/src/cmd/internal/obj/riscv/obj.go
+++ b/src/cmd/internal/obj/riscv/obj.go
@@ -600,6 +600,7 @@ func preprocess(ctxt *obj.Link, cursym *obj.LSym, newprog obj.ProgAlloc) {
 			if retReg == obj.REG_NONE {
 				retReg = REG_LR
 			}
+			p.Pos = p.Pos.WithXlogue(src.PosEpilogueBegin)
 
 			if stacksize != 0 {
 				// Restore LR.

--- a/src/cmd/internal/obj/s390x/objz.go
+++ b/src/cmd/internal/obj/s390x/objz.go
@@ -32,6 +32,7 @@ package s390x
 import (
 	"cmd/internal/obj"
 	"cmd/internal/objabi"
+	"cmd/internal/src"
 	"cmd/internal/sys"
 	"internal/abi"
 	"log"
@@ -389,6 +390,7 @@ func preprocess(ctxt *obj.Link, cursym *obj.LSym, newprog obj.ProgAlloc) {
 			if retReg == obj.REG_NONE {
 				retReg = REG_LR
 			}
+			p.Pos = p.Pos.WithXlogue(src.PosEpilogueBegin)
 
 			if c.cursym.Func().Text.Mark&LEAF != 0 {
 				if autosize == 0 {

--- a/src/cmd/internal/obj/x86/obj6.go
+++ b/src/cmd/internal/obj/x86/obj6.go
@@ -821,6 +821,7 @@ func preprocess(ctxt *obj.Link, cursym *obj.LSym, newprog obj.ProgAlloc) {
 		}
 
 		if autoffset != 0 {
+			p.Pos = p.Pos.WithXlogue(src.PosEpilogueBegin)
 			to := p.To // Keep To attached to RET for retjmp below
 			p.To = obj.Addr{}
 			if localoffset != 0 {

--- a/src/cmd/link/internal/ld/dwarf.go
+++ b/src/cmd/link/internal/ld/dwarf.go
@@ -1062,7 +1062,7 @@ const (
 	LINE_BASE   = -4
 	LINE_RANGE  = 10
 	PC_RANGE    = (255 - OPCODE_BASE) / LINE_RANGE
-	OPCODE_BASE = 11
+	OPCODE_BASE = 13
 )
 
 /*
@@ -1329,6 +1329,8 @@ func (d *dwctxt) writelines(unit *sym.CompilationUnit, lineProlog loader.Sym) []
 	lsu.AddUint8(0)                // standard_opcode_lengths[8]
 	lsu.AddUint8(1)                // standard_opcode_lengths[9]
 	lsu.AddUint8(0)                // standard_opcode_lengths[10]
+	lsu.AddUint8(0)                // standard_opcode_lengths[11]
+	lsu.AddUint8(1)                // standard_opcode_lengths[12]
 
 	// Call helper to emit dir and file sections.
 	d.writeDirFileTables(unit, lsu)

--- a/src/cmd/link/internal/ld/dwarf_test.go
+++ b/src/cmd/link/internal/ld/dwarf_test.go
@@ -1378,6 +1378,92 @@ func TestIssue38192(t *testing.T) {
 	}
 }
 
+func TestEpilogueBegin(t *testing.T) {
+	testenv.MustHaveGoBuild(t)
+	mustHaveDWARF(t)
+	t.Parallel()
+
+	// Build a Go program with multiple return sites and verify that
+	// the DWARF line table contains epilogue_begin markers.
+	dir := t.TempDir()
+	f := gobuild(t, dir, `
+package main
+
+//go:noinline
+func multiReturn(x int) int {
+	if x > 10 {
+		return x + 1
+	}
+	if x < -10 {
+		return x - 1
+	}
+	return 0
+}
+
+func main() {
+	multiReturn(42)
+}
+`, NoOpt)
+	defer f.Close()
+
+	dw, err := f.DWARF()
+	if err != nil {
+		t.Fatalf("error parsing DWARF: %v", err)
+	}
+
+	var prologueEndCount, epilogueBeginCount int
+
+	rdr := dw.Reader()
+	for {
+		e, err := rdr.Next()
+		if err != nil {
+			t.Fatalf("error reading DWARF: %v", err)
+		}
+		if e == nil {
+			break
+		}
+		if e.Tag != dwarf.TagCompileUnit {
+			continue
+		}
+		lnrdr, err := dw.LineReader(e)
+		if err != nil {
+			t.Fatalf("error creating DWARF line reader: %v", err)
+		}
+		if lnrdr == nil {
+			continue
+		}
+		var lne dwarf.LineEntry
+		for {
+			err := lnrdr.Next(&lne)
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("error reading next DWARF line: %v", err)
+			}
+			if !strings.HasSuffix(lne.File.Name, "test.go") {
+				continue
+			}
+			if lne.PrologueEnd {
+				prologueEndCount++
+			}
+			if lne.EpilogueBegin {
+				epilogueBeginCount++
+			}
+		}
+		rdr.SkipChildren()
+	}
+	f.Close()
+
+	if prologueEndCount == 0 {
+		t.Error("no prologue_end markers found in DWARF line table")
+	}
+	if epilogueBeginCount == 0 {
+		t.Error("no epilogue_begin markers found in DWARF line table")
+	}
+	t.Logf("found %d prologue_end and %d epilogue_begin markers", prologueEndCount, epilogueBeginCount)
+}
+
 func TestIssue39757(t *testing.T) {
 	testenv.MustHaveGoBuild(t)
 


### PR DESCRIPTION
Mark the beginning of function epilogues in the DWARF line table
by emitting DW_LNS_set_epilogue_begin at each return site.

Also, bump OPCODE_BASE from 11 to 13 so that set_epilogue_begin 
and set_isa are correctly recognized as standard opcodes rather than
special opcodes.

Fixes #69329