### PR TITLE
crypto/x509: use %w for error wrapping on Darwin

### DIFF
--- a/src/crypto/x509/root_darwin.go
+++ b/src/crypto/x509/root_darwin.go
@@ -68,7 +68,7 @@ func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate
 		case macos.ErrSecNotTrusted:
 			return nil, UnknownAuthorityError{Cert: c}
 		default:
-			return nil, fmt.Errorf("x509: %s", err)
+			return nil, fmt.Errorf("x509: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Use the %w verb instead of %s in the default error case
of systemVerify on Darwin so that callers can inspect
the underlying macOS security framework error.

Updates #30322