### PR TITLE
runtime/s390x: use ABIInternal convention in cgocallbackg

### DIFF
--- a/src/runtime/asm_s390x.s
+++ b/src/runtime/asm_s390x.s
@@ -688,18 +688,16 @@ havem:
 	// will seamlessly trace back into the earlier calls.
 	MOVD	m_curg(R8), g
 	BL	runtime·save_g(SB)
-	MOVD	(g_sched+gobuf_sp)(g), R4 // prepare stack as R4
+	XOR	R0, R0			// restore zero register, as required by ABIInternal
+	MOVD	(g_sched+gobuf_sp)(g), R6 // prepare stack as R6
 	MOVD	(g_sched+gobuf_pc)(g), R5
-	MOVD	R5, -(24+8)(R4)	// "saved LR"; must match frame size
+	MOVD	R5, -(24+8)(R6)	// "saved LR"; must match frame size
 	// Gather our arguments into registers.
-	MOVD	fn+0(FP), R1
-	MOVD	frame+8(FP), R2
-	MOVD	ctxt+16(FP), R3
-	MOVD	$-(24+8)(R4), R15	// switch stack; must match frame size
-	MOVD	R1, 8(R15)
-	MOVD	R2, 16(R15)
-	MOVD	R3, 24(R15)
-	BL	runtime·cgocallbackg(SB)
+	MOVD	fn+0(FP), R2
+	MOVD	frame+8(FP), R3
+	MOVD	ctxt+16(FP), R4
+	MOVD	$-(24+8)(R6), R15	// switch stack; must match frame size
+	BL	runtime·cgocallbackg<ABIInternal>(SB)
 
 	// Restore g->sched (== m->curg->sched) from saved values.
 	MOVD	0(R15), R5


### PR DESCRIPTION
This change follows from CL 765581.

As expected, the program panics when an unpinned pointer is passed from Go to C. The stack trace shows an autogenerated frame by the linker.

    # cat -n main.c
         1  #include <stdio.h>
         2  #include "callbackErr.h"
         3
         4  int main(void) {
         5          GoMap m = GoFoo();
         6          (void)m;
         7          return 0;
         8  }

    # cat -n callbackErr.go
         1  package main
         2
         3  import (
         4          "C"
         5  )
         6
         7  //export GoFoo
         8  func GoFoo() map[int]int {
         9          return map[int]int{0: 1,}
        10  }
        11
        12  func main() {
        13  }

    # GOOS=linux GOARCH=s390x CGO_ENABLED=1 CC='zig cc -target s390x-linux-gnu' go build -buildmode=c-shared -o callbackErr.so callbackErr.go
    # zig cc -target s390x-linux-gnu -o main main.c callbackErr.so -I. -L. -Wl,-rpath,'$ORIGIN'
    # qemu-s390x -L /tmp/s390x-sysroot ./main
    [...]
    goroutine 17 [running, locked to thread]:
    panic({0x7e00f08455c0?, 0xe3d0d692020?})
            /usr/lib/go/src/runtime/panic.go:879 +0x16e
    runtime.cgoCheckArg(0x7e00f0846900, 0xe3d0d6a8060, 0x0?, 0x0, 0x1)
            /usr/lib/go/src/runtime/cgocall.go:659 +0x470
    runtime.cgoCheckResult({0x7e00f0846900, 0xe3d0d6a8060})
            /usr/lib/go/src/runtime/cgocall.go:829 +0x76
    _cgoexp_35a35dd190e3_GoFoo(0x7e00f10fe9b8)
            /mnt/tmp/callbackErr.go:8 +0x98
    runtime.cgocallbackg1(0x7e00f083a4a0, 0x7e00f10fe9b8, 0x0)
            /usr/lib/go/src/runtime/cgocall.go:466 +0x336
    runtime.cgocallbackg(0x7e00f083a4a0, 0x7e00f10fe9b8, 0x0)
            /usr/lib/go/src/runtime/cgocall.go:362 +0x194
    runtime.cgocallbackg(0x7e00f083a4a0, 0x7e00f10fe9b8, 0x0)
            <autogenerated>:1 +0x2a
    runtime.cgocallback(0x0, 0x0, 0x0)
            /usr/lib/go/src/runtime/asm_s390x.s:679 +0xdc
    runtime.goexit({})
            /usr/lib/go/src/runtime/asm_s390x.s:864 +0x2
    qemu: uncaught target signal 6 (Aborted) - core dumped
    Aborted                    (core dumped) qemu-s390x -L /tmp/s390x-sysroot ./main

Load the cgocallbackg arguments into the registers expected by ABIInternal.

Use ABIInternal convention at call site.

    [...]
    goroutine 17 [running, locked to thread]:
    panic({0x7cc309025698?, 0x4012246aa000?})
            /mnt/go/src/runtime/panic.go:878 +0x164
    runtime.cgoCheckArg(0x7cc30901fe70, 0x40122469c000, 0x0?, 0x0, 0x1)
            /mnt/go/src/runtime/cgocall.go:667 +0x470
    runtime.cgoCheckResult({0x7cc30901fe70, 0x40122469c000})
            /mnt/go/src/runtime/cgocall.go:837 +0x76
    _cgoexp_35a35dd190e3_GoFoo(0x7cc3098d99b8)
            /mnt/tmp/callbackErr.go:8 +0x98
    runtime.cgocallbackg1(0x7cc3090171e0, 0x7cc3098d99b8, 0x0)
            /mnt/go/src/runtime/cgocall.go:474 +0x346
    runtime.cgocallbackg(0x7cc3090171e0, 0x7cc3098d99b8, 0x0)
            /mnt/go/src/runtime/cgocall.go:362 +0x18a
    runtime.cgocallback(0x0, 0x0, 0x0)
            /mnt/go/src/runtime/asm_s390x.s:700 +0xce
    runtime.goexit({})
            /mnt/go/src/runtime/asm_s390x.s:866 +0x2
    qemu: uncaught target signal 6 (Aborted) - core dumped
    Aborted                    (core dumped) qemu-s390x -L /tmp/s390x-sysroot ./main

For #78934.