### PR TITLE
net: reject non-IPv6 addresses in brackets in SplitHostPort

### DIFF
--- a/src/net/ipsock.go
+++ b/src/net/ipsock.go
@@ -6,6 +6,7 @@ package net
 
 import (
 	"context"
+	"net/netip"
 	"internal/bytealg"
 	"runtime"
 	"sync"
@@ -200,6 +201,10 @@ func SplitHostPort(hostport string) (host, port string, err error) {
 		}
 		host = hostport[1:end]
 		j, k = 1, end+1 // there can't be a '[' resp. ']' before these positions
+		// Brackets are only valid for IPv6 addresses.
+		if _, err := netip.ParseAddr(host); err != nil {
+			return addrErr(hostport, "invalid brackets")
+		}
 	} else {
 		host = hostport[:i]
 		if bytealg.IndexByteString(host, ':') >= 0 {


### PR DESCRIPTION
RFC 3986 specifies that brackets in URL host
components are only valid for IPv6 addresses.
SplitHostPort was accepting [hostname]:port and
treating the hostname as the host, which can
produce technically invalid results when used on
URL host components.

This change validates that bracketed content is a
valid IPv6 address using netip.ParseAddr, returning
an invalid brackets error otherwise.

Fixes #78945