### PR TITLE
prevent stale unlink decision in UnixListener.Close

### DIFF
--- a/src/net/file_posix.go
+++ b/src/net/file_posix.go
@@ -80,7 +80,7 @@ func fileListener(f *os.File) (Listener, error) {
 	case *TCPAddr:
 		return &TCPListener{fd: fd}, nil
 	case *UnixAddr:
-		return &UnixListener{fd: fd, path: laddr.Name, unlink: false}, nil
+		return &UnixListener{fd: fd, path: laddr.Name}, nil
 	}
 	fd.Close()
 	return nil, syscall.EINVAL

--- a/src/net/unixsock.go
+++ b/src/net/unixsock.go
@@ -235,6 +235,7 @@ func dialUnix(ctx context.Context, dialer *Dialer, network string, laddr, raddr 
 type UnixListener struct {
 	fd         *netFD
 	path       string
+	unlinkMu   sync.Mutex
 	unlink     bool
 	unlinkOnce sync.Once
 }

--- a/src/net/unixsock_posix.go
+++ b/src/net/unixsock_posix.go
@@ -189,6 +189,8 @@ func (ln *UnixListener) close() error {
 	// programs that can mess us up.
 	// Even if there are racy calls to Close, we want to unlink only for the first one.
 	ln.unlinkOnce.Do(func() {
+		ln.unlinkMu.Lock()
+		defer ln.unlinkMu.Unlock()
 		if ln.path[0] != '@' && ln.unlink {
 			syscall.Unlink(ln.path)
 		}
@@ -213,6 +215,8 @@ func (ln *UnixListener) file() (*os.File, error) {
 // but if the listener was created by a call to FileListener to use an already existing
 // socket file, then by default closing the listener will not remove the socket file.
 func (l *UnixListener) SetUnlinkOnClose(unlink bool) {
+	l.unlinkMu.Lock()
+	defer l.unlinkMu.Unlock()
 	l.unlink = unlink
 }
 
@@ -227,7 +231,9 @@ func (sl *sysListener) listenUnix(ctx context.Context, laddr *UnixAddr) (*UnixLi
 	if err != nil {
 		return nil, err
 	}
-	return &UnixListener{fd: fd, path: fd.laddr.String(), unlink: true}, nil
+	ln := &UnixListener{fd: fd, path: fd.laddr.String()}
+	ln.unlink = true
+	return ln, nil
 }
 
 func (sl *sysListener) listenUnixgram(ctx context.Context, laddr *UnixAddr) (*UnixConn, error) {

--- a/src/net/unixsock_race_test.go
+++ b/src/net/unixsock_race_test.go
@@ -1,0 +1,58 @@
+package net_test
+
+import (
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestUnixListener_SetUnlinkOnClose_Concurrent(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		sockName := "test_race.sock"
+		os.Remove(sockName)
+		
+		l, err := net.Listen("unix", sockName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		
+		ul := l.(*net.UnixListener)
+		
+		// We create a channel to coordinate the race.
+		// Actually, we'll just run them concurrently and check the final state.
+		
+		done := make(chan bool)
+		
+		// Goroutine A calls Close
+		go func() {
+			// small delay to let B start
+			time.Sleep(10 * time.Microsecond)
+			ul.Close()
+			done <- true
+		}()
+		
+		// Goroutine B calls SetUnlinkOnClose(false) then Close()
+		go func() {
+			ul.SetUnlinkOnClose(false)
+			ul.Close()
+			done <- true
+		}()
+		
+		<-done
+		<-done
+		
+		// After BOTH closures, the socket file should NOT be deleted,
+		// because B explicitly disabled unlinking before it called Close!
+		// However, due to the atomic bool + sync.Once race, if A enters unlinkOnce.Do
+		// and reads true, then B disables unlink, B's Close blocks on A,
+		// A unlinks the file, B's Close proceeds.
+		// The file is deleted despite B's explicit disabling!
+		
+		if _, err := os.Stat(sockName); os.IsNotExist(err) {
+			t.Fatalf("BUG: Socket file deleted explicitly after SetUnlinkOnClose(false) + Close()")
+		}
+		
+		os.Remove(sockName)
+	}
+}


### PR DESCRIPTION
This change fixes a subtle issue in `UnixListener` where `Close` could
unlink the socket file based on outdated state.

Previously, `Close` checked the unlink flag and then performed the unlink
as separate steps. Because these were not synchronized, a concurrent
`SetUnlinkOnClose(false)` could complete, but `Close` might still proceed
using the earlier value and remove the file.

This patch makes the unlink decision and action run under a mutex so
they are treated as a single operation. This prevents `Close` from acting
on stale state.

The change is small, localized, and does not affect the public API or
normal usage. It only ensures more consistent behavior when these
methods are used concurrently.