### PR TITLE
net: clarify Windows resolver default behavior

### DIFF
--- a/src/net/net.go
+++ b/src/net/net.go
@@ -91,8 +91,9 @@ requires passing -lresolv when linking the C code.
 
 On Plan 9, the resolver always accesses /net/cs and /net/dns.
 
-On Windows, in Go 1.18.x and earlier, the resolver always used C
-library functions, such as GetAddrInfo and DnsQuery.
+On Windows, the resolver uses C library functions, such as GetAddrInfo
+and DnsQuery, by default. The pure Go resolver can be used instead by
+building with the netgo build tag.
 */
 package net
 


### PR DESCRIPTION
Good day,

This PR addresses golang/go#57663.

The original documentation stated:

> On Windows, in Go 1.18.x and earlier, the resolver always used C library functions, such as GetAddrInfo and DnsQuery.

This was confusing as it only described past behavior. The updated documentation now states:

> On Windows, the resolver uses C library functions, such as GetAddrInfo and DnsQuery, by default. The pure Go resolver can be used instead by building with the netgo build tag.

This clarifies the current default behavior while noting how to opt into the pure Go resolver.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
Jah-yee