### PR TITLE
all: fix typos in comments

### DIFF
--- a/src/cmd/go/testdata/script/mod_get_subdir.txt
+++ b/src/cmd/go/testdata/script/mod_get_subdir.txt
@@ -1,5 +1,5 @@
 # golang.org/issue/34055
-# Starting in Go 1.25, go-import meta tag support an optional subdirectory paramater.
+# Starting in Go 1.25, go-import meta tag support an optional subdirectory parameter.
 # The corresponding go-import meta tag is specified as
 # <meta name="go-import" content="vcs-test.golang.org/go/gitreposubdir git https://vcs-test.golang.org/git/gitreposubdir foo/subdir">
 # and contains the module in vcs-test.golang.org/git/gitreposubdir/foo/subdir.

--- a/src/encoding/json/v2/arshal_default.go
+++ b/src/encoding/json/v2/arshal_default.go
@@ -1871,7 +1871,7 @@ func makeInterfaceArshaler(t reflect.Type) *arshaler {
 	return &fncs
 }
 
-// isAnyType reports wether t is equivalent to the any interface type.
+// isAnyType reports whether t is equivalent to the any interface type.
 func isAnyType(t reflect.Type) bool {
 	// This is forward compatible if the Go language permits type sets within
 	// ordinary interfaces where an interface with zero methods does not


### PR DESCRIPTION

**Repo:** golang/go (⭐ 122000)
**Type:** docs
**Files changed:** 2
**Lines:** +2/-2

## What
Fixes two minor typos in comments: "wether" → "whether" in `src/encoding/json/v2/arshal_default.go` (godoc on `isAnyType`) and "paramater" → "parameter" in `src/cmd/go/testdata/script/mod_get_subdir.txt`.

## Why
Both are user-visible misspellings: the first appears in a godoc comment for a helper in the new `encoding/json/v2` package, and the second appears in a script-test header that documents the go-import meta tag subdirectory feature added in Go 1.25. Cleaning these up improves searchability and readability.

## Testing
Comment-only change with no functional effect. Verified the diff is limited to the two comment lines via `git diff --stat`. No build or tests required.

## Risk
Low — comment-only edits, no code or test logic touched.
