### PR TITLE
uuid: add comprehensive example functions for documentation

### DIFF
--- a/src/uuid/uuid_test.go
+++ b/src/uuid/uuid_test.go
@@ -6,6 +6,7 @@ package uuid_test
 
 import (
 	"encoding/binary"
+	"fmt"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -253,4 +254,126 @@ func BenchmarkParseError(b *testing.B) {
 	for b.Loop() {
 		uuid.Parse("00000000-0000-0000-0000-00000000000X")
 	}
+}
+
+// Example demonstrates basic UUID generation and parsing.
+func Example() {
+	// Generate a new UUID
+	id := uuid.New()
+	fmt.Printf("Generated UUID: %s\n", id)
+
+	// Parse a UUID string
+	parsed, err := uuid.Parse("f81d4fae-7dec-11d0-a765-00a0c91e6bf6")
+	if err != nil {
+		fmt.Printf("Error parsing: %v\n", err)
+		return
+	}
+	fmt.Printf("Parsed UUID: %s\n", parsed)
+
+	// Compare UUIDs
+	if id.Compare(parsed) == 0 {
+		fmt.Println("UUIDs are equal")
+	} else {
+		fmt.Println("UUIDs are different")
+	}
+
+	// Output:
+	// UUIDs are different
+}
+
+// ExampleNew demonstrates generating a new UUID.
+func ExampleNew() {
+	id := uuid.New()
+	fmt.Printf("UUID length: %d bytes\n", len(id))
+	// Output:
+	// UUID length: 16 bytes
+}
+
+// ExampleNewV4 demonstrates generating a version 4 (random) UUID.
+func ExampleNewV4() {
+	id := uuid.NewV4()
+	fmt.Printf("UUID version: %d\n", id[6]>>4)
+	// Output:
+	// UUID version: 4
+}
+
+// ExampleNewV7 demonstrates generating a version 7 (timestamp-based) UUID.
+func ExampleNewV7() {
+	id := uuid.NewV7()
+	fmt.Printf("UUID version: %d\n", id[6]>>4)
+	// Output:
+	// UUID version: 7
+}
+
+// ExampleParse demonstrates parsing UUID strings in various formats.
+func ExampleParse() {
+	// Standard format
+	u1, _ := uuid.Parse("f81d4fae-7dec-11d0-a765-00a0c91e6bf6")
+	fmt.Println(u1)
+
+	// Without hyphens
+	u2, _ := uuid.Parse("f81d4fae7dec11d0a76500a0c91e6bf6")
+	fmt.Println(u2)
+
+	// With braces
+	u3, _ := uuid.Parse("{f81d4fae-7dec-11d0-a765-00a0c91e6bf6}")
+	fmt.Println(u3)
+
+	// URN format
+	u4, _ := uuid.Parse("urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6")
+	fmt.Println(u4)
+
+	// Output:
+	// f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+	// f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+	// f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+	// f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+}
+
+// ExampleMustParse demonstrates parsing a UUID with panic on error.
+func ExampleMustParse() {
+	id := uuid.MustParse("f81d4fae-7dec-11d0-a765-00a0c91e6bf6")
+	fmt.Println(id)
+	// Output:
+	// f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+}
+
+// ExampleNil demonstrates the Nil UUID.
+func ExampleNil() {
+	id := uuid.Nil()
+	fmt.Println(id)
+	// Output:
+	// 00000000-0000-0000-0000-000000000000
+}
+
+// ExampleMax demonstrates the Max UUID.
+func ExampleMax() {
+	id := uuid.Max()
+	fmt.Println(id)
+	// Output:
+	// ffffffff-ffff-ffff-ffff-ffffffffffff
+}
+
+// ExampleUUID_String demonstrates converting a UUID to string.
+func ExampleUUID_String() {
+	id := uuid.MustParse("f81d4fae-7dec-11d0-a765-00a0c91e6bf6")
+	fmt.Println(id.String())
+	// Output:
+	// f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+}
+
+// ExampleUUID_Compare demonstrates comparing UUIDs.
+func ExampleUUID_Compare() {
+	id1 := uuid.MustParse("f81d4fae-7dec-11d0-a765-00a0c91e6bf6")
+	id2 := uuid.MustParse("f81d4fae-7dec-11d0-a765-00a0c91e6bf6")
+	id3 := uuid.MustParse("00000000-0000-0000-0000-000000000000")
+
+	fmt.Printf("id1 == id2: %v\n", id1.Compare(id2) == 0)
+	fmt.Printf("id1 > id3: %v\n", id1.Compare(id3) > 0)
+	fmt.Printf("id3 < id1: %v\n", id3.Compare(id1) < 0)
+
+	// Output:
+	// id1 == id2: true
+	// id1 > id3: true
+	// id3 < id1: true
 }


### PR DESCRIPTION
This commit adds example functions to the uuid package to improve documentation and demonstrate common usage patterns:

- Example: Basic UUID generation and parsing
- ExampleNew: Generating a new UUID
- ExampleNewV4: Version 4 (random) UUID generation
- ExampleNewV7: Version 7 (timestamp-based) UUID generation
- ExampleParse: Parsing UUIDs in various formats
- ExampleMustParse: Parsing with panic on error
- ExampleNil: The Nil UUID
- ExampleMax: The Max UUID
- ExampleUUID_String: Converting UUID to string
- ExampleUUID_Compare: Comparing UUIDs

These examples will appear in the package documentation and help users understand how to use the uuid package effectively.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
