### PR TITLE
internal/fuzz: fix race between context deadline and error suppression

### DIFF
--- a/src/cmd/internal/fuzztest/testdata/script/test_fuzz_fuzztime_timeout.txt
+++ b/src/cmd/internal/fuzztest/testdata/script/test_fuzz_fuzztime_timeout.txt
@@ -1,0 +1,35 @@
+# Regression test for go.dev/issue/75804.
+# When -fuzztime expires, the coordinator must not report a spurious
+# "context deadline exceeded" error.
+
+[!fuzz] skip
+[short] skip
+env GOCACHE=$WORK/cache
+
+go test -c -o $devnull
+
+env GOMAXPROCS=2
+
+go test -fuzz=FuzzNoop -fuzztime=1000ms
+go test -fuzz=FuzzNoop -fuzztime=100ms
+go test -fuzz=FuzzNoop -fuzztime=100ms
+go test -fuzz=FuzzNoop -fuzztime=100ms
+go test -fuzz=FuzzNoop -fuzztime=100ms
+
+-- go.mod --
+module fuzz
+
+go 1.24
+-- fuzz_noop_test.go --
+package fuzz_test
+
+import (
+	"testing"
+	"time"
+)
+
+func FuzzNoop(f *testing.F) {
+	f.Fuzz(func(*testing.T, []byte) {
+		time.Sleep(time.Millisecond)
+	})
+}

--- a/src/internal/fuzz/fuzz.go
+++ b/src/internal/fuzz/fuzz.go
@@ -126,10 +126,14 @@ func CoordinateFuzzing(ctx context.Context, opts CoordinateFuzzingOpts) (err err
 			}
 		}
 
-		if err == fuzzCtx.Err() || isInterruptError(err) {
+		if err == ctx.Err() || err == fuzzCtx.Err() || isInterruptError(err) {
 			// Suppress cancellation errors and terminations due to SIGINT.
 			// The messages are not helpful since either the user triggered the error
 			// (with ^C) or another more helpful message will be printed (a crasher).
+			//
+			// Also check ctx.Err() because when ctx's deadline expires, there
+			// is a window where ctx.Err() is set but fuzzCtx (a child) has
+			// not yet been canceled. See go.dev/issue/75804.
 			err = nil
 		}
 		if err != nil && (fuzzErr == nil || fuzzErr == ctx.Err()) {


### PR DESCRIPTION
When the coordinator's context deadline expires, there is a brief 
window where ctx.Err() is set but fuzzCtx (a child context) has not
yet been canceled. If the coordinator's event loop observes <-doneC
during this window, the stop function compares the error against 
fuzzCtx.Err() which is still nil, so the deadline error is not 
suppressed and leaks out as a spurious test failure.

Fix this by also comparing against ctx.Err() in the suppression check.
ctx.Err() is guaranteed to be set before ctx.Done() is closed because
cancelCtx.cancel stores the error before closing the done channel.

Fixes #75804
