### PR TITLE
hash/crc32: add crc32 assembly support for riscv64

### DIFF
--- a/src/hash/crc32/crc32_otherarch.go
+++ b/src/hash/crc32/crc32_otherarch.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !amd64 && !s390x && !ppc64le && !arm64 && !loong64
+//go:build !amd64 && !s390x && !ppc64le && !arm64 && !loong64 && !riscv64
 
 package crc32
 

--- a/src/hash/crc32/crc32_riscv64.go
+++ b/src/hash/crc32/crc32_riscv64.go
@@ -29,7 +29,7 @@ func archUpdateIEEE(crc uint32, p []byte) uint32 {
 		panic("arch-specific zbc instruction for IEEE not available")
 	}
 
-	if len(p) >= 64 {
+	if len(p) >= 16 {
 		left := len(p) & 15
 		do := len(p) - left
 		crc = ^ieeeUpdateCLMUL(^crc, p[:do])
@@ -60,7 +60,7 @@ func archUpdateCastagnoli(crc uint32, p []byte) uint32 {
 		panic("arch-specific zbc instruction for Castagnoli not available")
 	}
 
-	if len(p) >= 64 {
+	if len(p) >= 16 {
 		left := len(p) & 15
 		do := len(p) - left
 		crc = ^castagnoliUpdateCLMUL(^crc, p[:do])

--- a/src/hash/crc32/crc32_riscv64.go
+++ b/src/hash/crc32/crc32_riscv64.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package crc32
+
+import "internal/cpu"
+
+func ieeeUpdateCLMUL(crc uint32, p []byte) uint32
+
+func castagnoliUpdateCLMUL(crc uint32, p []byte) uint32
+
+func archAvailableIEEE() bool {
+	return cpu.RISCV64.HasZbc
+}
+
+var archIeeeTable8 *slicing8Table
+
+func archInitIEEE() {
+	if !cpu.RISCV64.HasZbc {
+		panic("arch-specific zbc instruction for IEEE not available")
+	}
+	// We still use slicing-by-8 for small buffers.
+	archIeeeTable8 = slicingMakeTable(IEEE)
+}
+
+func archUpdateIEEE(crc uint32, p []byte) uint32 {
+	if !cpu.RISCV64.HasZbc {
+		panic("arch-specific zbc instruction for IEEE not available")
+	}
+
+	if len(p) >= 64 {
+		left := len(p) & 15
+		do := len(p) - left
+		crc = ^ieeeUpdateCLMUL(^crc, p[:do])
+		p = p[do:]
+	}
+	if len(p) == 0 {
+		return crc
+	}
+	return slicingUpdate(crc, archIeeeTable8, p)
+}
+
+func archAvailableCastagnoli() bool {
+	return cpu.RISCV64.HasZbc
+}
+
+var archCastagnoliTable8 *slicing8Table
+
+func archInitCastagnoli() {
+	if !cpu.RISCV64.HasZbc {
+		panic("arch-specific zbc instruction for Castagnoli not available")
+	}
+	// We still use slicing-by-8 for small buffers.
+	archCastagnoliTable8 = slicingMakeTable(Castagnoli)
+}
+
+func archUpdateCastagnoli(crc uint32, p []byte) uint32 {
+	if !cpu.RISCV64.HasZbc {
+		panic("arch-specific zbc instruction for Castagnoli not available")
+	}
+
+	if len(p) >= 64 {
+		left := len(p) & 15
+		do := len(p) - left
+		crc = ^castagnoliUpdateCLMUL(^crc, p[:do])
+		p = p[do:]
+	}
+	if len(p) == 0 {
+		return crc
+	}
+	return slicingUpdate(crc, archCastagnoliTable8, p)
+}

--- a/src/hash/crc32/crc32_riscv64.s
+++ b/src/hash/crc32/crc32_riscv64.s
@@ -1,0 +1,228 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// RISC-V 64-bit CRC32 using carry-less multiplication (Zbc extension)
+// with Barrett reduction. Algorithm adapted from ISA-L's RISC-V CRC
+// implementation and Intel's PCLMULQDQ CRC paper.
+//
+// The algorithm works as follows:
+//   1. Load first 16 bytes of data, XOR the CRC seed into the low word
+//   2. Fold each subsequent 16-byte block using carry-less multiplication
+//   3. Final fold: reduce 128-bit accumulator to 64 bits
+//   4. Barrett reduction: reduce 64 bits to 32-bit CRC
+
+#include "textflag.h"
+
+// IEEE CRC32 constants (reflected polynomial 0xEDB88320)
+
+// Fold-by-128-bit (16-byte) constants for IEEE CRC32 reflected.
+// K1 and K2 are used to fold a 128-bit accumulator with new 16-byte data.
+DATA ieee_fold<>+0(SB)/8, $0xccaa009e   // K2 (fold high)
+DATA ieee_fold<>+8(SB)/8, $0xae689191   // K1 (fold low)
+GLOBL ieee_fold<>(SB), RODATA, $16
+
+// Final reduction constants for IEEE CRC32 reflected.
+// const_low:  128→64 bit fold constant (low)
+// const_high: 128→64 bit fold constant (high)
+// const_quo:  Barrett reduction quotient μ = floor(x^64 / P(x))
+// const_poly: CRC32-IEEE polynomial P(x) with implicit x^32 term
+DATA ieee_reduce<>+0(SB)/8, $0xb8bc6765     // const_low
+DATA ieee_reduce<>+8(SB)/8, $0xccaa009e     // const_high
+DATA ieee_reduce<>+16(SB)/8, $0x1f7011641   // const_quo (μ)
+DATA ieee_reduce<>+24(SB)/8, $0x1db710641   // const_poly (P)
+GLOBL ieee_reduce<>(SB), RODATA, $32
+
+// Castagnoli CRC32-C constants (reflected polynomial 0x82F63B78)
+// Fold-by-128-bit (16-byte) constants for Castagnoli CRC32-C reflected.
+DATA cast_fold<>+0(SB)/8, $0x493c7d27   // K2 (fold high)
+DATA cast_fold<>+8(SB)/8, $0xf20c0dfe   // K1 (fold low)
+GLOBL cast_fold<>(SB), RODATA, $16
+
+// Final reduction constants for Castagnoli CRC32-C reflected.
+DATA cast_reduce<>+0(SB)/8, $0xdd45aab8     // const_low
+DATA cast_reduce<>+8(SB)/8, $0x493c7d27     // const_high
+DATA cast_reduce<>+16(SB)/8, $0x0dea713f1   // const_quo (μ)
+DATA cast_reduce<>+24(SB)/8, $0x105ec76f1   // const_poly (P)
+GLOBL cast_reduce<>(SB), RODATA, $32
+
+// 32-bit mask constant
+DATA mask32<>+0(SB)/8, $0xffffffff
+GLOBL mask32<>(SB), RODATA, $8
+
+
+// Computes CRC32-IEEE using carry-less multiplication (Zbc extension).
+// Expects non-inverted CRC input. Returns non-inverted CRC.
+// Requires len(p) >= 64 and len(p) is a multiple of 16.
+TEXT ·ieeeUpdateCLMUL(SB), NOSPLIT, $0-36
+	MOVWU	crc+0(FP), X5		// CRC value (inverted by caller)
+	MOV	p+8(FP), X6		// data pointer
+	MOV	p_len+16(FP), X7	// len(p)
+
+	// Load first 16 bytes of data
+	MOV	(X6), X8		// t0 = low 64 bits
+	MOV	8(X6), X9		// t1 = high 64 bits
+	ADD	$16, X6
+	ADD	$-16, X7
+
+	// XOR CRC seed into the low word of the first block
+	XOR	X5, X8, X8
+
+	// Load fold constants: K2 (high), K1 (low)
+	MOV	ieee_fold<>+0(SB), X10		// K2
+	MOV	ieee_fold<>+8(SB), X11		// K1
+
+	// Main fold loop: process 16 bytes per iteration.
+	// We fold the 128-bit accumulator (X8, X9) with each new 16-byte block.
+	MOV	$16, X12
+ieee_fold_loop:
+	BLT	X7, X12, ieee_fold_done
+
+	// Load next 16 bytes of data
+	MOV	(X6), X13		// d0 = new low 64 bits
+	MOV	8(X6), X14		// d1 = new high 64 bits
+	ADD	$16, X6
+	ADD	$-16, X7
+
+	// Carry-less multiply fold:
+	//   new_low  = clmul(K1, t0)  XOR clmul(K2, t1)  XOR d0
+	//   new_high = clmulh(K1, t0) XOR clmulh(K2, t1) XOR d1
+	CLMUL	X11, X8, X15		// clmul(K1, t0) → low result
+	CLMULH	X11, X8, X16		// clmulh(K1, t0) → high result
+	CLMUL	X10, X9, X17		// clmul(K2, t1) → low result
+	CLMULH	X10, X9, X18		// clmulh(K2, t1) → high result
+
+	// Combine fold results with new data
+	XOR	X15, X17, X8		// t0 = fold_low
+	XOR	X8, X13, X8		// t0 ^= d0
+	XOR	X16, X18, X9		// t1 = fold_high
+	XOR	X9, X14, X9		// t1 ^= d1
+
+	JMP	ieee_fold_loop
+
+ieee_fold_done:
+	// (X8, X9) = (t0, t1) holds the folded 128-bit accumulator.
+	// Now reduce 128 bits → 64 bits → 32 bits.
+
+	// Load final reduction constants
+	MOV	ieee_reduce<>+0(SB), X10	// const_low
+	MOV	ieee_reduce<>+8(SB), X11	// const_high
+
+	// 128-bit → 64-bit folding
+	// Formula (from ISA-L reflected CRC):
+	//   t4 = clmul(t0, const_high)
+	//   t3h = clmulh(t0, const_high)
+	//   t1 = t1 XOR t4
+	//   low32 = t1 & 0xFFFFFFFF
+	//   high32 = t1 >> 32
+	//   f = clmul(low32, const_low)
+	//   result = (t3h << 32) XOR high32 XOR f
+	CLMUL	X11, X8, X12		// t4 = clmul(t0, const_high)
+	CLMULH	X11, X8, X13		// t3h = clmulh(t0, const_high)
+	XOR	X9, X12, X9		// t1 = t1 XOR t4
+
+	// Extract low 32 and high 32 bits from t1
+	MOV	mask32<>(SB), X20	// X20 = 0xFFFFFFFF
+	AND	X9, X20, X14		// low32 = t1 & 0xFFFFFFFF
+	SRLI	$32, X9, X15		// high32 = t1 >> 32
+
+	CLMUL	X10, X14, X16		// f = clmul(low32, const_low)
+	SLLI	$32, X13, X13		// t3h <<= 32
+	XOR	X13, X15, X17		// result = (t3h << 32) XOR high32
+	XOR	X17, X16, X17		// result ^= f
+
+	// Barrett reduction: 64 bits → 32 bits
+	// Formula:
+	//   tmp = clmul(result_low32, μ)
+	//   tmp = clmul(tmp_low32, P)
+	//   crc = (result XOR tmp) >> 32
+	AND	X17, X20, X18		// low32 = result & 0xFFFFFFFF
+	MOV	ieee_reduce<>+16(SB), X21	// const_quo (μ)
+	MOV	ieee_reduce<>+24(SB), X22	// const_poly (P)
+	CLMUL	X21, X18, X18		// tmp = clmul(low32, μ)
+	AND	X18, X20, X18		// tmp = tmp & 0xFFFFFFFF
+	CLMUL	X22, X18, X18		// tmp = clmul(tmp, P)
+	XOR	X17, X18, X18		// result = result XOR tmp
+	SRLI	$32, X18, X5		// CRC = upper 32 bits
+
+	MOVW	X5, ret+32(FP)
+	RET
+
+
+// Computes CRC32-C (Castagnoli) using carry-less multiplication (Zbc extension).
+// Expects non-inverted CRC input. Returns non-inverted CRC.
+// Requires len(p) >= 64 and len(p) is a multiple of 16.
+TEXT ·castagnoliUpdateCLMUL(SB), NOSPLIT, $0-36
+	MOVWU	crc+0(FP), X5		// CRC value (inverted by caller)
+	MOV	p+8(FP), X6		// data pointer
+	MOV	p_len+16(FP), X7	// len(p)
+
+	// Load first 16 bytes of data
+	MOV	(X6), X8		// t0 = low 64 bits
+	MOV	8(X6), X9		// t1 = high 64 bits
+	ADD	$16, X6
+	ADD	$-16, X7
+
+	// XOR CRC seed into the low word of the first block
+	XOR	X5, X8, X8
+
+	// Load fold constants: K2 (high), K1 (low)
+	MOV	cast_fold<>+0(SB), X10		// K2
+	MOV	cast_fold<>+8(SB), X11		// K1
+
+	// Main fold loop: process 16 bytes per iteration.
+	MOV	$16, X12
+cast_fold_loop:
+	BLT	X7, X12, cast_fold_done
+
+	// Load next 16 bytes of data
+	MOV	(X6), X13		// d0 = new low 64 bits
+	MOV	8(X6), X14		// d1 = new high 64 bits
+	ADD	$16, X6
+	ADD	$-16, X7
+
+	// Carry-less multiply fold
+	CLMUL	X11, X8, X15		// clmul(K1, t0)
+	CLMULH	X11, X8, X16		// clmulh(K1, t0)
+	CLMUL	X10, X9, X17		// clmul(K2, t1)
+	CLMULH	X10, X9, X18		// clmulh(K2, t1)
+
+	// Combine fold results with new data
+	XOR	X15, X17, X8		// t0 = fold_low
+	XOR	X8, X13, X8		// t0 ^= d0
+	XOR	X16, X18, X9		// t1 = fold_high
+	XOR	X9, X14, X9		// t1 ^= d1
+
+	JMP	cast_fold_loop
+
+cast_fold_done:
+	// Load final reduction constants
+	MOV	cast_reduce<>+0(SB), X10	// const_low
+	MOV	cast_reduce<>+8(SB), X11	// const_high
+
+	// 128-bit → 64-bit folding
+	CLMUL	X11, X8, X12		// t4 = clmul(t0, const_high)
+	CLMULH	X11, X8, X13		// t3h = clmulh(t0, const_high)
+	XOR	X9, X12, X9		// t1 = t1 XOR t4
+
+	MOV	mask32<>(SB), X20	// X20 = 0xFFFFFFFF
+	AND	X9, X20, X14		// low32 = t1 & 0xFFFFFFFF
+	SRLI	$32, X9, X15		// high32 = t1 >> 32
+
+	CLMUL	X10, X14, X16		// f = clmul(low32, const_low)
+	SLLI	$32, X13, X13		// t3h <<= 32
+	XOR	X13, X15, X17		// result = (t3h << 32) XOR high32
+	XOR	X17, X16, X17		// result ^= f
+
+	// Barrett reduction: 64 bits → 32 bits
+	AND	X17, X20, X18		// low32 = result & 0xFFFFFFFF
+	MOV	cast_reduce<>+16(SB), X21	// const_quo (μ)
+	MOV	cast_reduce<>+24(SB), X22	// const_poly (P)
+	CLMUL	X21, X18, X18		// tmp = clmul(low32, μ)
+	AND	X18, X20, X18		// tmp = tmp & 0xFFFFFFFF
+	CLMUL	X22, X18, X18		// tmp = clmul(tmp, P)
+	XOR	X17, X18, X18		// result = result XOR tmp
+	SRLI	$32, X18, X5		// CRC = upper 32 bits
+
+	MOVW	X5, ret+32(FP)
+	RET

--- a/src/hash/crc32/crc32_test.go
+++ b/src/hash/crc32/crc32_test.go
@@ -332,7 +332,7 @@ func BenchmarkCRC32(b *testing.B) {
 
 func benchmarkAll(h hash.Hash32) func(b *testing.B) {
 	return func(b *testing.B) {
-		for _, size := range []int{15, 40, 512, 1 << 10, 4 << 10, 32 << 10} {
+		for _, size := range []int{15, 16, 32, 40, 60, 64, 120, 128, 400, 512, 1 << 10, 4 << 10, 32 << 10} {
 			name := fmt.Sprint(size)
 			if size >= 1024 {
 				name = fmt.Sprintf("%dkB", size/1024)


### PR DESCRIPTION
Add crc32 assembly support for riscv64 with zbc.

goos: linux
goarch: riscv64
pkg: hash/crc32
cpu: Spacemit(R) X60
                                        │ BenchmarkCRC32-before.txt │     BenchmarkCRC32-after.txt      │
                                        │           sec/op           │   sec/op     vs base               │
CRC32/poly=IEEE/size=15/align=0                          155.8n ± 0%   163.8n ± 0%   +5.13% (p=0.002 n=6)
CRC32/poly=IEEE/size=15/align=1                          156.3n ± 0%   164.5n ± 0%   +5.21% (p=0.002 n=6)
CRC32/poly=IEEE/size=16/align=0                         156.00n ± 0%   92.99n ± 0%  -40.39% (p=0.002 n=6)
CRC32/poly=IEEE/size=16/align=1                         155.35n ± 0%   95.01n ± 0%  -38.84% (p=0.002 n=6)
CRC32/poly=IEEE/size=32/align=0                         240.70n ± 0%   97.95n ± 0%  -59.30% (p=0.002 n=6)
CRC32/poly=IEEE/size=32/align=1                          238.6n ± 0%   100.5n ± 0%  -57.86% (p=0.002 n=6)
CRC32/poly=IEEE/size=40/align=0                          282.8n ± 0%   159.3n ± 0%  -43.66% (p=0.002 n=6)
CRC32/poly=IEEE/size=40/align=1                          280.2n ± 0%   162.2n ± 0%  -42.13% (p=0.002 n=6)
CRC32/poly=IEEE/size=60/align=0                          383.8n ± 0%   190.4n ± 0%  -50.38% (p=0.002 n=6)
CRC32/poly=IEEE/size=60/align=1                          379.3n ± 0%   191.4n ± 0%  -49.54% (p=0.002 n=6)
CRC32/poly=IEEE/size=64/align=0                          408.9n ± 0%   109.2n ± 0%  -73.29% (p=0.002 n=6)
CRC32/poly=IEEE/size=64/align=1                          404.8n ± 0%   110.4n ± 0%  -72.72% (p=0.002 n=6)
CRC32/poly=IEEE/size=120/align=0                         703.8n ± 0%   185.2n ± 0%  -73.68% (p=0.002 n=6)
CRC32/poly=IEEE/size=120/align=1                         694.9n ± 0%   186.8n ± 0%  -73.11% (p=0.002 n=6)
CRC32/poly=IEEE/size=128/align=0                         745.7n ± 0%   138.1n ± 0%  -81.48% (p=0.002 n=6)
CRC32/poly=IEEE/size=128/align=1                         736.5n ± 0%   139.3n ± 0%  -81.08% (p=0.002 n=6)
CRC32/poly=IEEE/size=400/align=0                        2178.5n ± 0%   223.6n ± 0%  -89.74% (p=0.002 n=6)
CRC32/poly=IEEE/size=400/align=1                        2147.5n ± 0%   224.8n ± 0%  -89.53% (p=0.002 n=6)
CRC32/poly=IEEE/size=512/align=0                        2768.0n ± 0%   258.7n ± 0%  -90.65% (p=0.002 n=6)
CRC32/poly=IEEE/size=512/align=1                        2729.0n ± 0%   259.9n ± 0%  -90.48% (p=0.002 n=6)
CRC32/poly=IEEE/size=1kB/align=0                        5466.5n ± 0%   419.6n ± 0%  -92.32% (p=0.002 n=6)
CRC32/poly=IEEE/size=1kB/align=1                        5385.5n ± 0%   420.9n ± 0%  -92.18% (p=0.002 n=6)
CRC32/poly=IEEE/size=4kB/align=0                        21.659µ ± 0%   1.388µ ± 0%  -93.59% (p=0.002 n=6)
CRC32/poly=IEEE/size=4kB/align=1                        21.332µ ± 0%   1.389µ ± 0%  -93.49% (p=0.002 n=6)
CRC32/poly=IEEE/size=32kB/align=0                       177.24µ ± 0%   10.96µ ± 0%  -93.81% (p=0.002 n=6)
CRC32/poly=IEEE/size=32kB/align=1                       174.69µ ± 0%   11.08µ ± 0%  -93.66% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=15/align=0                    155.9n ± 0%   161.6n ± 0%   +3.62% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=15/align=1                    156.6n ± 0%   162.2n ± 0%   +3.54% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=16/align=0                   156.00n ± 0%   92.30n ± 0%  -40.83% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=16/align=1                   155.30n ± 0%   94.36n ± 1%  -39.24% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=32/align=0                   240.15n ± 0%   97.54n ± 0%  -59.38% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=32/align=1                    238.2n ± 0%   100.1n ± 0%  -57.99% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=40/align=0                    282.3n ± 0%   157.0n ± 0%  -44.39% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=40/align=1                    279.8n ± 0%   159.7n ± 0%  -42.94% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=60/align=0                    384.1n ± 0%   187.5n ± 0%  -51.17% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=60/align=1                    379.8n ± 0%   189.1n ± 0%  -50.21% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=64/align=0                    408.7n ± 0%   108.5n ± 0%  -73.45% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=64/align=1                    404.3n ± 0%   109.8n ± 0%  -72.83% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=120/align=0                   703.5n ± 0%   183.2n ± 0%  -73.95% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=120/align=1                   695.0n ± 0%   184.6n ± 0%  -73.44% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=128/align=0                   745.8n ± 0%   128.7n ± 0%  -82.74% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=128/align=1                   736.4n ± 0%   130.0n ± 0%  -82.35% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=400/align=0                  2179.0n ± 0%   214.3n ± 0%  -90.17% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=400/align=1                  2147.0n ± 0%   215.6n ± 0%  -89.96% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=512/align=0                  2769.0n ± 0%   249.5n ± 0%  -90.99% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=512/align=1                  2729.0n ± 0%   250.7n ± 0%  -90.81% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=1kB/align=0                  5465.0n ± 0%   410.6n ± 0%  -92.49% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=1kB/align=1                  5385.5n ± 0%   411.7n ± 0%  -92.36% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=4kB/align=0                  21.658µ ± 0%   1.379µ ± 0%  -93.63% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=4kB/align=1                  21.335µ ± 0%   1.381µ ± 0%  -93.53% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=32kB/align=0                 177.25µ ± 0%   10.98µ ± 0%  -93.81% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=32kB/align=1                 174.84µ ± 0%   11.09µ ± 0%  -93.66% (p=0.002 n=6)
CRC32/poly=Koopman/size=15/align=0                       140.8n ± 0%   141.5n ± 0%   +0.46% (p=0.002 n=6)
CRC32/poly=Koopman/size=15/align=1                       141.4n ± 0%   141.9n ± 0%   +0.35% (p=0.002 n=6)
CRC32/poly=Koopman/size=16/align=0                       147.1n ± 0%   147.8n ± 0%   +0.48% (p=0.002 n=6)
CRC32/poly=Koopman/size=16/align=1                       147.1n ± 0%   147.7n ± 0%   +0.44% (p=0.002 n=6)
CRC32/poly=Koopman/size=32/align=0                       245.1n ± 0%   245.9n ± 0%   +0.33% (p=0.002 n=6)
CRC32/poly=Koopman/size=32/align=1                       245.1n ± 0%   245.9n ± 0%   +0.33% (p=0.002 n=6)
CRC32/poly=Koopman/size=40/align=0                       294.1n ± 0%   294.9n ± 1%   +0.27% (p=0.002 n=6)
CRC32/poly=Koopman/size=40/align=1                       294.1n ± 0%   294.9n ± 0%   +0.27% (p=0.002 n=6)
CRC32/poly=Koopman/size=60/align=0                       416.7n ± 0%   417.6n ± 0%   +0.23% (p=0.002 n=6)
CRC32/poly=Koopman/size=60/align=1                       416.7n ± 0%   417.6n ± 0%   +0.22% (p=0.002 n=6)
CRC32/poly=Koopman/size=64/align=0                       441.2n ± 0%   442.0n ± 0%   +0.17% (p=0.002 n=6)
CRC32/poly=Koopman/size=64/align=1                       441.2n ± 0%   442.2n ± 0%   +0.20% (p=0.002 n=6)
CRC32/poly=Koopman/size=120/align=0                      784.6n ± 0%   785.5n ± 1%   +0.12% (p=0.015 n=6)
CRC32/poly=Koopman/size=120/align=1                      784.7n ± 0%   785.4n ± 0%   +0.09% (p=0.002 n=6)
CRC32/poly=Koopman/size=128/align=0                      833.6n ± 0%   834.8n ± 0%   +0.14% (p=0.002 n=6)
CRC32/poly=Koopman/size=128/align=1                      833.6n ± 0%   834.7n ± 0%   +0.13% (p=0.002 n=6)
CRC32/poly=Koopman/size=400/align=0                      2.507µ ± 0%   2.508µ ± 0%        ~ (p=0.346 n=6)
CRC32/poly=Koopman/size=400/align=1                      2.507µ ± 0%   2.508µ ± 0%   +0.04% (p=0.032 n=6)
CRC32/poly=Koopman/size=512/align=0                      3.193µ ± 0%   3.194µ ± 0%        ~ (p=0.145 n=6)
CRC32/poly=Koopman/size=512/align=1                      3.194µ ± 0%   3.194µ ± 0%        ~ (p=0.121 n=6)
CRC32/poly=Koopman/size=1kB/align=0                      6.331µ ± 0%   6.331µ ± 0%        ~ (p=0.394 n=6)
CRC32/poly=Koopman/size=1kB/align=1                      6.332µ ± 0%   6.332µ ± 0%        ~ (p=0.987 n=6)
CRC32/poly=Koopman/size=4kB/align=0                      25.16µ ± 0%   25.16µ ± 0%        ~ (p=0.294 n=6)
CRC32/poly=Koopman/size=4kB/align=1                      25.16µ ± 0%   25.16µ ± 0%        ~ (p=1.000 n=6)
CRC32/poly=Koopman/size=32kB/align=0                     202.4µ ± 0%   202.3µ ± 0%        ~ (p=0.065 n=6)
CRC32/poly=Koopman/size=32kB/align=1                     202.4µ ± 0%   202.4µ ± 0%        ~ (p=0.394 n=6)
geomean                                                  1.272µ        463.1n       -63.60%

                                        │ BenchmarkCRC32-before.txt │       BenchmarkCRC32-after.txt        │
                                        │            B/s             │      B/s       vs base                 │
CRC32/poly=IEEE/size=15/align=0                         91.83Mi ± 0%    87.33Mi ± 0%     -4.91% (p=0.002 n=6)
CRC32/poly=IEEE/size=15/align=1                         91.50Mi ± 0%    86.99Mi ± 0%     -4.92% (p=0.002 n=6)
CRC32/poly=IEEE/size=16/align=0                         97.82Mi ± 0%   164.09Mi ± 0%    +67.74% (p=0.002 n=6)
CRC32/poly=IEEE/size=16/align=1                         98.23Mi ± 0%   160.60Mi ± 0%    +63.50% (p=0.002 n=6)
CRC32/poly=IEEE/size=32/align=0                         126.8Mi ± 0%    311.5Mi ± 0%   +145.68% (p=0.002 n=6)
CRC32/poly=IEEE/size=32/align=1                         127.9Mi ± 0%    303.6Mi ± 0%   +137.35% (p=0.002 n=6)
CRC32/poly=IEEE/size=40/align=0                         134.9Mi ± 0%    239.5Mi ± 0%    +77.49% (p=0.002 n=6)
CRC32/poly=IEEE/size=40/align=1                         136.2Mi ± 0%    235.2Mi ± 0%    +72.73% (p=0.002 n=6)
CRC32/poly=IEEE/size=60/align=0                         149.1Mi ± 0%    300.5Mi ± 0%   +101.55% (p=0.002 n=6)
CRC32/poly=IEEE/size=60/align=1                         150.8Mi ± 0%    299.0Mi ± 0%    +98.24% (p=0.002 n=6)
CRC32/poly=IEEE/size=64/align=0                         149.3Mi ± 0%    558.9Mi ± 0%   +274.43% (p=0.002 n=6)
CRC32/poly=IEEE/size=64/align=1                         150.8Mi ± 0%    552.7Mi ± 0%   +266.50% (p=0.002 n=6)
CRC32/poly=IEEE/size=120/align=0                        162.6Mi ± 0%    618.0Mi ± 0%   +280.05% (p=0.002 n=6)
CRC32/poly=IEEE/size=120/align=1                        164.7Mi ± 0%    612.4Mi ± 0%   +271.84% (p=0.002 n=6)
CRC32/poly=IEEE/size=128/align=0                        163.7Mi ± 0%    884.2Mi ± 0%   +440.14% (p=0.002 n=6)
CRC32/poly=IEEE/size=128/align=1                        165.8Mi ± 0%    876.4Mi ± 0%   +428.72% (p=0.002 n=6)
CRC32/poly=IEEE/size=400/align=0                        175.1Mi ± 0%   1706.2Mi ± 0%   +874.39% (p=0.002 n=6)
CRC32/poly=IEEE/size=400/align=1                        177.6Mi ± 0%   1696.6Mi ± 0%   +855.25% (p=0.002 n=6)
CRC32/poly=IEEE/size=512/align=0                        176.4Mi ± 0%   1887.1Mi ± 0%   +969.77% (p=0.002 n=6)
CRC32/poly=IEEE/size=512/align=1                        178.9Mi ± 0%   1878.6Mi ± 0%   +949.84% (p=0.002 n=6)
CRC32/poly=IEEE/size=1kB/align=0                        178.7Mi ± 0%   2327.4Mi ± 0%  +1202.71% (p=0.002 n=6)
CRC32/poly=IEEE/size=1kB/align=1                        181.3Mi ± 0%   2320.4Mi ± 0%  +1179.58% (p=0.002 n=6)
CRC32/poly=IEEE/size=4kB/align=0                        180.3Mi ± 0%   2815.2Mi ± 0%  +1460.96% (p=0.002 n=6)
CRC32/poly=IEEE/size=4kB/align=1                        183.1Mi ± 0%   2811.6Mi ± 0%  +1435.43% (p=0.002 n=6)
CRC32/poly=IEEE/size=32kB/align=0                       176.3Mi ± 0%   2850.5Mi ± 0%  +1516.73% (p=0.002 n=6)
CRC32/poly=IEEE/size=32kB/align=1                       178.9Mi ± 0%   2820.5Mi ± 0%  +1476.72% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=15/align=0                   91.73Mi ± 0%    88.55Mi ± 0%     -3.47% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=15/align=1                   91.33Mi ± 0%    88.21Mi ± 0%     -3.41% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=16/align=0                   97.82Mi ± 0%   165.31Mi ± 0%    +68.99% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=16/align=1                   98.23Mi ± 0%   161.71Mi ± 1%    +64.62% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=32/align=0                   127.1Mi ± 0%    312.9Mi ± 0%   +146.21% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=32/align=1                   128.1Mi ± 0%    305.0Mi ± 0%   +138.12% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=40/align=0                   135.1Mi ± 0%    243.0Mi ± 0%    +79.83% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=40/align=1                   136.4Mi ± 0%    239.0Mi ± 0%    +75.26% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=60/align=0                   149.0Mi ± 0%    305.1Mi ± 0%   +104.76% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=60/align=1                   150.7Mi ± 0%    302.6Mi ± 0%   +100.85% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=64/align=0                   149.3Mi ± 0%    562.5Mi ± 0%   +276.69% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=64/align=1                   151.0Mi ± 0%    555.6Mi ± 0%   +267.98% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=120/align=0                  162.7Mi ± 0%    624.4Mi ± 0%   +283.87% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=120/align=1                  164.7Mi ± 0%    619.9Mi ± 0%   +276.46% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=128/align=0                  163.7Mi ± 0%    948.8Mi ± 0%   +479.65% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=128/align=1                  165.8Mi ± 0%    938.9Mi ± 0%   +466.33% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=400/align=0                  175.1Mi ± 0%   1779.8Mi ± 0%   +916.44% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=400/align=1                  177.6Mi ± 0%   1769.4Mi ± 0%   +896.01% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=512/align=0                  176.4Mi ± 0%   1957.0Mi ± 0%  +1009.66% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=512/align=1                  178.9Mi ± 0%   1947.3Mi ± 0%   +988.30% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=1kB/align=0                  178.7Mi ± 0%   2378.3Mi ± 0%  +1230.84% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=1kB/align=1                  181.3Mi ± 0%   2372.2Mi ± 0%  +1208.27% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=4kB/align=0                  180.4Mi ± 0%   2833.6Mi ± 0%  +1471.00% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=4kB/align=1                  183.1Mi ± 0%   2829.4Mi ± 0%  +1445.36% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=32kB/align=0                 176.3Mi ± 0%   2846.6Mi ± 0%  +1514.65% (p=0.002 n=6)
CRC32/poly=Castagnoli/size=32kB/align=1                 178.7Mi ± 0%   2819.2Mi ± 0%  +1477.31% (p=0.002 n=6)
CRC32/poly=Koopman/size=15/align=0                      101.6Mi ± 0%    101.2Mi ± 0%     -0.45% (p=0.002 n=6)
CRC32/poly=Koopman/size=15/align=1                      101.2Mi ± 0%    100.8Mi ± 0%     -0.33% (p=0.002 n=6)
CRC32/poly=Koopman/size=16/align=0                      103.8Mi ± 0%    103.2Mi ± 0%     -0.49% (p=0.002 n=6)
CRC32/poly=Koopman/size=16/align=1                      103.8Mi ± 0%    103.3Mi ± 0%     -0.42% (p=0.002 n=6)
CRC32/poly=Koopman/size=32/align=0                      124.5Mi ± 0%    124.1Mi ± 0%     -0.32% (p=0.002 n=6)
CRC32/poly=Koopman/size=32/align=1                      124.5Mi ± 0%    124.1Mi ± 0%     -0.34% (p=0.002 n=6)
CRC32/poly=Koopman/size=40/align=0                      129.7Mi ± 0%    129.4Mi ± 1%     -0.25% (p=0.002 n=6)
CRC32/poly=Koopman/size=40/align=1                      129.7Mi ± 0%    129.4Mi ± 0%     -0.25% (p=0.002 n=6)
CRC32/poly=Koopman/size=60/align=0                      137.3Mi ± 0%    137.0Mi ± 0%     -0.23% (p=0.002 n=6)
CRC32/poly=Koopman/size=60/align=1                      137.3Mi ± 0%    137.0Mi ± 0%     -0.22% (p=0.002 n=6)
CRC32/poly=Koopman/size=64/align=0                      138.3Mi ± 0%    138.1Mi ± 0%     -0.17% (p=0.002 n=6)
CRC32/poly=Koopman/size=64/align=1                      138.3Mi ± 0%    138.0Mi ± 0%     -0.20% (p=0.002 n=6)
CRC32/poly=Koopman/size=120/align=0                     145.9Mi ± 0%    145.7Mi ± 1%     -0.11% (p=0.019 n=6)
CRC32/poly=Koopman/size=120/align=1                     145.8Mi ± 0%    145.7Mi ± 0%     -0.10% (p=0.002 n=6)
CRC32/poly=Koopman/size=128/align=0                     146.4Mi ± 0%    146.2Mi ± 0%     -0.15% (p=0.002 n=6)
CRC32/poly=Koopman/size=128/align=1                     146.4Mi ± 0%    146.2Mi ± 0%     -0.13% (p=0.002 n=6)
CRC32/poly=Koopman/size=400/align=0                     152.2Mi ± 0%    152.1Mi ± 0%          ~ (p=0.063 n=6)
CRC32/poly=Koopman/size=400/align=1                     152.2Mi ± 0%    152.1Mi ± 0%     -0.04% (p=0.026 n=6)
CRC32/poly=Koopman/size=512/align=0                     152.9Mi ± 0%    152.9Mi ± 0%     -0.04% (p=0.035 n=6)
CRC32/poly=Koopman/size=512/align=1                     152.9Mi ± 0%    152.9Mi ± 0%          ~ (p=0.087 n=6)
CRC32/poly=Koopman/size=1kB/align=0                     154.2Mi ± 0%    154.2Mi ± 0%          ~ (p=0.455 n=6)
CRC32/poly=Koopman/size=1kB/align=1                     154.2Mi ± 0%    154.2Mi ± 0%          ~ (p=0.784 n=6)
CRC32/poly=Koopman/size=4kB/align=0                     155.3Mi ± 0%    155.3Mi ± 0%          ~ (p=0.223 n=6)
CRC32/poly=Koopman/size=4kB/align=1                     155.3Mi ± 0%    155.3Mi ± 0%          ~ (p=0.913 n=6)
CRC32/poly=Koopman/size=32kB/align=0                    154.4Mi ± 0%    154.5Mi ± 0%          ~ (p=0.065 n=6)
CRC32/poly=Koopman/size=32kB/align=1                    154.4Mi ± 0%    154.4Mi ± 0%          ~ (p=0.301 n=6)
geomean                                                 144.6Mi         397.1Mi        +174.71%