### PR TITLE
archive/tar: fix silent integer overflow and truncation of Uid/Gid

### DIFF
--- a/src/archive/tar/reader.go
+++ b/src/archive/tar/reader.go
@@ -275,10 +275,16 @@ func mergePAX(hdr *Header, paxHdrs map[string]string) (err error) {
 			hdr.Gname = v
 		case paxUid:
 			id64, err = strconv.ParseInt(v, 10, 64)
-			hdr.Uid = int(id64) // Integer overflow possible
+			if err == nil && int64(int(id64)) != id64 {
+				err = ErrHeader
+			}
+			hdr.Uid = int(id64) // Integer overflow prevented
 		case paxGid:
 			id64, err = strconv.ParseInt(v, 10, 64)
-			hdr.Gid = int(id64) // Integer overflow possible
+			if err == nil && int64(int(id64)) != id64 {
+				err = ErrHeader
+			}
+			hdr.Gid = int(id64) // Integer overflow prevented
 		case paxAtime:
 			hdr.AccessTime, err = parsePAXTime(v)
 		case paxMtime:
@@ -383,8 +389,16 @@ func (tr *Reader) readHeader() (*Header, *block, error) {
 	hdr.Linkname = p.parseString(v7.linkName())
 	hdr.Size = p.parseNumeric(v7.size())
 	hdr.Mode = p.parseNumeric(v7.mode())
-	hdr.Uid = int(p.parseNumeric(v7.uid()))
-	hdr.Gid = int(p.parseNumeric(v7.gid()))
+	uid := p.parseNumeric(v7.uid())
+	if int64(int(uid)) != uid {
+		p.err = ErrHeader
+	}
+	hdr.Uid = int(uid)
+	gid := p.parseNumeric(v7.gid())
+	if int64(int(gid)) != gid {
+		p.err = ErrHeader
+	}
+	hdr.Gid = int(gid)
 	hdr.ModTime = time.Unix(p.parseNumeric(v7.modTime()), 0)
 
 	// Unpack format specific fields.


### PR DESCRIPTION
This cleans up a dangerous integer arithmetic issue in
archive/tar/reader.go.

When parsing Uid and Gid from a tar header (both V7/USTAR headers and
PAX extended headers), the parser reads the values as int64 but casts
them to a native int (for example, hdr.Uid = int(id64)).

On 32-bit architectures this results in a silent integer overflow. A
crafted archive with a Uid of 4294967296 (2^32) truncates to 0. If an
extraction tool trusts the Header.Uid field, the file is extracted with
root (UID 0) ownership instead of the intended user.

The fix adds a boundary check (int64(int(id)) != id) in both readHeader
and mergePAX. If the 64-bit id cannot fit into a native int without
truncation, parsing now fails with ErrHeader instead of returning a
silently truncated value.
