### PR TITLE
os/user: use %w for error wrapping on Plan 9

### DIFF
--- a/src/os/user/lookup_plan9.go
+++ b/src/os/user/lookup_plan9.go
@@ -30,7 +30,7 @@ var (
 func current() (*User, error) {
 	ubytes, err := os.ReadFile("/dev/user")
 	if err != nil {
-		return nil, fmt.Errorf("user: %s", err)
+		return nil, fmt.Errorf("user: %w", err)
 	}
 
 	uname := string(ubytes)


### PR DESCRIPTION
Replace %s with %w in fmt.Errorf to enable proper error chain
inspection with errors.Is and errors.As.

## Background

Go 1.13 introduced the %w verb for fmt.Errorf, which creates wrapped
errors that can be inspected programmatically. This is the recommended
pattern for errors that callers might need to handle specifically.

## Problem

The Plan 9 user lookup implementation uses %s to format the error
from reading /dev/user:

    ubytes, err := os.ReadFile("/dev/user")
    if err != nil {
        return nil, fmt.Errorf("user: %s", err)
    }

Using %s converts the underlying os.ReadFile error to a string,
breaking the error chain. Callers cannot use errors.Is() to detect
specific errors like os.ErrPermission or os.ErrNotExist.

## Solution

Replace %s with %w to preserve the error chain.

## Example

Before this change:

    u, err := user.Current()
    // Cannot detect the underlying file error

After this change:

    u, err := user.Current()
    if errors.Is(err, os.ErrPermission) {
        // Handle permission denied specifically
    }

## History

This code was written before Go 1.13 (2019) when %w was introduced,
explaining why %s was used originally. Plan 9 is a niche platform,
but proper error handling is still valuable for debugging.

## Platform

Plan 9 is an operating system from Bell Labs. The os/user package
provides partial support on Plan 9, reading the current user from
/dev/user. This is the only error-wrapping site in the Plan 9
implementation.

Updates #30322