### PR TITLE
cmd/go: make go install warn when package is not main

### DIFF
--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -765,7 +765,7 @@ func InstallPackages(ld *modload.Loader, ctx context.Context, patterns []string,
 				// The ones inside GOPATH should have a target (in GOPATH/pkg)
 				// or else something is wrong and worth reporting (like a ConflictDir).
 			case p.Name != "main" && p.Module != nil:
-				// Non-executables have no target (except the cache) when building with modules.
+				base.Errorf("go: package %s is not a main package", p.ImportPath)
 			case p.Name != "main" && p.Standard && p.Internal.Build.PkgObj == "":
 				// Most packages in std do not need an installed .a, because they can be
 				// rebuilt and used directly from the build cache.


### PR DESCRIPTION
Good day,

When 'go install' is called with a package that is not a main package, it now prints an error message instead of silently doing nothing.

Before:
```
$ go install
$ 
```

After:
```
$ go install
go: package hello is not a main package
```

This makes 'go install' behavior consistent with 'go run', which already prints 'package command-line-arguments is not a main package' when run on a non-main package file.

Fixes #58666

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly, RoomWithOutRoof