### PR TITLE
go/format: use %w for error wrapping

### DIFF
--- a/src/go/format/format.go
+++ b/src/go/format/format.go
@@ -76,7 +76,7 @@ func Node(dst io.Writer, fset *token.FileSet, node any) error {
 		file, err = parser.ParseFile(fset, "", buf.Bytes(), parserMode)
 		if err != nil {
 			// We should never get here. If we do, provide good diagnostic.
-			return fmt.Errorf("format.Node internal error (%s)", err)
+			return fmt.Errorf("format.Node internal error (%w)", err)
 		}
 		ast.SortImports(fset, file)
 


### PR DESCRIPTION
Replace %s with %w in fmt.Errorf to enable proper error chain
inspection with errors.Is and errors.As.

## Background

Go 1.13 introduced the %w verb for fmt.Errorf, which creates wrapped
errors that can be inspected programmatically. This is the recommended
pattern for errors that callers might need to handle specifically.

## Problem

The go/format package uses %s to format internal errors:

    file, err = parser.ParseFile(fset, "", buf.Bytes(), parserMode)
    if err != nil {
        // We should never get here. If we do, provide good diagnostic.
        return fmt.Errorf("format.Node internal error (%s)", err)
    }

Using %s converts the underlying parser error to a string, breaking
the error chain.

## Solution

Replace %s with %w to preserve the error chain.

## Context

The comment says "We should never get here" - this error path is
unexpected. The go/format package reformats Go source code by:
1. Parsing the source
2. Reprinting with go/printer

If parsing succeeds initially but fails after reformatting, something
is wrong with the formatter itself.

## Impact

Even though this is an internal error path, proper error wrapping helps
debugging. Tools using go/format can inspect the underlying parser error:

    err := format.Node(&buf, fset, node)
    var parseErr parser.Error
    if errors.As(err, &parseErr) {
        // Get the specific parsing error details
    }

## History

This code predates Go 1.13 (2019) when %w was introduced, explaining
why %s was used originally. The comment indicates this is an edge case
that should rarely occur.

Updates #30322