### PR TITLE
cmd/internal/obj/x86: shorten MOVQ r64, imm32 for positive immediates

### DIFF
--- a/src/cmd/asm/internal/asm/testdata/amd64enc.s
+++ b/src/cmd/asm/internal/asm/testdata/amd64enc.s
@@ -2425,6 +2425,15 @@ TEXT asmtest(SB),DUPOK|NOSPLIT,$0
 	MOVQ $-249346713, (R11)                 // 49c703674523f1
 	MOVQ $-249346713, DX                    // 48c7c2674523f1
 	MOVQ $-249346713, R11                   // 49c7c3674523f1
+	// Positive immediates that fit in 32 bits use the shorter 5-byte
+	// MOV r64, imm32 (zero-extended) form rather than the 7-byte sign-
+	// extended c7 /0 form. See Ziq_rp in cmd/internal/obj/x86/asm6.go.
+	MOVQ $305419896, DX                     // ba78563412
+	MOVQ $305419896, R11                    // 41bb78563412
+	MOVQ $2147483648, DX                    // ba00000080
+	MOVQ $2147483648, R11                   // 41bb00000080
+	MOVQ $4294967295, DX                    // baffffffff
+	MOVQ $4294967295, R11                   // 41bbffffffff
 	MOVQ DX, (BX)                           // 488913
 	MOVQ R11, (BX)                          // 4c891b
 	MOVQ DX, (R11)                          // 498913

--- a/src/cmd/internal/obj/x86/asm6.go
+++ b/src/cmd/internal/obj/x86/asm6.go
@@ -484,8 +484,7 @@ var ymovq = []ytab{
 	// valid only in 64-bit mode, usually with 64-bit prefix
 	{Zr_m, 1, argList{Yrl, Yml}},      // 0x89
 	{Zm_r, 1, argList{Yml, Yrl}},      // 0x8b
-	{Zilo_m, 2, argList{Ys32, Yrl}},   // 32 bit signed 0xc7,(0)
-	{Ziq_rp, 1, argList{Yi64, Yrl}},   // 0xb8 -- 32/64 bit immediate
+	{Ziq_rp, 1, argList{Yi64, Yrl}},   // 0xb8 -- 32/64 bit immediate (Ziq_rp picks 5/7/10-byte form)
 	{Zilo_m, 2, argList{Yi32, Yml}},   // 0xc7,(0)
 	{Zm_r_xm, 1, argList{Ymm, Ymr}},   // 0x6e MMX MOVD
 	{Zr_m_xm, 1, argList{Ymr, Ymm}},   // 0x7e MMX MOVD
@@ -1225,7 +1224,7 @@ var optab =
 	{AMOVNTPD, yxr_ml, Pe, opBytes{0x2b}},
 	{AMOVNTPS, yxr_ml, Pm, opBytes{0x2b}},
 	{AMOVNTQ, ymr_ml, Pm, opBytes{0xe7}},
-	{AMOVQ, ymovq, Pw8, opBytes{0x6f, 0x7f, Pf2, 0xd6, Pf3, 0x7e, Pe, 0xd6, 0x89, 0x8b, 0xc7, 00, 0xb8, 0xc7, 00, 0x6e, 0x7e, Pe, 0x6e, Pe, 0x7e, 0}},
+	{AMOVQ, ymovq, Pw8, opBytes{0x6f, 0x7f, Pf2, 0xd6, Pf3, 0x7e, Pe, 0xd6, 0x89, 0x8b, 0xb8, 0xc7, 00, 0x6e, 0x7e, Pe, 0x6e, Pe, 0x7e, 0}},
 	{AMOVQOZX, ymrxr, Pf3, opBytes{0xd6, 0x7e}},
 	{AMOVSB, ynone, Pb, opBytes{0xa4}},
 	{AMOVSD, yxmov, Pf2, opBytes{0x10, 0x11}},

--- a/src/runtime/sys_linux_amd64.s
+++ b/src/runtime/sys_linux_amd64.s
@@ -480,7 +480,13 @@ sigtrampnog:
 // the name. The gdb source code is:
 // https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=gdb/amd64-linux-tdep.c;h=cbbac1a0c64e1deb8181b9d0ff6404e328e2979d#l178
 TEXT runtime·sigreturn__sigaction(SB),NOSPLIT,$0
-	MOVQ	$SYS_rt_sigreturn, AX
+	// The 7-byte sign-extended "48 c7 c0 0f 00 00 00" form of
+	// "MOVQ $SYS_rt_sigreturn, AX" is required: gdb and libgcc match
+	// these exact bytes to recognize the signal trampoline. The Go
+	// assembler now emits the 5-byte zero-extended "b8 0f 00 00 00"
+	// form for positive imm32, so write the bytes by hand.
+	BYTE $0x48; BYTE $0xc7; BYTE $0xc0
+	BYTE $0x0f; BYTE $0x00; BYTE $0x00; BYTE $0x00
 	SYSCALL
 	INT $3	// not reached
 


### PR DESCRIPTION
The ymovq ytab listed {Zilo_m, argList{Ys32, Yrl}} (sign-extended C7
form, 7 bytes) ahead of {Ziq_rp, argList{Yi64, Yrl}}. Since oclass
returns Ys32 for any positive int that fits in s32, every such MOVQ
to register matched the 7-byte form even though Ziq_rp already picks
the optimal 5/7/10-byte encoding based on the value.

Drop the Ys32 entry so all MOVQ immediate-to-register routes through
Ziq_rp, which emits:
  - B8+rd imm32        (5 bytes) when v fits in u32 (implicit zero-ext)
  - 48 C7 /0 imm32     (7 bytes) when v is negative s32 (sign-extends)
  - 48 B8+rd imm64    (10 bytes) otherwise

Add amd64enc test cases covering the positive-imm32 path, including
the 0x80000000 boundary where the sign- and zero-extended forms differ.

The sigreturn__sigaction trampoline in sys_linux_amd64.s previously
relied on the 7-byte encoding of "MOVQ \$SYS_rt_sigreturn, AX" because
gdb and libgcc recognize the Linux signal trampoline by exact byte
match against glibc's __restore_rt. Hand-emit the required bytes with
BYTE directives so the shorter encoding doesn't break gdb backtraces
through signal frames (TestGdbCoreSignalBacktrace).

Verified with x86lint: "oversized MOV encoding" findings drop to zero
on gofmt (422 -> 0) and cmd/go (412 -> 0). Text section shrinks by
811 bytes (0.029%) on gofmt and 1502 bytes (0.010%) on cmd/go.