### PR TITLE
net/http: fix NewClientConn not fully respected the passed-in context

### DIFF
--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -2058,6 +2058,19 @@ func (t *Transport) dialConn(ctx context.Context, cm connectMethod, isClientConn
 	http2 := unencryptedHTTP2 ||
 		(pconn.tlsState != nil && pconn.tlsState.NegotiatedProtocol == "h2")
 
+	if isClientConn && http2 && ctx.Done() != nil {
+		// Close the connection if ctx is canceled before the function returns.
+		stop := context.AfterFunc(ctx, func() {
+			_ = pconn.conn.Close()
+		})
+		defer func() {
+			if !stop() {
+				// Return context error to user.
+				err = ctx.Err()
+			}
+		}()
+	}
+
 	if http2 && t.h2Transport != nil {
 		if isClientConn {
 			cc, err := t.http2NewClientConn(pconn.conn, internalStateHook)


### PR DESCRIPTION
The internal http2NewClientConn method in HTTP/2 actually performs
writes (eg: http2clientPreface, initialSettings, windowUpdate),
including flush operations (cc.bw.Flush()).
This causes the process to deviate from the passed-in ctx constraint.

Use context.AfterFunc internally to close timed-out connections,
similar to HandshakeContext in *tls.Conn.

Fixes #79253