### PR TITLE
cmd/link/internal/ppc64: fix XCOFF reloc handling for R_ADDRPOWER_TOCREL

### DIFF
--- a/src/cmd/link/internal/ppc64/asm.go
+++ b/src/cmd/link/internal/ppc64/asm.go
@@ -886,8 +886,7 @@ func xcoffreloc1(arch *sys.Arch, out *ld.OutBuf, ldr *loader.Loader, s loader.Sy
 			v |= 0x3F << 8
 		}
 		emitReloc(v, 0)
-	case objabi.R_ADDRPOWER_TOCREL:
-	case objabi.R_ADDRPOWER_TOCREL_DS:
+	case objabi.R_ADDRPOWER_TOCREL, objabi.R_ADDRPOWER_TOCREL_DS:
 		emitReloc(ld.XCOFF_R_TOCU|(0x0F<<8), 2)
 		emitReloc(ld.XCOFF_R_TOCL|(0x0F<<8), 6)
 	case objabi.R_POWER_TLS_LE:


### PR DESCRIPTION
In Go switch statements, case bodies do not fall through to the next case. The previous code had an empty case for R_ADDRPOWER_TOCREL followed by R_ADDRPOWER_TOCREL_DS, so R_ADDRPOWER_TOCREL matched the empty case and skipped the emitReloc calls. Combine both relocation types in one case so they share the correct TOC relocation sequence.


