### PR TITLE
net/http: fix Transport's UnencryptedHTTP2 does not work TLS without ALPN

### DIFF
--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -2050,8 +2050,7 @@ func (t *Transport) dialConn(ctx context.Context, cm connectMethod, isClientConn
 	}
 
 	// Possible unencrypted HTTP/2 with prior knowledge.
-	unencryptedHTTP2 := pconn.tlsState == nil &&
-		t.Protocols != nil &&
+	unencryptedHTTP2 := t.Protocols != nil &&
 		t.Protocols.UnencryptedHTTP2() &&
 		!t.Protocols.HTTP1()
 


### PR DESCRIPTION
When we make a request on a tlsconn, 
but the server does not return an ALPN handshake,
the transport unexpectedly falls back to HTTP/1.1.

No fallback behavior should occur when Protocols.HTTP1() is not true,
checking c.tlsState is unnecessary and should not be performed.

Fixes #79296