### PR TITLE
net/http/internal/http2: support non-tls.Conn TLS conn in forceCloseConn

### DIFF
--- a/src/net/http/internal/http2/transport.go
+++ b/src/net/http/internal/http2/transport.go
@@ -929,7 +929,7 @@ func (cc *ClientConn) closeConn() {
 // A tls.Conn.Close can hang for a long time if the peer is unresponsive.
 // Try to shut it down more aggressively.
 func (cc *ClientConn) forceCloseConn() {
-	tc, ok := cc.tconn.(*tls.Conn)
+	tc, ok := cc.tconn.(interface{ NetConn() net.Conn })
 	if !ok {
 		return
 	}


### PR DESCRIPTION
We have already implemented support for net/http transport
using a non-*tls.Conn net.Conn with a ConnectionState method
 in 15b9fc2659f77608548cb279c5e0565b0664cfca.

Therefore, some optimizations within HTTP/2 for *tls.Conn should
also apply to non-tls.Conn TLS Conn types.