### PR TITLE
net/http: fix Server's UnencryptedHTTP2 does not work TLS without ALPN

### DIFF
--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -2026,7 +2026,7 @@ func (c *conn) serve(ctx context.Context) {
 	c.bufw = newBufioWriterSize(checkConnErrorWriter{c}, 4<<10)
 
 	protos := c.server.protocols()
-	if c.tlsState == nil && protos.UnencryptedHTTP2() {
+	if protos.UnencryptedHTTP2() {
 		if c.maybeServeUnencryptedHTTP2(ctx) {
 			return
 		}


### PR DESCRIPTION
According to x/net/http2/h2c, after enabling UnencryptedHTTP2
on the server side, it should unconditionally check whether the
client is sending PRI * HTTP/2.0.

Due to additional checks in the current code, 
it actually won't work without ALPN if a tlsconn is passed in.

But when UnencryptedHTTP2 is enabled, 
checking c.tlsState is unnecessary and should not be performed.

Fixes #79293