### PR TITLE
net: reject non-IPv6 in brackets in SplitHostPort (fixes #78945)

### DIFF
--- a/src/net/ipsock.go
+++ b/src/net/ipsock.go
@@ -199,6 +199,10 @@ func SplitHostPort(hostport string) (host, port string, err error) {
 			return addrErr(hostport, missingPort)
 		}
 		host = hostport[1:end]
+		// Validate: content of [...] must be an IPv6 literal, per RFC 3986
+		if net.ParseIPv6(host) == nil {
+			return addrErr(hostport, "invalid IPv6 address in brackets")
+		}
 		j, k = 1, end+1 // there can't be a '[' resp. ']' before these positions
 	} else {
 		host = hostport[:i]

--- a/src/net/ipsock_test.go
+++ b/src/net/ipsock_test.go
@@ -304,3 +304,25 @@ func TestListenIPv6WildcardAddr(t *testing.T) {
 		t.Errorf("Listen(\"tcp\", \"[::]:0\") bound to %v, want IPv6 address", addr)
 	}
 }
+
+func TestSplitHostPortRejectsNonIPv6InBrackets(t *testing.T) {
+	// Regression test for golang/go#78945
+	// SplitHostPort should reject [non-ipv6]:port like [hostname]:port
+	tests := []struct {
+		hostport string
+		wantErr  bool
+	}{
+		{"[localhost]:8080", true},  // plain hostname, not IPv6
+		{"[foo]:8080", true},        // plain hostname, not IPv6
+		{"[myserver]:443", true},    // plain hostname, not IPv6
+		{"[::1]:8080", false},      // actual IPv6
+		{"[2001:db8::1]:8080", false}, // actual IPv6
+		{"[::ffff:192.168.1.1]:8080", false}, // IPv4-mapped IPv6
+	}
+	for _, tt := range tests {
+		_, _, err := SplitHostPort(tt.hostport)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("SplitHostPort(%q) err=%v, wantErr=%v", tt.hostport, err, tt.wantErr)
+		}
+	}
+}


### PR DESCRIPTION
Fixes golang/go#78945

## Summary
When SplitHostPort encounters [host] syntax (brackets), it now validates that the content is a valid IPv6 address per RFC 3986. Plain hostnames like [localhost]:8080 or [foo]:443 are rejected.

## Changes
- **src/net/ipsock.go**: Added net.ParseIPv6(host) check after extracting bracketed content. Returns error 'invalid IPv6 address in brackets' for non-IPv6 content.

## Test
- Added TestSplitHostPortRejectsNonIPv6InBrackets regression test.

## Why this matters
The bracketed syntax was designed only for IPv6 addresses. Accepting plain hostnames like [hostname] creates ambiguity with URLs and allows technically-invalid addresses through.