### PR TITLE
go/types: fix data race in Alias.cleanup for nil-checker instantiation

### DIFF
--- a/src/cmd/compile/internal/types2/alias.go
+++ b/src/cmd/compile/internal/types2/alias.go
@@ -122,6 +122,8 @@ func (check *Checker) newAlias(obj *TypeName, rhs Type) *Alias {
 	// Ensure that a.actual is set at the end of type checking.
 	if check != nil {
 		check.needsCleanup(a)
+	} else {
+		a.cleanup()
 	}
 
 	return a

--- a/src/go/types/alias.go
+++ b/src/go/types/alias.go
@@ -125,6 +125,8 @@ func (check *Checker) newAlias(obj *TypeName, rhs Type) *Alias {
 	// Ensure that a.actual is set at the end of type checking.
 	if check != nil {
 		check.needsCleanup(a)
+	} else {
+		a.cleanup()
 	}
 
 	return a

--- a/src/go/types/api_test.go
+++ b/src/go/types/api_test.go
@@ -2479,6 +2479,50 @@ type GI = G[int]
 	}
 }
 
+func TestInstantiateAliasRace(t *testing.T) {
+	// This test verifies the fix for issue #79035.
+	// When types.Instantiate is called with check == nil (as done by
+	// golang.org/x/tools/go/ssa), the resulting *Alias instances must
+	// have a.actual set to prevent data races during concurrent calls
+	// to types.Identical.
+	const src = `package p
+
+type A[T any] = func(T)
+
+type S[T any] struct {
+	F A[T]
+}
+`
+	pkg := mustTypecheck(src, nil, nil)
+
+	// Get the generic alias A[T]
+	obj := pkg.Scope().Lookup("A")
+	if obj == nil {
+		t.Fatal("A not found")
+	}
+
+	// Instantiate with nil checker (simulating SSA behavior)
+	inst, err := Instantiate(nil, obj.Type(), []Type{Typ[Int]}, true)
+	if err != nil {
+		t.Fatalf("Instantiate failed: %v", err)
+	}
+
+	// Race: multiple goroutines call Identical on the instantiated alias.
+	// Without the fix, this races on the lazy initialization of a.actual
+	// in unalias().
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_ = Identical(inst, inst)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
 func TestInstantiateErrors(t *testing.T) {
 	tests := []struct {
 		src    string // by convention, T must be the type being instantiated


### PR DESCRIPTION
When types.Instantiate is called with check == nil (as done by
golang.org/x/tools/go/ssa), the resulting *Alias instances had
a.actual == nil. Concurrent calls to types.Identical would then
race on the lazy initialization in unalias().

This change adds an else clause to (*Checker).newAlias to call
a.cleanup() inline when check == nil, ensuring a.actual is set
before the alias escapes.

The new test TestInstantiateAliasRace reproduces the race when
the fix is not present and passes with the fix applied.

Fixes #79035