### PR TITLE
cmd/go: maintain toolchain for godebug default in go mod tidy

### DIFF
--- a/src/cmd/go/internal/modload/init.go
+++ b/src/cmd/go/internal/modload/init.go
@@ -1525,11 +1525,42 @@ func rootsFromModFile(ld *Loader, m module.Version, modFile *modfile.File, addTo
 	}
 	goVersion := gover.FromGoMod(modFile)
 	var toolchain string
-	if addToolchainRoot && modFile.Toolchain != nil {
-		toolchain = modFile.Toolchain.Name
+	if addToolchainRoot {
+		toolchain = toolchainForModFile(modFile)
 	}
 	roots = appendGoAndToolchainRoots(roots, goVersion, toolchain, direct)
 	return roots, direct
+}
+
+func toolchainForModFile(modFile *modfile.File) string {
+	toolchain := ""
+	if modFile.Toolchain != nil {
+		toolchain = modFile.Toolchain.Name
+	}
+
+	required := godebugDefaultToolchain(modFile.Godebug)
+	if required == "" || toolchain == "default" {
+		return toolchain
+	}
+	if toolchain == "" || gover.Compare(gover.FromToolchain(toolchain), gover.FromToolchain(required)) < 0 {
+		return required
+	}
+	return toolchain
+}
+
+func godebugDefaultToolchain(godebugs []*modfile.Godebug) string {
+	toolchain := ""
+	for _, g := range godebugs {
+		if g.Key == "default" && strings.HasPrefix(g.Value, "go") {
+			toolchain = g.Value
+			v := gover.FromToolchain(toolchain)
+			if gover.IsLang(v) && gover.Compare(v, "1.21") >= 0 {
+				// Starting with Go 1.21, language versions do not name toolchains.
+				toolchain += ".0"
+			}
+		}
+	}
+	return toolchain
 }
 
 func appendGoAndToolchainRoots(roots []module.Version, goVersion, toolchain string, direct map[string]bool) []module.Version {

--- a/src/cmd/go/testdata/script/mod_tidy_godebug_toolchain.txt
+++ b/src/cmd/go/testdata/script/mod_tidy_godebug_toolchain.txt
@@ -1,0 +1,19 @@
+env TESTGO_VERSION=go1.26.0
+env TESTGO_VERSION_SWITCH=switch
+env GOTOOLCHAIN=auto
+
+go mod init m
+go get go@1.25.0
+
+# A GODEBUG default language version uses the first toolchain for that language.
+go mod edit -godebug default=go1.26
+go mod tidy
+grep 'toolchain go1.26.0' go.mod
+
+go mod edit -godebug default=go1.26.0
+go mod tidy
+grep 'toolchain go1.26.0' go.mod
+
+env TESTGO_VERSION=go1.25.0
+go list -m
+stdout '^m$'


### PR DESCRIPTION
When godebug default=go1.x implies a newer minimum toolchain than the
go line alone, go mod tidy should preserve a matching toolchain
directive in go.mod.

Without that, tidy can leave go.mod in a state where an older Go
toolchain fails to load the file instead of following the normal
toolchain-switching path.

This change treats godebug default=go1.x as an implicit minimum
toolchain requirement when computing the main module roots for the
tidy rewrite path. It also adds a regression test covering that case.

Fixes #79153