### PR TITLE
fmt: add examples for Append, Appendf, and Appendln

### DIFF
--- a/src/fmt/example_test.go
+++ b/src/fmt/example_test.go
@@ -363,3 +363,60 @@ func Example_formats() {
 	// [97 226 140 152] [97 226 140 152] a⌘ "a⌘" 61e28c98 61 e2 8c 98
 	// 1973-11-29 21:33:09 +0000 UTC "1973-11-29 21:33:09 +0000 UTC"
 }
+
+func ExampleAppend() {
+	b := []byte("Hello ")
+	b = fmt.Append(b, "World", "!")
+	fmt.Println(string(b))
+	// Output:
+	// Hello World!
+}
+
+func ExampleAppend_builder() {
+	// Building a message incrementally
+	b := make([]byte, 0, 64)
+	b = fmt.Append(b, "Status:")
+	b = fmt.Append(b, "OK")
+	b = fmt.Append(b, "(", 200, ")")
+	fmt.Println(string(b))
+	// Output:
+	// Status: OK ( 200 )
+}
+
+func ExampleAppendf() {
+	b := []byte("Error: ")
+	b = fmt.Appendf(b, "user %q (id %d) not found", "alice", 42)
+	fmt.Println(string(b))
+	// Output:
+	// Error: user "alice" (id 42) not found
+}
+
+func ExampleAppendf_log() {
+	// Building a log entry with timestamp
+	b := []byte("[2024-01-15 10:30:00] ")
+	b = fmt.Appendf(b, "Request from %s took %dms", "192.168.1.1", 150)
+	fmt.Println(string(b))
+	// Output:
+	// [2024-01-15 10:30:00] Request from 192.168.1.1 took 150ms
+}
+
+func ExampleAppendln() {
+	b := []byte("Log entry: ")
+	b = fmt.Appendln(b, "User", "logged in", "successfully")
+	fmt.Print(string(b))
+	// Output:
+	// Log entry: User logged in successfully
+}
+
+func ExampleAppendln_multiple() {
+	// Building multiple lines
+	b := make([]byte, 0, 128)
+	b = fmt.Appendln(b, "Line", 1)
+	b = fmt.Appendln(b, "Line", 2)
+	b = fmt.Appendln(b, "Line", 3)
+	fmt.Print(string(b))
+	// Output:
+	// Line 1
+	// Line 2
+	// Line 3
+}


### PR DESCRIPTION
Add comprehensive examples demonstrating the Append family of functions that format and append to byte slices. These functions are useful for building strings efficiently without intermediate allocations.

Examples show:
- Basic usage of Append, Appendf, and Appendln
- Incremental message building
- Log entry formatting
- Multiple line construction

The examples complement the existing Sprint/Fprint examples and demonstrate efficient byte slice manipulation patterns.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
