### PR TITLE
internal/fuzz: use full int64/uint64 range in mutator

### DIFF
--- a/src/internal/fuzz/mutator.go
+++ b/src/internal/fuzz/mutator.go
@@ -66,7 +66,7 @@ func (m *mutator) mutate(vals []any, maxBytes int) {
 	case int16:
 		vals[i] = int16(m.mutateInt(int64(v), math.MaxInt16))
 	case int64:
-		vals[i] = m.mutateInt(v, maxInt)
+		vals[i] = m.mutateInt(v, math.MaxInt64)
 	case uint:
 		vals[i] = uint(m.mutateUInt(uint64(v), maxUint))
 	case uint16:
@@ -74,7 +74,7 @@ func (m *mutator) mutate(vals []any, maxBytes int) {
 	case uint32:
 		vals[i] = uint32(m.mutateUInt(uint64(v), math.MaxUint32))
 	case uint64:
-		vals[i] = m.mutateUInt(v, maxUint)
+		vals[i] = m.mutateUInt(v, math.MaxUint64)
 	case float32:
 		vals[i] = float32(m.mutateFloat(float64(v), math.MaxFloat32))
 	case float64:


### PR DESCRIPTION
On 32-bit platforms maxInt and maxUint reflect the native int/uint size, so int64 and uint64 inputs were incorrectly bounded when mutating fuzz arguments.