### PR TITLE
net/http/httputil: clear RawQuery when url.ParseQuery fails

### DIFF
--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -924,7 +924,10 @@ func (c switchProtocolCopier) copyToBackend(errc chan<- error) {
 
 func cleanQueryParams(s string) string {
 	reencode := func(s string) string {
-		v, _ := url.ParseQuery(s)
+		v, err := url.ParseQuery(s)
+		if err != nil {
+			return ""
+		}
 		return v.Encode()
 	}
 	for i := 0; i < len(s); {


### PR DESCRIPTION
When ReverseProxy's cleanQueryParams encounters a query string that\nfails to parse (too many params exceeding urlmaxqueryparams), return\nempty string instead of passing through the unparsable RawQuery.\nThis prevents Rewrite from seeing different query params than what\nthe backend receives.\n\nFixes golang/go#78948 (CVE-2026-39825)