### PR TITLE
cmd/go/internal/doc: reject meta packages in go doc

### DIFF
--- a/src/cmd/go/internal/doc/doc.go
+++ b/src/cmd/go/internal/doc/doc.go
@@ -236,11 +236,17 @@ func do(ctx context.Context, writer io.Writer, flagSet *flag.FlagSet, args []str
 			// Outside a module or workspace, go to the documentation for the standard library.
 			return doPkgsite(ctx, "std", "")
 		}
+		if args := flagSet.Args(); len(args) == 1 && args[0] == "std" {
+			return doPkgsite(ctx, "std", "")
+		}
 
 		// If args are provided, we need to figure out which page to open on the pkgsite
 		// instance. Run the logic below to determine a match for a symbol, method,
 		// or field, but don't actually print the documentation to the output.
 		writer = io.Discard
+	}
+	if a := flagSet.Args(); len(a) > 0 && search.IsMetaPackage(a[0]) {
+		return fmt.Errorf("go doc does not support meta-package argument %q", a[0])
 	}
 	var paths []string
 	var symbol, method string

--- a/src/cmd/go/internal/doc/doc_test.go
+++ b/src/cmd/go/internal/doc/doc_test.go
@@ -1273,6 +1273,31 @@ func TestNoPackageClauseWhenNoMatch(t *testing.T) {
 	}
 }
 
+func TestMetaPackage(t *testing.T) {
+	maybeSkip(t)
+	for _, args := range [][]string{
+		{"std"},
+		{"cmd"},
+		{"all"},
+		{"tool"},
+		{"work"},
+		{"std", "Foo"},
+	} {
+		var b strings.Builder
+		var flagSet flag.FlagSet
+		err := do(t.Context(), &b, &flagSet, args)
+		if err == nil {
+			t.Fatalf("expected error for go doc %s; got output:\n%s", strings.Join(args, " "), b.String())
+		}
+		if want := `go doc does not support meta-package argument "` + args[0] + `"`; !strings.Contains(err.Error(), want) {
+			t.Fatalf("unexpected error for go doc %s: %v", strings.Join(args, " "), err)
+		}
+		if b.Len() != 0 {
+			t.Fatalf("go doc %s produced unexpected output:\n%s", strings.Join(args, " "), b.String())
+		}
+	}
+}
+
 type trimTest struct {
 	path   string
 	prefix string

--- a/src/cmd/go/testdata/script/doc.txt
+++ b/src/cmd/go/testdata/script/doc.txt
@@ -60,6 +60,24 @@ stdout .
 go doc Method
 stdout .
 
+# Meta packages are package patterns, not documentable packages.
+# Regression test for golang.org/issue/53446.
+! go doc std
+stderr '^doc: go doc does not support meta-package argument "std"$'
+! stdout .
+
+! go doc all
+stderr '^doc: go doc does not support meta-package argument "all"$'
+! stdout .
+
+! go doc std Foo
+stderr '^doc: go doc does not support meta-package argument "std"$'
+! stdout .
+
+env TEST_GODOC_URL_FILE=$WORK/url.txt
+go doc -http std
+grep '/std' $TEST_GODOC_URL_FILE
+
 -- go.mod --
 module p/v2
 


### PR DESCRIPTION
Meta-package names such as std, cmd, tool, work, and all are package
patterns that expand to multiple packages, not single documentable
packages. Today go doc std can fall through package resolution and print
documentation for an unrelated first match such as archive/tar.

Reject these names when they are the first argument to go doc, including
the two-argument form such as go doc std Foo. Keep go doc -http std
routing to the standard library page.

Fixes #53446 