### PR TITLE
net/url: add examples for URL.Clone and Values.Clone

### DIFF
--- a/src/net/url/example_test.go
+++ b/src/net/url/example_test.go
@@ -385,3 +385,67 @@ func toJSON(m any) string {
 	}
 	return strings.ReplaceAll(string(js), ",", ", ")
 }
+
+// ExampleURL_Clone demonstrates creating a deep copy of a URL.
+func ExampleURL_Clone() {
+	u, err := url.Parse("https://example.com/path?query=value#fragment")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Clone creates a deep copy of the URL.
+	clone := u.Clone()
+
+	// Modifying the clone doesn't affect the original.
+	clone.Host = "different.com"
+	clone.Path = "/newpath"
+
+	fmt.Println("Original:", u)
+	fmt.Println("Clone:", clone)
+
+	// Output:
+	// Original: https://example.com/path?query=value#fragment
+	// Clone: https://different.com/newpath?query=value#fragment
+}
+
+// ExampleURL_Clone_nil demonstrates that cloning a nil URL returns nil.
+func ExampleURL_Clone_nil() {
+	var u *url.URL
+	clone := u.Clone()
+	fmt.Println(clone == nil)
+
+	// Output:
+	// true
+}
+
+// ExampleValues_Clone demonstrates creating a deep copy of Values.
+func ExampleValues_Clone() {
+	v := url.Values{}
+	v.Add("color", "red")
+	v.Add("color", "blue")
+	v.Add("size", "large")
+
+	// Clone creates a deep copy of the Values.
+	clone := v.Clone()
+
+	// Modifying the clone doesn't affect the original.
+	clone.Set("color", "green")
+	clone.Add("shape", "circle")
+
+	fmt.Println("Original:", v.Encode())
+	fmt.Println("Clone:", clone.Encode())
+
+	// Output:
+	// Original: color=red&color=blue&size=large
+	// Clone: color=green&shape=circle&size=large
+}
+
+// ExampleValues_Clone_nil demonstrates that cloning nil Values returns nil.
+func ExampleValues_Clone_nil() {
+	var v url.Values
+	clone := v.Clone()
+	fmt.Println(clone == nil)
+
+	// Output:
+	// true
+}


### PR DESCRIPTION
Add four examples demonstrating the new Clone methods for URL and Values types.

ExampleURL_Clone shows how to create a deep copy of a URL and demonstrates that modifications to the clone don't affect the original.

ExampleURL_Clone_nil demonstrates that cloning a nil URL returns nil.

ExampleValues_Clone shows how to create a deep copy of Values and demonstrates that modifications to the clone don't affect the original.

ExampleValues_Clone_nil demonstrates that cloning nil Values returns nil.

Related to issue #73450.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
