### PR TITLE
internal/routebsd: fix offset for Flags in InterfaceAddrMessage on openbsd

### DIFF
--- a/src/internal/routebsd/interface_openbsd.go
+++ b/src/internal/routebsd/interface_openbsd.go
@@ -54,7 +54,7 @@ func (*wireFormat) parseInterfaceAddrMessage(b []byte) (Message, error) {
 	m := &InterfaceAddrMessage{
 		Version: int(b[2]),
 		Type:    int(b[3]),
-		Flags:   int(nativeEndian.Uint32(b[12:16])),
+		Flags:   int(nativeEndian.Uint32(b[16:20])),
 		Index:   int(nativeEndian.Uint16(b[6:8])),
 		raw:     b[:l],
 	}


### PR DESCRIPTION
According to [OpenBSD manual][1], ifa_msghdr.ifam_flags should start from
offset 16 instead of 12.

This change corrects the extraction of InterfaceAddrMessage.Flags on OpenBSD.


[1]: https://man.openbsd.org/route.4#:~:text=data%20about%20if%20*/%0A%7D%3B-,struct%20ifa_msghdr,-%7B%0A%09u_short%09ifam_msglen%3B%09/*%20to
