### PR TITLE
net/http: reject control characters in Response.Write

### DIFF
--- a/src/net/http/response.go
+++ b/src/net/http/response.go
@@ -259,6 +259,10 @@ func (r *Response) Write(w io.Writer) error {
 		text = strings.TrimPrefix(text, strconv.Itoa(r.StatusCode)+" ")
 	}
 
+	if stringContainsCTLByte(text) {
+		return errors.New("net/http: can't write control character in Response.Status")
+	}
+
 	if _, err := fmt.Fprintf(w, "HTTP/%d.%d %03d %s\r\n", r.ProtoMajor, r.ProtoMinor, r.StatusCode, text); err != nil {
 		return err
 	}

--- a/src/net/http/responsewrite_test.go
+++ b/src/net/http/responsewrite_test.go
@@ -11,15 +11,16 @@ import (
 )
 
 type respWriteTest struct {
-	Resp Response
-	Raw  string
+	Resp      Response
+	Raw       string
+	WantError string // if non-empty, expect Write to return an error containing this string
 }
 
 func TestResponseWrite(t *testing.T) {
 	respWriteTests := []respWriteTest{
 		// HTTP/1.0, identity coding; no trailer
 		{
-			Response{
+			Resp: Response{
 				StatusCode:    503,
 				ProtoMajor:    1,
 				ProtoMinor:    0,
@@ -28,14 +29,13 @@ func TestResponseWrite(t *testing.T) {
 				Body:          io.NopCloser(strings.NewReader("abcdef")),
 				ContentLength: 6,
 			},
-
-			"HTTP/1.0 503 Service Unavailable\r\n" +
+			Raw: "HTTP/1.0 503 Service Unavailable\r\n" +
 				"Content-Length: 6\r\n\r\n" +
 				"abcdef",
 		},
 		// Unchunked response without Content-Length.
 		{
-			Response{
+			Resp: Response{
 				StatusCode:    200,
 				ProtoMajor:    1,
 				ProtoMinor:    0,
@@ -44,13 +44,13 @@ func TestResponseWrite(t *testing.T) {
 				Body:          io.NopCloser(strings.NewReader("abcdef")),
 				ContentLength: -1,
 			},
-			"HTTP/1.0 200 OK\r\n" +
+			Raw: "HTTP/1.0 200 OK\r\n" +
 				"\r\n" +
 				"abcdef",
 		},
 		// HTTP/1.1 response with unknown length and Connection: close
 		{
-			Response{
+			Resp: Response{
 				StatusCode:    200,
 				ProtoMajor:    1,
 				ProtoMinor:    1,
@@ -60,14 +60,14 @@ func TestResponseWrite(t *testing.T) {
 				ContentLength: -1,
 				Close:         true,
 			},
-			"HTTP/1.1 200 OK\r\n" +
+			Raw: "HTTP/1.1 200 OK\r\n" +
 				"Connection: close\r\n" +
 				"\r\n" +
 				"abcdef",
 		},
 		// HTTP/1.1 response with unknown length and not setting connection: close
 		{
-			Response{
+			Resp: Response{
 				StatusCode:    200,
 				ProtoMajor:    1,
 				ProtoMinor:    1,
@@ -77,7 +77,7 @@ func TestResponseWrite(t *testing.T) {
 				ContentLength: -1,
 				Close:         false,
 			},
-			"HTTP/1.1 200 OK\r\n" +
+			Raw: "HTTP/1.1 200 OK\r\n" +
 				"Connection: close\r\n" +
 				"\r\n" +
 				"abcdef",
@@ -85,7 +85,7 @@ func TestResponseWrite(t *testing.T) {
 		// HTTP/1.1 response with unknown length and not setting connection: close, but
 		// setting chunked.
 		{
-			Response{
+			Resp: Response{
 				StatusCode:       200,
 				ProtoMajor:       1,
 				ProtoMinor:       1,
@@ -96,13 +96,13 @@ func TestResponseWrite(t *testing.T) {
 				TransferEncoding: []string{"chunked"},
 				Close:            false,
 			},
-			"HTTP/1.1 200 OK\r\n" +
+			Raw: "HTTP/1.1 200 OK\r\n" +
 				"Transfer-Encoding: chunked\r\n\r\n" +
 				"6\r\nabcdef\r\n0\r\n\r\n",
 		},
 		// HTTP/1.1 response 0 content-length, and nil body
 		{
-			Response{
+			Resp: Response{
 				StatusCode:    200,
 				ProtoMajor:    1,
 				ProtoMinor:    1,
@@ -112,13 +112,13 @@ func TestResponseWrite(t *testing.T) {
 				ContentLength: 0,
 				Close:         false,
 			},
-			"HTTP/1.1 200 OK\r\n" +
+			Raw: "HTTP/1.1 200 OK\r\n" +
 				"Content-Length: 0\r\n" +
 				"\r\n",
 		},
 		// HTTP/1.1 response 0 content-length, and non-nil empty body
 		{
-			Response{
+			Resp: Response{
 				StatusCode:    200,
 				ProtoMajor:    1,
 				ProtoMinor:    1,
@@ -128,13 +128,13 @@ func TestResponseWrite(t *testing.T) {
 				ContentLength: 0,
 				Close:         false,
 			},
-			"HTTP/1.1 200 OK\r\n" +
+			Raw: "HTTP/1.1 200 OK\r\n" +
 				"Content-Length: 0\r\n" +
 				"\r\n",
 		},
 		// HTTP/1.1 response 0 content-length, and non-nil non-empty body
 		{
-			Response{
+			Resp: Response{
 				StatusCode:    200,
 				ProtoMajor:    1,
 				ProtoMinor:    1,
@@ -144,13 +144,13 @@ func TestResponseWrite(t *testing.T) {
 				ContentLength: 0,
 				Close:         false,
 			},
-			"HTTP/1.1 200 OK\r\n" +
+			Raw: "HTTP/1.1 200 OK\r\n" +
 				"Connection: close\r\n" +
 				"\r\nfoo",
 		},
 		// HTTP/1.1, chunked coding; empty trailer; close
 		{
-			Response{
+			Resp: Response{
 				StatusCode:       200,
 				ProtoMajor:       1,
 				ProtoMinor:       1,
@@ -161,8 +161,7 @@ func TestResponseWrite(t *testing.T) {
 				TransferEncoding: []string{"chunked"},
 				Close:            true,
 			},
-
-			"HTTP/1.1 200 OK\r\n" +
+			Raw: "HTTP/1.1 200 OK\r\n" +
 				"Connection: close\r\n" +
 				"Transfer-Encoding: chunked\r\n\r\n" +
 				"6\r\nabcdef\r\n0\r\n\r\n",
@@ -171,7 +170,7 @@ func TestResponseWrite(t *testing.T) {
 		// Header value with a newline character (Issue 914).
 		// Also tests removal of leading and trailing whitespace.
 		{
-			Response{
+			Resp: Response{
 				StatusCode: 204,
 				ProtoMajor: 1,
 				ProtoMinor: 1,
@@ -184,8 +183,7 @@ func TestResponseWrite(t *testing.T) {
 				TransferEncoding: []string{"chunked"},
 				Close:            true,
 			},
-
-			"HTTP/1.1 204 No Content\r\n" +
+			Raw: "HTTP/1.1 204 No Content\r\n" +
 				"Connection: close\r\n" +
 				"Foo: Bar Baz\r\n" +
 				"\r\n",
@@ -194,7 +192,7 @@ func TestResponseWrite(t *testing.T) {
 		// Want a single Content-Length header. Fixing issue 8180 where
 		// there were two.
 		{
-			Response{
+			Resp: Response{
 				StatusCode:       StatusOK,
 				ProtoMajor:       1,
 				ProtoMinor:       1,
@@ -204,13 +202,13 @@ func TestResponseWrite(t *testing.T) {
 				TransferEncoding: nil,
 				Body:             nil,
 			},
-			"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
+			Raw: "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
 		},
 
 		// When a response to a POST has Content-Length: -1, make sure we don't
 		// write the Content-Length as -1.
 		{
-			Response{
+			Resp: Response{
 				StatusCode:    StatusOK,
 				ProtoMajor:    1,
 				ProtoMinor:    1,
@@ -219,7 +217,7 @@ func TestResponseWrite(t *testing.T) {
 				ContentLength: -1,
 				Body:          io.NopCloser(strings.NewReader("abcdef")),
 			},
-			"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nabcdef",
+			Raw: "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nabcdef",
 		},
 
 		// Status code under 100 should be zero-padded to
@@ -227,7 +225,7 @@ func TestResponseWrite(t *testing.T) {
 		// consistent with generating three digits, since the
 		// Transport requires it)
 		{
-			Response{
+			Resp: Response{
 				StatusCode: 7,
 				Status:     "license to violate specs",
 				ProtoMajor: 1,
@@ -236,14 +234,13 @@ func TestResponseWrite(t *testing.T) {
 				Header:     Header{},
 				Body:       nil,
 			},
-
-			"HTTP/1.0 007 license to violate specs\r\nContent-Length: 0\r\n\r\n",
+			Raw: "HTTP/1.0 007 license to violate specs\r\nContent-Length: 0\r\n\r\n",
 		},
 
 		// No stutter.  Status code in 1xx range response should
 		// not include a Content-Length header.  See issue #16942.
 		{
-			Response{
+			Resp: Response{
 				StatusCode: 123,
 				Status:     "123 Sesame Street",
 				ProtoMajor: 1,
@@ -252,14 +249,13 @@ func TestResponseWrite(t *testing.T) {
 				Header:     Header{},
 				Body:       nil,
 			},
-
-			"HTTP/1.0 123 Sesame Street\r\n\r\n",
+			Raw: "HTTP/1.0 123 Sesame Street\r\n\r\n",
 		},
 
 		// Status code 204 (No content) response should not include a
 		// Content-Length header.  See issue #16942.
 		{
-			Response{
+			Resp: Response{
 				StatusCode: 204,
 				Status:     "No Content",
 				ProtoMajor: 1,
@@ -268,8 +264,22 @@ func TestResponseWrite(t *testing.T) {
 				Header:     Header{},
 				Body:       nil,
 			},
+			Raw: "HTTP/1.0 204 No Content\r\n\r\n",
+		},
 
-			"HTTP/1.0 204 No Content\r\n\r\n",
+		// Control character in Status should cause Write to return an error.
+		// See issue #78774.
+		{
+			Resp: Response{
+				StatusCode: 200,
+				Status:     "200 OK\r\nEvil-Header: injected",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				Request:    dummyReq("GET"),
+				Header:     Header{},
+				Body:       nil,
+			},
+			WantError: "net/http: can't write control character in Response.Status",
 		},
 	}
 
@@ -277,6 +287,12 @@ func TestResponseWrite(t *testing.T) {
 		tt := &respWriteTests[i]
 		var braw strings.Builder
 		err := tt.Resp.Write(&braw)
+		if tt.WantError != "" {
+			if err == nil || err.Error() != tt.WantError {
+				t.Errorf("Test %d, error = %v, want %q", i, err, tt.WantError)
+			}
+			continue
+		}
 		if err != nil {
 			t.Errorf("error writing #%d: %s", i, err)
 			continue


### PR DESCRIPTION
## Summary
Fixes #78774.

## Problem
Response.Write did not validate the Status field for control characters before writing it to the wire. A crafted Status value containing \r\n could inject arbitrary headers into the HTTP response, enabling response splitting attacks.

## Solution
Add a stringContainsCTLByte check on the status text in Response.Write, mirroring the existing validation for Request.URL in Request.Write. Return an error if control characters are detected.

## Changes
- src/net/http/response.go: 4 lines added — CTL byte validation before writing the status line
- src/net/http/responsewrite_test.go: Convert respWriteTest entries to named fields and add WantError field to the test struct for extensible error-case testing; add test case for control character rejection