### PR TITLE
cmd/go: propagate GOTMPDIR to subprocess temp directory variables

### DIFF
--- a/src/cmd/go/internal/work/init.go
+++ b/src/cmd/go/internal/work/init.go
@@ -27,13 +27,13 @@ import (
 
 var buildInitStarted = false
 
-// makeCfgChangedEnv is the environment to set to
-// override the current environment for GOOS, GOARCH, and the GOARCH-specific
-// architecture environment variable to the configuration used by
-// the go command. They may be different because go tool <tool> for builtin
-// tools need to be built using the host configuration, so the configuration
-// used will be changed from that set in the environment. It is clipped
-// so its can append to it without changing it.
+// cfgChangedEnv is the environment variable overrides to pass to
+// subprocesses. It includes GOOS, GOARCH, and GOARCH-specific variables
+// when they differ from the current environment (because go tool <tool>
+// for builtin tools may need the host configuration), and TMPDIR (or TMP
+// on Windows) when GOTMPDIR is set, to ensure subprocesses create
+// temporary files in the user-configured directory.
+// It is clipped so callers can append to it without changing it.
 var cfgChangedEnv []string
 
 func makeCfgChangedEnv() []string {
@@ -47,7 +47,22 @@ func makeCfgChangedEnv() []string {
 	if archenv, val, changed := cfg.GetArchEnv(); changed {
 		env = append(env, archenv+"="+val)
 	}
+	if gotmpdir := cfg.Getenv("GOTMPDIR"); gotmpdir != "" {
+		env = append(env, tempEnvName()+"="+gotmpdir)
+	}
 	return slices.Clip(env)
+}
+
+// tempEnvName returns the name of the environment variable that
+// controls the default directory for temporary files on the
+// current host platform.
+func tempEnvName() string {
+	switch runtime.GOOS {
+	case "windows":
+		return "TMP"
+	default:
+		return "TMPDIR"
+	}
 }
 
 func BuildInit(ld *modload.Loader) {
@@ -62,6 +77,20 @@ func BuildInit(ld *modload.Loader) {
 	buildModeInit()
 	initCompilerConcurrencyPool()
 	cfgChangedEnv = makeCfgChangedEnv()
+
+	// If GOTMPDIR is set, propagate it to the platform-specific
+	// temporary directory environment variable so that subprocesses
+	// invoked by the go command (C compiler, linker, cgo, etc.)
+	// create their temporary files in the same directory.
+	// See issue #59636.
+	if gotmpdir := cfg.Getenv("GOTMPDIR"); gotmpdir != "" {
+		if runtime.GOOS == "windows" {
+			os.Setenv("TMP", gotmpdir)
+			os.Setenv("TEMP", gotmpdir)
+		} else {
+			os.Setenv("TMPDIR", gotmpdir)
+		}
+	}
 
 	if err := fsys.Init(); err != nil {
 		base.Fatal(err)

--- a/src/cmd/go/testdata/script/build_GOTMPDIR_subprocess.txt
+++ b/src/cmd/go/testdata/script/build_GOTMPDIR_subprocess.txt
@@ -1,0 +1,31 @@
+[short] skip 'runs go build'
+
+# Test that GOTMPDIR is propagated to subprocesses via TMPDIR (or TMP on Windows).
+# See issue #59636.
+
+# Set GOCACHE to a clean directory to ensure that 'go build' has work to report.
+[!GOOS:windows] env GOCACHE=$WORK/gocache
+[GOOS:windows] env GOCACHE=$WORK\gocache
+
+# When GOTMPDIR is set, 'go build -x' should show the platform-specific
+# temporary directory variable (TMPDIR or TMP) set to GOTMPDIR in the
+# environment of subprocesses such as the compiler and linker.
+[!GOOS:windows] env GOTMPDIR=$WORK/my-tmpdir
+[GOOS:windows] env GOTMPDIR=$WORK\my-tmpdir
+mkdir $GOTMPDIR
+go build -x -o $devnull hello.go
+[!GOOS:windows] stderr 'TMPDIR=.*my-tmpdir'
+[GOOS:windows] stderr 'TMP=.*my-tmpdir'
+
+# When GOTMPDIR is not set, TMPDIR should not appear in -x output
+# as an override (subprocesses use whatever TMPDIR is already set).
+env GOTMPDIR=
+[!GOOS:windows] env GOCACHE=$WORK/gocache2
+[GOOS:windows] env GOCACHE=$WORK\gocache2
+go build -x -o $devnull hello.go
+[!GOOS:windows] ! stderr 'TMPDIR=.*my-tmpdir'
+[GOOS:windows] ! stderr 'TMP=.*my-tmpdir'
+
+-- hello.go --
+package main
+func main() { println("hello") }

--- a/src/cmd/go/testdata/script/build_GOTMPDIR_subprocess.txt
+++ b/src/cmd/go/testdata/script/build_GOTMPDIR_subprocess.txt
@@ -1,0 +1,20 @@
+[short] skip 'runs go build'
+
+# Test that GOTMPDIR is propagated to subprocesses via TMPDIR (or TMP on Windows).
+# See issue #59636.
+
+# Set GOCACHE to a clean directory to ensure that 'go build' has work to report.
+env GOCACHE=$WORK${/}gocache
+
+# When GOTMPDIR is set, 'go build -x' should show the platform-specific
+# temporary directory variable (TMPDIR or TMP) set to GOTMPDIR in the
+# environment of subprocesses such as the compiler and linker.
+env GOTMPDIR=$WORK${/}my-tmpdir
+mkdir $GOTMPDIR
+go build -x -o $devnull hello.go
+[!GOOS:windows] stderr 'TMPDIR=.*my-tmpdir'
+[GOOS:windows] stderr 'TMP=.*my-tmpdir'
+
+-- hello.go --
+package main
+func main() { println("hello") }


### PR DESCRIPTION
 When GOTMPDIR is set, the go command uses it to create its own work                                                                                                                
  directory, but subprocesses such as the linker, C compiler, and cgo                                                                                                                
  still use the system default temporary directory. This is because                                                                                                                  
  GOTMPDIR is a Go-specific variable that external tools do not recognize.                                                                                                           
                                                                                                                                                                                     
  Fix this by translating GOTMPDIR into the platform-specific temporary                                                                                                              
  directory environment variable (TMPDIR on Unix, TMP/TEMP on Windows)                                                                                                               
  so that all subprocesses respect the user's configured temporary                                                                                                                   
  directory.                                                                                                                                                                         
                                                                                                                                                                                     
  The fix has two layers:                                                                                                                                                            
  - Add TMPDIR to cfgChangedEnv so it is explicitly passed to
    subprocesses that use it (compiler, assembler, linker, cgo)                                                                                                                      
    and is visible in 'go build -x' output.                                                                                                                                          
  - Call os.Setenv in BuildInit to set the process-level TMPDIR,                                                                                                                     
    covering subprocesses that do not receive cfgChangedEnv                                                                                                                          
    (C compiler, vet, pkg-config, etc.) via cmd.Environ().                                                                                                                           
                                                                                                                                                                                     
  Fixes #59636
