### PR TITLE
net/http: handle error

### DIFF
--- a/src/net/http/internal/http2/transport.go
+++ b/src/net/http/internal/http2/transport.go
@@ -2662,8 +2662,14 @@ func (rl *clientConnReadLoop) processSettings(f *SettingsFrame) error {
 		return err
 	}
 	if !f.IsAck() {
-		cc.fr.WriteSettingsAck()
-		cc.bw.Flush()
+		err := cc.fr.WriteSettingsAck()
+		if err != nil {
+			return err
+		}
+		err = cc.bw.Flush()
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
c.fr.WriteSettingsAck() and cc.bw.Flush() may return errors.
they should be handdle in right way, if they do return errors.