### PR TITLE
internal/profile: return error from gzip.Writer.Close in Profile.Write

### DIFF
--- a/src/internal/profile/profile.go
+++ b/src/internal/profile/profile.go
@@ -175,9 +175,11 @@ func (p *Profile) Write(w io.Writer) error {
 	p.preEncode()
 	b := marshal(p)
 	zw := gzip.NewWriter(w)
-	defer zw.Close()
-	_, err := zw.Write(b)
-	return err
+	if _, err := zw.Write(b); err != nil {
+		zw.Close()
+		return err
+	}
+	return zw.Close()
 }
 
 // CheckValid tests whether the profile is valid. Checks include, but are


### PR DESCRIPTION
Profile.Write defers gzip.Writer.Close without checking its return
value. Close flushes buffered data and writes the gzip footer (CRC32
checksum and size). If the flush or footer write fails, the caller
receives a nil error despite the output being truncated or corrupt.

This is called by runtime/pprof and net/http/pprof to serialize
profiles. A write error during gzip finalization (e.g., broken pipe,
full disk) produces corrupt output reported as success.

Remove the defer and call Close explicitly after Write, returning
its error. On Write failure, Close is still called to release
resources, but the Write error is returned.

Fixes #79423