### PR TITLE
fmt: clarify %q is for runes, not integers; note go vet warning

### DIFF
--- a/src/fmt/doc.go
+++ b/src/fmt/doc.go
@@ -39,14 +39,20 @@ Boolean:
 Integer:
 
 	%b	base 2
-	%c	the character represented by the corresponding Unicode code point
 	%d	base 10
 	%o	base 8
 	%O	base 8 with 0o prefix
-	%q	a single-quoted character literal safely escaped with Go syntax.
 	%x	base 16, with lower-case letters for a-f
 	%X	base 16, with upper-case letters for A-F
 	%U	Unicode format: U+1234; same as "U+%04X"
+
+Rune:
+
+	%c	the character represented by the corresponding Unicode code point
+	%q	a single-quoted character literal safely escaped with Go syntax.
+
+	For integers, go vet (as of Go 1.26) warns that use of %q is typically
+	a mistake; prefer %d, %x, or %o for integer formatting.
 
 Floating-point and complex constituents:
 


### PR DESCRIPTION
Good day,

This PR addresses issue #78486, which notes that the fmt documentation incorrectly lists the %q verb under the Integer section, suggesting it is a valid format for int types. However, as of Go 1.26, go vet correctly warns when %q is used with integer arguments (see #72850).

## Changes

1. **Removed %c and %q from the Integer section** - These verbs are semantically for character (rune) types, not arbitrary integers.

2. **Created a new Rune section** - Moved %c and %q into a dedicated Rune section, which correctly categorizes them.

3. **Added a note** - The new Rune section includes a note explaining that go vet (as of Go 1.26) warns when %q is used with integers, and suggests using %d, %x, or %o instead for integer formatting.

The %q verb for double-quoted strings (under String and slice of bytes) is unchanged.

## Testing

This is a documentation-only change. The existing behavior of the fmt package is unaffected.

---

Warmly,
RoomWithOutRoof