### PR TITLE
archive/tar: validate Linkname for insecure paths in Reader.Next

### DIFF
--- a/src/archive/tar/reader.go
+++ b/src/archive/tar/reader.go
@@ -52,20 +52,28 @@ func NewReader(r io.Reader) *Reader {
 // Programs that want to accept non-local names can ignore
 // the [ErrInsecurePath] error and use the returned header.
 func (tr *Reader) Next() (*Header, error) {
-	if tr.err != nil {
-		return nil, tr.err
-	}
-	hdr, err := tr.next()
-	tr.err = err
-	if err == nil && !filepath.IsLocal(hdr.Name) {
-		if tarinsecurepath.Value() == "0" {
-			tarinsecurepath.IncNonDefault()
-			err = ErrInsecurePath
-		}
-	}
-	return hdr, err
-}
+    if tr.err != nil {
+        return nil, tr.err
+    }
+    hdr, err := tr.next()
+    tr.err = err
+    if err == nil {
+    	insecure := !filepath.IsLocal(hdr.Name)
 
+    	if hdr.Linkname != "" {
+    	    link := path.Clean(hdr.Linkname)
+   	     if !filepath.IsLocal(link) {
+   	         insecure = true
+    	    }
+    	}
+
+    	if insecure && tarinsecurepath.Value() == "0" {
+  	      	tarinsecurepath.IncNonDefault()
+   	     	err = ErrInsecurePath
+   	 	}
+	}
+    return hdr, err
+}
 func (tr *Reader) next() (*Header, error) {
 	var paxHdrs map[string]string
 	var gnuLongName, gnuLongLink string

--- a/src/archive/tar/reader.go
+++ b/src/archive/tar/reader.go
@@ -45,35 +45,27 @@ func NewReader(r io.Reader) *Reader {
 // Any remaining data in the current file is automatically discarded.
 // At the end of the archive, Next returns the error io.EOF.
 //
-// If Next encounters a non-local name (as defined by [filepath.IsLocal])
-// and the GODEBUG environment variable contains `tarinsecurepath=0`,
-// Next returns the header with an [ErrInsecurePath] error.
-// A future version of Go may introduce this behavior by default.
+// If Next encounters a non-local name or link name (as defined by
+// [filepath.IsLocal]) and the GODEBUG environment variable contains
+// `tarinsecurepath=0`, Next returns the header with an [ErrInsecurePath]
+// error. A future version of Go may introduce this behavior by default.
 // Programs that want to accept non-local names can ignore
 // the [ErrInsecurePath] error and use the returned header.
 func (tr *Reader) Next() (*Header, error) {
-    if tr.err != nil {
-        return nil, tr.err
-    }
-    hdr, err := tr.next()
-    tr.err = err
-    if err == nil {
-    	insecure := !filepath.IsLocal(hdr.Name)
-
-    	if hdr.Linkname != "" {
-    	    link := path.Clean(hdr.Linkname)
-   	     if !filepath.IsLocal(link) {
-   	         insecure = true
-    	    }
-    	}
-
-    	if insecure && tarinsecurepath.Value() == "0" {
-  	      	tarinsecurepath.IncNonDefault()
-   	     	err = ErrInsecurePath
-   	 	}
+	if tr.err != nil {
+		return nil, tr.err
 	}
-    return hdr, err
+	hdr, err := tr.next()
+	tr.err = err
+	if err == nil && (!filepath.IsLocal(hdr.Name) || (hdr.Linkname != "" && !filepath.IsLocal(hdr.Linkname))) {
+		if tarinsecurepath.Value() == "0" {
+			tarinsecurepath.IncNonDefault()
+			err = ErrInsecurePath
+		}
+	}
+	return hdr, err
 }
+
 func (tr *Reader) next() (*Header, error) {
 	var paxHdrs map[string]string
 	var gnuLongName, gnuLongLink string

--- a/src/archive/tar/reader_test.go
+++ b/src/archive/tar/reader_test.go
@@ -1684,6 +1684,38 @@ func TestInsecurePaths(t *testing.T) {
 	}
 }
 
+func TestInsecureLinkname(t *testing.T) {
+	t.Setenv("GODEBUG", "tarinsecurepath=0")
+	var buf bytes.Buffer
+	tw := NewWriter(&buf)
+	tw.WriteHeader(&Header{
+		Name:     "secure",
+		Typeflag: TypeSymlink,
+		Linkname: "../outside",
+	})
+	const nextPath = "inside"
+	tw.WriteHeader(&Header{Name: nextPath})
+	tw.Close()
+
+	tr := NewReader(&buf)
+	h, err := tr.Next()
+	if err != ErrInsecurePath {
+		t.Fatalf("tr.Next for insecure linkname: got err %v, want ErrInsecurePath", err)
+	}
+	if h.Name != "secure" {
+		t.Fatalf("tr.Next for insecure linkname: got name %q, want %q", h.Name, "secure")
+	}
+
+	// Error should not be sticky.
+	h, err = tr.Next()
+	if err != nil {
+		t.Fatalf("tr.Next after insecure linkname: got err %v, want nil", err)
+	}
+	if h.Name != nextPath {
+		t.Fatalf("tr.Next after insecure linkname: got name %q, want %q", h.Name, nextPath)
+	}
+}
+
 func TestDisableInsecurePathCheck(t *testing.T) {
 	t.Setenv("GODEBUG", "tarinsecurepath=1")
 	var buf bytes.Buffer


### PR DESCRIPTION
The archive/tar Reader validates Header.Name for insecure paths when
GODEBUG=tarinsecurepath=0, but does not apply the same validation to
Header.Linkname.

This means an entry can pass the Header.Name check while carrying a
crafted Linkname that bypasses the intended path safety checks. Since
Header.Linkname is used when creating symlinks and hard links, it can
influence filesystem resolution during extraction in common usage
patterns, so it is equally security-sensitive.

Validate Header.Linkname with filepath.IsLocal in Reader.Next, matching
the existing Header.Name check, and return ErrInsecurePath when it is
non-local. Empty link names are skipped. Also add a regression test to
ensure an insecure Linkname triggers ErrInsecurePath without affecting
subsequent entries.

Updates #55356
