### PR TITLE
doc: format net package release note

### DIFF
--- a/doc/next/6-stdlib/99-minor/net/78137.md
+++ b/doc/next/6-stdlib/99-minor/net/78137.md
@@ -1,2 +1,1 @@
-net: UnixConn read methods now return io.EOF directly instead of
-wrapping it in net.OpError when the underlying read returns EOF.
+[UnixConn] read methods now return [io.EOF] directly instead of wrapping it in [net.OpError] when the underlying read returns EOF.


### PR DESCRIPTION
This PR fixes malformed standard library documentation links
in the Go 1.27 release notes for the net package.

Adheres to the release note formatting guidelines by using
[Package.Symbol] brackets for automatic linking.

Updates #78137