### PR TITLE
cmd/objdump: fix size of last symbol in Mach-O file

### DIFF
--- a/src/cmd/internal/objfile/macho.go
+++ b/src/cmd/internal/objfile/macho.go
@@ -55,6 +55,10 @@ func (f *machoFile) symbols() ([]Sym, error) {
 		i := sort.Search(len(addrs), func(x int) bool { return addrs[x] > s.Value })
 		if i < len(addrs) {
 			sym.Size = int64(addrs[i] - s.Value)
+		} else if int(s.Sect) <= len(f.macho.Sections) {
+			// Last symbol: use the end of the containing section.
+			sect := f.macho.Sections[s.Sect-1]
+			sym.Size = int64(sect.Addr + sect.Size - s.Value)
 		}
 		if s.Sect == 0 {
 			sym.Code = 'U'


### PR DESCRIPTION
Good day

## Problem

When running `go tool objdump` on a Mach-O binary on macOS, the last function in the file is not disassembled — only its `TEXT` line is shown, with no opcodes.

Root cause: In `cmd/internal/objfile/macho.go:symbols()`, the size of a symbol is computed by taking the difference between its address and the next higher symbol's address. For the last symbol in a file, there is no next symbol, so `sym.Size` remains 0. This causes objdump to skip disassembly.

## Solution

When the current symbol is the last one (no next symbol found, `i >= len(addrs)`), fall back to using the end of the containing section (`sect.Addr + sect.Size`) instead of leaving the size at 0.

## Testing

- The fix directly addresses the repro case from the issue: a binary with functions `f` and `g` where `g` is last
- `go build` of the `cmd` directory passes

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof