### PR TITLE
net/http: add HTTP2Config.EnableConnectProtocol

### DIFF
--- a/api/next/53208.txt
+++ b/api/next/53208.txt
@@ -1,0 +1,1 @@
+pkg net/http, type HTTP2Config struct, EnableConnectProtocol bool #53208

--- a/doc/next/6-stdlib/99-minor/net/http/53208.md
+++ b/doc/next/6-stdlib/99-minor/net/http/53208.md
@@ -1,0 +1,4 @@
+<!-- go.dev/issue/53208 -->
+The new [HTTP2Config.EnableConnectProtocol] field enables support for the
+Extended CONNECT protocol defined in [RFC 8441](https://www.rfc-editor.org/rfc/rfc8441).
+When enabled, HTTP/2 servers advertise support for Extended CONNECT requests.

--- a/src/net/http/http.go
+++ b/src/net/http/http.go
@@ -302,6 +302,13 @@ type HTTP2Config struct {
 	// cipher suites prohibited by the HTTP/2 spec.
 	PermitProhibitedCipherSuites bool
 
+	// EnableConnectProtocol, if true, enables support for
+	// the Extended CONNECT protocol defined in RFC 8441.
+	// When enabled, HTTP/2 servers will advertise support for Extended CONNECT.
+	// Extended CONNECT requests will include a ":protocol" pseudo header
+	// in the request headers.
+	EnableConnectProtocol bool
+
 	// CountError, if non-nil, is called on HTTP/2 errors.
 	// It is intended to increment a metric for monitoring.
 	// The errType contains only lowercase letters, digits, and underscores

--- a/src/net/http/http.go
+++ b/src/net/http/http.go
@@ -315,6 +315,13 @@ type HTTP2Config struct {
 	// cipher suites prohibited by the HTTP/2 spec.
 	PermitProhibitedCipherSuites bool
 
+	// EnableConnectProtocol, if true, enables support for
+	// the Extended CONNECT protocol defined in RFC 8441.
+	// When enabled, HTTP/2 servers will advertise support for Extended CONNECT.
+	// Extended CONNECT requests will include a ":protocol" pseudo header
+	// in the request headers.
+	EnableConnectProtocol bool
+
 	// CountError, if non-nil, is called on HTTP/2 errors.
 	// It is intended to increment a metric for monitoring.
 	// The errType contains only lowercase letters, digits, and underscores

--- a/src/net/http/internal/http2/config.go
+++ b/src/net/http/internal/http2/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	PingTimeout                   time.Duration
 	WriteByteTimeout              time.Duration
 	PermitProhibitedCipherSuites  bool
+	EnableConnectProtocol         bool
 	CountError                    func(errType string)
 }
 
@@ -111,6 +112,9 @@ func fillNetHTTPConfig(conf *Config, h2 Config) {
 	}
 	if h2.PermitProhibitedCipherSuites {
 		conf.PermitProhibitedCipherSuites = true
+	}
+	if h2.EnableConnectProtocol {
+		conf.EnableConnectProtocol = true
 	}
 	if h2.CountError != nil {
 		conf.CountError = h2.CountError

--- a/src/net/http/internal/http2/server.go
+++ b/src/net/http/internal/http2/server.go
@@ -481,6 +481,8 @@ type serverConn struct {
 	// Used for RFC 9218 prioritization.
 	hasIntermediary bool // connection is done via an intermediary / proxy
 	priorityAware   bool // the client has sent priority signal, meaning that it is aware of it.
+
+	extendedConnectAllowed bool // server advertised ENABLE_CONNECT_PROTOCOL to this client
 }
 
 func (sc *serverConn) writeSchedIgnoresRFC7540() bool {
@@ -779,7 +781,8 @@ func (sc *serverConn) serve(conf Config) {
 		{SettingHeaderTableSize, uint32(conf.MaxDecoderHeaderTableSize)},
 		{SettingInitialWindowSize, uint32(sc.initialStreamRecvWindowSize)},
 	}
-	if !disableExtendedConnectProtocol {
+	if conf.EnableConnectProtocol || !disableExtendedConnectProtocol {
+		sc.extendedConnectAllowed = true
 		settings = append(settings, Setting{SettingEnableConnectProtocol, 1})
 	}
 	if sc.writeSchedIgnoresRFC7540() {
@@ -2134,7 +2137,7 @@ func (sc *serverConn) newWriterAndRequest(st *stream, f *MetaHeadersFrame) (*res
 	}
 
 	// extended connect is disabled, so we should not see :protocol
-	if disableExtendedConnectProtocol && rp.Protocol != "" {
+	if !sc.extendedConnectAllowed && rp.Protocol != "" {
 		return nil, nil, sc.countError("bad_connect", streamError(f.StreamID, ErrCodeProtocol))
 	}
 

--- a/src/net/http/internal/http2/server.go
+++ b/src/net/http/internal/http2/server.go
@@ -484,6 +484,8 @@ type serverConn struct {
 	// Used for RFC 9218 prioritization.
 	hasIntermediary bool // connection is done via an intermediary / proxy
 	priorityAware   bool // the client has sent priority signal, meaning that it is aware of it.
+
+	extendedConnectAllowed bool // server advertised ENABLE_CONNECT_PROTOCOL to this client
 }
 
 func (sc *serverConn) writeSchedIgnoresRFC7540() bool {
@@ -782,7 +784,8 @@ func (sc *serverConn) serve(conf Config) {
 		{SettingHeaderTableSize, uint32(conf.MaxDecoderHeaderTableSize)},
 		{SettingInitialWindowSize, uint32(sc.initialStreamRecvWindowSize)},
 	}
-	if !disableExtendedConnectProtocol {
+	if conf.EnableConnectProtocol || !disableExtendedConnectProtocol {
+		sc.extendedConnectAllowed = true
 		settings = append(settings, Setting{SettingEnableConnectProtocol, 1})
 	}
 	if sc.writeSchedIgnoresRFC7540() {
@@ -2139,7 +2142,7 @@ func (sc *serverConn) newWriterAndRequest(st *stream, f *MetaHeadersFrame) (*res
 	}
 
 	// extended connect is disabled, so we should not see :protocol
-	if disableExtendedConnectProtocol && rp.Protocol != "" {
+	if !sc.extendedConnectAllowed && rp.Protocol != "" {
 		return nil, nil, sc.countError("bad_connect", streamError(f.StreamID, ErrCodeProtocol))
 	}
 

--- a/src/net/http/internal/http2/server_test.go
+++ b/src/net/http/internal/http2/server_test.go
@@ -4995,6 +4995,100 @@ func init() {
 	}
 }
 
+func TestServerEnableConnectProtocol_Settings(t *testing.T) {
+	SetDisableExtendedConnectProtocol(t, true)
+	for _, tt := range []struct {
+		name   string
+		enable bool
+		want   bool
+	}{
+		{name: "enabled", enable: true, want: true},
+		{name: "disabled", enable: false, want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			synctestTest(t, func(t testing.TB) {
+				var opts []any
+				if tt.enable {
+					opts = append(opts, func(h2 *http.HTTP2Config) {
+						h2.EnableConnectProtocol = true
+					})
+				}
+				st := newServerTester(t, nil, opts...)
+				defer st.Close()
+
+				var saw bool
+				st.greetAndCheckSettings(func(s Setting) error {
+					if s.ID == SettingEnableConnectProtocol {
+						saw = true
+					}
+					return nil
+				})
+				if saw != tt.want {
+					t.Errorf("ENABLE_CONNECT_PROTOCOL advertised=%v; want %v", saw, tt.want)
+				}
+			})
+		})
+	}
+}
+
+func TestEnableConnectProtocol_WithServerSupport(t *testing.T) {
+	t.Skip("https://go.dev/issue/53208 -- net/http needs to support the :protocol header")
+	SetDisableExtendedConnectProtocol(t, true)
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(":protocol") != "extended-connect" {
+			t.Fatalf("unexpected :protocol header: %q", r.Header.Get(":protocol"))
+		}
+		t.Log(io.Copy(w, r.Body))
+	}, func(h2 *http.HTTP2Config) {
+		h2.EnableConnectProtocol = true
+	})
+	tr := newTransport(t)
+	pr, pw := io.Pipe()
+	pwDone := make(chan struct{})
+	req, _ := http.NewRequest("CONNECT", ts.URL, pr)
+	req.Header.Set(":protocol", "extended-connect")
+	go func() {
+		pw.Write([]byte("hello, extended connect"))
+		pw.Close()
+		close(pwDone)
+	}()
+
+	res, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(body, []byte("hello, extended connect")) {
+		t.Fatal("unexpected body received")
+	}
+}
+
+func TestEnableConnectProtocol_WithoutServerSupport(t *testing.T) {
+	t.Skip("https://go.dev/issue/53208 -- net/http needs to support the :protocol header")
+	SetDisableExtendedConnectProtocol(t, true)
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(w, r.Body)
+	})
+	tr := newTransport(t)
+	pr, pw := io.Pipe()
+	pwDone := make(chan struct{})
+	req, _ := http.NewRequest("CONNECT", ts.URL, pr)
+	req.Header.Set(":protocol", "extended-connect")
+	go func() {
+		pw.Write([]byte("hello, extended connect"))
+		pw.Close()
+		close(pwDone)
+	}()
+
+	_, err := tr.RoundTrip(req)
+	if !errors.Is(err, ErrExtendedConnectNotSupported) {
+		t.Fatalf("expected ErrExtendedConnectNotSupported, got: %v", err)
+	}
+}
+
 func protocols(protos ...string) *http.Protocols {
 	p := new(http.Protocols)
 	for _, s := range protos {

--- a/src/net/http/internal/http2/server_test.go
+++ b/src/net/http/internal/http2/server_test.go
@@ -5360,6 +5360,100 @@ func init() {
 	}
 }
 
+func TestServerEnableConnectProtocol_Settings(t *testing.T) {
+	SetDisableExtendedConnectProtocol(t, true)
+	for _, tt := range []struct {
+		name   string
+		enable bool
+		want   bool
+	}{
+		{name: "enabled", enable: true, want: true},
+		{name: "disabled", enable: false, want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			synctestTest(t, func(t testing.TB) {
+				var opts []any
+				if tt.enable {
+					opts = append(opts, func(h2 *http.HTTP2Config) {
+						h2.EnableConnectProtocol = true
+					})
+				}
+				st := newServerTester(t, nil, opts...)
+				defer st.Close()
+
+				var saw bool
+				st.greetAndCheckSettings(func(s Setting) error {
+					if s.ID == SettingEnableConnectProtocol {
+						saw = true
+					}
+					return nil
+				})
+				if saw != tt.want {
+					t.Errorf("ENABLE_CONNECT_PROTOCOL advertised=%v; want %v", saw, tt.want)
+				}
+			})
+		})
+	}
+}
+
+func TestEnableConnectProtocol_WithServerSupport(t *testing.T) {
+	t.Skip("https://go.dev/issue/53208 -- net/http needs to support the :protocol header")
+	SetDisableExtendedConnectProtocol(t, true)
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(":protocol") != "extended-connect" {
+			t.Fatalf("unexpected :protocol header: %q", r.Header.Get(":protocol"))
+		}
+		t.Log(io.Copy(w, r.Body))
+	}, func(h2 *http.HTTP2Config) {
+		h2.EnableConnectProtocol = true
+	})
+	tr := newTransport(t)
+	pr, pw := io.Pipe()
+	pwDone := make(chan struct{})
+	req, _ := http.NewRequest("CONNECT", ts.URL, pr)
+	req.Header.Set(":protocol", "extended-connect")
+	go func() {
+		pw.Write([]byte("hello, extended connect"))
+		pw.Close()
+		close(pwDone)
+	}()
+
+	res, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(body, []byte("hello, extended connect")) {
+		t.Fatal("unexpected body received")
+	}
+}
+
+func TestEnableConnectProtocol_WithoutServerSupport(t *testing.T) {
+	t.Skip("https://go.dev/issue/53208 -- net/http needs to support the :protocol header")
+	SetDisableExtendedConnectProtocol(t, true)
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(w, r.Body)
+	})
+	tr := newTransport(t)
+	pr, pw := io.Pipe()
+	pwDone := make(chan struct{})
+	req, _ := http.NewRequest("CONNECT", ts.URL, pr)
+	req.Header.Set(":protocol", "extended-connect")
+	go func() {
+		pw.Write([]byte("hello, extended connect"))
+		pw.Close()
+		close(pwDone)
+	}()
+
+	_, err := tr.RoundTrip(req)
+	if !errors.Is(err, ErrExtendedConnectNotSupported) {
+		t.Fatalf("expected ErrExtendedConnectNotSupported, got: %v", err)
+	}
+}
+
 func protocols(protos ...string) *http.Protocols {
 	p := new(http.Protocols)
 	for _, s := range protos {

--- a/src/net/http/internal/http2/server_test.go
+++ b/src/net/http/internal/http2/server_test.go
@@ -5370,28 +5370,26 @@ func TestServerEnableConnectProtocol_Settings(t *testing.T) {
 		{name: "enabled", enable: true, want: true},
 		{name: "disabled", enable: false, want: false},
 	} {
-		t.Run(tt.name, func(t *testing.T) {
-			synctestTest(t, func(t testing.TB) {
-				var opts []any
-				if tt.enable {
-					opts = append(opts, func(h2 *http.HTTP2Config) {
-						h2.EnableConnectProtocol = true
-					})
-				}
-				st := newServerTester(t, nil, opts...)
-				defer st.Close()
-
-				var saw bool
-				st.greetAndCheckSettings(func(s Setting) error {
-					if s.ID == SettingEnableConnectProtocol {
-						saw = true
-					}
-					return nil
+		synctestSubtest(t, tt.name, func(t *testing.T) {
+			var opts []any
+			if tt.enable {
+				opts = append(opts, func(h2 *http.HTTP2Config) {
+					h2.EnableConnectProtocol = true
 				})
-				if saw != tt.want {
-					t.Errorf("ENABLE_CONNECT_PROTOCOL advertised=%v; want %v", saw, tt.want)
+			}
+			st := newServerTester(t, nil, opts...)
+			defer st.Close()
+
+			var saw bool
+			st.greetAndCheckSettings(func(s Setting) error {
+				if s.ID == SettingEnableConnectProtocol {
+					saw = true
 				}
+				return nil
 			})
+			if saw != tt.want {
+				t.Errorf("ENABLE_CONNECT_PROTOCOL advertised=%v; want %v", saw, tt.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
net/http: add HTTP2Config.EnableConnectProtocol

Introduce EnableConnectProtocol to HTTP2Config, allowing HTTP/2
servers to opt in to advertising Extended CONNECT support (RFC 8441)
on a per-server basis.

Extended CONNECT was disabled by default in Go 1.24 because browsers
interpret SETTINGS_ENABLE_CONNECT_PROTOCOL as implicit
WebSocket-over-HTTP/2 support, which breaks servers whose WebSocket
implementation does not support it (see #71128). EnableConnectProtocol
provides the knob needed for WebSocket layers that do support Extended
CONNECT to re-enable it without requiring GODEBUG=http2xconnect=1.
This is a problem because http2xconnect is not accessible via the
//go:debug directive.

When enabled, HTTP/2 servers advertise SETTINGS_ENABLE_CONNECT_PROTOCOL
in the initial SETTINGS frame. Incoming CONNECT requests that carry a
:protocol pseudo-header are forwarded to the handler with that value
accessible via r.Header.Get(":protocol").

The legacy disableExtendedConnectProtocol package variable and its
GODEBUG knob are preserved for backwards compatibility.

For #53208.
For #71128.
