### PR TITLE
fmt: clarify %q is not for arbitrary integers (fixes #78486)

### DIFF
--- a/src/fmt/doc.go
+++ b/src/fmt/doc.go
@@ -43,7 +43,8 @@ Integer:
 	%d	base 10
 	%o	base 8
 	%O	base 8 with 0o prefix
-	%q	a single-quoted character literal safely escaped with Go syntax.
+	%q	equivalent to issuing a single-quoted character literal (for a rune or
+		Unicode code point, not an arbitrary integer; for integers use %d, %x, etc.)
 	%x	base 16, with lower-case letters for a-f
 	%X	base 16, with upper-case letters for A-F
 	%U	Unicode format: U+1234; same as "U+%04X"


### PR DESCRIPTION
Good day

## What

This PR clarifies the documentation for the %q format verb in the fmt package, addressing issue #78486.

## Why

As of Go 1.26, `go vet` correctly flags uses like `fmt.Printf("%q", intVar)` as errors, because %q is not intended for arbitrary integers. However, the fmt documentation previously listed %q under the Integer section without clearly stating this restriction, leading to user confusion.

The current documentation reads:

```
%q	a single-quoted character literal safely escaped with Go syntax.
```

This implies %q can be used with integers, which is misleading.

## Change

Updated the Integer section description of %q to explicitly clarify:
- %q is for runes/Unicode code points (single-quoted character literals)
- It is NOT for arbitrary integers
- For integers, users should use %d, %x, etc.

The new documentation reads:

```
%q	equivalent to issuing a single-quoted character literal (for a rune or
	Unicode code point, not an arbitrary integer; for integers use %d, %x, etc.)
```

This is purely a documentation fix; the code behavior is unchanged.

## Testing

Verified that:
- `go vet` still correctly flags `fmt.Printf("%q", someInt)`
- `go vet` does not flag `fmt.Printf("%q", 'x')` or `fmt.Printf("%q", "hello")`
- `go doc fmt` shows the updated documentation

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof