### PR TITLE
runtime: exclude main goroutine blocked on select{} from goroutine leak profile

### DIFF
--- a/src/runtime/goroutineleakprofile_test.go
+++ b/src/runtime/goroutineleakprofile_test.go
@@ -194,6 +194,12 @@ func TestGoroutineLeakProfile(t *testing.T) {
 			`Mixed\.func1.1\(.* \[chan send\]`,
 		),
 		makeTest("NoLeakGlobal"),
+		// If the main goroutine is waiting on select{}, it should not be reported as a leak.
+		makeTest("SelectNoCasesMain",
+			// However, any goroutine leaking on a channel that is reachable from the main
+			// goroutine should be reported.
+			`SelectNoCasesMain\.func1\(.* \[chan receive\]`,
+		),
 	}
 
 	// Stress tests are flaky and we do not strictly care about their output.

--- a/src/runtime/mgc.go
+++ b/src/runtime/mgc.go
@@ -1342,12 +1342,10 @@ func findGoroutineLeaks() bool {
 	// The main goroutine is blocked by select{}, but holds a reference to "ch".
 	// Not treating the main goroutine as leaked would cause the analysis to
 	// miss the legitimate leak at the child goroutine.
-	if gp0 := allgs[0]; gp0.goid == 1 &&
-		gp0.waitreason == waitReasonSelectNoCases {
-		// proc.go comments state that the main goroutine always has goid=1
-		// and is placed at allgs[0].
-		// The goid check is only added to prevent slipping a bug in if that
-		// invariant no longer holds in future versions.
+	//
+	// The main goroutine should always be allgs[0], but double check
+	// in case that invariant changes in the future.
+	if gp0 := allgs[0]; gp0.goid == 1 && gp0.waitreason == waitReasonSelectNoCases {
 		casgstatus(gp0, _Gleaked, _Gwaiting)
 	}
 

--- a/src/runtime/mgc.go
+++ b/src/runtime/mgc.go
@@ -1315,6 +1315,42 @@ func findGoroutineLeaks() bool {
 			}
 		}
 	}
+
+	// Do not report the main goroutine if it is waiting on select{}.
+	//
+	// NOTE: We still treat the main goroutine as leaked during the analysis,
+	// but revert its status to _Gwaiting after the analysis to not include
+	// it in the goroutine leak profile.
+	// This preserves the effectiveness of goroutine leak detection
+	// if the main goroutine holds references to concurrency primitives causing
+	// other leaks.
+	//
+	// Example:
+	//
+	// ```go
+	// func main() {
+	// 	ch := make(chan int)
+	// 	go func() {
+	// 		...
+	// 		<-ch // Leaks
+	// 	}()
+	//
+	// 	select {}
+	// }
+	// ```
+	//
+	// The main goroutine is blocked by select{}, but holds a reference to "ch".
+	// Not treating the main goroutine as leaked would cause the analysis to
+	// miss the legitimate leak at the child goroutine.
+	if gp0 := allgs[0]; gp0.goid == 1 &&
+		gp0.waitreason == waitReasonSelectNoCases {
+		// proc.go comments state that the main goroutine always has goid=1
+		// and is placed at allgs[0].
+		// The goid check is only added to prevent slipping a bug in if that
+		// invariant no longer holds in future versions.
+		casgstatus(gp0, _Gleaked, _Gwaiting)
+	}
+
 	// Put the remaining roots as ready for marking and drain them.
 	work.markrootJobs.Add(int32(work.nStackRoots - work.nMaybeRunnableStackRoots))
 	work.nMaybeRunnableStackRoots = work.nStackRoots

--- a/src/runtime/testdata/testgoroutineleakprofile/simple.go
+++ b/src/runtime/testdata/testgoroutineleakprofile/simple.go
@@ -23,6 +23,7 @@ func init() {
 	register("NilRecv", NilRecv)
 	register("NilSend", NilSend)
 	register("SelectNoCases", SelectNoCases)
+	register("SelectNoCasesMain", SelectNoCasesMain)
 	register("ChanRecv", ChanRecv)
 	register("ChanSend", ChanSend)
 	register("Select", Select)
@@ -88,6 +89,27 @@ func SelectNoCases() {
 		runtime.Gosched()
 	}
 	prof.WriteTo(os.Stdout, 2)
+}
+
+func SelectNoCasesMain() {
+	prof := pprof.Lookup("goroutineleak")
+	ch := make(chan int)
+	go func() {
+		// Should be reported as a leak.
+		<-ch
+	}()
+	go func() {
+		for i := 0; i < yieldCount; i++ {
+			runtime.Gosched()
+		}
+		// Write a goroutine leak profile from
+		// the child goroutine.
+		prof.WriteTo(os.Stdout, 2)
+		// Forcefully exit the program.
+		os.Exit(0)
+	}()
+	// Should not be reported as a leak.
+	select {}
 }
 
 func ChanSend() {


### PR DESCRIPTION
The main goroutine is no longer included
in the goroutine leak profile if blocked
at select without cases.
The main goroutine is still treated as a
leak during the analysis to avoid degrading
analysis precision (see test), but has its status changed
from leaked back to waiting before the profile is written.

Based on feedback in https://github.com/golang/go/issues/74609#issuecomment-4297980817
