### PR TITLE
net/http: fix ServeMux routing of [hostname]:port

### DIFF
--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -2675,6 +2675,13 @@ func stripHostPort(h string) string {
 	}
 	host, _, err := net.SplitHostPort(h)
 	if err != nil {
+		// "[hostname]:port" is not a valid host (IPv6 uses [::1]:port).
+		// Strip brackets and recurse to strip the port.
+		if strings.HasPrefix(h, "[") {
+			if j := strings.IndexByte(h, ']'); j >= 0 {
+				return stripHostPort(h[1:j])
+			}
+		}
 		return h // on error, return unchanged
 	}
 	return host


### PR DESCRIPTION
## Summary

Fixes golang/go#78944.

## Problem

ServeMux incorrectly routes requests with a Host of `[hostname]:port` to the handler registered for `hostname`. The bracketed form is not valid for hostnames (only for IPv6); net.SplitHostPort returns an error, and the previous code returned the input unchanged (preserving the brackets).

## Solution

In `stripHostPort`, when SplitHostPort fails and the input starts with `[`, strip the brackets and recursively call `stripHostPort` to also strip the port. This correctly treats `[example.com]:80` as `example.com`.

## Changes

- `src/net/http/server.go`: 7 lines added to `stripHostPort` error path
