### PR TITLE
plan9: restore the check for close() return value in fork/exec

### DIFF
--- a/src/syscall/exec_plan9.go
+++ b/src/syscall/exec_plan9.go
@@ -197,7 +197,9 @@ dirloop:
 				// control file for descriptor <N> is named <N>ctl
 				continue
 			}
-			closeFdExcept(int(atoi(s)), pipe, dupdevfd, fd)
+			if !closeFdExcept(int(atoi(s)), pipe, dupdevfd, fd) {
+				goto childerror
+			}
 		}
 	}
 	RawSyscall(SYS_CLOSE, uintptr(dupdevfd), 0, 0)
@@ -309,16 +311,17 @@ childerror1:
 // close the numbered file descriptor, unless it is fd1, fd2, or a member of fds.
 //
 //go:nosplit
-func closeFdExcept(n int, fd1 int, fd2 int, fds []int) {
+func closeFdExcept(n int, fd1 int, fd2 int, fds []int) bool {
 	if n == fd1 || n == fd2 {
-		return
+		return true
 	}
 	for _, fd := range fds {
 		if n == fd {
-			return
+			return true
 		}
 	}
-	RawSyscall(SYS_CLOSE, uintptr(n), 0, 0)
+	r1, _, _ := RawSyscall(SYS_CLOSE, uintptr(n), 0, 0)
+	return r1 != -1
 }
 
 func cexecPipe(p []int) error {


### PR DESCRIPTION
With miller's fix applied [1], the race condition that yielded errors
from close() is gone. I've tested backporting that commit to Go 1.4
[2], and the build becomes 100% reliable. As such, ignoring an error
result that has already proven useful seems silly.

Now that the race is gone, restore the code that prints an error on
race conditions; we don't want to silently close the wrong fds.

[1] 639a20da908c2646de46b93ca2933651363ec22a
[2] http://okturing.com/src/19622/body