### PR TITLE
hash/maphash: add examples for Hasher interface

### DIFF
--- a/src/hash/maphash/example_test.go
+++ b/src/hash/maphash/example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Go Authors. All rights reserved.
+// Copyright 2025 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -7,31 +7,198 @@ package maphash_test
 import (
 	"fmt"
 	"hash/maphash"
+	"strings"
 )
 
-func Example() {
-	// The zero Hash value is valid and ready to use; setting an
-	// initial seed is not necessary.
-	var h maphash.Hash
+// CaseInsensitive is a Hasher[string] whose
+// equivalence relation ignores letter case.
+type CaseInsensitive struct{}
 
-	// Add a string to the hash, and print the current hash value.
-	h.WriteString("hello, ")
-	fmt.Printf("%#x\n", h.Sum64())
+func (CaseInsensitive) Hash(h *maphash.Hash, s string) {
+	h.WriteString(strings.ToLower(s))
+}
 
-	// Append additional data (in the form of a byte array).
-	h.Write([]byte{'w', 'o', 'r', 'l', 'd'})
-	fmt.Printf("%#x\n", h.Sum64())
+func (CaseInsensitive) Equal(x, y string) bool {
+	return strings.ToLower(x) == strings.ToLower(y)
+}
 
-	// Reset discards all data previously added to the Hash, without
-	// changing its seed.
-	h.Reset()
+// ExampleHasher demonstrates using the Hasher interface to create
+// a custom hash function for case-insensitive string comparison.
+func ExampleHasher() {
+	var hasher CaseInsensitive
 
-	// Use SetSeed to create a new Hash h2 which will behave
-	// identically to h.
-	var h2 maphash.Hash
-	h2.SetSeed(h.Seed())
+	// Create a hash with a fixed seed for reproducibility
+	seed := maphash.MakeSeed()
+	var h1, h2 maphash.Hash
+	h1.SetSeed(seed)
+	h2.SetSeed(seed)
 
-	h.WriteString("same")
-	h2.WriteString("same")
-	fmt.Printf("%#x == %#x\n", h.Sum64(), h2.Sum64())
+	// Hash "Hello" and "HELLO" - they should have the same hash
+	hasher.Hash(&h1, "Hello")
+	hasher.Hash(&h2, "HELLO")
+
+	fmt.Printf("Equal: %v\n", hasher.Equal("Hello", "HELLO"))
+	fmt.Printf("Same hash: %v\n", h1.Sum64() == h2.Sum64())
+
+	// Output:
+	// Equal: true
+	// Same hash: true
+}
+
+// ExampleComparableHasher demonstrates using ComparableHasher
+// for standard comparable types.
+func ExampleComparableHasher() {
+	var hasher maphash.ComparableHasher[int]
+
+	seed := maphash.MakeSeed()
+	var h1, h2 maphash.Hash
+	h1.SetSeed(seed)
+	h2.SetSeed(seed)
+
+	// Hash the same value twice
+	hasher.Hash(&h1, 42)
+	hasher.Hash(&h2, 42)
+
+	fmt.Printf("Equal: %v\n", hasher.Equal(42, 42))
+	fmt.Printf("Same hash: %v\n", h1.Sum64() == h2.Sum64())
+	fmt.Printf("Different values equal: %v\n", hasher.Equal(42, 43))
+
+	// Output:
+	// Equal: true
+	// Same hash: true
+	// Different values equal: false
+}
+
+type Person struct {
+	Name string
+	Age  int
+	ID   int // ID is ignored in comparison
+}
+
+// PersonByNameAge compares Person values by Name and Age only
+type PersonByNameAge struct{}
+
+func (PersonByNameAge) Hash(h *maphash.Hash, p Person) {
+	h.WriteString(p.Name)
+	maphash.WriteComparable(h, p.Age)
+}
+
+func (PersonByNameAge) Equal(x, y Person) bool {
+	return x.Name == y.Name && x.Age == y.Age
+}
+
+// ExampleHasher_structFields demonstrates creating a Hasher
+// for struct types that compares only specific fields.
+func ExampleHasher_structFields() {
+	var hasher PersonByNameAge
+
+	p1 := Person{Name: "Alice", Age: 30, ID: 1}
+	p2 := Person{Name: "Alice", Age: 30, ID: 2} // Different ID
+
+	fmt.Printf("Equal (ignoring ID): %v\n", hasher.Equal(p1, p2))
+
+	// Output:
+	// Equal (ignoring ID): true
+}
+
+// SimpleSet represents an unordered set of integers
+type SimpleSet map[int]struct{}
+
+type SetHasher struct{}
+
+func (SetHasher) Hash(hash *maphash.Hash, set SimpleSet) {
+	var accum uint64
+	for elem := range set {
+		// Initialize a hasher for the element,
+		// using same seed as the outer hash.
+		var sub maphash.Hash
+		sub.SetSeed(hash.Seed())
+
+		// Hash the element.
+		maphash.WriteComparable(&sub, elem)
+
+		// Mix the element's hash into the set's hash using XOR (commutative).
+		accum ^= sub.Sum64()
+	}
+	maphash.WriteComparable(hash, accum)
+}
+
+func (SetHasher) Equal(x, y SimpleSet) bool {
+	if len(x) != len(y) {
+		return false
+	}
+	for elem := range x {
+		if _, ok := y[elem]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// ExampleHasher_unorderedSet demonstrates hashing an unordered collection
+// using a commutative operation.
+func ExampleHasher_unorderedSet() {
+	var hasher SetHasher
+
+	// Create two sets with same elements in different order
+	set1 := SimpleSet{1: {}, 2: {}, 3: {}}
+	set2 := SimpleSet{3: {}, 1: {}, 2: {}}
+
+	seed := maphash.MakeSeed()
+	var h1, h2 maphash.Hash
+	h1.SetSeed(seed)
+	h2.SetSeed(seed)
+
+	hasher.Hash(&h1, set1)
+	hasher.Hash(&h2, set2)
+
+	fmt.Printf("Equal: %v\n", hasher.Equal(set1, set2))
+	fmt.Printf("Same hash: %v\n", h1.Sum64() == h2.Sum64())
+
+	// Output:
+	// Equal: true
+	// Same hash: true
+}
+
+type Data struct {
+	Value int
+}
+
+// DataPtrHasher compares *Data by value, not by pointer address
+type DataPtrHasher struct{}
+
+func (DataPtrHasher) Hash(h *maphash.Hash, p *Data) {
+	if p == nil {
+		h.WriteByte(0)
+		return
+	}
+	h.WriteByte(1)
+	maphash.WriteComparable(h, p.Value)
+}
+
+func (DataPtrHasher) Equal(x, y *Data) bool {
+	if x == nil && y == nil {
+		return true
+	}
+	if x == nil || y == nil {
+		return false
+	}
+	return x.Value == y.Value
+}
+
+// ExampleHasher_pointerComparison demonstrates creating a Hasher
+// for pointer types that compares the pointed-to values.
+func ExampleHasher_pointerComparison() {
+	var hasher DataPtrHasher
+
+	// Different pointers, same value
+	p1 := &Data{Value: 42}
+	p2 := &Data{Value: 42}
+
+	fmt.Printf("Pointers equal: %v\n", p1 == p2)
+	fmt.Printf("Values equal: %v\n", hasher.Equal(p1, p2))
+
+	// Output:
+	// Pointers equal: false
+	// Values equal: true
 }


### PR DESCRIPTION
Add comprehensive examples demonstrating the new Hasher[T] interface and ComparableHasher type introduced in Go 1.26.

Examples cover:
- Case-insensitive string hashing
- ComparableHasher for standard types
- Field-based struct comparison
- Unordered set hashing with commutative operations
- Pointer value comparison

Related to #70471

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
