### PR TITLE
archive/tar: return an error for UID/GID exceeding int range

### DIFF
--- a/src/archive/tar/stat_unix.go
+++ b/src/archive/tar/stat_unix.go
@@ -7,7 +7,9 @@
 package tar
 
 import (
+	"fmt"
 	"io/fs"
+	"math"
 	"os/user"
 	"runtime"
 	"strconv"
@@ -27,6 +29,16 @@ func statUnix(fi fs.FileInfo, h *Header, doNameLookups bool) error {
 	sys, ok := fi.Sys().(*syscall.Stat_t)
 	if !ok {
 		return nil
+	}
+	// On 32-bit platforms int is 32 bits wide, so a Uid or Gid with the high
+	// bit set would wrap to a negative value when converted from uint32.
+	// Report an error rather than storing a wrapped result. On 64-bit
+	// platforms int is wide enough to hold any uint32, so these never fire.
+	if int64(sys.Uid) > math.MaxInt {
+		return fmt.Errorf("archive/tar: uid %d does not fit in int", sys.Uid)
+	}
+	if int64(sys.Gid) > math.MaxInt {
+		return fmt.Errorf("archive/tar: gid %d does not fit in int", sys.Gid)
 	}
 	h.Uid = int(sys.Uid)
 	h.Gid = int(sys.Gid)

--- a/src/archive/tar/stat_unix_test.go
+++ b/src/archive/tar/stat_unix_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build unix
+
+package tar
+
+import (
+	"io/fs"
+	"math"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// statUnixFileInfo is a minimal fs.FileInfo whose Sys returns a
+// *syscall.Stat_t, which is all statUnix inspects.
+type statUnixFileInfo struct {
+	sys *syscall.Stat_t
+}
+
+func (f statUnixFileInfo) Name() string       { return "" }
+func (f statUnixFileInfo) Size() int64        { return 0 }
+func (f statUnixFileInfo) Mode() fs.FileMode  { return 0 }
+func (f statUnixFileInfo) ModTime() time.Time { return time.Time{} }
+func (f statUnixFileInfo) IsDir() bool        { return false }
+func (f statUnixFileInfo) Sys() any           { return f.sys }
+
+func TestStatUnixUIDGIDOverflow(t *testing.T) {
+	const id = uint32(math.MaxInt32) + 1
+	fi := statUnixFileInfo{sys: &syscall.Stat_t{Uid: id, Gid: id}}
+
+	var h Header
+	err := statUnix(fi, &h, false)
+
+	if int64(id) > math.MaxInt {
+		// 32-bit int: the value cannot be represented without wrapping to
+		// a negative number, so statUnix must report an error instead.
+		if err == nil {
+			t.Fatalf("statUnix(uid=%d) = nil error, want error", id)
+		}
+		return
+	}
+
+	// 64-bit int: the value fits, so it must round-trip unchanged and stay
+	// non-negative.
+	if err != nil {
+		t.Fatalf("statUnix(uid=%d) = %v, want nil error", id, err)
+	}
+	if h.Uid < 0 || h.Gid < 0 {
+		t.Errorf("statUnix gave negative Uid=%d Gid=%d, want non-negative", h.Uid, h.Gid)
+	}
+	if h.Uid != int(id) || h.Gid != int(id) {
+		t.Errorf("statUnix gave Uid=%d Gid=%d, want %d", h.Uid, h.Gid, id)
+	}
+}


### PR DESCRIPTION
On 32-bit platforms int is 32 bits wide, so converting the uint32 Uid
and Gid from syscall.Stat_t directly to int can wrap a value with the
high bit set into a negative number. statUnix then stored that wrapped
value in the Header.

Return an error when the value does not fit in an int instead of
silently storing a wrapped result. On 64-bit platforms int is wide
enough to hold any uint32, so behaviour there is unchanged.

A test covers both the wrapping case (error reported) and the in-range
case (value preserved and non-negative).
