### PR TITLE
net/http: update cancelTimerBody comment

### DIFF
--- a/src/net/http/client.go
+++ b/src/net/http/client.go
@@ -976,7 +976,7 @@ func (c *Client) CloseIdleConnections() {
 }
 
 // cancelTimerBody is an io.ReadCloser that wraps rc with two features:
-//  1. On Read error or close, the stop func is called.
+//  1. On Close, the stop func is called.
 //  2. On Read failure, if reqDidTimeout is true, the error is wrapped and
 //     marked as net.Error that hit its timeout.
 type cancelTimerBody struct {


### PR DESCRIPTION
In 76fbd6167364fb98e3ebe946cfc16b5b84d4240e we removed b.stop() but
failed to update the comment.