### PR TITLE
crypto/x509: use %w for error wrapping in parser

### DIFF
--- a/src/crypto/x509/parser.go
+++ b/src/crypto/x509/parser.go
@@ -169,7 +169,7 @@ func parseName(raw cryptobyte.String) (*pkix.RDNSequence, error) {
 			var err error
 			attr.Value, err = parseASN1String(valueTag, rawValue)
 			if err != nil {
-				return nil, fmt.Errorf("x509: invalid RDNSequence: invalid attribute value: %s", err)
+				return nil, fmt.Errorf("x509: invalid RDNSequence: invalid attribute value: %w", err)
 			}
 			rdnSet = append(rdnSet, attr)
 		}


### PR DESCRIPTION
Use the %w verb instead of %s in the fmt.Errorf call in
parseRDNSequence so that callers can use errors.Is and
errors.As on the underlying parsing error.

Updates #30322