### PR TITLE
image/gif: use %w for error wrapping

### DIFF
--- a/src/image/gif/reader.go
+++ b/src/image/gif/reader.go
@@ -292,7 +292,7 @@ func (d *decoder) readColorTable(fields byte) (color.Palette, error) {
 	n := 1 << (1 + uint(fields&fColorTableBitsMask))
 	err := readFull(d.r, d.tmp[:3*n])
 	if err != nil {
-		return nil, fmt.Errorf("gif: reading color table: %s", err)
+		return nil, fmt.Errorf("gif: reading color table: %w", err)
 	}
 	j, p := 0, make(color.Palette, n)
 	for i := range p {
@@ -358,7 +358,7 @@ func (d *decoder) readExtension() error {
 
 func (d *decoder) readGraphicControl() error {
 	if err := readFull(d.r, d.tmp[:6]); err != nil {
-		return fmt.Errorf("gif: can't read graphic control: %s", err)
+		return fmt.Errorf("gif: can't read graphic control: %w", err)
 	}
 	if d.tmp[0] != 4 {
 		return fmt.Errorf("gif: invalid graphic control extension block size: %d", d.tmp[0])
@@ -485,7 +485,7 @@ func (d *decoder) readImageDescriptor(keepAllFrames bool) error {
 
 func (d *decoder) newImageFromDescriptor() (*image.Paletted, error) {
 	if err := readFull(d.r, d.tmp[:9]); err != nil {
-		return nil, fmt.Errorf("gif: can't read image descriptor: %s", err)
+		return nil, fmt.Errorf("gif: can't read image descriptor: %w", err)
 	}
 	left := int(d.tmp[0]) + int(d.tmp[1])<<8
 	top := int(d.tmp[2]) + int(d.tmp[3])<<8


### PR DESCRIPTION
Replace %s with %w in fmt.Errorf calls to enable proper error chain
inspection with errors.Is and errors.As.

## Background

Go 1.13 introduced the %w verb for fmt.Errorf, which creates wrapped
errors that can be inspected programmatically. This is the recommended
pattern for errors that callers might need to handle specifically.

## Problem

The GIF decoder uses %s to format I/O errors in 3 locations:

- Line 295: readColorTable - "gif: reading color table: %s"
- Line 361: readGraphicControl - "gif: can't read graphic control: %s"  
- Line 488: newImageFromDescriptor - "gif: can't read image descriptor: %s"

Using %s converts the underlying io.Reader errors to strings, breaking
the error chain. Callers cannot use errors.Is() to detect specific
I/O errors like io.ErrUnexpectedEOF or context.Canceled.

## Solution

Replace %s with %w in all 3 locations to preserve the error chain.

## Example

Before this change:

    err := gif.DecodeAll(reader)
    // Cannot detect the underlying I/O error

After this change:

    err := gif.DecodeAll(reader)
    if errors.Is(err, io.ErrUnexpectedEOF) {
        // Handle truncated GIF specifically
    }
    if errors.Is(err, context.Canceled) {
        // Handle cancellation
    }

## History

The affected code dates from the early Go codebase:
- Line 295: Jeff R. Allen (2015-12-05)
- Lines 361, 488: Rob Pike (2011-05-07) - original GIF decoder

These predate Go 1.13 (2019) when %w was introduced, explaining why
%v/%s was used originally.

## Related

The file already uses %v for other errors (lines 240, 272, 308, 321, 330)
which don't wrap underlying errors. This change focuses on the 3 sites
that do wrap errors from the underlying reader.

Updates #30322