### PR TITLE
internal/cpu: detect GFNI independently of AVX-512F

### DIFF
--- a/src/internal/cpu/cpu_x86.go
+++ b/src/internal/cpu/cpu_x86.go
@@ -74,6 +74,7 @@ func doinit() {
 		{Name: "aes", Feature: &X86.HasAES},
 		{Name: "erms", Feature: &X86.HasERMS},
 		{Name: "fsrm", Feature: &X86.HasFSRM},
+		{Name: "gfni", Feature: &X86.HasGFNI},
 		{Name: "pclmulqdq", Feature: &X86.HasPCLMULQDQ},
 		{Name: "rdtscp", Feature: &X86.HasRDTSCP},
 		{Name: "sha", Feature: &X86.HasSHA},
@@ -175,6 +176,14 @@ func doinit() {
 	X86.HasSHA = isSet(ebx7, cpuid_SHA)
 	X86.HasVAES = isSet(ecx7, cpuid_VAES) && X86.HasAVX
 
+	// GFNI is available in VEX-encoded form on every CPU that reports the
+	// GFNI bit (CPUID leaf 7 ECX bit 8) and supports YMM, regardless of
+	// AVX-512. Gate on HasAVX (which requires OSXSAVE + YMM OS support) so
+	// callers can safely emit VEX-256 VGF2P8AFFINEQB on YMM. The
+	// EVEX-encoded form additionally requires AVX-512F; see HasAVX512GFNI
+	// below.
+	X86.HasGFNI = isSet(ecx7, cpuid_GFNI) && X86.HasAVX
+
 	X86.HasAVX512F = isSet(ebx7, cpuid_AVX512F) && osSupportsAVX512
 	if X86.HasAVX512F {
 		X86.HasAVX512CD = isSet(ebx7, cpuid_AVX512CD)
@@ -191,7 +200,6 @@ func doinit() {
 		X86.HasAVX512VPCLMULQDQ = isSet(ecx7, cpuid_AVX512VPCLMULQDQ)
 		X86.HasAVX512VBMI = isSet(ecx7, cpuid_AVX512_VBMI)
 		X86.HasAVX512VBMI2 = isSet(ecx7, cpuid_AVX512_VBMI2)
-		X86.HasGFNI = isSet(ecx7, cpuid_GFNI)
 		X86.HasAVX512BITALG = isSet(ecx7, cpuid_AVX512_BITALG)
 	}
 

--- a/src/internal/cpu/cpu_x86_test.go
+++ b/src/internal/cpu/cpu_x86_test.go
@@ -36,6 +36,46 @@ func TestX86ifAVX512VLhasAVX512F(t *testing.T) {
 	}
 }
 
+func TestX86ifGFNIhasAVX(t *testing.T) {
+	if X86.HasGFNI && !X86.HasAVX {
+		t.Fatalf("HasAVX expected true when HasGFNI is true, got false")
+	}
+}
+
+func TestX86ifAVX512GFNIhasGFNI(t *testing.T) {
+	// Skip if GODEBUG explicitly disabled gfni (directly or via cpu.all=off);
+	// processOptions would have cleared X86.HasGFNI but not X86.HasAVX512GFNI
+	// (which is not in the options table), so the invariant below would
+	// spuriously fire even though the hardware reports both bits.
+	if godebug.New("#cpu.gfni").Value() == "off" || godebug.New("#cpu.all").Value() == "off" {
+		t.Skip("skipping test: GODEBUG=cpu.gfni=off set")
+	}
+	if X86.HasAVX512GFNI && !X86.HasGFNI {
+		t.Fatalf("HasGFNI expected true when HasAVX512GFNI is true, got false")
+	}
+}
+
+func TestX86ifCPUIDGFNIhasGFNI(t *testing.T) {
+	if !X86.HasAVX {
+		t.Skip("skipping test: requires AVX (and thus YMM OS support)")
+	}
+	// Skip if GODEBUG explicitly disabled gfni (directly or via cpu.all=off);
+	// processOptions would have cleared X86.HasGFNI regardless of hardware
+	// state, so the CPUID comparison below would spuriously fire.
+	if godebug.New("#cpu.gfni").Value() == "off" || godebug.New("#cpu.all").Value() == "off" {
+		t.Skip("skipping test: GODEBUG=cpu.gfni=off set")
+	}
+	maxID, _, _, _ := Cpuid(0, 0)
+	if maxID < 7 {
+		t.Skip("skipping test: CPUID leaf 7 unavailable")
+	}
+	_, _, ecx7, _ := Cpuid(7, 0)
+	const gfniBit = 1 << 8
+	if ecx7&gfniBit != 0 && !X86.HasGFNI {
+		t.Fatalf("HasGFNI expected true when CPUID leaf 7 ECX bit 8 is set, got false")
+	}
+}
+
 func TestDisableSSE3(t *testing.T) {
 	if GetGOAMD64level() > 1 {
 		t.Skip("skipping test: can't run on GOAMD64>v1 machines")
@@ -53,5 +93,25 @@ func TestSSE3DebugOption(t *testing.T) {
 	want := false
 	if got := X86.HasSSE3; got != want {
 		t.Errorf("X86.HasSSE3 expected %v, got %v", want, got)
+	}
+}
+
+func TestDisableGFNI(t *testing.T) {
+	if !X86.HasGFNI {
+		t.Skip("skipping test: host does not advertise GFNI")
+	}
+	runDebugOptionsTest(t, "TestGFNIDebugOption", "cpu.gfni=off")
+}
+
+func TestGFNIDebugOption(t *testing.T) {
+	MustHaveDebugOptionsSupport(t)
+
+	if godebug.New("#cpu.gfni").Value() != "off" {
+		t.Skipf("skipping test: GODEBUG=cpu.gfni=off not set")
+	}
+
+	want := false
+	if got := X86.HasGFNI; got != want {
+		t.Errorf("X86.HasGFNI expected %v, got %v", want, got)
 	}
 }

--- a/src/internal/cpu/export_x86_test.go
+++ b/src/internal/cpu/export_x86_test.go
@@ -8,4 +8,5 @@ package cpu
 
 var (
 	GetGOAMD64level = getGOAMD64level
+	Cpuid           = cpuid
 )


### PR DESCRIPTION
GFNI is exposed in VEX-encoded form (VGF2P8AFFINEQB on XMM/YMM) on every
x86 CPU that reports the GFNI bit (CPUID leaf 7 ECX bit 8) and supports
YMM (HasAVX). Only the EVEX-encoded form requires AVX-512.

Since CL 655280 imported the Green Tea scan kernel, X86.HasGFNI was
populated inside the "if X86.HasAVX512F { ... }" block, leaving it false
on hosts that have VEX-256 GFNI but no AVX-512:

  - Intel 12th-14th generation consumer CPUs (Alder/Raptor Lake) where
    AVX-512 is fuse-locked off to maintain ISA homogeneity with the
    E-cores.
  - Intel Atom-derived SKUs (Jasper/Elkhart Lake, N100/N200/N300-series)
    which have shipped GFNI since Tremont but have never had AVX-512.

These platforms can execute VGF2P8AFFINEQB on YMM natively but the cpu
package incorrectly reported HasGFNI=false.

Move the standalone GFNI detection out of the AVX-512 block and gate it
on HasAVX (which requires OSXSAVE + YMM OS support), matching the
existing pattern for HasVAES. The EVEX form continues to be reported
separately via HasAVX512GFNI.

Add HasGFNI to the GODEBUG=cpu.* options table so users have a kill
switch on hosts the previous (over-restrictive) gating implicitly hid.
Without this, the only way to disable HasGFNI on a non-AVX-512 host
would be the sledgehammer GODEBUG=cpu.avx=off.

Add a regression test that reads CPUID leaf 7 ECX bit 8 directly and
asserts HasGFNI is set when the hardware bit is set and AVX is
available; verified to fail on the buggy code on an i9-14900K. Add a
paired TestDisableGFNI that exercises the new GODEBUG kill switch, and
TestX86ifGFNIhasAVX / TestX86ifAVX512GFNIhasGFNI invariant tests
following the established pattern in cpu_x86_test.go.

Fixes #79437
