### PR TITLE
fmt: clarify %q behavior with integers in documentation

### DIFF
--- a/src/fmt/doc.go
+++ b/src/fmt/doc.go
@@ -44,6 +44,10 @@ Integer:
 	%o	base 8
 	%O	base 8 with 0o prefix
 	%q	a single-quoted character literal safely escaped with Go syntax.
+		For integers, %q is accepted but the value is interpreted as a Unicode code point,
+		and the formatted result is the character with that code.
+		Since Go 1.26, using %q with an integer that does not implement error or Stringer
+		will fail vet checks.
 	%x	base 16, with lower-case letters for a-f
 	%X	base 16, with upper-case letters for A-F
 	%U	Unicode format: U+1234; same as "U+%04X"


### PR DESCRIPTION
Good day,

This PR addresses issue #78486, which points out that the fmt package documentation for the %q verb is misleading about its use with integer types.

**The Problem:**
The documentation for %q stated only that it produces 'a single-quoted character literal safely escaped with Go syntax,' which was interpreted by some as applying to integers. However, since Go 1.26, go vet correctly rejects the use of %q with integer types (that don't implement error or Stringer), as introduced in issue #72850.

**The Fix:**
This PR adds a clarifying note to the %q documentation explaining:
1. For integers, the value is interpreted as a Unicode code point
2. Since Go 1.26, using %q with an integer that does not implement error or Stringer will fail vet checks

The change is 4 lines added to src/fmt/doc.go, following the existing documentation style.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly,
RoomWithRoof