### PR TITLE
net: clarify Windows resolver behavior for Go 1.19+

### DIFF
--- a/src/net/net.go
+++ b/src/net/net.go
@@ -91,8 +91,7 @@ requires passing -lresolv when linking the C code.
 
 On Plan 9, the resolver always accesses /net/cs and /net/dns.
 
-On Windows, in Go 1.18.x and earlier, the resolver always used C
-library functions, such as GetAddrInfo and DnsQuery.
+On Windows, since Go 1.19, the resolver prefers the system DNS resolver (using GetAddrInfo and DnsQuery) but may fall back to using C library functions if the system resolver is unavailable.
 */
 package net
 


### PR DESCRIPTION
Good day

## Summary
This PR fixes the documentation in `src/net/net.go` regarding Windows DNS resolver behavior.

## Issue
Issue #57663 reports that the documentation states:

> On Windows, in Go 1.18.x and earlier, the resolver always used C library functions, such as GetAddrInfo and DnsQuery.

This is confusing for users on Go 1.19+ because it only describes behavior for older versions, not the current behavior.

## Fix
Updated the documentation to accurately describe behavior since Go 1.19:

> On Windows, since Go 1.19, the resolver prefers the system DNS resolver (using GetAddrInfo and DnsQuery) but may fall back to using C library functions if the system resolver is unavailable.

This provides clarity for all current Go users on Windows.

## Changes
- `src/net/net.go`: Updated Windows resolver documentation

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof