### PR TITLE
cmd/objdump: use section end for last symbol size in macho files

### DIFF
--- a/src/cmd/internal/objfile/macho.go
+++ b/src/cmd/internal/objfile/macho.go
@@ -55,6 +55,10 @@ func (f *machoFile) symbols() ([]Sym, error) {
 		i := sort.Search(len(addrs), func(x int) bool { return addrs[x] > s.Value })
 		if i < len(addrs) {
 			sym.Size = int64(addrs[i] - s.Value)
+		} else if s.Sect != 0 && int(s.Sect) <= len(f.macho.Sections) {
+			// Last symbol in file: use end of section.
+			sect := f.macho.Sections[s.Sect-1]
+			sym.Size = int64(sect.Addr + sect.Size - s.Value)
 		}
 		if s.Sect == 0 {
 			sym.Code = 'U'


### PR DESCRIPTION
In Mach-O files, the last symbol in a section gets size 0
because the code computes size as next_symbol_addr - this_symbol_addr,
and there is no next symbol for the last one.

Use the section end address (section.Addr + section.Size) as the
upper bound when computing the size of the last symbol in a section.

Fixes #78811