### PR TITLE
cmd/compile: optimize archInits lookup by replacing map with switch

### DIFF
--- a/src/cmd/compile/main.go
+++ b/src/cmd/compile/main.go
@@ -25,21 +25,33 @@ import (
 	"os"
 )
 
-var archInits = map[string]func(*ssagen.ArchInfo){
-	"386":      x86.Init,
-	"amd64":    amd64.Init,
-	"arm":      arm.Init,
-	"arm64":    arm64.Init,
-	"loong64":  loong64.Init,
-	"mips":     mips.Init,
-	"mipsle":   mips.Init,
-	"mips64":   mips64.Init,
-	"mips64le": mips64.Init,
-	"ppc64":    ppc64.Init,
-	"ppc64le":  ppc64.Init,
-	"riscv64":  riscv64.Init,
-	"s390x":    s390x.Init,
-	"wasm":     wasm.Init,
+func getArchInit(arch string) func(*ssagen.ArchInfo) {
+	switch arch {
+	case "386":
+		return x86.Init
+	case "amd64":
+		return amd64.Init
+	case "arm":
+		return arm.Init
+	case "arm64":
+		return arm64.Init
+	case "loong64":
+		return loong64.Init
+	case "mips", "mipsle":
+		return mips.Init
+	case "mips64", "mips64le":
+		return mips64.Init
+	case "ppc64", "ppc64le":
+		return ppc64.Init
+	case "riscv64":
+		return riscv64.Init
+	case "s390x":
+		return s390x.Init
+	case "wasm":
+		return wasm.Init
+	default:
+		return nil
+	}
 }
 
 func main() {
@@ -48,8 +60,8 @@ func main() {
 	log.SetPrefix("compile: ")
 
 	buildcfg.Check()
-	archInit, ok := archInits[buildcfg.GOARCH]
-	if !ok {
+	archInit := getArchInit(buildcfg.GOARCH)
+	if archInit == nil {
 		fmt.Fprintf(os.Stderr, "compile: unknown architecture %q\n", buildcfg.GOARCH)
 		os.Exit(2)
 	}


### PR DESCRIPTION
Replace the global architecture initialization map with a switch-based helper function in the compiler entry point.

### Changes
- Removed the global `map[string]func(*ssagen.ArchInfo)` used for architecture lookup.
- Added `getArchInit(arch string)` implemented using a `switch` statement.
- Updated `main.go` to use the new helper function.
- Preserved existing behavior for all supported architectures and error handling.
