### PR TITLE
weak, structs: add comprehensive example functions

### DIFF
--- a/src/structs/hostlayout_test.go
+++ b/src/structs/hostlayout_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package structs_test
+
+import (
+	"fmt"
+	"structs"
+	"unsafe"
+)
+
+// ExampleHostLayout demonstrates using HostLayout to match C struct layout.
+func ExampleHostLayout() {
+	// A struct that should match C memory layout
+	type CCompatible struct {
+		_ structs.HostLayout
+		a int32
+		b int64
+		c int32
+	}
+
+	var s CCompatible
+	s.a = 1
+	s.b = 2
+	s.c = 3
+
+	fmt.Printf("Size: %d bytes\n", unsafe.Sizeof(s))
+	fmt.Printf("Values: a=%d, b=%d, c=%d\n", s.a, s.b, s.c)
+
+	// Output:
+	// Size: 24 bytes
+	// Values: a=1, b=2, c=3
+}
+
+// Example_cInterop demonstrates using HostLayout for C interoperability.
+func Example_cInterop() {
+	// Struct designed to match a C struct definition
+	type Point struct {
+		_ structs.HostLayout
+		x float64
+		y float64
+	}
+
+	p := Point{x: 3.14, y: 2.71}
+	fmt.Printf("Point: (%.2f, %.2f)\n", p.x, p.y)
+
+	// Output:
+	// Point: (3.14, 2.71)
+}
+
+// Example_nestedStructs demonstrates that HostLayout only affects
+// the immediate struct, not nested structs.
+func Example_nestedStructs() {
+	type Inner struct {
+		value int32
+	}
+
+	type Outer struct {
+		_ structs.HostLayout
+		a int32
+		b Inner // Inner is NOT affected by HostLayout
+		c int32
+	}
+
+	var s Outer
+	s.a = 1
+	s.b.value = 2
+	s.c = 3
+
+	fmt.Printf("Outer size: %d bytes\n", unsafe.Sizeof(s))
+	fmt.Printf("Values: a=%d, b.value=%d, c=%d\n", s.a, s.b.value, s.c)
+
+	// Output:
+	// Outer size: 12 bytes
+	// Values: a=1, b.value=2, c=3
+}
+
+// Example_aliasing demonstrates that HostLayout can be aliased
+// and still maintains its properties.
+func Example_aliasing() {
+	// Create an alias for HostLayout
+	type HL structs.HostLayout
+
+	type Data struct {
+		_ HL // The alias works the same way
+		x int32
+		y int64
+	}
+
+	var d Data
+	d.x = 100
+	d.y = 200
+
+	fmt.Printf("Size: %d bytes\n", unsafe.Sizeof(d))
+	fmt.Printf("Values: x=%d, y=%d\n", d.x, d.y)
+
+	// Output:
+	// Size: 16 bytes
+	// Values: x=100, y=200
+}

--- a/src/weak/pointer_test.go
+++ b/src/weak/pointer_test.go
@@ -6,6 +6,7 @@ package weak_test
 
 import (
 	"context"
+	"fmt"
 	"internal/goarch"
 	"runtime"
 	"sync"
@@ -362,4 +363,234 @@ func TestPointerTiny(t *testing.T) {
 	if n < want {
 		t.Fatalf("not enough weak pointers are nil: expected at least %v, got %v", want, n)
 	}
+}
+
+// Example demonstrates basic usage of weak pointers.
+func Example() {
+	type Data struct {
+		value int
+	}
+
+	// Create a strong pointer
+	data := &Data{value: 42}
+
+	// Create a weak pointer
+	weakPtr := weak.Make(data)
+
+	// Access the value through the weak pointer
+	if ptr := weakPtr.Value(); ptr != nil {
+		fmt.Printf("Value: %d\n", ptr.value)
+	}
+
+	// Keep data alive
+	runtime.KeepAlive(data)
+
+	// Output:
+	// Value: 42
+}
+
+// ExampleMake demonstrates creating a weak pointer.
+func ExampleMake() {
+	type User struct {
+		name string
+		id   int
+	}
+
+	user := &User{name: "Alice", id: 1}
+	weakUser := weak.Make(user)
+
+	// The weak pointer doesn't prevent garbage collection
+	if ptr := weakUser.Value(); ptr != nil {
+		fmt.Printf("User: %s (ID: %d)\n", ptr.name, ptr.id)
+	}
+
+	runtime.KeepAlive(user)
+
+	// Output:
+	// User: Alice (ID: 1)
+}
+
+// ExampleMake_nil demonstrates creating a weak pointer from nil.
+func ExampleMake_nil() {
+	type Data struct {
+		value int
+	}
+
+	// Creating a weak pointer from nil
+	weakPtr := weak.Make[Data](nil)
+
+	// Value() always returns nil for weak pointers created from nil
+	if ptr := weakPtr.Value(); ptr == nil {
+		fmt.Println("Weak pointer is nil")
+	}
+
+	// Output:
+	// Weak pointer is nil
+}
+
+// ExamplePointer_Value demonstrates accessing the value of a weak pointer.
+func ExamplePointer_Value() {
+	type Cache struct {
+		data string
+	}
+
+	cache := &Cache{data: "cached value"}
+	weakCache := weak.Make(cache)
+
+	// Access the value
+	if ptr := weakCache.Value(); ptr != nil {
+		fmt.Printf("Cache data: %s\n", ptr.data)
+	} else {
+		fmt.Println("Cache was garbage collected")
+	}
+
+	runtime.KeepAlive(cache)
+
+	// Output:
+	// Cache data: cached value
+}
+
+// ExamplePointer_Value_garbageCollected demonstrates a weak pointer
+// after the object has been garbage collected.
+func ExamplePointer_Value_garbageCollected() {
+	type Temporary struct {
+		value int
+	}
+
+	// Create and immediately lose the strong reference
+	weakPtr := weak.Make(&Temporary{value: 100})
+
+	// Force garbage collection
+	runtime.GC()
+
+	// The weak pointer may now return nil
+	if ptr := weakPtr.Value(); ptr == nil {
+		fmt.Println("Object was garbage collected")
+	} else {
+		fmt.Printf("Object still exists: %d\n", ptr.value)
+	}
+
+	// Output:
+	// Object was garbage collected
+}
+
+// Example_cache demonstrates using weak pointers to implement a simple cache.
+func Example_cache() {
+	type CacheEntry struct {
+		key   string
+		value string
+	}
+
+	// Simple cache using weak pointers
+	cache := make(map[string]weak.Pointer[CacheEntry])
+
+	// Add an entry
+	entry := &CacheEntry{key: "user:1", value: "Alice"}
+	cache["user:1"] = weak.Make(entry)
+
+	// Retrieve from cache
+	if weakEntry := cache["user:1"]; weakEntry.Value() != nil {
+		fmt.Printf("Cache hit: %s\n", weakEntry.Value().value)
+	}
+
+	runtime.KeepAlive(entry)
+
+	// Output:
+	// Cache hit: Alice
+}
+
+// Example_canonicalization demonstrates using weak pointers for
+// canonicalization (ensuring only one instance of equal values exists).
+func Example_canonicalization() {
+	type String struct {
+		value string
+	}
+
+	// Canonicalization map
+	canon := make(map[string]weak.Pointer[String])
+
+	intern := func(s string) *String {
+		// Check if we already have this string
+		if wp, ok := canon[s]; ok {
+			if ptr := wp.Value(); ptr != nil {
+				return ptr
+			}
+		}
+
+		// Create new canonical instance
+		str := &String{value: s}
+		canon[s] = weak.Make(str)
+		return str
+	}
+
+	// Intern strings
+	s1 := intern("hello")
+	s2 := intern("hello")
+
+	// Both point to the same instance
+	fmt.Printf("Same instance: %v\n", s1 == s2)
+
+	runtime.KeepAlive(s1)
+	runtime.KeepAlive(s2)
+
+	// Output:
+	// Same instance: true
+}
+
+// Example_lifetimeTying demonstrates tying together lifetimes of separate values.
+func Example_lifetimeTying() {
+	type Resource struct {
+		id int
+	}
+
+	type Metadata struct {
+		description string
+	}
+
+	// Map tying metadata to resources using weak keys
+	metadata := make(map[weak.Pointer[Resource]]*Metadata)
+
+	resource := &Resource{id: 1}
+	weakResource := weak.Make(resource)
+
+	// Associate metadata with the resource
+	metadata[weakResource] = &Metadata{description: "Important resource"}
+
+	// Access metadata
+	if meta, ok := metadata[weakResource]; ok {
+		fmt.Printf("Metadata: %s\n", meta.description)
+	}
+
+	runtime.KeepAlive(resource)
+
+	// Output:
+	// Metadata: Important resource
+}
+
+// Example_equality demonstrates weak pointer equality semantics.
+func Example_equality() {
+	type Data struct {
+		a int
+		b int
+	}
+
+	data := &Data{a: 1, b: 2}
+
+	// Weak pointers to the same object are equal
+	wp1 := weak.Make(data)
+	wp2 := weak.Make(data)
+
+	fmt.Printf("Same object: %v\n", wp1 == wp2)
+
+	// Weak pointers to different fields are not equal
+	wpA := weak.Make(&data.a)
+	wpB := weak.Make(&data.b)
+
+	fmt.Printf("Different fields: %v\n", wpA == wpB)
+
+	runtime.KeepAlive(data)
+
+	// Output:
+	// Same object: true
+	// Different fields: false
 }


### PR DESCRIPTION
This commit adds example functions to the weak and structs packages to improve documentation and demonstrate usage patterns.

weak package examples:
- Example: Basic weak pointer usage
- ExampleMake: Creating weak pointers
- ExampleMake_nil: Creating weak pointers from nil
- ExamplePointer_Value: Accessing weak pointer values
- ExamplePointer_Value_garbageCollected: Behavior after GC
- Example_cache: Implementing a cache with weak pointers
- Example_canonicalization: String interning pattern
- Example_lifetimeTying: Tying object lifetimes together
- Example_equality: Weak pointer equality semantics

structs package examples:
- ExampleHostLayout: Basic HostLayout usage for C compatibility
- Example_cInterop: C struct interoperability
- Example_nestedStructs: HostLayout scope behavior
- Example_aliasing: Using HostLayout aliases

These examples demonstrate practical use cases including caches, canonicalization maps, lifetime management, and C interoperability.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
