### PR TITLE
fmt: clarify %q verb uses rune literal not character literal

### DIFF
--- a/src/fmt/doc.go
+++ b/src/fmt/doc.go
@@ -43,7 +43,7 @@ Integer:
 	%d	base 10
 	%o	base 8
 	%O	base 8 with 0o prefix
-	%q	a single-quoted character literal safely escaped with Go syntax.
+	%q	a single-quoted rune literal safely escaped with Go syntax.
 	%x	base 16, with lower-case letters for a-f
 	%X	base 16, with upper-case letters for A-F
 	%U	Unicode format: U+1234; same as "U+%04X"


### PR DESCRIPTION
Good day

This PR fixes issue #78486, which reports that the documentation for the %q verb incorrectly describes its behavior with integer arguments.

## Problem
The current documentation states:
`%q\ta single-quoted character literal safely escaped with Go syntax.`

However, this is a misnomer. The correct Go terminology is **rune literal**, not character literal. The %q verb with integers operates on Unicode code points (runes), not characters in the traditional sense.

## Fix
Changed the documentation from `character literal` to `rune literal` to match the correct Go specification terminology: https://go.dev/ref/spec#Rune_literals

## Testing
This is a documentation-only change. The fix clarifies the existing behavior rather than changing any functionality.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof