### PR TITLE
net/http: opt range

### DIFF
--- a/src/net/http/fs.go
+++ b/src/net/http/fs.go
@@ -1001,7 +1001,16 @@ type httpRange struct {
 }
 
 func (r httpRange) contentRange(size int64) string {
-	return fmt.Sprintf("bytes %d-%d/%d", r.start, r.start+r.length-1, size)
+	buf := make([]byte, 0, 80)
+	buf = append(buf, "bytes "...)
+
+	buf = strconv.AppendInt(buf, r.start, 10)
+	buf = append(buf, '-')
+
+	buf = strconv.AppendInt(buf, r.start+r.length-1, 10)
+	buf = append(buf, '/')
+	buf = strconv.AppendInt(buf, size, 10)
+	return string(buf)
 }
 
 func (r httpRange) mimeHeader(contentType string, size int64) textproto.MIMEHeader {


### PR DESCRIPTION
Before: 79.42 ns/op 40 B/op 3 allocs/op
After:  26.53 ns/op 24 B/op 1 allocs/op

3x faster, -16 B, -2 allocs per range header