### PR TITLE
net/http/internal/http2: enable SetReuseFrames in server and Transport

### DIFF
--- a/doc/godebug.md
+++ b/doc/godebug.md
@@ -188,6 +188,15 @@ Setting `x509sslcertoverrideplatform=0` disables this behavior in favor of using
 the platform certificate store instead of honoring the environment variables. We
 plan to remove this setting in Go 1.31.
 
+Go 1.27 added a new `http2reuseframes` setting that controls whether the
+net/http HTTP/2 server and Transport opt in to `Framer.SetReuseFrames`,
+which reuses parsed `*DataFrame`, `*WindowUpdateFrame`, `*HeadersFrame`,
+and `*MetaHeadersFrame` structs across `ReadFrame` calls to reduce
+per-frame heap allocation. The default is reuse on. Setting
+`http2reuseframes=0` reverts to allocating each parsed frame fresh,
+matching the pre-Go 1.27 behavior. As usual, programs in modules whose
+go.mod declares a Go version below 1.27 default to `http2reuseframes=0`.
+
 ### Go 1.26
 
 Go 1.26 added a new `httpcookiemaxnum` setting that controls the maximum number

--- a/doc/godebug.md
+++ b/doc/godebug.md
@@ -169,6 +169,16 @@ Go 1.28 and all future releases will support both the old and new
 encodings when reading data. This setting may be removed in a future Go release,
 Go 1.34 at the earliest.
 
+Go 1.28 added a new `http2reuseframes` setting that controls whether the
+net/http HTTP/2 server and Transport opt in to `Framer.SetReuseFrames`,
+which reuses parsed `*DataFrame`, `*WindowUpdateFrame`, `*HeadersFrame`,
+and `*MetaHeadersFrame` structs across `ReadFrame` calls to reduce
+per-frame heap allocation. The default is reuse on. Setting
+`http2reuseframes=0` reverts to allocating each parsed frame fresh,
+matching the pre-Go 1.28 behavior. Frame reuse has no observable effect
+on programs, so the default applies regardless of the Go version
+declared in go.mod.
+
 ### Go 1.27
 
 Go 1.27 removed the `gotypesalias` setting, as noted in the [Go 1.22](#go-122) section.

--- a/src/internal/godebugs/table.go
+++ b/src/internal/godebugs/table.go
@@ -42,6 +42,7 @@ var All = []Info{
 	{Name: "htmlmetacontenturlescape", Package: "html/template"},
 	{Name: "http2client", Package: "net/http"},
 	{Name: "http2debug", Package: "net/http", Opaque: true},
+	{Name: "http2reuseframes", Package: "net/http", Changed: 27, Old: "0"},
 	{Name: "http2server", Package: "net/http"},
 	{Name: "httpcookiemaxnum", Package: "net/http", Changed: 24, Old: "0"},
 	{Name: "httplaxcontentlength", Package: "net/http", Changed: 22, Old: "1"},

--- a/src/internal/godebugs/table.go
+++ b/src/internal/godebugs/table.go
@@ -42,6 +42,7 @@ var All = []Info{
 	{Name: "htmlmetacontenturlescape", Package: "html/template"},
 	{Name: "http2client", Package: "net/http"},
 	{Name: "http2debug", Package: "net/http", Opaque: true},
+	{Name: "http2reuseframes", Package: "net/http"},
 	{Name: "http2server", Package: "net/http"},
 	{Name: "httpcookiemaxnum", Package: "net/http", Changed: 24, Old: "0"},
 	{Name: "httplaxcontentlength", Package: "net/http", Changed: 22, Old: "1"},

--- a/src/net/http/internal/http2/export_test.go
+++ b/src/net/http/internal/http2/export_test.go
@@ -107,6 +107,10 @@ func (sc *serverConn) TestFramerMaxHeaderStringLen() int {
 	return sc.framer.maxHeaderStringLen()
 }
 
+func (sc *serverConn) TestFramerReusesFrames() bool {
+	return sc.framer.frameCache != nil
+}
+
 func (t *Transport) DialClientConn(ctx context.Context, addr string, singleUse bool) (*ClientConn, error) {
 	return t.dialClientConn(ctx, addr, singleUse)
 }
@@ -132,6 +136,10 @@ func (cc *ClientConn) TestRoundTrip(req *ClientRequest, f func(stremaID uint32))
 
 func (cc *ClientConn) TestHPACKEncoder() *hpack.Encoder {
 	return cc.henc
+}
+
+func (cc *ClientConn) TestFramerReusesFrames() bool {
+	return cc.fr.frameCache != nil
 }
 
 func (cc *ClientConn) TestPeerMaxHeaderTableSize() uint32 {

--- a/src/net/http/internal/http2/frame.go
+++ b/src/net/http/internal/http2/frame.go
@@ -435,6 +435,7 @@ func (fr *Framer) SetReuseFrames() {
 type frameCache struct {
 	dataFrame         DataFrame
 	windowUpdateFrame WindowUpdateFrame
+	headersFrame      HeadersFrame
 }
 
 func (fc *frameCache) getDataFrame() *DataFrame {
@@ -449,6 +450,13 @@ func (fc *frameCache) getWindowUpdateFrame() *WindowUpdateFrame {
 		return &WindowUpdateFrame{}
 	}
 	return &fc.windowUpdateFrame
+}
+
+func (fc *frameCache) getHeadersFrame() *HeadersFrame {
+	if fc == nil {
+		return &HeadersFrame{}
+	}
+	return &fc.headersFrame
 }
 
 // NewFramer returns a Framer that writes frames to w and reads them from r.
@@ -1066,6 +1074,12 @@ func (f *Framer) WriteWindowUpdate(streamID, incr uint32) error {
 
 // A HeadersFrame is used to open a stream and additionally carries a
 // header block fragment.
+//
+// When [Framer.SetReuseFrames] is in effect, the same *HeadersFrame
+// is returned by every (*Framer).ReadFrame call that parses a HEADERS
+// and its fields are overwritten on each call. The headerFragBuf
+// slice always aliases the framer's read buffer and must not be
+// retained past the next ReadFrame regardless of this setting.
 type HeadersFrame struct {
 	FrameHeader
 
@@ -1092,8 +1106,16 @@ func (f *HeadersFrame) HasPriority() bool {
 	return f.FrameHeader.Flags.Has(FlagHeadersPriority)
 }
 
-func parseHeadersFrame(_ *frameCache, fh FrameHeader, countError func(string), p []byte) (_ Frame, err error) {
-	hf := &HeadersFrame{
+// parseHeadersFrame populates the *HeadersFrame returned by
+// frameCache.getHeadersFrame. When [Framer.SetReuseFrames] is in
+// effect, that struct is reused across ReadFrame calls; the composite
+// literal reset below overwrites every field — including any added in
+// the future — so stale values (Priority, headerFragBuf) cannot leak
+// from a prior frame. TestReadFrameHeadersOverwrites guards this
+// property.
+func parseHeadersFrame(fc *frameCache, fh FrameHeader, countError func(string), p []byte) (_ Frame, err error) {
+	hf := fc.getHeadersFrame()
+	*hf = HeadersFrame{
 		FrameHeader: fh,
 	}
 	if fh.StreamID == 0 {

--- a/src/net/http/internal/http2/frame.go
+++ b/src/net/http/internal/http2/frame.go
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"internal/godebug"
 	"io"
 	"log"
 	"slices"
@@ -21,6 +22,24 @@ import (
 
 	"golang.org/x/net/http/httpguts"
 )
+
+// http2reuseframes controls whether the per-connection Framer in the
+// stdlib server and Transport opts in to SetReuseFrames. Default is
+// reuse on; GODEBUG=http2reuseframes=0 reverts to allocating each
+// parsed frame fresh, matching the pre-Go 1.27 behavior.
+var http2reuseframes = godebug.New("http2reuseframes")
+
+// setReuseFramesFromGODEBUG opts fr in to SetReuseFrames unless the
+// GODEBUG=http2reuseframes=0 opt-out is set. The server and Transport
+// both call this when constructing their per-connection Framer, so the
+// policy (and its non-default accounting) lives in one place.
+func (fr *Framer) setReuseFramesFromGODEBUG() {
+	if http2reuseframes.Value() == "0" {
+		http2reuseframes.IncNonDefault()
+		return
+	}
+	fr.SetReuseFrames()
+}
 
 const frameHeaderLen = 9
 

--- a/src/net/http/internal/http2/frame.go
+++ b/src/net/http/internal/http2/frame.go
@@ -436,6 +436,7 @@ type frameCache struct {
 	dataFrame         DataFrame
 	windowUpdateFrame WindowUpdateFrame
 	headersFrame      HeadersFrame
+	metaHeadersFrame  MetaHeadersFrame
 }
 
 func (fc *frameCache) getDataFrame() *DataFrame {
@@ -457,6 +458,13 @@ func (fc *frameCache) getHeadersFrame() *HeadersFrame {
 		return &HeadersFrame{}
 	}
 	return &fc.headersFrame
+}
+
+func (fc *frameCache) getMetaHeadersFrame() *MetaHeadersFrame {
+	if fc == nil {
+		return &MetaHeadersFrame{}
+	}
+	return &fc.metaHeadersFrame
 }
 
 // NewFramer returns a Framer that writes frames to w and reads them from r.
@@ -1638,6 +1646,15 @@ type headersOrContinuation interface {
 //
 // This type of frame does not appear on the wire and is only returned
 // by the Framer when Framer.ReadMetaHeaders is set.
+//
+// When [Framer.SetReuseFrames] is in effect, the same *MetaHeadersFrame
+// is returned by every ReadFrame call that produces one and its fields
+// are overwritten on each call. Callers must consume Fields and
+// Truncated before the next ReadFrame and must not retain the pointer.
+// The accessor methods enforce this: calling them after the next
+// ReadFrame panics, mirroring the protection DataFrame.Data has, so a
+// retention bug fails deterministically rather than silently reading
+// another frame's headers.
 type MetaHeadersFrame struct {
 	*HeadersFrame
 
@@ -1657,11 +1674,42 @@ type MetaHeadersFrame struct {
 	// and Fields is incomplete. The hpack decoder state is still
 	// valid, however.
 	Truncated bool
+
+	// owned is whether the frame is owned by the caller of ReadFrame:
+	// set when readMetaFrame returns mh and cleared by the next
+	// ReadFrame call via invalidate. The embedded HeadersFrame's valid
+	// bit cannot serve this purpose because readMetaFrame clears it
+	// when the header block fragment is consumed, before mh is
+	// returned.
+	//
+	// Like DataFrame's checkValid protection, this catches access to a
+	// stale frame, not every contract violation: once the Framer
+	// repopulates the cached struct with a new meta frame, the
+	// retained pointer becomes "owned" again and reads the new frame's
+	// fields. Without SetReuseFrames the guard is exact, since a
+	// retained frame is never repopulated.
+	owned bool
+}
+
+func (mh *MetaHeadersFrame) checkOwned() {
+	if !mh.owned {
+		panic("Frame accessor called on non-owned Frame")
+	}
+}
+
+// invalidate overrides the embedded FrameHeader's method so that the
+// next ReadFrame call (which invalidates the Framer's lastFrame)
+// revokes ownership of the whole MetaHeadersFrame, not only of the
+// embedded HeadersFrame.
+func (mh *MetaHeadersFrame) invalidate() {
+	mh.owned = false
+	mh.HeadersFrame.invalidate()
 }
 
 // PseudoValue returns the given pseudo header field's value.
 // The provided pseudo field should not contain the leading colon.
 func (mh *MetaHeadersFrame) PseudoValue(pseudo string) string {
+	mh.checkOwned()
 	for _, hf := range mh.Fields {
 		if !hf.IsPseudo() {
 			return ""
@@ -1676,6 +1724,7 @@ func (mh *MetaHeadersFrame) PseudoValue(pseudo string) string {
 // RegularFields returns the regular (non-pseudo) header fields of mh.
 // The caller does not own the returned slice.
 func (mh *MetaHeadersFrame) RegularFields() []hpack.HeaderField {
+	mh.checkOwned()
 	for i, hf := range mh.Fields {
 		if !hf.IsPseudo() {
 			return mh.Fields[i:]
@@ -1687,6 +1736,7 @@ func (mh *MetaHeadersFrame) RegularFields() []hpack.HeaderField {
 // PseudoFields returns the pseudo header fields of mh.
 // The caller does not own the returned slice.
 func (mh *MetaHeadersFrame) PseudoFields() []hpack.HeaderField {
+	mh.checkOwned()
 	for i, hf := range mh.Fields {
 		if !hf.IsPseudo() {
 			return mh.Fields[:i]
@@ -1696,6 +1746,7 @@ func (mh *MetaHeadersFrame) PseudoFields() []hpack.HeaderField {
 }
 
 func (mh *MetaHeadersFrame) rfc9218Priority(priorityAware bool) (p PriorityParam, priorityAwareAfter, hasIntermediary bool) {
+	mh.checkOwned()
 	var s string
 	for _, field := range mh.Fields {
 		if field.Name == "priority" {
@@ -1755,7 +1806,10 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (Frame, error) {
 	if fr.AllowIllegalReads {
 		return nil, errors.New("illegal use of AllowIllegalReads with ReadMetaHeaders")
 	}
-	mh := &MetaHeadersFrame{
+	mh := fr.frameCache.getMetaHeadersFrame()
+	// Wholesale reset so values from a previous parse (Fields,
+	// Truncated, or any future-added field) cannot leak through.
+	*mh = MetaHeadersFrame{
 		HeadersFrame: hf,
 	}
 	var remainSize = fr.maxHeaderListSize()
@@ -1853,6 +1907,15 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (Frame, error) {
 
 	mh.HeadersFrame.headerFragBuf = nil
 	mh.HeadersFrame.invalidate()
+
+	// The header block is complete, so mh is the frame handed to the
+	// caller: mark it owned and make it the Framer's lastFrame so the
+	// next ReadFrame revokes ownership and the accessor methods panic
+	// on a stale frame instead of reading fields a later parse may
+	// have overwritten in place. (checkPseudos below relies on the
+	// ownership being established first.)
+	mh.owned = true
+	fr.lastFrame = mh
 
 	if err := hdec.Close(); err != nil {
 		return mh, ConnectionError(ErrCodeCompression)

--- a/src/net/http/internal/http2/frame.go
+++ b/src/net/http/internal/http2/frame.go
@@ -467,6 +467,12 @@ func (fc *frameCache) getMetaHeadersFrame() *MetaHeadersFrame {
 	return &fc.metaHeadersFrame
 }
 
+// maxRetainedMetaFields caps the capacity of the Fields backing array
+// that readMetaFrame keeps in the cached MetaHeadersFrame across
+// parses. Above the cap, the array is dropped at the start of the next
+// parse and that parse pays the modest append-growth cost again.
+const maxRetainedMetaFields = 64
+
 // NewFramer returns a Framer that writes frames to w and reads them from r.
 func NewFramer(w io.Writer, r io.Reader) *Framer {
 	fr := &Framer{
@@ -1661,7 +1667,8 @@ type MetaHeadersFrame struct {
 	// Fields are the fields contained in the HEADERS and
 	// CONTINUATION frames. The underlying slice is owned by the
 	// Framer and must not be retained after the next call to
-	// ReadFrame.
+	// ReadFrame: when [Framer.SetReuseFrames] is in effect, the next
+	// meta parse clears and overwrites the backing array in place.
 	//
 	// Fields are guaranteed to be in the correct http2 order and
 	// not have unknown pseudo header fields or invalid header
@@ -1807,11 +1814,31 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (Frame, error) {
 		return nil, errors.New("illegal use of AllowIllegalReads with ReadMetaHeaders")
 	}
 	mh := fr.frameCache.getMetaHeadersFrame()
-	// Wholesale reset so values from a previous parse (Fields,
-	// Truncated, or any future-added field) cannot leak through.
+	// Reuse the Fields backing array from the previous parse. It is
+	// non-empty only when mh is the cached frame, so without
+	// SetReuseFrames every parse still gets a fresh array. The
+	// MetaHeadersFrame.Fields contract (the slice is owned by the
+	// Framer and must not be retained past the next ReadFrame) is
+	// what makes the in-place overwrite legal.
+	//
+	// Clear the entire retained array before reuse: header values can
+	// hold secrets (Cookie, Authorization, HPACK Sensitive fields),
+	// and the slots beyond the next parse's length would otherwise
+	// keep them reachable for the lifetime of the connection. Drop
+	// arrays grown past maxRetainedMetaFields so a single large
+	// HEADERS frame cannot permanently inflate per-connection memory.
+	fields := mh.Fields
+	if cap(fields) > maxRetainedMetaFields {
+		fields = nil
+	} else {
+		clear(fields[:cap(fields)])
+	}
+	// Wholesale reset so values from a previous parse (Truncated, or
+	// any future-added field) cannot leak through.
 	*mh = MetaHeadersFrame{
 		HeadersFrame: hf,
 	}
+	mh.Fields = fields[:0]
 	var remainSize = fr.maxHeaderListSize()
 	var sawRegular bool
 

--- a/src/net/http/internal/http2/frame.go
+++ b/src/net/http/internal/http2/frame.go
@@ -433,7 +433,8 @@ func (fr *Framer) SetReuseFrames() {
 }
 
 type frameCache struct {
-	dataFrame DataFrame
+	dataFrame         DataFrame
+	windowUpdateFrame WindowUpdateFrame
 }
 
 func (fc *frameCache) getDataFrame() *DataFrame {
@@ -441,6 +442,13 @@ func (fc *frameCache) getDataFrame() *DataFrame {
 		return &DataFrame{}
 	}
 	return &fc.dataFrame
+}
+
+func (fc *frameCache) getWindowUpdateFrame() *WindowUpdateFrame {
+	if fc == nil {
+		return &WindowUpdateFrame{}
+	}
+	return &fc.windowUpdateFrame
 }
 
 // NewFramer returns a Framer that writes frames to w and reads them from r.
@@ -996,12 +1004,25 @@ func parseUnknownFrame(_ *frameCache, fh FrameHeader, countError func(string), p
 
 // A WindowUpdateFrame is used to implement flow control.
 // See https://httpwg.org/specs/rfc7540.html#rfc.section.6.9
+//
+// When [Framer.SetReuseFrames] is in effect, the same *WindowUpdateFrame
+// is returned by every (*Framer).ReadFrame call that parses a
+// WINDOW_UPDATE and its fields are overwritten on each call, so callers
+// must consume the StreamID and Increment fields before the next
+// ReadFrame and must not retain the pointer.
 type WindowUpdateFrame struct {
 	FrameHeader
 	Increment uint32 // never read with high bit set
 }
 
-func parseWindowUpdateFrame(_ *frameCache, fh FrameHeader, countError func(string), p []byte) (Frame, error) {
+// parseWindowUpdateFrame populates the *WindowUpdateFrame returned by
+// frameCache.getWindowUpdateFrame. When [Framer.SetReuseFrames] is in
+// effect, that struct is reused across ReadFrame calls; the composite
+// literal reset below overwrites every field, so stale data from a
+// previous frame cannot leak even if a field is added to
+// WindowUpdateFrame later. TestReadFrameWindowUpdateOverwrites guards
+// this property.
+func parseWindowUpdateFrame(fc *frameCache, fh FrameHeader, countError func(string), p []byte) (Frame, error) {
 	if len(p) != 4 {
 		countError("frame_windowupdate_bad_len")
 		return nil, ConnectionError(ErrCodeFrameSize)
@@ -1021,10 +1042,12 @@ func parseWindowUpdateFrame(_ *frameCache, fh FrameHeader, countError func(strin
 		countError("frame_windowupdate_zero_inc_stream")
 		return nil, streamError(fh.StreamID, ErrCodeProtocol)
 	}
-	return &WindowUpdateFrame{
+	wuf := fc.getWindowUpdateFrame()
+	*wuf = WindowUpdateFrame{
 		FrameHeader: fh,
 		Increment:   inc,
-	}, nil
+	}
+	return wuf, nil
 }
 
 // WriteWindowUpdate writes a WINDOW_UPDATE frame.

--- a/src/net/http/internal/http2/frame.go
+++ b/src/net/http/internal/http2/frame.go
@@ -445,6 +445,7 @@ func (fr *Framer) SetReuseFrames() {
 type frameCache struct {
 	dataFrame         DataFrame
 	windowUpdateFrame WindowUpdateFrame
+	headersFrame      HeadersFrame
 }
 
 func (fc *frameCache) getDataFrame() *DataFrame {
@@ -459,6 +460,13 @@ func (fc *frameCache) getWindowUpdateFrame() *WindowUpdateFrame {
 		return &WindowUpdateFrame{}
 	}
 	return &fc.windowUpdateFrame
+}
+
+func (fc *frameCache) getHeadersFrame() *HeadersFrame {
+	if fc == nil {
+		return &HeadersFrame{}
+	}
+	return &fc.headersFrame
 }
 
 // NewFramer returns a Framer that writes frames to w and reads them from r.
@@ -1076,6 +1084,12 @@ func (f *Framer) WriteWindowUpdate(streamID, incr uint32) error {
 
 // A HeadersFrame is used to open a stream and additionally carries a
 // header block fragment.
+//
+// When [Framer.SetReuseFrames] is in effect, the same *HeadersFrame
+// is returned by every (*Framer).ReadFrame call that parses a HEADERS
+// and its fields are overwritten on each call. The headerFragBuf
+// slice always aliases the framer's read buffer and must not be
+// retained past the next ReadFrame regardless of this setting.
 type HeadersFrame struct {
 	FrameHeader
 
@@ -1102,8 +1116,16 @@ func (f *HeadersFrame) HasPriority() bool {
 	return f.FrameHeader.Flags.Has(FlagHeadersPriority)
 }
 
-func parseHeadersFrame(_ *frameCache, fh FrameHeader, countError func(string), p []byte) (_ Frame, err error) {
-	hf := &HeadersFrame{
+// parseHeadersFrame populates the *HeadersFrame returned by
+// frameCache.getHeadersFrame. When [Framer.SetReuseFrames] is in
+// effect, that struct is reused across ReadFrame calls; the composite
+// literal reset below overwrites every field — including any added in
+// the future — so stale values (Priority, or any flag-dependent field
+// added later) cannot leak from a prior frame.
+// TestReadFrameHeadersOverwrites guards this property.
+func parseHeadersFrame(fc *frameCache, fh FrameHeader, countError func(string), p []byte) (_ Frame, err error) {
+	hf := fc.getHeadersFrame()
+	*hf = HeadersFrame{
 		FrameHeader: fh,
 	}
 	if fh.StreamID == 0 {

--- a/src/net/http/internal/http2/frame.go
+++ b/src/net/http/internal/http2/frame.go
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"internal/godebug"
 	"io"
 	"log"
 	"slices"
@@ -21,6 +22,24 @@ import (
 
 	"golang.org/x/net/http/httpguts"
 )
+
+// http2reuseframes controls whether the per-connection Framer in the
+// stdlib server and Transport opts in to SetReuseFrames. Default is
+// reuse on; GODEBUG=http2reuseframes=0 reverts to allocating each
+// parsed frame fresh, matching the pre-Go 1.28 behavior.
+var http2reuseframes = godebug.New("http2reuseframes")
+
+// setReuseFramesFromGODEBUG opts fr in to SetReuseFrames unless the
+// GODEBUG=http2reuseframes=0 opt-out is set. The server and Transport
+// both call this when constructing their per-connection Framer, so the
+// policy (and its non-default accounting) lives in one place.
+func (fr *Framer) setReuseFramesFromGODEBUG() {
+	if http2reuseframes.Value() == "0" {
+		http2reuseframes.IncNonDefault()
+		return
+	}
+	fr.SetReuseFrames()
+}
 
 const frameHeaderLen = 9
 

--- a/src/net/http/internal/http2/frame.go
+++ b/src/net/http/internal/http2/frame.go
@@ -443,7 +443,8 @@ func (fr *Framer) SetReuseFrames() {
 }
 
 type frameCache struct {
-	dataFrame DataFrame
+	dataFrame         DataFrame
+	windowUpdateFrame WindowUpdateFrame
 }
 
 func (fc *frameCache) getDataFrame() *DataFrame {
@@ -451,6 +452,13 @@ func (fc *frameCache) getDataFrame() *DataFrame {
 		return &DataFrame{}
 	}
 	return &fc.dataFrame
+}
+
+func (fc *frameCache) getWindowUpdateFrame() *WindowUpdateFrame {
+	if fc == nil {
+		return &WindowUpdateFrame{}
+	}
+	return &fc.windowUpdateFrame
 }
 
 // NewFramer returns a Framer that writes frames to w and reads them from r.
@@ -1006,12 +1014,25 @@ func parseUnknownFrame(_ *frameCache, fh FrameHeader, countError func(string), p
 
 // A WindowUpdateFrame is used to implement flow control.
 // See https://httpwg.org/specs/rfc7540.html#rfc.section.6.9
+//
+// When [Framer.SetReuseFrames] is in effect, the same *WindowUpdateFrame
+// is returned by every (*Framer).ReadFrame call that parses a
+// WINDOW_UPDATE and its fields are overwritten on each call, so callers
+// must consume the StreamID and Increment fields before the next
+// ReadFrame and must not retain the pointer.
 type WindowUpdateFrame struct {
 	FrameHeader
 	Increment uint32 // never read with high bit set
 }
 
-func parseWindowUpdateFrame(_ *frameCache, fh FrameHeader, countError func(string), p []byte) (Frame, error) {
+// parseWindowUpdateFrame populates the *WindowUpdateFrame returned by
+// frameCache.getWindowUpdateFrame. When [Framer.SetReuseFrames] is in
+// effect, that struct is reused across ReadFrame calls; the composite
+// literal reset below overwrites every field, so stale data from a
+// previous frame cannot leak even if a field is added to
+// WindowUpdateFrame later. TestReadFrameWindowUpdateOverwrites guards
+// this property.
+func parseWindowUpdateFrame(fc *frameCache, fh FrameHeader, countError func(string), p []byte) (Frame, error) {
 	if len(p) != 4 {
 		countError("frame_windowupdate_bad_len")
 		return nil, ConnectionError(ErrCodeFrameSize)
@@ -1031,10 +1052,12 @@ func parseWindowUpdateFrame(_ *frameCache, fh FrameHeader, countError func(strin
 		countError("frame_windowupdate_zero_inc_stream")
 		return nil, streamError(fh.StreamID, ErrCodeProtocol)
 	}
-	return &WindowUpdateFrame{
+	wuf := fc.getWindowUpdateFrame()
+	*wuf = WindowUpdateFrame{
 		FrameHeader: fh,
 		Increment:   inc,
-	}, nil
+	}
+	return wuf, nil
 }
 
 // WriteWindowUpdate writes a WINDOW_UPDATE frame.

--- a/src/net/http/internal/http2/frame.go
+++ b/src/net/http/internal/http2/frame.go
@@ -477,6 +477,23 @@ func (fc *frameCache) getMetaHeadersFrame() *MetaHeadersFrame {
 	return &fc.metaHeadersFrame
 }
 
+// maxRetainedMetaFields caps the number of fields a header block may
+// have for its Fields backing array to be kept in the cached
+// MetaHeadersFrame for the next meta parse. Above the cap, the array
+// is dropped when the frame is invalidated and the next parse pays
+// the modest append-growth cost again.
+//
+// The check is on the length of the parsed block, not on the capacity
+// of its backing array: append rounds capacity up to a size class, so
+// the capacity never equals this constant, and checking it would drop
+// the array for every block bigger than the largest size class below
+// the cap (35 fields as of this writing), silently defeating the
+// reuse for exactly the header-heavy connections that need it most.
+// Retained memory stays bounded either way: a block of at most
+// maxRetainedMetaFields fields has a backing array of at most the
+// next size class up.
+const maxRetainedMetaFields = 64
+
 // NewFramer returns a Framer that writes frames to w and reads them from r.
 func NewFramer(w io.Writer, r io.Reader) *Framer {
 	fr := &Framer{
@@ -546,6 +563,16 @@ func terminalReadFrameError(err error) bool {
 // responsible for the error.
 func (fr *Framer) ReadFrameHeader() (FrameHeader, error) {
 	fr.errDetail = nil
+	// The previous frame's contract ends at this call, not when the
+	// next frame arrives: invalidate it before blocking on the header
+	// read, so that a cached frame does not pin what it parsed (in
+	// particular a MetaHeadersFrame's decoded header fields) for as
+	// long as the connection sits idle. ReadFrameForHeader invalidates
+	// again for callers that read the header themselves; invalidate
+	// is idempotent.
+	if fr.lastFrame != nil {
+		fr.lastFrame.invalidate()
+	}
 	fh, err := readFrameHeader(fr.headerBuf[:], fr.r)
 	if err != nil {
 		return fh, err
@@ -1672,7 +1699,8 @@ type MetaHeadersFrame struct {
 	// Fields are the fields contained in the HEADERS and
 	// CONTINUATION frames. The underlying slice is owned by the
 	// Framer and must not be retained after the next call to
-	// ReadFrame.
+	// ReadFrame: when [Framer.SetReuseFrames] is in effect, the next
+	// meta parse clears and overwrites the backing array in place.
 	//
 	// Fields are guaranteed to be in the correct http2 order and
 	// not have unknown pseudo header fields or invalid header
@@ -1714,8 +1742,29 @@ func (mh *MetaHeadersFrame) checkOwned() {
 // next ReadFrame call (which invalidates the Framer's lastFrame)
 // revokes ownership of the whole MetaHeadersFrame, not only of the
 // embedded HeadersFrame.
+//
+// It also releases the parsed header fields. The Fields contract ends
+// here, and header values can hold secrets (Cookie, Authorization,
+// HPACK Sensitive fields), so the strings are dropped now instead of
+// staying reachable from the cached frame until the next HEADERS
+// frame arrives on the connection, which on an idle connection may
+// be never. The backing array is kept for the next meta parse unless
+// the block was larger than maxRetainedMetaFields, so a single large
+// HEADERS frame cannot permanently inflate per-connection memory.
+//
+// Clearing the slice's length is enough to clear the whole backing
+// array: the slots in [len, cap) are already zero, because
+// readMetaFrame is the only writer of the array, it only ever writes
+// through append, and an append that grows the array gets fresh
+// (zeroed) memory and copies only the live elements into it.
 func (mh *MetaHeadersFrame) invalidate() {
 	mh.owned = false
+	if len(mh.Fields) > maxRetainedMetaFields {
+		mh.Fields = nil
+	} else {
+		clear(mh.Fields)
+		mh.Fields = mh.Fields[:0]
+	}
 	mh.HeadersFrame.invalidate()
 }
 
@@ -1820,11 +1869,31 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (Frame, error) {
 		return nil, errors.New("illegal use of AllowIllegalReads with ReadMetaHeaders")
 	}
 	mh := fr.frameCache.getMetaHeadersFrame()
-	// Wholesale reset so values from a previous parse (Fields,
-	// Truncated, or any future-added field) cannot leak through.
+	// Reuse the Fields backing array from the previous parse. It is
+	// non-nil only when mh is the cached frame, so without
+	// SetReuseFrames every parse still gets a fresh array. The
+	// MetaHeadersFrame.Fields contract (the slice is owned by the
+	// Framer and must not be retained past the next ReadFrame) is
+	// what makes the in-place overwrite legal.
+	//
+	// The cached frame was the Framer's lastFrame, so the ReadFrame
+	// call that led here has already run invalidate, which cleared
+	// the array (or dropped it, if the previous block was too large
+	// to retain). Repeat that here rather than rely on it: a parse
+	// that failed before making mh the lastFrame leaves its partial
+	// Fields behind, and clearing an already-cleared slice is cheap.
+	fields := mh.Fields
+	if len(fields) > maxRetainedMetaFields {
+		fields = nil
+	} else {
+		clear(fields)
+	}
+	// Wholesale reset so values from a previous parse (Truncated, or
+	// any future-added field) cannot leak through.
 	*mh = MetaHeadersFrame{
 		HeadersFrame: hf,
 	}
+	mh.Fields = fields[:0]
 	var remainSize = fr.maxHeaderListSize()
 	var sawRegular bool
 	var headerCount int

--- a/src/net/http/internal/http2/frame.go
+++ b/src/net/http/internal/http2/frame.go
@@ -446,6 +446,7 @@ type frameCache struct {
 	dataFrame         DataFrame
 	windowUpdateFrame WindowUpdateFrame
 	headersFrame      HeadersFrame
+	metaHeadersFrame  MetaHeadersFrame
 }
 
 func (fc *frameCache) getDataFrame() *DataFrame {
@@ -467,6 +468,13 @@ func (fc *frameCache) getHeadersFrame() *HeadersFrame {
 		return &HeadersFrame{}
 	}
 	return &fc.headersFrame
+}
+
+func (fc *frameCache) getMetaHeadersFrame() *MetaHeadersFrame {
+	if fc == nil {
+		return &MetaHeadersFrame{}
+	}
+	return &fc.metaHeadersFrame
 }
 
 // NewFramer returns a Framer that writes frames to w and reads them from r.
@@ -1648,6 +1656,16 @@ type headersOrContinuation interface {
 //
 // This type of frame does not appear on the wire and is only returned
 // by the Framer when Framer.ReadMetaHeaders is set.
+//
+// When [Framer.SetReuseFrames] is in effect, the same *MetaHeadersFrame
+// is returned by every ReadFrame call that produces one and its fields
+// are overwritten on each call. Callers must consume Fields and
+// Truncated before the next ReadFrame and must not retain the pointer.
+// The accessor methods enforce this: calling them after the next
+// ReadFrame panics, mirroring the protection DataFrame.Data has, so a
+// retention bug fails deterministically rather than silently reading
+// another frame's headers. Direct reads of the Fields slice are not
+// guarded.
 type MetaHeadersFrame struct {
 	*HeadersFrame
 
@@ -1667,11 +1685,44 @@ type MetaHeadersFrame struct {
 	// and Fields is incomplete. The hpack decoder state is still
 	// valid, however.
 	Truncated bool
+
+	// owned is whether the frame is owned by the caller of ReadFrame:
+	// set when readMetaFrame returns mh without an error and cleared
+	// by the next ReadFrame call via invalidate. A frame returned
+	// together with an error is never owned; only its Header is
+	// meaningful to the caller. The embedded HeadersFrame's valid
+	// bit cannot serve this purpose because readMetaFrame clears it
+	// when the header block fragment is consumed, before mh is
+	// returned.
+	//
+	// Like DataFrame's checkValid protection, this catches access to a
+	// stale frame, not every contract violation: once the Framer
+	// repopulates the cached struct with a new meta frame, the
+	// retained pointer becomes "owned" again and reads the new frame's
+	// fields. Without SetReuseFrames the guard is exact, since a
+	// retained frame is never repopulated.
+	owned bool
+}
+
+func (mh *MetaHeadersFrame) checkOwned() {
+	if !mh.owned {
+		panic("Frame accessor called on non-owned Frame")
+	}
+}
+
+// invalidate overrides the embedded FrameHeader's method so that the
+// next ReadFrame call (which invalidates the Framer's lastFrame)
+// revokes ownership of the whole MetaHeadersFrame, not only of the
+// embedded HeadersFrame.
+func (mh *MetaHeadersFrame) invalidate() {
+	mh.owned = false
+	mh.HeadersFrame.invalidate()
 }
 
 // PseudoValue returns the given pseudo header field's value.
 // The provided pseudo field should not contain the leading colon.
 func (mh *MetaHeadersFrame) PseudoValue(pseudo string) string {
+	mh.checkOwned()
 	for _, hf := range mh.Fields {
 		if !hf.IsPseudo() {
 			return ""
@@ -1686,6 +1737,7 @@ func (mh *MetaHeadersFrame) PseudoValue(pseudo string) string {
 // RegularFields returns the regular (non-pseudo) header fields of mh.
 // The caller does not own the returned slice.
 func (mh *MetaHeadersFrame) RegularFields() []hpack.HeaderField {
+	mh.checkOwned()
 	for i, hf := range mh.Fields {
 		if !hf.IsPseudo() {
 			return mh.Fields[i:]
@@ -1697,6 +1749,7 @@ func (mh *MetaHeadersFrame) RegularFields() []hpack.HeaderField {
 // PseudoFields returns the pseudo header fields of mh.
 // The caller does not own the returned slice.
 func (mh *MetaHeadersFrame) PseudoFields() []hpack.HeaderField {
+	mh.checkOwned()
 	for i, hf := range mh.Fields {
 		if !hf.IsPseudo() {
 			return mh.Fields[:i]
@@ -1706,6 +1759,7 @@ func (mh *MetaHeadersFrame) PseudoFields() []hpack.HeaderField {
 }
 
 func (mh *MetaHeadersFrame) rfc9218Priority(priorityAware bool) (p PriorityParam, priorityAwareAfter, hasIntermediary bool) {
+	mh.checkOwned()
 	var s string
 	for _, field := range mh.Fields {
 		if field.Name == "priority" {
@@ -1765,7 +1819,10 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (Frame, error) {
 	if fr.AllowIllegalReads {
 		return nil, errors.New("illegal use of AllowIllegalReads with ReadMetaHeaders")
 	}
-	mh := &MetaHeadersFrame{
+	mh := fr.frameCache.getMetaHeadersFrame()
+	// Wholesale reset so values from a previous parse (Fields,
+	// Truncated, or any future-added field) cannot leak through.
+	*mh = MetaHeadersFrame{
 		HeadersFrame: hf,
 	}
 	var remainSize = fr.maxHeaderListSize()
@@ -1862,6 +1919,12 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (Frame, error) {
 		if hc.HeadersEnded() {
 			break
 		}
+		// This re-enters ReadFrame while the HeadersFrame and the
+		// MetaHeadersFrame, both possibly cached, are in use. That is
+		// safe only because checkFrameOrder guarantees the next frame
+		// is a CONTINUATION and ContinuationFrame is not part of
+		// frameCache: caching it, or resetting cached frames eagerly in
+		// ReadFrame, would corrupt a multi-frame header block mid-parse.
 		if f, err := fr.ReadFrame(); err != nil {
 			return nil, err
 		} else {
@@ -1871,6 +1934,11 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (Frame, error) {
 
 	mh.HeadersFrame.headerFragBuf = nil
 	mh.HeadersFrame.invalidate()
+
+	// The header block is complete: make mh the Framer's lastFrame so
+	// that the next ReadFrame invalidates it, whether or not the checks
+	// below accept it.
+	fr.lastFrame = mh
 
 	if err := hdec.Close(); err != nil {
 		return mh, ConnectionError(ErrCodeCompression)
@@ -1882,6 +1950,14 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (Frame, error) {
 		}
 		return nil, StreamError{mh.StreamID, ErrCodeProtocol, invalid}
 	}
+	// The header block decoded cleanly, so mh is the frame handed to
+	// the caller: mark it owned, so that the accessor methods work
+	// until the next ReadFrame revokes ownership and panic on a stale
+	// frame instead of reading fields a later parse may have
+	// overwritten in place. A frame returned together with an error
+	// stays unowned. (checkPseudos relies on the ownership being
+	// established first.)
+	mh.owned = true
 	if err := mh.checkPseudos(); err != nil {
 		fr.errDetail = err
 		if VerboseLogs {

--- a/src/net/http/internal/http2/frame.go
+++ b/src/net/http/internal/http2/frame.go
@@ -372,6 +372,115 @@ type Framer struct {
 	debugWriteLoggerf func(string, ...any)
 
 	frameCache *frameCache // nil if frames aren't reused (default)
+
+	// metaParse is the state readMetaFrame's hpack emit callback
+	// reads and updates. See metaParseState.
+	metaParse metaParseState
+
+	// emitMetaFieldFunc is the method value (*Framer).emitMetaField,
+	// built on first use. Evaluating a method value allocates a
+	// closure, so readMetaFrame builds it once per Framer instead of
+	// once per HEADERS frame.
+	emitMetaFieldFunc func(hpack.HeaderField)
+}
+
+// metaParseState is the per-parse state of readMetaFrame that its
+// hpack emit callback has to see. It lives on the Framer so that the
+// callback can be a single method value registered once, rather than
+// a fresh closure with a separately boxed variable per captured
+// field allocated on every HEADERS frame.
+//
+// Only one meta parse can be in flight per Framer: readMetaFrame's
+// CONTINUATION loop is the only reentrant path into ReadFrame, and
+// checkFrameOrder guarantees the frames it reads there are
+// CONTINUATION, never HEADERS.
+type metaParseState struct {
+	// mh is the frame being filled in. endMetaParse clears it, so
+	// that a Framer without SetReuseFrames does not retain the
+	// MetaHeadersFrame it handed to the caller.
+	mh *MetaHeadersFrame
+
+	// hdec is the decoder this parse installed the callback on. It is
+	// held here rather than read back out of fr.ReadMetaHeaders so
+	// that the callback and its teardown act on the same decoder the
+	// parse started with, exactly as the closure this replaced did.
+	hdec *hpack.Decoder
+
+	// remainSize is the number of header list bytes still accepted.
+	remainSize uint32
+
+	// headerCount counts emitted fields, against MaxHeaderValueCount.
+	headerCount int
+
+	// sawRegular records whether a non-pseudo field has been seen, so
+	// that a pseudo field after one can be rejected.
+	sawRegular bool
+
+	// invalid is the first pseudo/name/value validation error, if any.
+	invalid error
+}
+
+// noopEmitFunc discards a decoded header field. readMetaFrame installs
+// it when it is done, so that the decoder holds no reference to the
+// parsed frame and a field emitted outside a parse cannot reach a nil
+// metaParse.mh.
+func noopEmitFunc(hpack.HeaderField) {}
+
+// emitMetaField is the hpack decoder's emit callback while
+// readMetaFrame is running. It is the method form of what used to be a
+// per-parse closure; the variables it used to capture now live in
+// fr.metaParse.
+func (fr *Framer) emitMetaField(hf hpack.HeaderField) {
+	mp := &fr.metaParse
+	hdec := mp.hdec
+	if VerboseLogs && fr.logReads {
+		fr.debugReadLoggerf("http2: decoded hpack field %+v", hf)
+	}
+	mp.headerCount++
+	if limit := fr.maxHeaderValueCount(); limit > 0 && mp.headerCount > limit {
+		hdec.SetEmitEnabled(false)
+		mp.mh.Truncated = true
+		mp.remainSize = 0
+		return
+	}
+	if !httpguts.ValidHeaderFieldValue(hf.Value) {
+		// Don't include the value in the error, because it may be sensitive.
+		mp.invalid = headerFieldValueError(hf.Name)
+	}
+	isPseudo := strings.HasPrefix(hf.Name, ":")
+	if isPseudo {
+		if mp.sawRegular {
+			mp.invalid = errPseudoAfterRegular
+		}
+	} else {
+		mp.sawRegular = true
+		if !validWireHeaderFieldName(hf.Name) {
+			mp.invalid = headerFieldNameError(hf.Name)
+		}
+	}
+
+	if mp.invalid != nil {
+		hdec.SetEmitEnabled(false)
+		return
+	}
+
+	size := hf.Size()
+	if size > mp.remainSize {
+		hdec.SetEmitEnabled(false)
+		mp.mh.Truncated = true
+		mp.remainSize = 0
+		return
+	}
+	mp.remainSize -= size
+
+	mp.mh.Fields = append(mp.mh.Fields, hf)
+}
+
+// endMetaParse tears down the state emitMetaField reads, once the
+// parse that set it up is over.
+func (fr *Framer) endMetaParse() {
+	fr.metaParse.hdec.SetEmitFunc(noopEmitFunc)
+	fr.metaParse = metaParseState{}
 }
 
 func (fr *Framer) maxHeaderListSize() uint32 {
@@ -1913,59 +2022,28 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (Frame, error) {
 		HeadersFrame: hf,
 	}
 	mh.Fields = fields[:0]
-	var remainSize = fr.maxHeaderListSize()
-	var sawRegular bool
-	var headerCount int
 
-	var invalid error // pseudo header field errors
+	// Set up the state the emit callback mutates. It lives on the
+	// Framer rather than in a closure so that the callback can be a
+	// method value built once per Framer: a fresh closure here would
+	// heap-allocate itself plus a box for each variable it captures,
+	// on every HEADERS frame.
 	hdec := fr.ReadMetaHeaders
+	fr.metaParse = metaParseState{
+		mh:         mh,
+		hdec:       hdec,
+		remainSize: fr.maxHeaderListSize(),
+	}
+	mp := &fr.metaParse
 	hdec.SetEmitEnabled(true)
 	hdec.SetMaxStringLength(fr.maxHeaderStringLen())
-	hdec.SetEmitFunc(func(hf hpack.HeaderField) {
-		if VerboseLogs && fr.logReads {
-			fr.debugReadLoggerf("http2: decoded hpack field %+v", hf)
-		}
-		headerCount++
-		if limit := fr.maxHeaderValueCount(); limit > 0 && headerCount > limit {
-			hdec.SetEmitEnabled(false)
-			mh.Truncated = true
-			remainSize = 0
-			return
-		}
-		if !httpguts.ValidHeaderFieldValue(hf.Value) {
-			// Don't include the value in the error, because it may be sensitive.
-			invalid = headerFieldValueError(hf.Name)
-		}
-		isPseudo := strings.HasPrefix(hf.Name, ":")
-		if isPseudo {
-			if sawRegular {
-				invalid = errPseudoAfterRegular
-			}
-		} else {
-			sawRegular = true
-			if !validWireHeaderFieldName(hf.Name) {
-				invalid = headerFieldNameError(hf.Name)
-			}
-		}
-
-		if invalid != nil {
-			hdec.SetEmitEnabled(false)
-			return
-		}
-
-		size := hf.Size()
-		if size > remainSize {
-			hdec.SetEmitEnabled(false)
-			mh.Truncated = true
-			remainSize = 0
-			return
-		}
-		remainSize -= size
-
-		mh.Fields = append(mh.Fields, hf)
-	})
-	// Lose reference to MetaHeadersFrame:
-	defer hdec.SetEmitFunc(func(hf hpack.HeaderField) {})
+	if fr.emitMetaFieldFunc == nil {
+		fr.emitMetaFieldFunc = fr.emitMetaField
+	}
+	hdec.SetEmitFunc(fr.emitMetaFieldFunc)
+	// Uninstall the callback and lose the reference to the
+	// MetaHeadersFrame:
+	defer fr.endMetaParse()
 
 	var hc headersOrContinuation = hf
 	for {
@@ -1979,7 +2057,7 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (Frame, error) {
 		// exceeded the max header list size (in which case remainSize is 0),
 		// or a frame whose encoded size is more than twice the remaining
 		// header list bytes we're willing to accept.
-		if int64(len(frag)) > int64(2*remainSize) {
+		if int64(len(frag)) > int64(2*mp.remainSize) {
 			if VerboseLogs {
 				log.Printf("http2: header list too large")
 			}
@@ -1991,9 +2069,9 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (Frame, error) {
 		// Also close the connection after any CONTINUATION frame following an
 		// invalid header, since we stop tracking the size of the headers after
 		// an invalid one.
-		if invalid != nil {
+		if mp.invalid != nil {
 			if VerboseLogs {
-				log.Printf("http2: invalid header: %v", invalid)
+				log.Printf("http2: invalid header: %v", mp.invalid)
 			}
 			// It would be nice to send a RST_STREAM before sending the GOAWAY,
 			// but the structure of the server's frame writer makes this difficult.
@@ -2031,12 +2109,12 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (Frame, error) {
 	if err := hdec.Close(); err != nil {
 		return mh, ConnectionError(ErrCodeCompression)
 	}
-	if invalid != nil {
-		fr.errDetail = invalid
+	if mp.invalid != nil {
+		fr.errDetail = mp.invalid
 		if VerboseLogs {
-			log.Printf("http2: invalid header: %v", invalid)
+			log.Printf("http2: invalid header: %v", mp.invalid)
 		}
-		return nil, StreamError{mh.StreamID, ErrCodeProtocol, invalid}
+		return nil, StreamError{mh.StreamID, ErrCodeProtocol, mp.invalid}
 	}
 	// The header block decoded cleanly, so mh is the frame handed to
 	// the caller: mark it owned, so that the accessor methods work

--- a/src/net/http/internal/http2/frame_reuse_e2e_test.go
+++ b/src/net/http/internal/http2/frame_reuse_e2e_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package http2_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestFrameReuseEndToEndStress drives concurrent multiplexed requests
+// through the real net/http HTTP/2 server and Transport (both of
+// which call SetReuseFrames on the per-connection Framer) and touches
+// every field reachable from a request/response in ways that would
+// race against the read loop's next ReadFrame if anything still
+// aliased the cached frame after the readMore gate (server) or
+// read-loop iteration (Transport).
+//
+// Under -race this is a regression test against future refactors of
+// processHeaders / handleResponse / processTrailers / processData
+// that fail to copy aliased data. The synthetic Framer-pair tests in
+// frame_reuse_race_test.go cannot reach the production process* code
+// paths; this one does.
+//
+// The handler and client iterate Name/Value byte-by-byte so that any
+// aliasing leak shows up as a concrete read concurrent with a write
+// in bytes.(*Reader).Read inside ReadFrame.
+func TestFrameReuseEndToEndStress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping stress test in short mode")
+	}
+
+	const responseBody = "the quick brown fox jumps over the lazy dog"
+
+	touchHeader := func(h http.Header) byte {
+		var sink byte
+		for k, vs := range h {
+			for i := 0; i < len(k); i++ {
+				sink ^= k[i]
+			}
+			for _, v := range vs {
+				for i := 0; i < len(v); i++ {
+					sink ^= v[i]
+				}
+			}
+		}
+		return sink
+	}
+
+	ts := newTestServer(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			_ = touchHeader(r.Header)
+			if _, err := io.Copy(io.Discard, r.Body); err != nil {
+				t.Errorf("server body copy: %v", err)
+				return
+			}
+			_ = touchHeader(r.Trailer)
+			w.Header().Set("Trailer", "X-Server-Trailer")
+			w.Header().Set("X-Response-Header", "response-value")
+			w.WriteHeader(http.StatusOK)
+			io.WriteString(w, responseBody)
+			w.Header().Set("X-Server-Trailer", "server-trailer-value")
+		},
+		optQuiet,
+	)
+
+	tr := newTransport(t)
+
+	const (
+		workers    = 8
+		iterations = 25
+	)
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				body := strings.NewReader("client request body content")
+				req, err := http.NewRequest("POST", ts.URL, body)
+				if err != nil {
+					t.Errorf("NewRequest: %v", err)
+					return
+				}
+				req.Header.Set("X-Test-Header", "client-header-value")
+				req.Trailer = http.Header{
+					"X-Client-Trailer": []string{"client-trailer-value"},
+				}
+				res, err := tr.RoundTrip(req)
+				if err != nil {
+					t.Errorf("RoundTrip: %v", err)
+					return
+				}
+				_ = touchHeader(res.Header)
+				if _, err := io.Copy(io.Discard, res.Body); err != nil {
+					res.Body.Close()
+					t.Errorf("client body copy: %v", err)
+					return
+				}
+				if err := res.Body.Close(); err != nil {
+					t.Errorf("body close: %v", err)
+					return
+				}
+				_ = touchHeader(res.Trailer)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/src/net/http/internal/http2/frame_reuse_e2e_test.go
+++ b/src/net/http/internal/http2/frame_reuse_e2e_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package http2_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"testing/synctest"
+)
+
+// TestFrameReuseEndToEndStress drives concurrent multiplexed requests
+// through the real net/http HTTP/2 server and Transport (both of
+// which call SetReuseFrames on the per-connection Framer) and touches
+// every field reachable from a request/response in ways that would
+// race against the read loop's next ReadFrame if anything still
+// aliased the cached frame after the readMore gate (server) or
+// read-loop iteration (Transport).
+//
+// Under -race this is a regression test against future refactors of
+// processHeaders / handleResponse / processTrailers / processData
+// that fail to copy aliased data. The synthetic Framer-pair tests in
+// frame_reuse_race_test.go cannot reach the production process* code
+// paths; this one does.
+//
+// The handler and client iterate Name/Value byte-by-byte so that any
+// aliasing leak shows up as a concrete read concurrent with a write
+// in bytes.(*Reader).Read inside ReadFrame.
+func TestFrameReuseEndToEndStress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping stress test in short mode")
+	}
+
+	const responseBody = "the quick brown fox jumps over the lazy dog"
+
+	touchHeader := func(h http.Header) byte {
+		var sink byte
+		for k, vs := range h {
+			for i := 0; i < len(k); i++ {
+				sink ^= k[i]
+			}
+			for _, v := range vs {
+				for i := 0; i < len(v); i++ {
+					sink ^= v[i]
+				}
+			}
+		}
+		return sink
+	}
+
+	ts := newTestServer(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			_ = touchHeader(r.Header)
+			if _, err := io.Copy(io.Discard, r.Body); err != nil {
+				t.Errorf("server body copy: %v", err)
+				return
+			}
+			_ = touchHeader(r.Trailer)
+			w.Header().Set("Trailer", "X-Server-Trailer")
+			w.Header().Set("X-Response-Header", "response-value")
+			w.WriteHeader(http.StatusOK)
+			io.WriteString(w, responseBody)
+			w.Header().Set("X-Server-Trailer", "server-trailer-value")
+		},
+		optQuiet,
+	)
+
+	tr := newTransport(t)
+
+	const (
+		workers    = 8
+		iterations = 25
+	)
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				body := strings.NewReader("client request body content")
+				req, err := http.NewRequest("POST", ts.URL, body)
+				if err != nil {
+					t.Errorf("NewRequest: %v", err)
+					return
+				}
+				req.Header.Set("X-Test-Header", "client-header-value")
+				req.Trailer = http.Header{
+					"X-Client-Trailer": []string{"client-trailer-value"},
+				}
+				res, err := tr.RoundTrip(req)
+				if err != nil {
+					t.Errorf("RoundTrip: %v", err)
+					return
+				}
+				_ = touchHeader(res.Header)
+				if _, err := io.Copy(io.Discard, res.Body); err != nil {
+					res.Body.Close()
+					t.Errorf("client body copy: %v", err)
+					return
+				}
+				if err := res.Body.Close(); err != nil {
+					t.Errorf("body close: %v", err)
+					return
+				}
+				_ = touchHeader(res.Trailer)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestReuseFramesGODEBUGWiring verifies that the server and the
+// Transport both apply the setting to their per-connection Framer.
+func TestReuseFramesGODEBUGWiring(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		godebug   string
+		wantReuse bool
+	}{
+		{"default", "", true},
+		{"off", "http2reuseframes=0", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GODEBUG", tc.godebug)
+			synctest.Test(t, func(t *testing.T) {
+				st := newServerTester(t, func(w http.ResponseWriter, r *http.Request) {}, optQuiet)
+				defer st.Close()
+				if got := st.sc.TestFramerReusesFrames(); got != tc.wantReuse {
+					t.Errorf("server frame reuse = %v, want %v", got, tc.wantReuse)
+				}
+				tcc := newTestClientConn(t)
+				if got := tcc.cc.TestFramerReusesFrames(); got != tc.wantReuse {
+					t.Errorf("Transport frame reuse = %v, want %v", got, tc.wantReuse)
+				}
+			})
+		})
+	}
+}

--- a/src/net/http/internal/http2/frame_reuse_godebug_test.go
+++ b/src/net/http/internal/http2/frame_reuse_godebug_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package http2
+
+import (
+	"io"
+	"runtime/metrics"
+	"testing"
+)
+
+// reuseFramesNonDefaultCount returns how many times the
+// http2reuseframes=0 opt-out has been taken, as reported through
+// runtime/metrics.
+func reuseFramesNonDefaultCount(t *testing.T) uint64 {
+	t.Helper()
+	s := []metrics.Sample{{Name: "/godebug/non-default-behavior/http2reuseframes:events"}}
+	metrics.Read(s)
+	if s[0].Value.Kind() != metrics.KindUint64 {
+		t.Fatalf("metric %s has kind %v, want KindUint64", s[0].Name, s[0].Value.Kind())
+	}
+	return s[0].Value.Uint64()
+}
+
+// TestSetReuseFramesFromGODEBUG verifies the http2reuseframes escape
+// hatch on a bare Framer: reuse is on by default and with
+// http2reuseframes=1, off with http2reuseframes=0, and only the
+// opt-out is counted as a non-default behavior.
+func TestSetReuseFramesFromGODEBUG(t *testing.T) {
+	for _, tc := range []struct {
+		godebug   string
+		wantReuse bool
+	}{
+		{"", true},
+		{"http2reuseframes=1", true},
+		{"http2reuseframes=0", false},
+	} {
+		t.Run("GODEBUG="+tc.godebug, func(t *testing.T) {
+			t.Setenv("GODEBUG", tc.godebug)
+			before := reuseFramesNonDefaultCount(t)
+			fr := NewFramer(io.Discard, nil)
+			fr.setReuseFramesFromGODEBUG()
+			if got := fr.frameCache != nil; got != tc.wantReuse {
+				t.Errorf("frame reuse = %v, want %v", got, tc.wantReuse)
+			}
+			wantCounted := uint64(0)
+			if !tc.wantReuse {
+				wantCounted = 1
+			}
+			if got := reuseFramesNonDefaultCount(t) - before; got != wantCounted {
+				t.Errorf("non-default behavior count grew by %d, want %d", got, wantCounted)
+			}
+		})
+	}
+}

--- a/src/net/http/internal/http2/frame_reuse_race_test.go
+++ b/src/net/http/internal/http2/frame_reuse_race_test.go
@@ -1,0 +1,422 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package http2
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/net/http2/hpack"
+)
+
+// The tests in this file exercise the Framer.SetReuseFrames contract
+// from a concurrency angle. The reuse contract says the *Frame returned
+// by ReadFrame, any slice aliasing the Framer's read buffer reachable
+// from that frame, and the MetaHeadersFrame Fields slice are only valid
+// until the next ReadFrame call. A retention bug under reuse manifests
+// as one goroutine reading a retained slice while another (the reader)
+// writes into the same backing memory on the next ReadFrame.
+//
+// These tests model the server's readFrames goroutine pattern (one
+// reader goroutine, one consumer goroutine separated by a gate
+// channel) and aim to be effective under "go test -race". Each runs
+// twice: a "meta" variant with ReadMetaHeaders set, where HEADERS
+// surface as *MetaHeadersFrame, and a "raw" variant without it, where
+// HEADERS and CONTINUATION surface individually and their
+// HeaderBlockFragment aliases the read buffer.
+//
+//   - TestFrameReuseRaceCorrect: faithful gated handoff. Must NOT race
+//     under -race, regardless of how many frames are read. This is a
+//     positive control that asserts the gated pattern is safe with
+//     reuse on.
+//
+//   - TestFrameReuseRaceAdversarial: deliberately leaks a slice past
+//     the gate. Must race under -race. Guarded behind the
+//     H2_REUSE_RACE_NEGATIVE=1 env var so normal `go test` and CI
+//     stay green; the assertion of the negative case is the race
+//     detector itself.
+//
+// A companion end-to-end stress test exists in
+// frame_reuse_e2e_test.go (package http2_test) which drives the real
+// net/http HTTP/2 server and Transport under -race. The synthetic
+// tests in this file cannot reach the production process* code paths;
+// the e2e test does.
+
+// preEncodeReuseRaceStream encodes a long sequence of frames
+// exercising every frame type extended by SetReuseFrames: DATA,
+// WINDOW_UPDATE, HEADERS, and HEADERS+CONTINUATION (so the meta
+// header path runs). All HEADERS/DATA payloads are the same size so
+// the framer's readBuf does not reallocate between frames; the
+// retained slice in the adversarial subtest therefore continues to
+// alias the same backing array that the next ReadFrame writes into.
+// The header blocks stay at four fields, well under
+// maxRetainedMetaFields, so the meta path keeps reusing one Fields
+// backing array for the same reason.
+func preEncodeReuseRaceStream(tb testing.TB, iters int) []byte {
+	tb.Helper()
+	var buf bytes.Buffer
+	fr := NewFramer(&buf, nil)
+	// Encode HPACK fields once; reuse to keep payload sizes stable.
+	hdrBlock := encodeHeaderRaw(tb,
+		":method", "GET",
+		":path", "/",
+		":scheme", "http",
+		":authority", "example.com",
+	)
+	// Split hdrBlock so we can emit HEADERS+CONTINUATION for the
+	// meta path.
+	half := len(hdrBlock) / 2
+	if half == 0 {
+		half = 1
+	}
+	// Use a fixed-length data payload so the readBuf size stays
+	// constant once it grows on the first read.
+	dataPayload := bytes.Repeat([]byte{0xab}, 64)
+
+	for i := 0; i < iters; i++ {
+		streamID := uint32(2*i + 1)
+		// DATA
+		if err := fr.WriteData(streamID, false, dataPayload); err != nil {
+			tb.Fatal(err)
+		}
+		// WINDOW_UPDATE
+		if err := fr.WriteWindowUpdate(streamID, uint32(1+i%4096)); err != nil {
+			tb.Fatal(err)
+		}
+		// HEADERS (single-frame, EndHeaders=true)
+		if err := fr.WriteHeaders(HeadersFrameParam{
+			StreamID:      streamID,
+			BlockFragment: hdrBlock,
+			EndHeaders:    true,
+		}); err != nil {
+			tb.Fatal(err)
+		}
+		// HEADERS + CONTINUATION (drives the meta-headers path when
+		// ReadMetaHeaders is set, and the CONTINUATION path when not)
+		if err := fr.WriteHeaders(HeadersFrameParam{
+			StreamID:      streamID,
+			BlockFragment: hdrBlock[:half],
+			EndHeaders:    false,
+		}); err != nil {
+			tb.Fatal(err)
+		}
+		if err := fr.WriteContinuation(streamID, true, hdrBlock[half:]); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	return buf.Bytes()
+}
+
+// newReuseRaceFramer builds a SetReuseFrames Framer over the
+// pre-encoded stream, with the meta-headers decoder installed when
+// meta is set.
+func newReuseRaceFramer(encoded []byte, meta bool) *Framer {
+	fr := NewFramer(io.Discard, bytes.NewReader(encoded))
+	fr.SetReuseFrames()
+	if meta {
+		fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+	}
+	return fr
+}
+
+// runReadFramesGoroutine launches a goroutine that mimics
+// serverConn.readFrames: reads a frame, sends it to ch, waits on the
+// returned gate before reading the next. Returns the gate channel and
+// a done channel that closes once the reader goroutine exits.
+type framedRead struct {
+	frame Frame
+	err   error
+	// done must be called once the consumer no longer retains frame
+	// or any slice aliasing the framer's read buffer.
+	done chan<- struct{}
+}
+
+func runReadFramesGoroutine(tb testing.TB, fr *Framer, ch chan<- framedRead) (exited <-chan struct{}) {
+	tb.Helper()
+	exitc := make(chan struct{})
+	go func() {
+		defer close(exitc)
+		for {
+			gate := make(chan struct{})
+			f, err := fr.ReadFrame()
+			ch <- framedRead{frame: f, err: err, done: gate}
+			// Wait for the consumer to signal done before reading
+			// again. This re-creates the readFrames gate.
+			<-gate
+			if err != nil {
+				return
+			}
+		}
+	}()
+	return exitc
+}
+
+// consumeSliceWork is a noinline helper that reads every byte of b
+// once. Its only purpose is to ensure the race detector observes a
+// read of the memory backing b. If a concurrent goroutine writes the
+// same memory without a happens-before edge, -race will fire here.
+//
+//go:noinline
+func consumeSliceWork(b []byte) byte {
+	var x byte
+	for _, v := range b {
+		x ^= v
+	}
+	return x
+}
+
+// consumeHeaderFieldWork reads every HeaderField element of fields,
+// plus the name+value string bytes. Ranging over a retained Fields
+// slice reads the HeaderField structs out of the backing array the
+// Framer owns; with SetReuseFrames, the next meta parse clears and
+// re-appends into that same array, so the race detector observes the
+// conflict on the struct memory. The string bytes themselves are
+// independent allocations (hpack hands out fresh strings per decode),
+// so they never alias the framer's read buffer.
+//
+//go:noinline
+func consumeHeaderFieldWork(fields []hpack.HeaderField) byte {
+	var x byte
+	for _, hf := range fields {
+		for i := 0; i < len(hf.Name); i++ {
+			x ^= hf.Name[i]
+		}
+		for i := 0; i < len(hf.Value); i++ {
+			x ^= hf.Value[i]
+		}
+	}
+	return x
+}
+
+// TestFrameReuseRaceCorrect runs the full reader-consumer dance with
+// SetReuseFrames enabled, consuming every frame's payload before
+// signaling the gate. Under -race, this MUST NOT fire.
+//
+// What this catches: a reuse implementation that mutates the cached
+// frame or its backing buffer before the consumer signals done (for
+// example, by parsing the next frame eagerly on a background
+// goroutine or by reusing the buffer for some other purpose).
+func TestFrameReuseRaceCorrect(t *testing.T) {
+	t.Run("meta", func(t *testing.T) { testFrameReuseRaceCorrect(t, true) })
+	t.Run("raw", func(t *testing.T) { testFrameReuseRaceCorrect(t, false) })
+}
+
+func testFrameReuseRaceCorrect(t *testing.T, meta bool) {
+	const iters = 200
+
+	encoded := preEncodeReuseRaceStream(t, iters)
+	fr := newReuseRaceFramer(encoded, meta)
+
+	ch := make(chan framedRead)
+	exitc := runReadFramesGoroutine(t, fr, ch)
+
+	// sink lets the compiler keep the work observable.
+	var sink atomic.Uint64
+	frames := 0
+
+	for {
+		select {
+		case res := <-ch:
+			if res.err == io.EOF {
+				close(res.done)
+				goto drain
+			}
+			if res.err != nil {
+				t.Fatalf("unexpected ReadFrame error: %v", res.err)
+			}
+			frames++
+			// Consume the slice/fields synchronously. Once we
+			// signal done, we forget the frame.
+			switch f := res.frame.(type) {
+			case *DataFrame:
+				sink.Add(uint64(consumeSliceWork(f.Data())))
+			case *HeadersFrame:
+				sink.Add(uint64(consumeSliceWork(f.HeaderBlockFragment())))
+			case *ContinuationFrame:
+				sink.Add(uint64(consumeSliceWork(f.HeaderBlockFragment())))
+			case *MetaHeadersFrame:
+				sink.Add(uint64(consumeHeaderFieldWork(f.Fields)))
+			case *WindowUpdateFrame:
+				sink.Add(uint64(f.Increment))
+			default:
+				t.Fatalf("unexpected frame type %T", res.frame)
+			}
+			close(res.done) // gate: reader may proceed.
+		case <-time.After(30 * time.Second):
+			t.Fatal("timed out waiting for next frame")
+		}
+	}
+drain:
+	<-exitc
+	// meta: DATA, WINDOW_UPDATE, and two MetaHeadersFrames per iter.
+	// raw: the second HEADERS surfaces as HEADERS+CONTINUATION.
+	wantFrames := iters * 4
+	if !meta {
+		wantFrames = iters * 5
+	}
+	if frames != wantFrames {
+		t.Errorf("consumed %d frames, want %d", frames, wantFrames)
+	}
+	t.Logf("consumed %d frames, sink=%d", frames, sink.Load())
+}
+
+// TestFrameReuseRaceAdversarial deliberately violates the reuse
+// contract: the consumer hands a retained slice to a sidecar
+// goroutine that keeps reading it indefinitely, while the gate is
+// signaled immediately so the reader proceeds to overwrite the same
+// memory. Under -race, this MUST fire.
+//
+// It is guarded behind H2_REUSE_RACE_NEGATIVE=1 because it is a
+// negative control: failure (i.e., no race detected) is what we want
+// to be loud about during development, but a passing test on stock
+// CI is uninteresting. Run it as:
+//
+//	H2_REUSE_RACE_NEGATIVE=1 go test -race -run TestFrameReuseRaceAdversarial
+//
+// What it would catch in production code: any handler/code path that
+// holds onto Data, HeaderBlockFragment, or the MetaHeadersFrame
+// Fields slice past the readMore call.
+func TestFrameReuseRaceAdversarial(t *testing.T) {
+	if os.Getenv("H2_REUSE_RACE_NEGATIVE") != "1" {
+		t.Skip("skipping adversarial negative-control test; " +
+			"set H2_REUSE_RACE_NEGATIVE=1 to run under -race")
+	}
+	t.Run("meta", func(t *testing.T) { testFrameReuseRaceAdversarial(t, true) })
+	t.Run("raw", func(t *testing.T) { testFrameReuseRaceAdversarial(t, false) })
+}
+
+func testFrameReuseRaceAdversarial(t *testing.T, meta bool) {
+	// 50 outer iterations -> 200+ frames. That is far more than
+	// enough scheduler interleavings for the race detector to
+	// observe at least one concurrent read/write conflict.
+	const iters = 50
+	const maxLiveAttackers = 8 // cap concurrent attacker goroutines
+
+	encoded := preEncodeReuseRaceStream(t, iters)
+	fr := newReuseRaceFramer(encoded, meta)
+
+	ch := make(chan framedRead)
+	exitc := runReadFramesGoroutine(t, fr, ch)
+
+	// stopAttackers is closed when the test is winding down to let
+	// any retained-slice readers exit.
+	stopAttackers := make(chan struct{})
+	var attackers sync.WaitGroup
+	// Token bucket bounds the number of attacker goroutines alive
+	// at any time; without it the race detector slows to a crawl as
+	// many hundreds of goroutines all hammer the read buffer.
+	tokens := make(chan struct{}, maxLiveAttackers)
+
+	// retainedRefs accumulates references we deliberately leak past
+	// the gate. Holding them in the test goroutine keeps them
+	// reachable for the GC's view, but the race detector still
+	// catches read/write conflicts on the underlying memory.
+	type retainedSlice struct {
+		b []byte
+	}
+	type retainedFields struct {
+		hf []hpack.HeaderField
+	}
+	var refs []any
+
+	startAttacker := func(read func()) {
+		// Block briefly if too many attackers are already running.
+		// This will bound the runtime overhead without weakening the
+		// race detector signal (each retained reference still gets
+		// a goroutine that overlaps the next ReadFrame).
+		select {
+		case tokens <- struct{}{}:
+		case <-stopAttackers:
+			return
+		}
+		attackers.Add(1)
+		go func() {
+			defer attackers.Done()
+			defer func() { <-tokens }()
+			for i := 0; i < 200; i++ {
+				select {
+				case <-stopAttackers:
+					return
+				default:
+				}
+				read()
+			}
+		}()
+	}
+
+	var sink atomic.Uint64
+
+	for {
+		select {
+		case res := <-ch:
+			if res.err == io.EOF {
+				close(res.done)
+				goto drain
+			}
+			if res.err != nil {
+				t.Fatalf("unexpected ReadFrame error: %v", res.err)
+			}
+			switch f := res.frame.(type) {
+			case *DataFrame:
+				retained := retainedSlice{b: f.Data()}
+				refs = append(refs, retained)
+				startAttacker(func() {
+					sink.Add(uint64(consumeSliceWork(retained.b)))
+				})
+			case *HeadersFrame:
+				// The fragment aliases the framer's read buffer,
+				// which the next ReadFrame overwrites.
+				retained := retainedSlice{b: f.HeaderBlockFragment()}
+				refs = append(refs, retained)
+				startAttacker(func() {
+					sink.Add(uint64(consumeSliceWork(retained.b)))
+				})
+			case *ContinuationFrame:
+				retained := retainedSlice{b: f.HeaderBlockFragment()}
+				refs = append(refs, retained)
+				startAttacker(func() {
+					sink.Add(uint64(consumeSliceWork(retained.b)))
+				})
+			case *MetaHeadersFrame:
+				// Retaining the Fields slice past the gate violates
+				// the reuse contract: the next meta parse clears and
+				// re-appends into the same backing array, so the
+				// attacker's reads of the HeaderField structs race
+				// with the Framer's writes.
+				retained := retainedFields{hf: f.Fields}
+				refs = append(refs, retained)
+				startAttacker(func() {
+					sink.Add(uint64(consumeHeaderFieldWork(retained.hf)))
+				})
+			case *WindowUpdateFrame:
+				// No slice to retain on WindowUpdateFrame, just
+				// signal done.
+			default:
+				t.Fatalf("unexpected frame type %T", res.frame)
+			}
+			// Adversarial: signal done immediately, even though
+			// we still have outstanding readers of the frame's
+			// memory.
+			close(res.done)
+		case <-time.After(30 * time.Second):
+			t.Fatal("timed out waiting for next frame")
+		}
+	}
+drain:
+	close(stopAttackers)
+	attackers.Wait()
+	<-exitc
+	// Force refs to outlive the loop above so the compiler does
+	// not eliminate the retentions.
+	if len(refs) == 0 {
+		t.Fatalf("expected retained references, got 0")
+	}
+	t.Logf("retained %d references, sink=%d", len(refs), sink.Load())
+}

--- a/src/net/http/internal/http2/frame_reuse_race_test.go
+++ b/src/net/http/internal/http2/frame_reuse_race_test.go
@@ -1,0 +1,463 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package http2
+
+import (
+	"bytes"
+	"internal/race"
+	"internal/testenv"
+	"io"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/net/http2/hpack"
+)
+
+// The tests in this file exercise the Framer.SetReuseFrames contract
+// from a concurrency angle. The reuse contract says the *Frame returned
+// by ReadFrame, any slice aliasing the Framer's read buffer reachable
+// from that frame, and the MetaHeadersFrame Fields slice are only valid
+// until the next ReadFrame call. A retention bug under reuse manifests
+// as one goroutine reading a retained slice while another (the reader)
+// writes into the same backing memory on the next ReadFrame.
+//
+// These tests model the server's readFrames goroutine pattern (one
+// reader goroutine, one consumer goroutine separated by a gate
+// channel) and aim to be effective under "go test -race". Each runs
+// twice: a "meta" variant with ReadMetaHeaders set, where HEADERS
+// surface as *MetaHeadersFrame, and a "raw" variant without it, where
+// HEADERS and CONTINUATION surface individually and their
+// HeaderBlockFragment aliases the read buffer.
+//
+//   - TestFrameReuseRaceCorrect: faithful gated handoff. Must NOT race
+//     under -race, regardless of how many frames are read. This is a
+//     positive control that asserts the gated pattern is safe with
+//     reuse on.
+//
+//   - TestFrameReuseRaceAdversarial: deliberately leaks a slice past
+//     the gate. Must race under -race. It runs the leaking code in a
+//     child process and asserts that the race detector reports the
+//     race there, so the negative control is checked by every -race
+//     run instead of relying on someone remembering to run it.
+//
+// A companion end-to-end stress test exists in
+// frame_reuse_e2e_test.go (package http2_test) which drives the real
+// net/http HTTP/2 server and Transport under -race. The synthetic
+// tests in this file cannot reach the production process* code paths;
+// the e2e test does.
+
+// preEncodeReuseRaceStream encodes a long sequence of frames
+// exercising every frame type extended by SetReuseFrames: DATA,
+// WINDOW_UPDATE, HEADERS, and HEADERS+CONTINUATION (so the meta
+// header path runs). All HEADERS/DATA payloads are the same size so
+// the framer's readBuf does not reallocate between frames; the
+// retained slice in the adversarial subtest therefore continues to
+// alias the same backing array that the next ReadFrame writes into.
+// The header blocks stay at four fields, well under
+// maxRetainedMetaFields, so the meta path keeps reusing one Fields
+// backing array for the same reason.
+func preEncodeReuseRaceStream(tb testing.TB, iters int) []byte {
+	tb.Helper()
+	var buf bytes.Buffer
+	fr := NewFramer(&buf, nil)
+	// Encode HPACK fields once; reuse to keep payload sizes stable.
+	hdrBlock := encodeHeaderRaw(tb,
+		":method", "GET",
+		":path", "/",
+		":scheme", "http",
+		":authority", "example.com",
+	)
+	// Split hdrBlock so we can emit HEADERS+CONTINUATION for the
+	// meta path.
+	half := len(hdrBlock) / 2
+	if half == 0 {
+		half = 1
+	}
+	// Use a fixed-length data payload so the readBuf size stays
+	// constant once it grows on the first read.
+	dataPayload := bytes.Repeat([]byte{0xab}, 64)
+
+	for i := 0; i < iters; i++ {
+		streamID := uint32(2*i + 1)
+		// DATA
+		if err := fr.WriteData(streamID, false, dataPayload); err != nil {
+			tb.Fatal(err)
+		}
+		// WINDOW_UPDATE
+		if err := fr.WriteWindowUpdate(streamID, uint32(1+i%4096)); err != nil {
+			tb.Fatal(err)
+		}
+		// HEADERS (single-frame, EndHeaders=true)
+		if err := fr.WriteHeaders(HeadersFrameParam{
+			StreamID:      streamID,
+			BlockFragment: hdrBlock,
+			EndHeaders:    true,
+		}); err != nil {
+			tb.Fatal(err)
+		}
+		// HEADERS + CONTINUATION (drives the meta-headers path when
+		// ReadMetaHeaders is set, and the CONTINUATION path when not)
+		if err := fr.WriteHeaders(HeadersFrameParam{
+			StreamID:      streamID,
+			BlockFragment: hdrBlock[:half],
+			EndHeaders:    false,
+		}); err != nil {
+			tb.Fatal(err)
+		}
+		if err := fr.WriteContinuation(streamID, true, hdrBlock[half:]); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	return buf.Bytes()
+}
+
+// newReuseRaceFramer builds a SetReuseFrames Framer over the
+// pre-encoded stream, with the meta-headers decoder installed when
+// meta is set.
+func newReuseRaceFramer(encoded []byte, meta bool) *Framer {
+	fr := NewFramer(io.Discard, bytes.NewReader(encoded))
+	fr.SetReuseFrames()
+	if meta {
+		fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+	}
+	return fr
+}
+
+// runReadFramesGoroutine launches a goroutine that mimics
+// serverConn.readFrames: reads a frame, sends it to ch, waits on the
+// returned gate before reading the next. Returns the gate channel and
+// a done channel that closes once the reader goroutine exits.
+type framedRead struct {
+	frame Frame
+	err   error
+	// done must be called once the consumer no longer retains frame
+	// or any slice aliasing the framer's read buffer.
+	done chan<- struct{}
+}
+
+func runReadFramesGoroutine(tb testing.TB, fr *Framer, ch chan<- framedRead) (exited <-chan struct{}) {
+	tb.Helper()
+	exitc := make(chan struct{})
+	go func() {
+		defer close(exitc)
+		for {
+			gate := make(chan struct{})
+			f, err := fr.ReadFrame()
+			ch <- framedRead{frame: f, err: err, done: gate}
+			// Wait for the consumer to signal done before reading
+			// again. This re-creates the readFrames gate.
+			<-gate
+			if err != nil {
+				return
+			}
+		}
+	}()
+	return exitc
+}
+
+// consumeSliceWork is a noinline helper that reads every byte of b
+// once. Its only purpose is to ensure the race detector observes a
+// read of the memory backing b. If a concurrent goroutine writes the
+// same memory without a happens-before edge, -race will fire here.
+//
+//go:noinline
+func consumeSliceWork(b []byte) byte {
+	var x byte
+	for _, v := range b {
+		x ^= v
+	}
+	return x
+}
+
+// touchHeaderFieldWork reads the HeaderField structs of fields without
+// dereferencing their strings. The adversarial test retains fields
+// past the gate and reads them while the Framer clears and overwrites
+// the same array; that is the race the detector must report, and
+// reading only the string headers keeps a torn read from turning into
+// a nil dereference before it is reported.
+//
+//go:noinline
+func touchHeaderFieldWork(fields []hpack.HeaderField) byte {
+	var x byte
+	for i := range fields {
+		x ^= byte(len(fields[i].Name) + len(fields[i].Value))
+		if fields[i].Sensitive {
+			x ^= 1
+		}
+	}
+	return x
+}
+
+// consumeHeaderFieldWork reads every HeaderField element of fields,
+// plus the name+value string bytes. Ranging over a retained Fields
+// slice reads the HeaderField structs out of the backing array the
+// Framer owns; with SetReuseFrames, the next meta parse clears and
+// re-appends into that same array, so the race detector observes the
+// conflict on the struct memory. The string bytes themselves are
+// independent allocations (hpack hands out fresh strings per decode),
+// so they never alias the framer's read buffer.
+//
+//go:noinline
+func consumeHeaderFieldWork(fields []hpack.HeaderField) byte {
+	var x byte
+	for _, hf := range fields {
+		for i := 0; i < len(hf.Name); i++ {
+			x ^= hf.Name[i]
+		}
+		for i := 0; i < len(hf.Value); i++ {
+			x ^= hf.Value[i]
+		}
+	}
+	return x
+}
+
+// TestFrameReuseRaceCorrect runs the full reader-consumer dance with
+// SetReuseFrames enabled, consuming every frame's payload before
+// signaling the gate. Under -race, this MUST NOT fire.
+//
+// What this catches: a reuse implementation that mutates the cached
+// frame or its backing buffer before the consumer signals done (for
+// example, by parsing the next frame eagerly on a background
+// goroutine or by reusing the buffer for some other purpose).
+func TestFrameReuseRaceCorrect(t *testing.T) {
+	t.Run("meta", func(t *testing.T) { testFrameReuseRaceCorrect(t, true) })
+	t.Run("raw", func(t *testing.T) { testFrameReuseRaceCorrect(t, false) })
+}
+
+func testFrameReuseRaceCorrect(t *testing.T, meta bool) {
+	const iters = 200
+
+	encoded := preEncodeReuseRaceStream(t, iters)
+	fr := newReuseRaceFramer(encoded, meta)
+
+	ch := make(chan framedRead)
+	exitc := runReadFramesGoroutine(t, fr, ch)
+
+	// sink lets the compiler keep the work observable.
+	var sink atomic.Uint64
+	frames := 0
+
+	for {
+		select {
+		case res := <-ch:
+			if res.err == io.EOF {
+				close(res.done)
+				goto drain
+			}
+			if res.err != nil {
+				t.Fatalf("unexpected ReadFrame error: %v", res.err)
+			}
+			frames++
+			// Consume the slice/fields synchronously. Once we
+			// signal done, we forget the frame.
+			switch f := res.frame.(type) {
+			case *DataFrame:
+				sink.Add(uint64(consumeSliceWork(f.Data())))
+			case *HeadersFrame:
+				sink.Add(uint64(consumeSliceWork(f.HeaderBlockFragment())))
+			case *ContinuationFrame:
+				sink.Add(uint64(consumeSliceWork(f.HeaderBlockFragment())))
+			case *MetaHeadersFrame:
+				sink.Add(uint64(consumeHeaderFieldWork(f.Fields)))
+			case *WindowUpdateFrame:
+				sink.Add(uint64(f.Increment))
+			default:
+				t.Fatalf("unexpected frame type %T", res.frame)
+			}
+			close(res.done) // gate: reader may proceed.
+		case <-time.After(30 * time.Second):
+			t.Fatal("timed out waiting for next frame")
+		}
+	}
+drain:
+	<-exitc
+	// meta: DATA, WINDOW_UPDATE, and two MetaHeadersFrames per iter.
+	// raw: the second HEADERS surfaces as HEADERS+CONTINUATION.
+	wantFrames := iters * 4
+	if !meta {
+		wantFrames = iters * 5
+	}
+	if frames != wantFrames {
+		t.Errorf("consumed %d frames, want %d", frames, wantFrames)
+	}
+	t.Logf("consumed %d frames, sink=%d", frames, sink.Load())
+}
+
+// TestFrameReuseRaceAdversarial deliberately violates the reuse
+// contract: the consumer hands a retained slice to a sidecar
+// goroutine that keeps reading it, while the gate is signaled
+// immediately so the reader proceeds to overwrite the same memory.
+// Under -race, this MUST be reported.
+//
+// As a negative control it cannot run in-process: a reported race
+// fails the test binary. Instead it re-executes the test binary to run
+// testFrameReuseRaceAdversarial in a child process and checks that the
+// child reports a data race. The child runs with GORACE=halt_on_error=1
+// so that it stops at the first report, before the torn reads it
+// provokes can crash it.
+//
+// What it would catch in production code: any handler/code path that
+// holds onto Data, HeaderBlockFragment, or the MetaHeadersFrame
+// Fields slice past the readMore call.
+func TestFrameReuseRaceAdversarial(t *testing.T) {
+	if !race.Enabled {
+		t.Skip("negative control needs the race detector")
+	}
+	for _, variant := range []string{"meta", "raw"} {
+		t.Run(variant, func(t *testing.T) {
+			cmd := testenv.Command(t, testenv.Executable(t), "-test.run=^TestFrameReuseRaceAdversarialChild$", "-test.v")
+			cmd.Env = append(os.Environ(), "H2_REUSE_RACE_CHILD="+variant, "GORACE=halt_on_error=1")
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("child process passed; want a data race report\n%s", out)
+			}
+			if !bytes.Contains(out, []byte("WARNING: DATA RACE")) {
+				t.Fatalf("child process failed without a data race report: %v\n%s", err, out)
+			}
+		})
+	}
+}
+
+// TestFrameReuseRaceAdversarialChild is the child process side of
+// TestFrameReuseRaceAdversarial. It does nothing unless run by it.
+func TestFrameReuseRaceAdversarialChild(t *testing.T) {
+	variant := os.Getenv("H2_REUSE_RACE_CHILD")
+	if variant == "" {
+		t.Skip("child process of TestFrameReuseRaceAdversarial")
+	}
+	testFrameReuseRaceAdversarial(t, variant == "meta")
+}
+
+func testFrameReuseRaceAdversarial(t *testing.T, meta bool) {
+	// 50 outer iterations -> 200+ frames. That is far more than
+	// enough scheduler interleavings for the race detector to
+	// observe at least one concurrent read/write conflict.
+	const iters = 50
+	const maxLiveAttackers = 8 // cap concurrent attacker goroutines
+
+	encoded := preEncodeReuseRaceStream(t, iters)
+	fr := newReuseRaceFramer(encoded, meta)
+
+	ch := make(chan framedRead)
+	exitc := runReadFramesGoroutine(t, fr, ch)
+
+	// stopAttackers is closed when the test is winding down to let
+	// any retained-slice readers exit.
+	stopAttackers := make(chan struct{})
+	var attackers sync.WaitGroup
+	// Token bucket bounds the number of attacker goroutines alive
+	// at any time; without it the race detector slows to a crawl as
+	// many hundreds of goroutines all hammer the read buffer.
+	tokens := make(chan struct{}, maxLiveAttackers)
+
+	// retainedRefs accumulates references we deliberately leak past
+	// the gate. Holding them in the test goroutine keeps them
+	// reachable for the GC's view, but the race detector still
+	// catches read/write conflicts on the underlying memory.
+	type retainedSlice struct {
+		b []byte
+	}
+	type retainedFields struct {
+		hf []hpack.HeaderField
+	}
+	var refs []any
+
+	startAttacker := func(read func()) {
+		// Block briefly if too many attackers are already running.
+		// This will bound the runtime overhead without weakening the
+		// race detector signal (each retained reference still gets
+		// a goroutine that overlaps the next ReadFrame).
+		select {
+		case tokens <- struct{}{}:
+		case <-stopAttackers:
+			return
+		}
+		attackers.Add(1)
+		go func() {
+			defer attackers.Done()
+			defer func() { <-tokens }()
+			for i := 0; i < 200; i++ {
+				select {
+				case <-stopAttackers:
+					return
+				default:
+				}
+				read()
+			}
+		}()
+	}
+
+	var sink atomic.Uint64
+
+	for {
+		select {
+		case res := <-ch:
+			if res.err == io.EOF {
+				close(res.done)
+				goto drain
+			}
+			if res.err != nil {
+				t.Fatalf("unexpected ReadFrame error: %v", res.err)
+			}
+			switch f := res.frame.(type) {
+			case *DataFrame:
+				retained := retainedSlice{b: f.Data()}
+				refs = append(refs, retained)
+				startAttacker(func() {
+					sink.Add(uint64(consumeSliceWork(retained.b)))
+				})
+			case *HeadersFrame:
+				// The fragment aliases the framer's read buffer,
+				// which the next ReadFrame overwrites.
+				retained := retainedSlice{b: f.HeaderBlockFragment()}
+				refs = append(refs, retained)
+				startAttacker(func() {
+					sink.Add(uint64(consumeSliceWork(retained.b)))
+				})
+			case *ContinuationFrame:
+				retained := retainedSlice{b: f.HeaderBlockFragment()}
+				refs = append(refs, retained)
+				startAttacker(func() {
+					sink.Add(uint64(consumeSliceWork(retained.b)))
+				})
+			case *MetaHeadersFrame:
+				// Retaining the Fields slice past the gate violates
+				// the reuse contract: the next ReadFrame clears the
+				// backing array and the next meta parse re-appends
+				// into it, so the attacker's reads of the HeaderField
+				// structs race with the Framer's writes.
+				retained := retainedFields{hf: f.Fields}
+				refs = append(refs, retained)
+				startAttacker(func() {
+					sink.Add(uint64(touchHeaderFieldWork(retained.hf)))
+				})
+			case *WindowUpdateFrame:
+				// No slice to retain on WindowUpdateFrame, just
+				// signal done.
+			default:
+				t.Fatalf("unexpected frame type %T", res.frame)
+			}
+			// Adversarial: signal done immediately, even though
+			// we still have outstanding readers of the frame's
+			// memory.
+			close(res.done)
+		case <-time.After(30 * time.Second):
+			t.Fatal("timed out waiting for next frame")
+		}
+	}
+drain:
+	close(stopAttackers)
+	attackers.Wait()
+	<-exitc
+	// Force refs to outlive the loop above so the compiler does
+	// not eliminate the retentions.
+	if len(refs) == 0 {
+		t.Fatalf("expected retained references, got 0")
+	}
+	t.Logf("retained %d references, sink=%d", len(refs), sink.Load())
+}

--- a/src/net/http/internal/http2/frame_test.go
+++ b/src/net/http/internal/http2/frame_test.go
@@ -1179,6 +1179,169 @@ func TestReadFrameHeadersDistinctWithoutReuse(t *testing.T) {
 	}
 }
 
+// TestReadMetaFrameReusesMetaHeadersFrame verifies that every
+// ReadFrame call returning a *MetaHeadersFrame returns the same
+// cached pointer when SetReuseFrames is in effect.
+func TestReadMetaFrameReusesMetaHeadersFrame(t *testing.T) {
+	fr, buf := testFramer()
+	fr.SetReuseFrames()
+	fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+
+	writeMetaHeaders(t, fr, 1, ":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x")
+	first, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstMH, ok := first.(*MetaHeadersFrame)
+	if !ok {
+		t.Fatalf("first frame is %T, want *MetaHeadersFrame", first)
+	}
+
+	for i, streamID := range []uint32{3, 5, 7} {
+		buf.Reset()
+		writeMetaHeaders(t, fr, streamID, ":method", "POST", ":path", "/p", ":scheme", "http", ":authority", "y")
+		f, err := fr.ReadFrame()
+		if err != nil {
+			t.Fatal(err)
+		}
+		mh, ok := f.(*MetaHeadersFrame)
+		if !ok {
+			t.Fatalf("iter %d: frame is %T, want *MetaHeadersFrame", i, f)
+		}
+		if mh != firstMH {
+			t.Errorf("iter %d: *MetaHeadersFrame pointer changed: have %p, want %p", i, mh, firstMH)
+		}
+		if mh.StreamID != streamID {
+			t.Errorf("iter %d: StreamID = %d, want %d", i, mh.StreamID, streamID)
+		}
+	}
+}
+
+// TestReadMetaFrameMetaHeadersOverwrites verifies the cached
+// MetaHeadersFrame's Truncated flag (and any future-added field)
+// does not leak from a prior parse: the explicit
+// `*mh = MetaHeadersFrame{...}` reset at the start of readMetaFrame
+// must zero every field.
+func TestReadMetaFrameMetaHeadersOverwrites(t *testing.T) {
+	fr, buf := testFramer()
+	fr.SetReuseFrames()
+	fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+	// MaxHeaderListSize that fits the first two HPACK fields (each
+	// encodes as size = name + value + 32 = 42 for the pseudo-headers
+	// used below) but truncates from the third onward. The block of
+	// hpack-encoded bytes stays well under 2*MaxHeaderListSize so the
+	// early "header list too large" abort doesn't fire.
+	fr.MaxHeaderListSize = 100
+
+	// First parse: too-many headers -> Truncated.
+	writeMetaHeaders(t, fr, 1, ":method", "GET", ":path", "/a", ":scheme", "http", ":authority", "x")
+	first, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mh1 := first.(*MetaHeadersFrame)
+	if !mh1.Truncated {
+		t.Fatalf("test setup: first parse not marked Truncated as expected")
+	}
+
+	// Raise the limit, parse a fitting frame, and confirm Truncated
+	// did not bleed into the second result.
+	fr.MaxHeaderListSize = 1 << 16
+	buf.Reset()
+	writeMetaHeaders(t, fr, 3, ":method", "GET", ":path", "/b", ":scheme", "http", ":authority", "y")
+	second, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mh2 := second.(*MetaHeadersFrame)
+	if mh2 != mh1 {
+		t.Fatalf("expected same cached *MetaHeadersFrame; have %p, want %p", mh2, mh1)
+	}
+	if mh2.Truncated {
+		t.Errorf("Truncated leaked from prior parse")
+	}
+}
+
+// TestReadMetaFrameDistinctWithoutReuse asserts the pre-SetReuseFrames
+// contract for the meta-headers path: without opting in, each
+// readMetaFrame returns a distinct *MetaHeadersFrame.
+func TestReadMetaFrameDistinctWithoutReuse(t *testing.T) {
+	fr, buf := testFramer()
+	fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+
+	writeMetaHeaders(t, fr, 1, ":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x")
+	first, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mh1 := first.(*MetaHeadersFrame)
+
+	buf.Reset()
+	writeMetaHeaders(t, fr, 3, ":method", "POST", ":path", "/p", ":scheme", "http", ":authority", "y")
+	second, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mh2 := second.(*MetaHeadersFrame)
+
+	if mh1 == mh2 {
+		t.Errorf("without SetReuseFrames, expected distinct *MetaHeadersFrame pointers; got same: %p", mh1)
+	}
+	if mh1.StreamID != 1 {
+		t.Errorf("first MH mutated after second ReadFrame: StreamID=%d, want 1", mh1.StreamID)
+	}
+	if mh2.StreamID != 3 {
+		t.Errorf("second MH StreamID = %d, want 3", mh2.StreamID)
+	}
+}
+
+// TestMetaHeadersFrameAccessorPanicsWhenStale verifies the ownership
+// guard on MetaHeadersFrame's accessor methods: once the next
+// ReadFrame call has been made, PseudoValue (and the other Fields
+// accessors) on a retained frame panic — mirroring DataFrame.Data —
+// instead of silently returning fields that a later parse may have
+// overwritten in place. The guard applies with and without
+// SetReuseFrames. An intervening non-HEADERS frame is read because a
+// subsequent meta parse would repopulate the cached struct and
+// re-mark it owned, which the guard (like DataFrame's) does not
+// detect.
+func TestMetaHeadersFrameAccessorPanicsWhenStale(t *testing.T) {
+	for _, reuse := range []bool{true, false} {
+		t.Run(fmt.Sprintf("reuse=%v", reuse), func(t *testing.T) {
+			fr, buf := testFramer()
+			if reuse {
+				fr.SetReuseFrames()
+			}
+			fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+
+			writeMetaHeaders(t, fr, 1, ":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x")
+			f, err := fr.ReadFrame()
+			if err != nil {
+				t.Fatal(err)
+			}
+			mh := f.(*MetaHeadersFrame)
+			if got := mh.PseudoValue("method"); got != "GET" {
+				t.Fatalf(`PseudoValue("method") = %q, want "GET"`, got)
+			}
+
+			buf.Reset()
+			if err := fr.WriteWindowUpdate(1, 5); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := fr.ReadFrame(); err != nil {
+				t.Fatal(err)
+			}
+
+			defer func() {
+				if recover() == nil {
+					t.Errorf("PseudoValue on a stale MetaHeadersFrame did not panic")
+				}
+			}()
+			mh.PseudoValue("method")
+		})
+	}
+}
+
 func TestWritePing(t *testing.T)    { testWritePing(t, false) }
 func TestWritePingAck(t *testing.T) { testWritePing(t, true) }
 
@@ -1525,6 +1688,7 @@ func TestMetaFrameHeader(t *testing.T) {
 				},
 			},
 			Fields: []hpack.HeaderField(nil),
+			owned:  true,
 		}
 		for len(pairs) > 0 {
 			mh.Fields = append(mh.Fields, hpack.HeaderField{
@@ -1831,6 +1995,20 @@ func encodeHeaderRaw(t testing.TB, headers ...string) []byte {
 		headers = headers[2:]
 	}
 	return buf.Bytes()
+}
+
+// writeMetaHeaders HPACK-encodes the name/value pairs and writes them
+// to fr as a single HEADERS frame with EndHeaders set.
+func writeMetaHeaders(t testing.TB, fr *Framer, streamID uint32, pairs ...string) {
+	t.Helper()
+	block := encodeHeaderRaw(t, pairs...)
+	if err := fr.WriteHeaders(HeadersFrameParam{
+		StreamID:      streamID,
+		BlockFragment: block,
+		EndHeaders:    true,
+	}); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestSettingsDuplicates(t *testing.T) {

--- a/src/net/http/internal/http2/frame_test.go
+++ b/src/net/http/internal/http2/frame_test.go
@@ -2340,3 +2340,92 @@ func TestTypeFrameParserHolePanic(t *testing.T) {
 		t.Errorf("got %T; want *UnknownFrame", f)
 	}
 }
+
+// benchmarkReadFrameReuse measures the per-parse cost of repeatedly
+// reading the single pre-encoded frame in encoded, in Default
+// (allocate per parse) and Reused (SetReuseFrames) variants. When
+// meta is set, the Framer decodes HEADERS via ReadMetaHeaders. One
+// warm-up read keeps the Framer's read-buffer growth out of the
+// measurement.
+func benchmarkReadFrameReuse(b *testing.B, meta bool, encoded []byte) {
+	run := func(b *testing.B, reuse bool) {
+		rbuf := bytes.NewReader(encoded)
+		fr := NewFramer(io.Discard, rbuf)
+		if meta {
+			fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+		}
+		if reuse {
+			fr.SetReuseFrames()
+		}
+		rbuf.Reset(encoded)
+		if _, err := fr.ReadFrame(); err != nil {
+			b.Fatal(err)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			rbuf.Reset(encoded)
+			if _, err := fr.ReadFrame(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	b.Run("Default", func(b *testing.B) { run(b, false) })
+	b.Run("Reused", func(b *testing.B) { run(b, true) })
+}
+
+// BenchmarkParseDataFrame measures the per-parse cost of DATA
+// frames with and without SetReuseFrames. The DataFrame cache is the
+// preexisting one; this exists so its contribution can be compared
+// directly against the WindowUpdate/Headers/MetaHeaders caches added
+// in this stack.
+func BenchmarkParseDataFrame(b *testing.B) {
+	var enc bytes.Buffer
+	if err := NewFramer(&enc, nil).WriteData(1, false, []byte("abc")); err != nil {
+		b.Fatal(err)
+	}
+	benchmarkReadFrameReuse(b, false, enc.Bytes())
+}
+
+// BenchmarkParseWindowUpdateFrame measures the per-parse cost of
+// WINDOW_UPDATE frames with and without SetReuseFrames. The Default
+// case allocates a fresh *WindowUpdateFrame each call; Reused uses
+// the cached one.
+func BenchmarkParseWindowUpdateFrame(b *testing.B) {
+	var enc bytes.Buffer
+	if err := NewFramer(&enc, nil).WriteWindowUpdate(1, 7); err != nil {
+		b.Fatal(err)
+	}
+	benchmarkReadFrameReuse(b, false, enc.Bytes())
+}
+
+// BenchmarkParseHeadersFrame measures HEADERS parsing with and
+// without SetReuseFrames.
+func BenchmarkParseHeadersFrame(b *testing.B) {
+	var enc bytes.Buffer
+	if err := NewFramer(&enc, nil).WriteHeaders(HeadersFrameParam{
+		StreamID:      1,
+		BlockFragment: []byte("abc"),
+		EndHeaders:    true,
+	}); err != nil {
+		b.Fatal(err)
+	}
+	benchmarkReadFrameReuse(b, false, enc.Bytes())
+}
+
+// BenchmarkReadMetaFrame measures HEADERS+HPACK decoding via
+// readMetaFrame with and without SetReuseFrames. With reuse, the
+// cached *HeadersFrame and *MetaHeadersFrame wrappers and the Fields
+// backing array are all eliminated from the allocation count.
+func BenchmarkReadMetaFrame(b *testing.B) {
+	block := encodeHeaderRaw(b, ":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x")
+	var enc bytes.Buffer
+	if err := NewFramer(&enc, nil).WriteHeaders(HeadersFrameParam{
+		StreamID:      1,
+		BlockFragment: block,
+		EndHeaders:    true,
+	}); err != nil {
+		b.Fatal(err)
+	}
+	benchmarkReadFrameReuse(b, true, enc.Bytes())
+}

--- a/src/net/http/internal/http2/frame_test.go
+++ b/src/net/http/internal/http2/frame_test.go
@@ -1016,6 +1016,169 @@ func TestReadFrameWindowUpdateDistinctWithoutReuse(t *testing.T) {
 	}
 }
 
+// TestReadFrameReusesHeadersFrame verifies that ReadFrame returns
+// the same *HeadersFrame pointer for every HEADERS parsed when
+// SetReuseFrames is in effect.
+func TestReadFrameReusesHeadersFrame(t *testing.T) {
+	fr, buf := testFramer()
+	fr.SetReuseFrames()
+
+	write := func(streamID uint32) {
+		t.Helper()
+		if err := fr.WriteHeaders(HeadersFrameParam{
+			StreamID:      streamID,
+			BlockFragment: []byte("abc"),
+			EndHeaders:    true,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write(1)
+	first, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstHF, ok := first.(*HeadersFrame)
+	if !ok {
+		t.Fatalf("first frame is %T, want *HeadersFrame", first)
+	}
+
+	for i, streamID := range []uint32{3, 5, 7} {
+		buf.Reset()
+		write(streamID)
+		f, err := fr.ReadFrame()
+		if err != nil {
+			t.Fatal(err)
+		}
+		hf, ok := f.(*HeadersFrame)
+		if !ok {
+			t.Fatalf("iter %d: frame is %T, want *HeadersFrame", i, f)
+		}
+		if hf != firstHF {
+			t.Errorf("iter %d: pointer changed: have %p, want %p", i, hf, firstHF)
+		}
+		if hf.StreamID != streamID {
+			t.Errorf("iter %d: StreamID = %d, want %d", i, hf.StreamID, streamID)
+		}
+	}
+}
+
+// TestReadFrameHeadersOverwrites is a defensive test against future
+// maintenance hazards. When SetReuseFrames is in effect, the cached
+// *HeadersFrame is reused across ReadFrame calls; any field that
+// parseHeadersFrame forgets to assign would leak from the previous
+// frame to the next caller.
+//
+// The test parses a HEADERS frame WITH Priority and padding to
+// populate all fields, then parses a second frame WITHOUT either
+// flag and asserts the previous Priority and headerFragBuf-related
+// state do not bleed through.
+func TestReadFrameHeadersOverwrites(t *testing.T) {
+	fr, buf := testFramer()
+	fr.SetReuseFrames()
+
+	// First frame: priority + padding to populate every field.
+	if err := fr.WriteHeaders(HeadersFrameParam{
+		StreamID:      9,
+		BlockFragment: []byte("xyz"),
+		EndHeaders:    true,
+		PadLength:     3,
+		Priority: PriorityParam{
+			StreamDep: 7,
+			Exclusive: true,
+			Weight:    100,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	first, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hf1 := first.(*HeadersFrame)
+	if hf1.Priority.StreamDep != 7 || !hf1.Priority.Exclusive || hf1.Priority.Weight != 100 {
+		t.Fatalf("test setup: first frame priority = %+v; want StreamDep=7 Exclusive=true Weight=100", hf1.Priority)
+	}
+
+	// Second frame: no priority, no padding. Priority must reset.
+	buf.Reset()
+	if err := fr.WriteHeaders(HeadersFrameParam{
+		StreamID:      11,
+		BlockFragment: []byte("ab"),
+		EndHeaders:    true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	second, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hf2 := second.(*HeadersFrame)
+	if hf2 != hf1 {
+		t.Fatalf("expected same pointer (cached); have %p, want %p", hf2, hf1)
+	}
+	if (hf2.Priority != PriorityParam{}) {
+		t.Errorf("Priority leak: %+v (want zero)", hf2.Priority)
+	}
+	if hf2.Flags.Has(FlagHeadersPriority) || hf2.Flags.Has(FlagHeadersPadded) {
+		t.Errorf("Flags leak: %x", hf2.Flags)
+	}
+	if hf2.StreamID != 11 {
+		t.Errorf("StreamID = %d, want 11", hf2.StreamID)
+	}
+}
+
+// TestReadFrameHeadersDistinctWithoutReuse asserts the
+// pre-SetReuseFrames contract: without opting in, each parsed
+// HEADERS returns a distinct *HeadersFrame whose Priority and
+// FrameHeader remain stable after a subsequent ReadFrame.
+func TestReadFrameHeadersDistinctWithoutReuse(t *testing.T) {
+	fr, buf := testFramer()
+
+	if err := fr.WriteHeaders(HeadersFrameParam{
+		StreamID:      1,
+		BlockFragment: []byte("abc"),
+		EndHeaders:    true,
+		Priority: PriorityParam{
+			StreamDep: 7,
+			Exclusive: true,
+			Weight:    100,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	first, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hf1 := first.(*HeadersFrame)
+
+	buf.Reset()
+	if err := fr.WriteHeaders(HeadersFrameParam{
+		StreamID:      3,
+		BlockFragment: []byte("xy"),
+		EndHeaders:    true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	second, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hf2 := second.(*HeadersFrame)
+
+	if hf1 == hf2 {
+		t.Errorf("without SetReuseFrames, expected distinct pointers; got same: %p", hf1)
+	}
+	if hf1.StreamID != 1 || hf1.Priority.StreamDep != 7 {
+		t.Errorf("first HF mutated after second ReadFrame: StreamID=%d Priority=%+v", hf1.StreamID, hf1.Priority)
+	}
+	if hf2.StreamID != 3 {
+		t.Errorf("second HF StreamID = %d, want 3", hf2.StreamID)
+	}
+}
+
 func TestWritePing(t *testing.T)    { testWritePing(t, false) }
 func TestWritePingAck(t *testing.T) { testWritePing(t, true) }
 

--- a/src/net/http/internal/http2/frame_test.go
+++ b/src/net/http/internal/http2/frame_test.go
@@ -1342,6 +1342,150 @@ func TestMetaHeadersFrameAccessorPanicsWhenStale(t *testing.T) {
 	}
 }
 
+// TestReadMetaFrameReusesFieldsSlice verifies that, when
+// SetReuseFrames is in effect, readMetaFrame reuses the backing array
+// of MetaHeadersFrame.Fields across parses instead of growing a fresh
+// slice from nil each time. The Fields documentation already forbids
+// retaining the slice past the next ReadFrame, and the package's
+// consumers copy field strings into their own header maps
+// synchronously, so the in-place overwrite is within contract.
+func TestReadMetaFrameReusesFieldsSlice(t *testing.T) {
+	fr, buf := testFramer()
+	fr.SetReuseFrames()
+	fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+
+	readMeta := func() *MetaHeadersFrame {
+		t.Helper()
+		f, err := fr.ReadFrame()
+		if err != nil {
+			t.Fatal(err)
+		}
+		mh, ok := f.(*MetaHeadersFrame)
+		if !ok {
+			t.Fatalf("got %T, want *MetaHeadersFrame", f)
+		}
+		return mh
+	}
+
+	// First read populates the cached slice.
+	writeMetaHeaders(t, fr, 1, ":method", "GET", ":path", "/a", ":scheme", "http", ":authority", "x")
+	mh := readMeta()
+	if len(mh.Fields) != 4 {
+		t.Fatalf("first parse: got %d fields, want 4", len(mh.Fields))
+	}
+	backing1 := unsafe.SliceData(mh.Fields)
+
+	// A second read of the same shape must reuse the backing array.
+	buf.Reset()
+	writeMetaHeaders(t, fr, 3, ":method", "POST", ":path", "/b", ":scheme", "https", ":authority", "y")
+	mh = readMeta()
+	if len(mh.Fields) != 4 {
+		t.Fatalf("second parse: got %d fields, want 4", len(mh.Fields))
+	}
+	if backing := unsafe.SliceData(mh.Fields); backing != backing1 {
+		t.Errorf("Fields backing array changed between equal-size reads: have %p, want %p", backing, backing1)
+	}
+
+	// A larger read may grow the slice; a subsequent equal-size read
+	// must then reuse the grown array.
+	buf.Reset()
+	writeMetaHeaders(t, fr, 5,
+		":method", "GET", ":path", "/c", ":scheme", "http", ":authority", "z",
+		"x-a", "1", "x-b", "2", "x-c", "3", "x-d", "4")
+	mh = readMeta()
+	if len(mh.Fields) != 8 {
+		t.Fatalf("third parse: got %d fields, want 8", len(mh.Fields))
+	}
+	backing3 := unsafe.SliceData(mh.Fields)
+
+	buf.Reset()
+	writeMetaHeaders(t, fr, 7,
+		":method", "GET", ":path", "/d", ":scheme", "http", ":authority", "z",
+		"x-a", "5", "x-b", "6", "x-c", "7", "x-d", "8")
+	mh = readMeta()
+	if backing := unsafe.SliceData(mh.Fields); backing != backing3 {
+		t.Errorf("Fields backing array changed after equal-size read: have %p, want %p", backing, backing3)
+	}
+}
+
+// TestReadMetaFrameFieldsClearsSensitiveTail verifies the memory
+// hygiene of the Fields reuse: header values can hold secrets, so the
+// retained backing array must be cleared before reuse. After a parse
+// shorter than its predecessor, no slot beyond the new length may
+// still reference the earlier parse's strings.
+func TestReadMetaFrameFieldsClearsSensitiveTail(t *testing.T) {
+	fr, buf := testFramer()
+	fr.SetReuseFrames()
+	fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+
+	const secret = "secret-cookie-value-do-not-retain"
+	writeMetaHeaders(t, fr, 1,
+		":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x",
+		"cookie", secret)
+	if _, err := fr.ReadFrame(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Shorter second parse: the slots beyond its length must have
+	// been cleared, not merely left beyond the slice length.
+	buf.Reset()
+	writeMetaHeaders(t, fr, 3, ":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x")
+	f, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mh := f.(*MetaHeadersFrame)
+
+	full := mh.Fields[:cap(mh.Fields)]
+	for i := len(mh.Fields); i < len(full); i++ {
+		if full[i] != (hpack.HeaderField{}) {
+			t.Errorf("Fields slot %d beyond len not cleared: %+v", i, full[i])
+		}
+		if full[i].Value == secret {
+			t.Errorf("Fields slot %d still references the previous parse's secret", i)
+		}
+	}
+}
+
+// TestReadMetaFrameFieldsRetentionCap verifies that a single large
+// HEADERS frame does not permanently inflate the per-Framer Fields
+// cache: an array grown past maxRetainedMetaFields is dropped at the
+// start of the next parse.
+func TestReadMetaFrameFieldsRetentionCap(t *testing.T) {
+	fr, buf := testFramer()
+	fr.SetReuseFrames()
+	fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+
+	big := []string{":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x"}
+	for i := 0; i < 2*maxRetainedMetaFields; i++ {
+		big = append(big, fmt.Sprintf("x-h-%03d", i), "v")
+	}
+	writeMetaHeaders(t, fr, 1, big...)
+	f, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mh := f.(*MetaHeadersFrame)
+	if cap(mh.Fields) <= maxRetainedMetaFields {
+		t.Fatalf("test setup: large parse cap = %d, want > %d", cap(mh.Fields), maxRetainedMetaFields)
+	}
+	bigBacking := unsafe.SliceData(mh.Fields)
+
+	buf.Reset()
+	writeMetaHeaders(t, fr, 3, ":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x")
+	f, err = fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mh = f.(*MetaHeadersFrame)
+	if backing := unsafe.SliceData(mh.Fields); backing == bigBacking {
+		t.Errorf("oversized Fields backing array was retained across parses")
+	}
+	if cap(mh.Fields) > maxRetainedMetaFields {
+		t.Errorf("cap(Fields) = %d after small parse, want <= %d", cap(mh.Fields), maxRetainedMetaFields)
+	}
+}
+
 func TestWritePing(t *testing.T)    { testWritePing(t, false) }
 func TestWritePingAck(t *testing.T) { testWritePing(t, true) }
 

--- a/src/net/http/internal/http2/frame_test.go
+++ b/src/net/http/internal/http2/frame_test.go
@@ -764,6 +764,258 @@ func TestWriteWindowUpdate(t *testing.T) {
 	}
 }
 
+// TestReadFrameReusesWindowUpdate verifies that ReadFrame returns the
+// same *WindowUpdateFrame pointer for every WINDOW_UPDATE parsed when
+// SetReuseFrames is in effect, so the parse path does not allocate a
+// fresh struct each time.
+func TestReadFrameReusesWindowUpdate(t *testing.T) {
+	fr, buf := testFramer()
+	fr.SetReuseFrames()
+
+	// First read populates the cached struct.
+	if err := fr.WriteWindowUpdate(1, 5); err != nil {
+		t.Fatal(err)
+	}
+	first, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstWU, ok := first.(*WindowUpdateFrame)
+	if !ok {
+		t.Fatalf("first frame is %T, want *WindowUpdateFrame", first)
+	}
+	if firstWU.StreamID != 1 || firstWU.Increment != 5 {
+		t.Fatalf("first WINDOW_UPDATE = %+v; want StreamID=1 Increment=5", firstWU)
+	}
+
+	// Subsequent WINDOW_UPDATEs return the same pointer with the new
+	// values. Because the pointer is reused, the originally-returned
+	// firstWU also reflects the latest fields after each ReadFrame.
+	cases := []struct {
+		streamID, increment uint32
+	}{
+		{streamID: 3, increment: 7},
+		{streamID: 1, increment: 1024},
+		{streamID: 1, increment: 1},
+	}
+	for i, tc := range cases {
+		buf.Reset()
+		if err := fr.WriteWindowUpdate(tc.streamID, tc.increment); err != nil {
+			t.Fatal(err)
+		}
+		f, err := fr.ReadFrame()
+		if err != nil {
+			t.Fatal(err)
+		}
+		wu, ok := f.(*WindowUpdateFrame)
+		if !ok {
+			t.Fatalf("iter %d: frame is %T, want *WindowUpdateFrame", i, f)
+		}
+		if wu != firstWU {
+			t.Errorf("iter %d: pointer changed: have %p, want %p", i, wu, firstWU)
+		}
+		if wu.StreamID != tc.streamID || wu.Increment != tc.increment {
+			t.Errorf("iter %d: got %+v; want StreamID=%d Increment=%d",
+				i, wu, tc.streamID, tc.increment)
+		}
+		if firstWU.StreamID != tc.streamID || firstWU.Increment != tc.increment {
+			t.Errorf("iter %d: firstWU = %+v; want StreamID=%d Increment=%d (reuse contract violated)",
+				i, firstWU, tc.streamID, tc.increment)
+		}
+	}
+
+	// Interleaving WINDOW_UPDATE with a different frame type does not
+	// disturb reuse: the cached struct is re-validated when the next
+	// WINDOW_UPDATE is parsed.
+	buf.Reset()
+	if err := fr.WritePing(false, [8]byte{1, 2, 3, 4, 5, 6, 7, 8}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fr.ReadFrame(); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+	if err := fr.WriteWindowUpdate(5, 9000); err != nil {
+		t.Fatal(err)
+	}
+	f, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wu, ok := f.(*WindowUpdateFrame)
+	if !ok {
+		t.Fatalf("after PING, frame is %T, want *WindowUpdateFrame", f)
+	}
+	if wu != firstWU {
+		t.Errorf("after PING, pointer changed: have %p, want %p", wu, firstWU)
+	}
+	if wu.StreamID != 5 || wu.Increment != 9000 {
+		t.Errorf("after PING, got %+v; want StreamID=5 Increment=9000", wu)
+	}
+}
+
+// TestReadFrameWindowUpdateNoAllocsWhenReused locks in the
+// zero-allocation invariant for the WINDOW_UPDATE parse path when
+// SetReuseFrames is in effect. If a regression makes
+// parseWindowUpdateFrame allocate, this fails rather than only showing
+// up in benchmarks.
+func TestReadFrameWindowUpdateNoAllocsWhenReused(t *testing.T) {
+	// Pre-encode a WINDOW_UPDATE frame.
+	var enc bytes.Buffer
+	if err := NewFramer(&enc, nil).WriteWindowUpdate(1, 7); err != nil {
+		t.Fatal(err)
+	}
+	encoded := enc.Bytes()
+
+	rbuf := bytes.NewReader(encoded)
+	fr := NewFramer(io.Discard, rbuf)
+	fr.SetReuseFrames()
+
+	// Warm up the read buffer so its growth does not count toward the
+	// measurement.
+	rbuf.Reset(encoded)
+	if _, err := fr.ReadFrame(); err != nil {
+		t.Fatal(err)
+	}
+
+	allocs := testing.AllocsPerRun(50, func() {
+		rbuf.Reset(encoded)
+		if _, err := fr.ReadFrame(); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if allocs != 0 {
+		t.Errorf("ReadFrame for WINDOW_UPDATE allocates %v objects/op; want 0", allocs)
+	}
+}
+
+// TestReadFrameWindowUpdateOverwrites is a defensive test against
+// future maintenance hazards. When SetReuseFrames is in effect, the
+// cached *WindowUpdateFrame is reused across ReadFrame calls.
+// parseWindowUpdateFrame resets the whole struct with a composite
+// literal, so no field can survive from a previous frame; this test
+// guards that property against a future regression to field-by-field
+// assignment (which could silently leak stale data if a field were
+// added).
+//
+// The test poisons every byte of the cached struct, parses a fresh
+// WINDOW_UPDATE, and then verifies every field reflects the new frame
+// rather than the poison.
+func TestReadFrameWindowUpdateOverwrites(t *testing.T) {
+	fr, buf := testFramer()
+	fr.SetReuseFrames()
+
+	// First read to obtain the cached struct pointer.
+	if err := fr.WriteWindowUpdate(1, 5); err != nil {
+		t.Fatal(err)
+	}
+	first, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wuf, ok := first.(*WindowUpdateFrame)
+	if !ok {
+		t.Fatalf("first frame is %T, want *WindowUpdateFrame", first)
+	}
+
+	// Fill every byte of the cached struct with 0xFF. If any field is
+	// left unassigned by the next parse, it will keep this poison value.
+	//
+	// valid is a bool, and any non-zero byte reads as true; bulk 0xFF
+	// poison would therefore mask a parser that forgets to reassign
+	// valid. Set valid to false separately so the post-parse
+	// expectation (valid == true) genuinely tests a fresh write.
+	poison := unsafe.Slice((*byte)(unsafe.Pointer(wuf)), unsafe.Sizeof(*wuf))
+	for i := range poison {
+		poison[i] = 0xFF
+	}
+	wuf.valid = false
+
+	// Parse a fresh WINDOW_UPDATE. The poison must be fully gone.
+	buf.Reset()
+	const wantStreamID = 42
+	const wantIncrement = 100
+	if err := fr.WriteWindowUpdate(wantStreamID, wantIncrement); err != nil {
+		t.Fatal(err)
+	}
+	f, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wu, ok := f.(*WindowUpdateFrame)
+	if !ok {
+		t.Fatalf("frame is %T, want *WindowUpdateFrame", f)
+	}
+	if wu != wuf {
+		t.Fatalf("pointer changed after poison: have %p, want %p", wu, wuf)
+	}
+
+	// Check every field. Failure on any of these means
+	// parseWindowUpdateFrame left a field unassigned, which would leak
+	// data from a previous frame to the next consumer.
+	if wu.Type != FrameWindowUpdate {
+		t.Errorf("Type = %v (poison leak); want %v", wu.Type, FrameWindowUpdate)
+	}
+	if wu.Flags != 0 {
+		t.Errorf("Flags = %#x (poison leak); want 0", wu.Flags)
+	}
+	if wu.Length != 4 {
+		t.Errorf("Length = %d (poison leak); want 4", wu.Length)
+	}
+	if wu.StreamID != wantStreamID {
+		t.Errorf("StreamID = %d (poison leak); want %d", wu.StreamID, wantStreamID)
+	}
+	if !wu.valid {
+		t.Errorf("valid = false (poison leak); want true")
+	}
+	if wu.Increment != wantIncrement {
+		t.Errorf("Increment = %d (poison leak); want %d", wu.Increment, wantIncrement)
+	}
+}
+
+// TestReadFrameWindowUpdateDistinctWithoutReuse asserts the
+// pre-SetReuseFrames contract: without opting in, each parsed
+// WINDOW_UPDATE returns a distinct *WindowUpdateFrame whose fields
+// remain valid even after a subsequent ReadFrame.
+func TestReadFrameWindowUpdateDistinctWithoutReuse(t *testing.T) {
+	fr, buf := testFramer()
+
+	if err := fr.WriteWindowUpdate(1, 5); err != nil {
+		t.Fatal(err)
+	}
+	first, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstWU, ok := first.(*WindowUpdateFrame)
+	if !ok {
+		t.Fatalf("first frame is %T, want *WindowUpdateFrame", first)
+	}
+
+	buf.Reset()
+	if err := fr.WriteWindowUpdate(3, 7); err != nil {
+		t.Fatal(err)
+	}
+	second, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondWU, ok := second.(*WindowUpdateFrame)
+	if !ok {
+		t.Fatalf("second frame is %T, want *WindowUpdateFrame", second)
+	}
+
+	if firstWU == secondWU {
+		t.Errorf("without SetReuseFrames, expected distinct pointers; got same: %p", firstWU)
+	}
+	if firstWU.StreamID != 1 || firstWU.Increment != 5 {
+		t.Errorf("first WU mutated after second ReadFrame: %+v; want StreamID=1 Increment=5", firstWU)
+	}
+	if secondWU.StreamID != 3 || secondWU.Increment != 7 {
+		t.Errorf("second WU = %+v; want StreamID=3 Increment=7", secondWU)
+	}
+}
+
 func TestWritePing(t *testing.T)    { testWritePing(t, false) }
 func TestWritePingAck(t *testing.T) { testWritePing(t, true) }
 
@@ -1321,8 +1573,7 @@ func TestSetReuseFrames(t *testing.T) {
 	fr, buf := testFramer()
 	fr.SetReuseFrames()
 
-	// Check that DataFrames are reused. Note that
-	// SetReuseFrames only currently implements reuse of DataFrames.
+	// Check that DataFrames are reused.
 	firstDf := readAndVerifyDataFrame("ABC", 3, fr, buf, t)
 
 	for range 10 {
@@ -1370,7 +1621,6 @@ func TestNoSetReuseFrames(t *testing.T) {
 	dfSoFar := make([]any, numNewDataFrames)
 
 	// Check that DataFrames are not reused if SetReuseFrames wasn't called.
-	// SetReuseFrames only currently implements reuse of DataFrames.
 	for i := range numNewDataFrames {
 		df := readAndVerifyDataFrame("XYZ", 3, fr, buf, t)
 		for _, item := range dfSoFar {

--- a/src/net/http/internal/http2/frame_test.go
+++ b/src/net/http/internal/http2/frame_test.go
@@ -1270,6 +1270,280 @@ func TestMetaHeadersFrameAccessorPanicsWhenStale(t *testing.T) {
 	}
 }
 
+// TestReadMetaFrameReusesFieldsSlice verifies that, when
+// SetReuseFrames is in effect, readMetaFrame reuses the backing array
+// of MetaHeadersFrame.Fields across parses instead of growing a fresh
+// slice from nil each time. The Fields documentation already forbids
+// retaining the slice past the next ReadFrame, and the package's
+// consumers copy field strings into their own header maps
+// synchronously, so the in-place overwrite is within contract.
+func TestReadMetaFrameReusesFieldsSlice(t *testing.T) {
+	fr, buf := testFramer()
+	fr.SetReuseFrames()
+	fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+
+	readMeta := func() *MetaHeadersFrame {
+		t.Helper()
+		f, err := fr.ReadFrame()
+		if err != nil {
+			t.Fatal(err)
+		}
+		mh, ok := f.(*MetaHeadersFrame)
+		if !ok {
+			t.Fatalf("got %T, want *MetaHeadersFrame", f)
+		}
+		return mh
+	}
+
+	// First read populates the cached slice.
+	writeMetaHeaders(t, fr, 1, ":method", "GET", ":path", "/a", ":scheme", "http", ":authority", "x")
+	mh := readMeta()
+	if len(mh.Fields) != 4 {
+		t.Fatalf("first parse: got %d fields, want 4", len(mh.Fields))
+	}
+	backing1 := unsafe.SliceData(mh.Fields)
+
+	// A second read of the same shape must reuse the backing array.
+	buf.Reset()
+	writeMetaHeaders(t, fr, 3, ":method", "POST", ":path", "/b", ":scheme", "https", ":authority", "y")
+	mh = readMeta()
+	if len(mh.Fields) != 4 {
+		t.Fatalf("second parse: got %d fields, want 4", len(mh.Fields))
+	}
+	if backing := unsafe.SliceData(mh.Fields); backing != backing1 {
+		t.Errorf("Fields backing array changed between equal-size reads: have %p, want %p", backing, backing1)
+	}
+
+	// A larger read may grow the slice; a subsequent equal-size read
+	// must then reuse the grown array.
+	buf.Reset()
+	writeMetaHeaders(t, fr, 5,
+		":method", "GET", ":path", "/c", ":scheme", "http", ":authority", "z",
+		"x-a", "1", "x-b", "2", "x-c", "3", "x-d", "4")
+	mh = readMeta()
+	if len(mh.Fields) != 8 {
+		t.Fatalf("third parse: got %d fields, want 8", len(mh.Fields))
+	}
+	backing3 := unsafe.SliceData(mh.Fields)
+
+	buf.Reset()
+	writeMetaHeaders(t, fr, 7,
+		":method", "GET", ":path", "/d", ":scheme", "http", ":authority", "z",
+		"x-a", "5", "x-b", "6", "x-c", "7", "x-d", "8")
+	mh = readMeta()
+	if backing := unsafe.SliceData(mh.Fields); backing != backing3 {
+		t.Errorf("Fields backing array changed after equal-size read: have %p, want %p", backing, backing3)
+	}
+}
+
+// TestReadMetaFrameFieldsClearsSensitiveTail verifies the memory
+// hygiene of the Fields reuse: header values can hold secrets, so the
+// retained backing array must be cleared before reuse. After a parse
+// shorter than its predecessor, no slot beyond the new length may
+// still reference the earlier parse's strings.
+func TestReadMetaFrameFieldsClearsSensitiveTail(t *testing.T) {
+	fr, buf := testFramer()
+	fr.SetReuseFrames()
+	fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+
+	const secret = "secret-cookie-value-do-not-retain"
+	writeMetaHeaders(t, fr, 1,
+		":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x",
+		"cookie", secret)
+	if _, err := fr.ReadFrame(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Shorter second parse: the slots beyond its length must have
+	// been cleared, not merely left beyond the slice length.
+	buf.Reset()
+	writeMetaHeaders(t, fr, 3, ":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x")
+	f, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mh := f.(*MetaHeadersFrame)
+
+	full := mh.Fields[:cap(mh.Fields)]
+	for i := len(mh.Fields); i < len(full); i++ {
+		if full[i] != (hpack.HeaderField{}) {
+			t.Errorf("Fields slot %d beyond len not cleared: %+v", i, full[i])
+		}
+	}
+}
+
+// TestReadMetaFrameFieldsRetentionCap verifies that a single large
+// HEADERS frame does not permanently inflate the per-Framer Fields
+// cache: the array of a block larger than maxRetainedMetaFields is
+// dropped when the frame is invalidated, so the next parse starts
+// from a fresh one.
+func TestReadMetaFrameFieldsRetentionCap(t *testing.T) {
+	fr, buf := testFramer()
+	fr.SetReuseFrames()
+	fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+
+	big := []string{":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x"}
+	for i := 0; i < 2*maxRetainedMetaFields; i++ {
+		big = append(big, fmt.Sprintf("x-h-%03d", i), "v")
+	}
+	writeMetaHeaders(t, fr, 1, big...)
+	f, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mh := f.(*MetaHeadersFrame)
+	if cap(mh.Fields) <= maxRetainedMetaFields {
+		t.Fatalf("test setup: large parse cap = %d, want > %d", cap(mh.Fields), maxRetainedMetaFields)
+	}
+	bigBacking := unsafe.SliceData(mh.Fields)
+
+	buf.Reset()
+	writeMetaHeaders(t, fr, 3, ":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x")
+	f, err = fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mh = f.(*MetaHeadersFrame)
+	if backing := unsafe.SliceData(mh.Fields); backing == bigBacking {
+		t.Errorf("oversized Fields backing array was retained across parses")
+	}
+	if cap(mh.Fields) > maxRetainedMetaFields {
+		t.Errorf("cap(Fields) = %d after small parse, want <= %d", cap(mh.Fields), maxRetainedMetaFields)
+	}
+}
+
+// TestReadMetaFrameRetainsMidSizeFieldsArray guards the retention cap
+// against being expressed in terms of capacity again: append rounds
+// capacity up to a size class, so a block with well under
+// maxRetainedMetaFields fields can still have cap(Fields) above it,
+// and a capacity check would drop the array on every parse.
+func TestReadMetaFrameRetainsMidSizeFieldsArray(t *testing.T) {
+	for _, n := range []int{4, 20, 40, maxRetainedMetaFields} {
+		t.Run(fmt.Sprint(n), func(t *testing.T) {
+			fr, buf := testFramer()
+			fr.SetReuseFrames()
+			fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+
+			pairs := []string{":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x"}
+			for i := len(pairs) / 2; i < n; i++ {
+				pairs = append(pairs, fmt.Sprintf("x-h-%03d", i), "v")
+			}
+			readMeta := func() *MetaHeadersFrame {
+				t.Helper()
+				f, err := fr.ReadFrame()
+				if err != nil {
+					t.Fatal(err)
+				}
+				return f.(*MetaHeadersFrame)
+			}
+
+			writeMetaHeaders(t, fr, 1, pairs...)
+			mh := readMeta()
+			if len(mh.Fields) != n {
+				t.Fatalf("got %d fields, want %d", len(mh.Fields), n)
+			}
+			first := unsafe.SliceData(mh.Fields)
+
+			buf.Reset()
+			writeMetaHeaders(t, fr, 3, pairs...)
+			mh = readMeta()
+			if backing := unsafe.SliceData(mh.Fields); backing != first {
+				t.Errorf("Fields backing array not retained across %d-field parses (cap=%d)", n, cap(mh.Fields))
+			}
+		})
+	}
+}
+
+// TestReadMetaFrameFieldsTailStaysZero checks the invariant that makes
+// clearing only the slice's length sufficient: nothing is ever written
+// to the backing array beyond the current length, so the slots in
+// [len, cap) are always zero, whatever sequence of block sizes a
+// connection sees.
+func TestReadMetaFrameFieldsTailStaysZero(t *testing.T) {
+	fr, buf := testFramer()
+	fr.SetReuseFrames()
+	fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+
+	const secret = "secret-cookie-value-do-not-retain"
+	for i, n := range []int{40, 5, 30, 1, 20, 4, 60, 2} {
+		buf.Reset()
+		pairs := []string{":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x"}
+		for j := len(pairs) / 2; j < n; j++ {
+			pairs = append(pairs, fmt.Sprintf("x-h-%03d", j), secret)
+		}
+		writeMetaHeaders(t, fr, uint32(2*i+1), pairs...)
+		f, err := fr.ReadFrame()
+		if err != nil {
+			t.Fatal(err)
+		}
+		mh := f.(*MetaHeadersFrame)
+		full := mh.Fields[:cap(mh.Fields)]
+		for k := len(mh.Fields); k < len(full); k++ {
+			if full[k] != (hpack.HeaderField{}) {
+				t.Fatalf("after %d-field parse (#%d): Fields[%d] beyond len is %+v, want zero", n, i, k, full[k])
+			}
+		}
+	}
+}
+
+// TestMetaHeadersFrameInvalidateReleasesFields verifies that the parsed
+// header fields are released as soon as the next ReadFrame call
+// begins, whatever frame type follows, rather than staying reachable
+// from the cached frame until the next HEADERS frame: a connection
+// that goes idle after a request must not pin that request's header
+// values. The backing array itself is kept for the next meta parse.
+func TestMetaHeadersFrameInvalidateReleasesFields(t *testing.T) {
+	fr, buf := testFramer()
+	fr.SetReuseFrames()
+	fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+
+	const secret = "secret-cookie-value-do-not-retain"
+	writeMetaHeaders(t, fr, 1,
+		":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x",
+		"cookie", secret)
+	f, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mh := f.(*MetaHeadersFrame)
+	if got := mh.PseudoValue("method"); got != "GET" {
+		t.Fatalf("PseudoValue(method) = %q, want GET", got)
+	}
+	backing := unsafe.SliceData(mh.Fields)
+	full := mh.Fields[:cap(mh.Fields)]
+
+	// Any following frame ends the contract. With no further HEADERS
+	// on the connection, this is the only point at which the fields
+	// could be released before the connection closes.
+	buf.Reset()
+	if err := fr.WriteWindowUpdate(1, 1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fr.ReadFrame(); err != nil {
+		t.Fatal(err)
+	}
+	if len(mh.Fields) != 0 {
+		t.Errorf("len(Fields) = %d after the next ReadFrame, want 0", len(mh.Fields))
+	}
+	for i, hf := range full {
+		if hf != (hpack.HeaderField{}) {
+			t.Errorf("Fields slot %d still holds %+v after the next ReadFrame", i, hf)
+		}
+	}
+
+	// The array is kept for the next meta parse.
+	buf.Reset()
+	writeMetaHeaders(t, fr, 3, ":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x")
+	f, err = fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mh = f.(*MetaHeadersFrame)
+	if unsafe.SliceData(mh.Fields) != backing {
+		t.Errorf("Fields backing array was not retained across invalidate")
+	}
+}
+
 func TestWritePing(t *testing.T)    { testWritePing(t, false) }
 func TestWritePingAck(t *testing.T) { testWritePing(t, true) }
 

--- a/src/net/http/internal/http2/frame_test.go
+++ b/src/net/http/internal/http2/frame_test.go
@@ -1104,6 +1104,172 @@ func TestReadFrameHeadersDistinctWithoutReuse(t *testing.T) {
 	testFrameDistinctWithoutReuse(t, false, writeHeadersFrame, checkHeadersFrame)
 }
 
+// writeMetaHeadersFrame and checkMetaHeadersFrame are the meta-headers
+// parameters for testFrameReuse and testFrameDistinctWithoutReuse.
+// check reads only the StreamID: the accessor methods are guarded once
+// the next ReadFrame has been called, which
+// TestMetaHeadersFrameAccessorPanicsWhenStale covers.
+func writeMetaHeadersFrame(t testing.TB, fr *Framer, streamID uint32) {
+	t.Helper()
+	writeMetaHeaders(t, fr, streamID, ":method", "GET", ":path", fmt.Sprintf("/%d", streamID), ":scheme", "http", ":authority", "x")
+}
+
+func checkMetaHeadersFrame(t testing.TB, f *MetaHeadersFrame, streamID uint32) {
+	t.Helper()
+	if f.StreamID != streamID {
+		t.Errorf("MetaHeadersFrame StreamID = %d, want %d", f.StreamID, streamID)
+	}
+}
+
+// TestReadMetaFrameReusesMetaHeadersFrame verifies that every
+// ReadFrame call returning a *MetaHeadersFrame returns the same
+// cached pointer when SetReuseFrames is in effect.
+func TestReadMetaFrameReusesMetaHeadersFrame(t *testing.T) {
+	testFrameReuse(t, true, writeMetaHeadersFrame, checkMetaHeadersFrame)
+}
+
+// TestReadMetaFrameMetaHeadersOverwrites verifies the cached
+// MetaHeadersFrame's Truncated flag (and any future-added field)
+// does not leak from a prior parse: the explicit
+// `*mh = MetaHeadersFrame{...}` reset at the start of readMetaFrame
+// must zero every field.
+func TestReadMetaFrameMetaHeadersOverwrites(t *testing.T) {
+	fr, buf := testFramer()
+	fr.SetReuseFrames()
+	fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+	// MaxHeaderListSize that fits the first two HPACK fields (each
+	// encodes as size = name + value + 32 = 42 for the pseudo-headers
+	// used below) but truncates from the third onward. The block of
+	// hpack-encoded bytes stays well under 2*MaxHeaderListSize so the
+	// early "header list too large" abort doesn't fire.
+	fr.MaxHeaderListSize = 100
+
+	// First parse: too-many headers -> Truncated.
+	writeMetaHeaders(t, fr, 1, ":method", "GET", ":path", "/a", ":scheme", "http", ":authority", "x")
+	first, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mh1 := first.(*MetaHeadersFrame)
+	if !mh1.Truncated {
+		t.Fatalf("test setup: first parse not marked Truncated as expected")
+	}
+
+	// Raise the limit, parse a fitting frame, and confirm Truncated
+	// did not bleed into the second result.
+	fr.MaxHeaderListSize = 1 << 16
+	buf.Reset()
+	writeMetaHeaders(t, fr, 3, ":method", "GET", ":path", "/b", ":scheme", "http", ":authority", "y")
+	second, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mh2 := second.(*MetaHeadersFrame)
+	if mh2 != mh1 {
+		t.Fatalf("expected same cached *MetaHeadersFrame; have %p, want %p", mh2, mh1)
+	}
+	if mh2.Truncated {
+		t.Errorf("Truncated leaked from prior parse")
+	}
+}
+
+// TestReadMetaFrameDistinctWithoutReuse asserts the pre-SetReuseFrames
+// contract for the meta-headers path: without opting in, each
+// readMetaFrame returns a distinct *MetaHeadersFrame.
+func TestReadMetaFrameDistinctWithoutReuse(t *testing.T) {
+	testFrameDistinctWithoutReuse(t, true, writeMetaHeadersFrame, checkMetaHeadersFrame)
+}
+
+// TestMetaHeadersFrameNotOwnedOnError verifies that a MetaHeadersFrame
+// returned together with an error is not owned by the caller: only its
+// Header is meaningful (the server reads the StreamID of such a frame
+// to pick the last stream for its GOAWAY), and the accessor methods
+// panic.
+func TestMetaHeadersFrameNotOwnedOnError(t *testing.T) {
+	fr, _ := testFramer()
+	fr.SetReuseFrames()
+	fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+	// A header block more than twice the size the Framer is willing
+	// to accept is rejected before it is decoded.
+	fr.MaxHeaderListSize = 1
+
+	writeMetaHeaders(t, fr, 1, ":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x")
+	f, err := fr.ReadFrame()
+	if err != ConnectionError(ErrCodeProtocol) {
+		t.Fatalf("ReadFrame error = %v, want %v", err, ConnectionError(ErrCodeProtocol))
+	}
+	mh, ok := f.(*MetaHeadersFrame)
+	if !ok {
+		t.Fatalf("frame returned with the error is %T, want *MetaHeadersFrame", f)
+	}
+	if got := mh.Header().StreamID; got != 1 {
+		t.Errorf("Header().StreamID = %d, want 1", got)
+	}
+	defer func() {
+		const want = "Frame accessor called on non-owned Frame"
+		if got := recover(); got != want {
+			t.Errorf("PseudoValue on a frame returned with an error: recovered %v, want panic %q", got, want)
+		}
+	}()
+	mh.PseudoValue("method")
+}
+
+// TestMetaHeadersFrameAccessorPanicsWhenStale verifies the ownership
+// guard on every guarded MetaHeadersFrame accessor: once the next
+// ReadFrame call has been made, calling one on a retained frame panics
+// (mirroring DataFrame.Data) instead of silently returning fields that
+// a later parse may have overwritten in place. The guard applies with
+// and without SetReuseFrames. An intervening non-HEADERS frame is read
+// because a subsequent meta parse would repopulate the cached struct
+// and re-mark it owned, which the guard (like DataFrame's) does not
+// detect.
+func TestMetaHeadersFrameAccessorPanicsWhenStale(t *testing.T) {
+	accessors := []struct {
+		name string
+		call func(mh *MetaHeadersFrame)
+	}{
+		{"PseudoValue", func(mh *MetaHeadersFrame) { mh.PseudoValue("method") }},
+		{"RegularFields", func(mh *MetaHeadersFrame) { mh.RegularFields() }},
+		{"PseudoFields", func(mh *MetaHeadersFrame) { mh.PseudoFields() }},
+		{"rfc9218Priority", func(mh *MetaHeadersFrame) { mh.rfc9218Priority(false) }},
+	}
+	for _, reuse := range []bool{true, false} {
+		for _, a := range accessors {
+			t.Run(fmt.Sprintf("reuse=%v/%s", reuse, a.name), func(t *testing.T) {
+				fr, buf := testFramer()
+				if reuse {
+					fr.SetReuseFrames()
+				}
+				fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+
+				writeMetaHeaders(t, fr, 1, ":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x")
+				f, err := fr.ReadFrame()
+				if err != nil {
+					t.Fatal(err)
+				}
+				mh := f.(*MetaHeadersFrame)
+				a.call(mh) // owned: must not panic
+
+				buf.Reset()
+				if err := fr.WriteWindowUpdate(1, 5); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := fr.ReadFrame(); err != nil {
+					t.Fatal(err)
+				}
+
+				defer func() {
+					const want = "Frame accessor called on non-owned Frame"
+					if got := recover(); got != want {
+						t.Errorf("%s on a stale MetaHeadersFrame: recovered %v, want panic %q", a.name, got, want)
+					}
+				}()
+				a.call(mh)
+			})
+		}
+	}
+}
+
 func TestWritePing(t *testing.T)    { testWritePing(t, false) }
 func TestWritePingAck(t *testing.T) { testWritePing(t, true) }
 
@@ -1450,6 +1616,7 @@ func TestMetaFrameHeader(t *testing.T) {
 				},
 			},
 			Fields: []hpack.HeaderField(nil),
+			owned:  true,
 		}
 		for len(pairs) > 0 {
 			mh.Fields = append(mh.Fields, hpack.HeaderField{
@@ -1756,6 +1923,20 @@ func encodeHeaderRaw(t testing.TB, headers ...string) []byte {
 		headers = headers[2:]
 	}
 	return buf.Bytes()
+}
+
+// writeMetaHeaders HPACK-encodes the name/value pairs and writes them
+// to fr as a single HEADERS frame with EndHeaders set.
+func writeMetaHeaders(t testing.TB, fr *Framer, streamID uint32, pairs ...string) {
+	t.Helper()
+	block := encodeHeaderRaw(t, pairs...)
+	if err := fr.WriteHeaders(HeadersFrameParam{
+		StreamID:      streamID,
+		BlockFragment: block,
+		EndHeaders:    true,
+	}); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestSettingsDuplicates(t *testing.T) {

--- a/src/net/http/internal/http2/frame_test.go
+++ b/src/net/http/internal/http2/frame_test.go
@@ -1001,6 +1001,109 @@ func TestReadFrameWindowUpdateDistinctWithoutReuse(t *testing.T) {
 	testFrameDistinctWithoutReuse(t, false, writeWindowUpdateFrame, checkWindowUpdateFrame)
 }
 
+// writeHeadersFrame and checkHeadersFrame are the HEADERS parameters
+// for testFrameReuse and testFrameDistinctWithoutReuse. The frame
+// carries a priority, so that a field beyond the FrameHeader is
+// checked as well.
+func writeHeadersFrame(t testing.TB, fr *Framer, streamID uint32) {
+	t.Helper()
+	if err := fr.WriteHeaders(HeadersFrameParam{
+		StreamID:      streamID,
+		BlockFragment: []byte("abc"),
+		EndHeaders:    true,
+		Priority:      PriorityParam{StreamDep: 100 + streamID, Weight: 42},
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func checkHeadersFrame(t testing.TB, f *HeadersFrame, streamID uint32) {
+	t.Helper()
+	if f.StreamID != streamID || !f.HasPriority() || f.Priority.StreamDep != 100+streamID || f.Priority.Weight != 42 {
+		t.Errorf("HEADERS = %+v; want StreamID=%d Priority.StreamDep=%d Priority.Weight=42", f, streamID, 100+streamID)
+	}
+}
+
+// TestReadFrameReusesHeadersFrame verifies that ReadFrame returns
+// the same *HeadersFrame pointer for every HEADERS parsed when
+// SetReuseFrames is in effect.
+func TestReadFrameReusesHeadersFrame(t *testing.T) {
+	testFrameReuse(t, false, writeHeadersFrame, checkHeadersFrame)
+}
+
+// TestReadFrameHeadersOverwrites is a defensive test against future
+// maintenance hazards. When SetReuseFrames is in effect, the cached
+// *HeadersFrame is reused across ReadFrame calls; any field that
+// parseHeadersFrame forgets to assign would leak from the previous
+// frame to the next caller.
+//
+// The test parses a HEADERS frame WITH Priority and padding to
+// populate all fields, then parses a second frame WITHOUT either
+// flag and asserts the previous Priority and headerFragBuf-related
+// state do not bleed through.
+func TestReadFrameHeadersOverwrites(t *testing.T) {
+	fr, buf := testFramer()
+	fr.SetReuseFrames()
+
+	// First frame: priority + padding to populate every field.
+	if err := fr.WriteHeaders(HeadersFrameParam{
+		StreamID:      9,
+		BlockFragment: []byte("xyz"),
+		EndHeaders:    true,
+		PadLength:     3,
+		Priority: PriorityParam{
+			StreamDep: 7,
+			Exclusive: true,
+			Weight:    100,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	first, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hf1 := first.(*HeadersFrame)
+	if hf1.Priority.StreamDep != 7 || !hf1.Priority.Exclusive || hf1.Priority.Weight != 100 {
+		t.Fatalf("test setup: first frame priority = %+v; want StreamDep=7 Exclusive=true Weight=100", hf1.Priority)
+	}
+
+	// Second frame: no priority, no padding. Priority must reset.
+	buf.Reset()
+	if err := fr.WriteHeaders(HeadersFrameParam{
+		StreamID:      11,
+		BlockFragment: []byte("ab"),
+		EndHeaders:    true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	second, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hf2 := second.(*HeadersFrame)
+	if hf2 != hf1 {
+		t.Fatalf("expected same pointer (cached); have %p, want %p", hf2, hf1)
+	}
+	if (hf2.Priority != PriorityParam{}) {
+		t.Errorf("Priority leak: %+v (want zero)", hf2.Priority)
+	}
+	if hf2.Flags.Has(FlagHeadersPriority) || hf2.Flags.Has(FlagHeadersPadded) {
+		t.Errorf("Flags leak: %x", hf2.Flags)
+	}
+	if hf2.StreamID != 11 {
+		t.Errorf("StreamID = %d, want 11", hf2.StreamID)
+	}
+}
+
+// TestReadFrameHeadersDistinctWithoutReuse asserts the
+// pre-SetReuseFrames contract: without opting in, each parsed
+// HEADERS returns a distinct *HeadersFrame whose Priority and
+// FrameHeader remain stable after a subsequent ReadFrame.
+func TestReadFrameHeadersDistinctWithoutReuse(t *testing.T) {
+	testFrameDistinctWithoutReuse(t, false, writeHeadersFrame, checkHeadersFrame)
+}
+
 func TestWritePing(t *testing.T)    { testWritePing(t, false) }
 func TestWritePingAck(t *testing.T) { testWritePing(t, true) }
 

--- a/src/net/http/internal/http2/frame_test.go
+++ b/src/net/http/internal/http2/frame_test.go
@@ -7,6 +7,7 @@ package http2
 import (
 	"bytes"
 	"fmt"
+	"internal/race"
 	"io"
 	"reflect"
 	"strings"
@@ -764,6 +765,242 @@ func TestWriteWindowUpdate(t *testing.T) {
 	}
 }
 
+// readFrameAs writes one frame for streamID with write, reads it back
+// from fr, and asserts that it parsed as an F.
+func readFrameAs[F Frame](t testing.TB, fr *Framer, buf *bytes.Buffer, write func(t testing.TB, fr *Framer, streamID uint32), streamID uint32) F {
+	t.Helper()
+	buf.Reset()
+	write(t, fr, streamID)
+	f, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ff, ok := f.(F)
+	if !ok {
+		t.Fatalf("stream %d: frame is %T, want %T", streamID, f, ff)
+	}
+	return ff
+}
+
+// testFrameReuse verifies the SetReuseFrames contract for one frame
+// type: every ReadFrame that parses a frame of type F returns the same
+// pointer, holding the values of the frame just parsed, and a frame of
+// another type in between does not disturb that. write emits a frame
+// for a stream; check asserts that a parsed frame carries the values
+// write produced for that stream, reading only fields that stay
+// readable on a reused frame.
+func testFrameReuse[F Frame](t *testing.T, meta bool, write func(t testing.TB, fr *Framer, streamID uint32), check func(t testing.TB, f F, streamID uint32)) {
+	fr, buf := testFramer()
+	fr.SetReuseFrames()
+	if meta {
+		fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+	}
+
+	first := readFrameAs[F](t, fr, buf, write, 1)
+	check(t, first, 1)
+
+	// Later frames return the same pointer with the new values, so the
+	// pointer returned first reflects each later parse as well.
+	for _, streamID := range []uint32{3, 1, 5} {
+		f := readFrameAs[F](t, fr, buf, write, streamID)
+		if any(f) != any(first) {
+			t.Errorf("stream %d: pointer changed: have %p, want %p", streamID, any(f), any(first))
+		}
+		check(t, f, streamID)
+		check(t, first, streamID)
+	}
+
+	// A frame of another type in between does not disturb reuse: the
+	// cached struct is repopulated by the next parse of type F.
+	buf.Reset()
+	if err := fr.WritePing(false, [8]byte{1, 2, 3, 4, 5, 6, 7, 8}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fr.ReadFrame(); err != nil {
+		t.Fatal(err)
+	}
+	f := readFrameAs[F](t, fr, buf, write, 7)
+	if any(f) != any(first) {
+		t.Errorf("after PING: pointer changed: have %p, want %p", any(f), any(first))
+	}
+	check(t, f, 7)
+}
+
+// testFrameDistinctWithoutReuse verifies the pre-SetReuseFrames
+// contract for one frame type: without opting in, each parse returns a
+// distinct pointer, and the first frame is intact after the second
+// ReadFrame.
+func testFrameDistinctWithoutReuse[F Frame](t *testing.T, meta bool, write func(t testing.TB, fr *Framer, streamID uint32), check func(t testing.TB, f F, streamID uint32)) {
+	fr, buf := testFramer()
+	if meta {
+		fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+	}
+	first := readFrameAs[F](t, fr, buf, write, 1)
+	second := readFrameAs[F](t, fr, buf, write, 3)
+	if any(first) == any(second) {
+		t.Errorf("without SetReuseFrames, expected distinct pointers; got the same: %p", any(first))
+	}
+	check(t, first, 1)
+	check(t, second, 3)
+}
+
+// writeWindowUpdateFrame and checkWindowUpdateFrame are the WINDOW_UPDATE
+// parameters for testFrameReuse and testFrameDistinctWithoutReuse.
+func writeWindowUpdateFrame(t testing.TB, fr *Framer, streamID uint32) {
+	t.Helper()
+	if err := fr.WriteWindowUpdate(streamID, 1000+streamID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func checkWindowUpdateFrame(t testing.TB, f *WindowUpdateFrame, streamID uint32) {
+	t.Helper()
+	if f.StreamID != streamID || f.Increment != 1000+streamID {
+		t.Errorf("WINDOW_UPDATE = %+v; want StreamID=%d Increment=%d", f, streamID, 1000+streamID)
+	}
+}
+
+// TestReadFrameReusesWindowUpdate verifies that ReadFrame returns the
+// same *WindowUpdateFrame pointer for every WINDOW_UPDATE parsed when
+// SetReuseFrames is in effect, so the parse path does not allocate a
+// fresh struct each time.
+func TestReadFrameReusesWindowUpdate(t *testing.T) {
+	testFrameReuse(t, false, writeWindowUpdateFrame, checkWindowUpdateFrame)
+}
+
+// TestReadFrameWindowUpdateNoAllocsWhenReused locks in the
+// zero-allocation invariant for the WINDOW_UPDATE parse path when
+// SetReuseFrames is in effect. If a regression makes
+// parseWindowUpdateFrame allocate, this fails rather than only showing
+// up in benchmarks.
+func TestReadFrameWindowUpdateNoAllocsWhenReused(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping alloc test in short mode")
+	}
+	if race.Enabled {
+		t.Skip("skipping alloc test under race detector")
+	}
+	// Pre-encode a WINDOW_UPDATE frame.
+	var enc bytes.Buffer
+	if err := NewFramer(&enc, nil).WriteWindowUpdate(1, 7); err != nil {
+		t.Fatal(err)
+	}
+	encoded := enc.Bytes()
+
+	rbuf := bytes.NewReader(encoded)
+	fr := NewFramer(io.Discard, rbuf)
+	fr.SetReuseFrames()
+
+	// Warm up the read buffer so its growth does not count toward the
+	// measurement.
+	rbuf.Reset(encoded)
+	if _, err := fr.ReadFrame(); err != nil {
+		t.Fatal(err)
+	}
+
+	allocs := testing.AllocsPerRun(50, func() {
+		rbuf.Reset(encoded)
+		if _, err := fr.ReadFrame(); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if allocs != 0 {
+		t.Errorf("ReadFrame for WINDOW_UPDATE allocates %v objects/op; want 0", allocs)
+	}
+}
+
+// TestReadFrameWindowUpdateOverwrites is a defensive test against
+// future maintenance hazards. When SetReuseFrames is in effect, the
+// cached *WindowUpdateFrame is reused across ReadFrame calls.
+// parseWindowUpdateFrame resets the whole struct with a composite
+// literal, so no field can survive from a previous frame; this test
+// guards that property against a future regression to field-by-field
+// assignment (which could silently leak stale data if a field were
+// added).
+//
+// The test poisons every byte of the cached struct, parses a fresh
+// WINDOW_UPDATE, and then verifies every field reflects the new frame
+// rather than the poison.
+func TestReadFrameWindowUpdateOverwrites(t *testing.T) {
+	fr, buf := testFramer()
+	fr.SetReuseFrames()
+
+	// First read to obtain the cached struct pointer.
+	if err := fr.WriteWindowUpdate(1, 5); err != nil {
+		t.Fatal(err)
+	}
+	first, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wuf, ok := first.(*WindowUpdateFrame)
+	if !ok {
+		t.Fatalf("first frame is %T, want *WindowUpdateFrame", first)
+	}
+
+	// Fill every byte of the cached struct with 0xFF. If any field is
+	// left unassigned by the next parse, it will keep this poison value.
+	//
+	// valid is a bool, and any non-zero byte reads as true; bulk 0xFF
+	// poison would therefore mask a parser that forgets to reassign
+	// valid. Set valid to false separately so the post-parse
+	// expectation (valid == true) genuinely tests a fresh write.
+	poison := unsafe.Slice((*byte)(unsafe.Pointer(wuf)), unsafe.Sizeof(*wuf))
+	for i := range poison {
+		poison[i] = 0xFF
+	}
+	wuf.valid = false
+
+	// Parse a fresh WINDOW_UPDATE. The poison must be fully gone.
+	buf.Reset()
+	const wantStreamID = 42
+	const wantIncrement = 100
+	if err := fr.WriteWindowUpdate(wantStreamID, wantIncrement); err != nil {
+		t.Fatal(err)
+	}
+	f, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wu, ok := f.(*WindowUpdateFrame)
+	if !ok {
+		t.Fatalf("frame is %T, want *WindowUpdateFrame", f)
+	}
+	if wu != wuf {
+		t.Fatalf("pointer changed after poison: have %p, want %p", wu, wuf)
+	}
+
+	// Check every field. Failure on any of these means
+	// parseWindowUpdateFrame left a field unassigned, which would leak
+	// data from a previous frame to the next consumer.
+	if wu.Type != FrameWindowUpdate {
+		t.Errorf("Type = %v (poison leak); want %v", wu.Type, FrameWindowUpdate)
+	}
+	if wu.Flags != 0 {
+		t.Errorf("Flags = %#x (poison leak); want 0", wu.Flags)
+	}
+	if wu.Length != 4 {
+		t.Errorf("Length = %d (poison leak); want 4", wu.Length)
+	}
+	if wu.StreamID != wantStreamID {
+		t.Errorf("StreamID = %d (poison leak); want %d", wu.StreamID, wantStreamID)
+	}
+	if !wu.valid {
+		t.Errorf("valid = false (poison leak); want true")
+	}
+	if wu.Increment != wantIncrement {
+		t.Errorf("Increment = %d (poison leak); want %d", wu.Increment, wantIncrement)
+	}
+}
+
+// TestReadFrameWindowUpdateDistinctWithoutReuse asserts the
+// pre-SetReuseFrames contract: without opting in, each parsed
+// WINDOW_UPDATE returns a distinct *WindowUpdateFrame whose fields
+// remain valid even after a subsequent ReadFrame.
+func TestReadFrameWindowUpdateDistinctWithoutReuse(t *testing.T) {
+	testFrameDistinctWithoutReuse(t, false, writeWindowUpdateFrame, checkWindowUpdateFrame)
+}
+
 func TestWritePing(t *testing.T)    { testWritePing(t, false) }
 func TestWritePingAck(t *testing.T) { testWritePing(t, true) }
 
@@ -1321,8 +1558,7 @@ func TestSetReuseFrames(t *testing.T) {
 	fr, buf := testFramer()
 	fr.SetReuseFrames()
 
-	// Check that DataFrames are reused. Note that
-	// SetReuseFrames only currently implements reuse of DataFrames.
+	// Check that DataFrames are reused.
 	firstDf := readAndVerifyDataFrame("ABC", 3, fr, buf, t)
 
 	for range 10 {
@@ -1370,7 +1606,6 @@ func TestNoSetReuseFrames(t *testing.T) {
 	dfSoFar := make([]any, numNewDataFrames)
 
 	// Check that DataFrames are not reused if SetReuseFrames wasn't called.
-	// SetReuseFrames only currently implements reuse of DataFrames.
 	for i := range numNewDataFrames {
 		df := readAndVerifyDataFrame("XYZ", 3, fr, buf, t)
 		for _, item := range dfSoFar {

--- a/src/net/http/internal/http2/frame_test.go
+++ b/src/net/http/internal/http2/frame_test.go
@@ -2398,3 +2398,118 @@ func TestTypeFrameParserHolePanic(t *testing.T) {
 		t.Errorf("got %T; want *UnknownFrame", f)
 	}
 }
+
+// benchmarkReadFrameReuse measures the per-parse cost of repeatedly
+// reading the single pre-encoded frame in encoded, in Default
+// (allocate per parse) and Reused (SetReuseFrames) variants. When
+// meta is set, the Framer decodes HEADERS via ReadMetaHeaders. One
+// warm-up read keeps the Framer's read-buffer growth out of the
+// measurement.
+func benchmarkReadFrameReuse(b *testing.B, meta bool, encoded []byte) {
+	run := func(b *testing.B, reuse bool) {
+		rbuf := bytes.NewReader(encoded)
+		fr := NewFramer(io.Discard, rbuf)
+		if meta {
+			fr.ReadMetaHeaders = hpack.NewDecoder(initialHeaderTableSize, nil)
+		}
+		if reuse {
+			fr.SetReuseFrames()
+		}
+		rbuf.Reset(encoded)
+		if _, err := fr.ReadFrame(); err != nil {
+			b.Fatal(err)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			rbuf.Reset(encoded)
+			if _, err := fr.ReadFrame(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	b.Run("Default", func(b *testing.B) { run(b, false) })
+	b.Run("Reused", func(b *testing.B) { run(b, true) })
+}
+
+// BenchmarkParseDataFrame measures the per-parse cost of DATA
+// frames with and without SetReuseFrames. The DataFrame cache is the
+// preexisting one; this exists so its contribution can be compared
+// directly against the WindowUpdate/Headers/MetaHeaders caches added
+// in this stack.
+func BenchmarkParseDataFrame(b *testing.B) {
+	var enc bytes.Buffer
+	if err := NewFramer(&enc, nil).WriteData(1, false, []byte("abc")); err != nil {
+		b.Fatal(err)
+	}
+	benchmarkReadFrameReuse(b, false, enc.Bytes())
+}
+
+// BenchmarkParseWindowUpdateFrame measures the per-parse cost of
+// WINDOW_UPDATE frames with and without SetReuseFrames. The Default
+// case allocates a fresh *WindowUpdateFrame each call; Reused uses
+// the cached one.
+func BenchmarkParseWindowUpdateFrame(b *testing.B) {
+	var enc bytes.Buffer
+	if err := NewFramer(&enc, nil).WriteWindowUpdate(1, 7); err != nil {
+		b.Fatal(err)
+	}
+	benchmarkReadFrameReuse(b, false, enc.Bytes())
+}
+
+// BenchmarkParseHeadersFrame measures HEADERS parsing with and
+// without SetReuseFrames.
+func BenchmarkParseHeadersFrame(b *testing.B) {
+	var enc bytes.Buffer
+	if err := NewFramer(&enc, nil).WriteHeaders(HeadersFrameParam{
+		StreamID:      1,
+		BlockFragment: []byte("abc"),
+		EndHeaders:    true,
+	}); err != nil {
+		b.Fatal(err)
+	}
+	benchmarkReadFrameReuse(b, false, enc.Bytes())
+}
+
+// BenchmarkReadMetaFrame measures HEADERS+HPACK decoding via
+// readMetaFrame with and without SetReuseFrames. With reuse, the
+// cached *HeadersFrame and *MetaHeadersFrame wrappers and the Fields
+// backing array are all eliminated from the allocation count.
+func BenchmarkReadMetaFrame(b *testing.B) {
+	block := encodeHeaderRaw(b, ":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x")
+	var enc bytes.Buffer
+	if err := NewFramer(&enc, nil).WriteHeaders(HeadersFrameParam{
+		StreamID:      1,
+		BlockFragment: block,
+		EndHeaders:    true,
+	}); err != nil {
+		b.Fatal(err)
+	}
+	benchmarkReadFrameReuse(b, true, enc.Bytes())
+}
+
+// BenchmarkReadMetaFrameFields measures readMetaFrame across header
+// block sizes, with and without SetReuseFrames. The sizes bracket
+// maxRetainedMetaFields: up to it, the Reused arm must not allocate
+// for the Fields array at all; above it, every parse grows a fresh
+// one.
+func BenchmarkReadMetaFrameFields(b *testing.B) {
+	for _, n := range []int{4, 10, 30, 40, maxRetainedMetaFields, 100} {
+		pairs := []string{":method", "GET", ":path", "/", ":scheme", "http", ":authority", "x"}
+		for i := len(pairs) / 2; i < n; i++ {
+			pairs = append(pairs, fmt.Sprintf("x-field-%03d", i), fmt.Sprintf("value-%d", i))
+		}
+		block := encodeHeaderRaw(b, pairs...)
+		var enc bytes.Buffer
+		if err := NewFramer(&enc, nil).WriteHeaders(HeadersFrameParam{
+			StreamID:      1,
+			BlockFragment: block,
+			EndHeaders:    true,
+		}); err != nil {
+			b.Fatal(err)
+		}
+		b.Run(fmt.Sprintf("%dFields", n), func(b *testing.B) {
+			benchmarkReadFrameReuse(b, true, enc.Bytes())
+		})
+	}
+}

--- a/src/net/http/internal/http2/server.go
+++ b/src/net/http/internal/http2/server.go
@@ -322,6 +322,7 @@ func (s *Server) serveConn(c net.Conn, opts *ServeConnOpts, newf func(*serverCon
 	fr.ReadMetaHeaders = hpack.NewDecoder(uint32(conf.MaxDecoderHeaderTableSize), nil)
 	fr.MaxHeaderListSize = sc.maxHeaderListSize()
 	fr.SetMaxReadFrameSize(uint32(conf.MaxReadFrameSize))
+	fr.setReuseFramesFromGODEBUG()
 	sc.framer = fr
 
 	if tc, ok := c.(connectionStater); ok {
@@ -1498,6 +1499,11 @@ func (sc *serverConn) processPing(f *PingFrame) error {
 		// PROTOCOL_ERROR."
 		return sc.countError("ping_on_stream", ConnectionError(ErrCodeProtocol))
 	}
+	// writePingAck retains f past this readMore cycle: the ack is
+	// written asynchronously by the write scheduler, possibly after
+	// the read loop has parsed the next frame. That is safe only
+	// because PingFrame is not part of the Framer's frameCache; if it
+	// is ever added there, copy f.Data before queueing the ack.
 	sc.writeFrame(FrameWriteRequest{write: writePingAck{f}})
 	return nil
 }

--- a/src/net/http/internal/http2/server.go
+++ b/src/net/http/internal/http2/server.go
@@ -337,6 +337,7 @@ func (s *Server) serveConn(c net.Conn, opts *ServeConnOpts, newf func(*serverCon
 	fr.MaxHeaderListSize = sc.maxHeaderListSize()
 	fr.MaxHeaderValueCount = sc.hs.MaxHeaderValueCount()
 	fr.SetMaxReadFrameSize(uint32(conf.MaxReadFrameSize))
+	fr.setReuseFramesFromGODEBUG()
 	sc.framer = fr
 
 	if tc, ok := c.(connectionStater); ok {
@@ -1514,6 +1515,11 @@ func (sc *serverConn) processPing(f *PingFrame) error {
 		// PROTOCOL_ERROR."
 		return sc.countError("ping_on_stream", ConnectionError(ErrCodeProtocol))
 	}
+	// writePingAck retains f past this readMore cycle: the ack is
+	// written asynchronously by the write scheduler, possibly after
+	// the read loop has parsed the next frame. That is safe only
+	// because PingFrame is not part of the Framer's frameCache; if it
+	// is ever added there, copy f.Data before queueing the ack.
 	sc.writeFrame(FrameWriteRequest{write: writePingAck{f}})
 	return nil
 }

--- a/src/net/http/internal/http2/server.go
+++ b/src/net/http/internal/http2/server.go
@@ -2192,10 +2192,29 @@ func (sc *serverConn) newWriterAndRequest(st *stream, f *MetaHeadersFrame) (*res
 		return nil, nil, sc.countError("bad_path_method", streamError(f.StreamID, ErrCodeProtocol))
 	}
 
-	header := make(Header)
+	// Build the request header map with one []string allocation for
+	// the whole block instead of one per key: most header keys are
+	// single-valued, so hand each new key a one-element window into a
+	// shared backing array. This mirrors what
+	// clientConnReadLoop.handleResponse does for response headers.
+	regularFields := f.RegularFields()
+	strs := make([]string, len(regularFields))
+	header := make(Header, len(regularFields))
 	rp.Header = header
-	for _, hf := range f.RegularFields() {
-		header.Add(sc.canonicalHeader(hf.Name), hf.Value)
+	for _, hf := range regularFields {
+		key := sc.canonicalHeader(hf.Name)
+		vv := header[key]
+		if vv == nil && len(strs) > 0 {
+			// More than likely this will be a single-element key.
+			// Most headers aren't multi-valued.
+			// Set the capacity on strs[0] to 1, so any future append
+			// won't extend the slice into the other strings.
+			vv, strs = strs[:1:1], strs[1:]
+			vv[0] = hf.Value
+			header[key] = vv
+		} else {
+			header[key] = append(vv, hf.Value)
+		}
 	}
 	if rp.Authority == "" {
 		rp.Authority = header.Get("Host")

--- a/src/net/http/internal/http2/transport.go
+++ b/src/net/http/internal/http2/transport.go
@@ -662,6 +662,7 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool, internalStateHook 
 	maxHeaderTableSize := uint32(conf.MaxDecoderHeaderTableSize)
 	cc.fr.ReadMetaHeaders = hpack.NewDecoder(maxHeaderTableSize, nil)
 	cc.fr.MaxHeaderListSize = t.maxHeaderListSize()
+	cc.fr.setReuseFramesFromGODEBUG()
 
 	cc.henc = hpack.NewEncoder(&cc.hbuf)
 	cc.henc.SetMaxDynamicTableSizeLimit(uint32(conf.MaxEncoderHeaderTableSize))
@@ -2619,6 +2620,13 @@ func (rl *clientConnReadLoop) processGoAway(f *GoAwayFrame) error {
 	cc.mu.Lock()
 	defer cc.mu.Unlock()
 
+	// cc.goAway retains f past this ReadFrame iteration: its
+	// LastStreamID and ErrCode are read at read-loop teardown and by
+	// later processGoAway calls. That is safe only because
+	// GoAwayFrame is not part of the Framer's frameCache; if it is
+	// ever added there, copy the fields needed here instead of
+	// retaining the frame. (DebugData is already copied below, before
+	// the next ReadFrame invalidates it.)
 	old := cc.goAway
 	cc.goAway = f
 

--- a/src/net/http/internal/http2/transport.go
+++ b/src/net/http/internal/http2/transport.go
@@ -691,6 +691,7 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool, internalStateHook 
 	maxHeaderTableSize := uint32(conf.MaxDecoderHeaderTableSize)
 	cc.fr.ReadMetaHeaders = hpack.NewDecoder(maxHeaderTableSize, nil)
 	cc.fr.MaxHeaderListSize = t.maxHeaderListSize()
+	cc.fr.setReuseFramesFromGODEBUG()
 
 	cc.henc = hpack.NewEncoder(&cc.hbuf)
 	cc.henc.SetMaxDynamicTableSizeLimit(uint32(conf.MaxEncoderHeaderTableSize))
@@ -2776,6 +2777,13 @@ func (rl *clientConnReadLoop) processGoAway(f *GoAwayFrame) error {
 	cc.mu.Lock()
 	defer cc.mu.Unlock()
 
+	// cc.goAway retains f past this ReadFrame iteration: its
+	// LastStreamID and ErrCode are read at read-loop teardown and by
+	// later processGoAway calls. That is safe only because
+	// GoAwayFrame is not part of the Framer's frameCache; if it is
+	// ever added there, copy the fields needed here instead of
+	// retaining the frame. (DebugData is already copied below, before
+	// the next ReadFrame invalidates it.)
 	old := cc.goAway
 	cc.goAway = f
 

--- a/src/runtime/metrics/doc.go
+++ b/src/runtime/metrics/doc.go
@@ -311,6 +311,11 @@ Below is the full list of supported metrics, ordered lexicographically.
 		The number of non-default behaviors executed by the net/http
 		package due to a non-default GODEBUG=http2client=... setting.
 
+	/godebug/non-default-behavior/http2reuseframes:events
+		The number of non-default behaviors executed by the net/http
+		package due to a non-default GODEBUG=http2reuseframes=...
+		setting.
+
 	/godebug/non-default-behavior/http2server:events
 		The number of non-default behaviors executed by the net/http
 		package due to a non-default GODEBUG=http2server=... setting.


### PR DESCRIPTION
This stack extends Framer.SetReuseFrames to cover *WindowUpdateFrame,
*HeadersFrame, and *MetaHeadersFrame (in addition to the existing
*DataFrame), reuses the MetaHeadersFrame Fields backing array across
parses, then calls SetReuseFrames once on the per-connection Framer
in serverConn and Transport.newClientConn. Result: -32% geomean
allocations per op on the package's read-path benchmarks (about
-49% on downloads, -20% on header-bound requests), with no
measurable change on write-path benchmarks and no API change.

A new GODEBUG=http2reuseframes=0 setting is registered alongside
http2client / http2server / http2debug and reverts to the pre-CL
allocate-per-frame behavior.

Background

Framer.SetReuseFrames has shipped as an opt-in Framer method since
golang/net CL 34812 (commit bb807669, 2017-02-27, fixing #18502). It
was added for gRPC-Go, whose Framer profiling showed parseDataFrame
accounting for ~66% of allocations (1.4 GB of 2.2 GB) on a 64-conn /
100-stream / 900K RT/sec benchmark. gRPC-Go calls SetReuseFrames
directly on the Framer it owns.

No in-tree caller in the standard library has ever opted in, so the
cache has been effectively dead code from the stdlib's perspective
for nine years. This CL turns it on.

Prior attempts and reviewer concerns

This is the third attempt to enable frame reuse on the stdlib's
HTTP/2 server/Transport:

  - Issue #68352 (still open, 2024-07-09): a request to improve
    frame decoding performance. neild rejected a user-facing config
    option ("There's no need for a user-configurable option here.
    If there are performance improvements that can be made to frame
    decoding in the HTTP/2 implementation, we can just make them.")
    but left the door open for internal enablement.

  - golang/net CL 597455 (PR golang/net#216, 2024-07-10): tried to
    enable on both server and Transport unconditionally. neild's
    blocking review: "this is not correct. The server read goroutine
    (serverConn.readFrames) reads frames and delivers them to the
    main server goroutine for processing," and "Changing the HTTP/2
    server and/or transport to use the frame cache is likely to
    require some significant refactoring." Stale; never landed.

  - golang/net CL 676235 (server-only, 2025-05-25): neild Hold+1 on
    2025-06-24: "this is not a safe change for the server.
    SetReuseFrames causes each frame to be invalidated by the next
    call to ReadFrame, but the server processes frames concurrently
    with ReadFrame calls." Abandoned 2025-10-24.

The blocker on both prior CLs was correctness, specifically retention
of frame data past the next ReadFrame. This CL addresses that with a
static retention audit, an ownership guard that turns retention bugs
into deterministic panics, race-detector tests that exercise the
gated handoff, an end-to-end stress test under -race, and a GODEBUG
escape hatch in case the analysis missed something.

Stack layout

Nine commits, each independently reviewable:

  1. reuse *WindowUpdateFrame across ReadFrame calls
  2. reuse *HeadersFrame across ReadFrame calls
  3. reuse *MetaHeadersFrame across ReadFrame calls, with an
     ownership guard on its accessor methods
  4. reuse the MetaHeadersFrame Fields slice across parses
  5. add microbenchmarks for the SetReuseFrames path
  6. add race-detector tests (positive control, and an adversarial
     negative control that runs in a child process)
  7. enable SetReuseFrames in server and Transport, register
     http2reuseframes GODEBUG, add end-to-end stress and GODEBUG
     wiring tests
  8. register the meta-frame hpack emit callback once per Framer,
     which takes a meta parse with reuse on to zero allocations
  9. build the server request header map with one []string, as the
     Transport already does for responses (independent of frame
     reuse; can be split into its own CL)

Commits 1-3 mirror the existing *DataFrame cache pattern from CL
34812: wholesale "*p = T{...}" reset at the top of each parse
function, slot in frameCache, nil-safe get<Type>Frame getter. No
behavior change without SetReuseFrames; the caches are dormant unless
opted in.

Commit 3 also gives MetaHeadersFrame the equivalent of DataFrame's
checkValid protection: an owned bit set when readMetaFrame returns
the frame without an error and revoked by the next ReadFrame (the
frame becomes the Framer's lastFrame and overrides invalidate); a
frame returned together with an error is never owned and only its
Header is meaningful. PseudoValue,
RegularFields, PseudoFields, and rfc9218Priority panic on a stale
frame, so a retention bug fails deterministically instead of
silently reading another stream's headers.

Commit 4 is where most of the HEADERS-path win comes from: the
Fields backing array stays in the cached frame and is re-filled by
the next meta parse. Two safeguards: the parsed fields are released
as soon as the contract permits, in invalidate at the next ReadFrame
call (which now runs before the Framer blocks on the next frame
header), so an idle connection does not pin its last request's
header values, which can hold secrets (Cookie, Authorization, HPACK
Sensitive fields); and the array is dropped after a block of more
than 64 fields, so a single large HEADERS frame cannot permanently
inflate per-connection memory. The cap is checked against the
block's length rather than the array's capacity: append rounds
capacity up to size classes (35, then 76 entries for this element
size), so a capacity check would never retain an array for a block
above 35 fields.

Safety analysis

Static retention audit across every code path that consumes a
reusable *Frame, plus a separate concurrency audit. Per frame type:

  *DataFrame
    f.Data() is copied into dataBuffer.Write
    (databuffer.go:126 copy(chunk[b.w:], p)) before readMore. The
    pool-allocated chunk has independent backing.

  *WindowUpdateFrame
    Struct has only scalar fields. Safe by construction.

  *HeadersFrame
    Both server and Transport set Framer.ReadMetaHeaders during init,
    so a bare *HeadersFrame never reaches consumer code.
    readMetaFrame clears headerFragBuf=nil and invalidates the
    embedded *HeadersFrame before returning.

  *MetaHeadersFrame
    The Fields backing array is reused across parses, so consumers
    must not retain the slice -- and cannot do so unnoticed: the
    accessor methods panic once the next ReadFrame has been called,
    and the adversarial race test verifies -race observes
    retained-slice reads. (Direct reads of the Fields slice are not
    guarded; the two in-tree sites that read it directly, the
    server's newWriterAndRequest and the Transport's 1xx size
    accounting, do so synchronously before returning.)
    hpack.decodeString returns string(u.b) or
    buf.String(), both of which copy, so Name/Value strings are
    independently allocated and alias neither readBuf nor the Fields
    array. Server's processHeaders / newWriterAndRequest and
    Transport's handleResponse / processTrailers iterate Fields
    synchronously and copy into fresh http.Header maps before
    returning. No code stores *MetaHeadersFrame past dispatch.

Concurrency:

  Server: serverConn.readFrames sends each parsed frame on
    readFrameCh then blocks on gate. The serve goroutine receives,
    calls processFrameFromReader synchronously, then res.readMore(),
    which releases the gate. The single readMore call site fires
    only after the synchronous dispatch returns, so the cache is
    never overwritten while consumer code still references it.

  Transport: clientConnReadLoop.run reads frames in a tight loop
    with no per-frame gate, so each process* function must fully
    consume aliased data before returning. Verified: every byte that
    escapes the loop is either copied (DataFrame -> bufPipe) or
    composed of immutable, independently-allocated Go strings
    (Header maps populated from hpack-decoded strings).

  Spawned goroutines: runHandler (server) only sees the fresh
    *ServerRequest whose Header/Trailer/URL are independently
    allocated. writeFrameAsync, body-close, Shutdown, ping writers
    don't touch read-side cached frames.

Two retention sites intentionally remain outside the reuse contract
and are documented in place rather than silently exempt:
processPing queues writePingAck{f}, which the write scheduler may
serve after the next ReadFrame, and processGoAway stores f in
cc.goAway, whose scalar fields are read at read-loop teardown. Both
are safe solely because PingFrame and GoAwayFrame are not part of
frameCache; the comments require copying the needed fields before
either type is ever added to the cache.

Benchmarks

End-to-end, -count=3 -benchmem, darwin/arm64 (Apple silicon),
reuse on vs GODEBUG=http2reuseframes=0 on this tree (the GODEBUG-off
path is the pre-CL allocation behavior); medians.

Allocations per op (the main win):

    Benchmark                       off      on       delta
    ClientRequestHeaders/0              45       34   -24.4%
    ClientRequestHeaders/10             58       46   -20.7%
    ClientRequestHeaders/100           232      226    -2.6%
    ClientRequestHeaders/1000        3,040    3,032    -0.3%
    ClientResponseHeaders/0             45       34   -24.4%
    ClientResponseHeaders/10           110       97   -11.8%
    ClientResponseHeaders/100          570      562    -1.4%
    ClientResponseHeaders/1000       6,851    6,843    -0.1%
    DownloadFrameSize/16k           357.1k   197.2k   -44.8%
    DownloadFrameSize/64k            97.1k    49.9k   -48.6%
    DownloadFrameSize/128k           49.5k    24.6k   -50.2%
    DownloadFrameSize/256k           24.5k    12.3k   -49.7%
    DownloadFrameSize/512k           12.3k    6,123   -50.1%
    ClientGzip                         168       58   -65.5%
    geomean (allocs/op)                            -31.8%

Write-side benchmarks are unchanged; those paths don't touch
ReadFrame. Header-bound benchmarks at 0/10 headers move by
-10% to -3% in wall time; download throughput is flat within
socket noise.

Per-cache attribution from the microbenchmarks added in commit 5
(darwin/arm64, this tree; ReadMetaFrameFields/N is a block of N
fields, and above the 64-field cap the Reused arm rebuilds the
array every parse by design):

    Cache                   Default ns / B / allocs   Reused ns / B / allocs
    ParseDataFrame              25 /    48 /   1         18 /     0 /   0
    ParseWindowUpdateFrame      23 /    16 /   1         18 /     0 /   0
    ParseHeadersFrame           26 /    48 /   1         20 /     0 /   0
    ReadMetaFrame              192 /   384 /   5        123 /     0 /   0
    ReadMetaFrameFields/40    6142 /  6757 /  81       5513 /   864 /  72
    ReadMetaFrameFields/64    9678 /  7334 / 129       9057 /  1441 / 120
    ReadMetaFrameFields/100  14748 / 14348 / 202      14730 / 14252 / 200

The four allocations that used to remain in ReadMetaFrame/Reused
(the hpack emit closure and its boxed captures) are gone as of
commit 8, which registers the callback once per Framer. Commit 9 is
independent of frame reuse: it removes the server's per-key []string
allocation when building the request Header map, which is most of
the delta at 100+ request headers above.

Test plan

frame_reuse_race_test.go (package http2, synthetic Framer-pair
tests, each run in a "meta" variant where HEADERS surface as
*MetaHeadersFrame and a "raw" variant where HEADERS/CONTINUATION
surface individually and HeaderBlockFragment aliases the read
buffer):

  - TestFrameReuseRaceCorrect: positive control. Models
    serverConn.readFrames with a reader goroutine, a channel, a
    per-frame gate, and a consumer that fully consumes payload
    before signalling done. 800/1000 frames across DATA,
    WINDOW_UPDATE, HEADERS, HEADERS+CONTINUATION. Must PASS under
    -race.

  - TestFrameReuseRaceAdversarial: negative control. Same plumbing,
    but deliberately leaks slices into a sidecar goroutine across
    the next ReadFrame. Under -race it re-executes the test binary
    to run the leaking code in a child process (with
    GORACE=halt_on_error=1) and asserts that the child reports a
    data race, so the control runs on every -race run; without
    -race it is skipped. The detector fires for every retained
    case: Data, HeaderBlockFragment, and the Fields slice (which
    races against the next ReadFrame's clear of the backing array).

frame_reuse_e2e_test.go (package http2_test, real server +
Transport, lands with the enablement commit):

  - TestFrameReuseEndToEndStress: 8 workers x 25 multiplexed
    requests through the real httptest-based HTTP/2 server and
    net/http.Transport, both running with SetReuseFrames enabled.
    Handler and client touch every byte of every header name/value
    and trailer in both directions, drain bodies. Regression test
    against future refactors of processHeaders / handleResponse /
    processTrailers / processData that fail to copy aliased data.

Per-type unit tests land with each cache commit, sharing two generic
helpers (testFrameReuse, testFrameDistinctWithoutReuse):
pointer-stability and no-alloc tests (the latter skipped in -short
mode and under -race, like net/http's alloc tests), poison-overwrite
tests for stale-field leaks, distinct-pointer tests for the reuse-off
contract, accessor-panic tests for all four guarded accessors and
for a frame returned together with an error, and Fields tests for
backing-array reuse across block sizes up to the cap, the
tail-stays-zero invariant behind the clear, release at the next
ReadFrame call, and the retention cap. The enablement commit adds
TestSetReuseFramesFromGODEBUG (the helper and its non-default
metric) and TestReuseFramesGODEBUGWiring (server and Transport both
honor the setting).

Validation runs (darwin/arm64, this revision):

    Run                                              Result
    net/http/internal/http2 (full, -short, -race)    PASS
    same with GODEBUG=http2reuseframes=0
        (full, -race)                                PASS
    every commit in the stack: gofmt, vet, -short,
        and the reuse tests under -race              PASS
    net/http (full, -short -race, GODEBUG=0 -short)  PASS
    net/http/httputil, httptest, httpcommon          PASS
    internal/godebugs, runtime/metrics,
        go/build TestDependencies                    PASS
    TestFrameReuseRaceAdversarial (meta+raw) -race   PASS (the child
        process reports the race in every retained case)
    TestFrameReuseEndToEndStress -race               PASS

GODEBUG escape hatch

Registered alongside the existing http2 GODEBUGs in
src/internal/godebugs/table.go, with no version-dependent default:

    Value                              Behavior
    unset or http2reuseframes=1        reuse on (default)
    GODEBUG=http2reuseframes=0         reuse off (pre-CL behavior)
                                       increments
                                       /godebug/non-default-behavior/
                                       http2reuseframes:events

Documented in doc/godebug.md under the Go 1.28 section. The setting
has no version-dependent default: frame reuse changes no observable
behavior, so gating it on the go.mod version would only withhold the
allocation savings from existing programs. The check-and-count logic
lives in a single Framer helper (setReuseFramesFromGODEBUG) called by
both the server and the Transport, and TestReuseFramesGODEBUGWiring
checks both call sites.

The intent is a compat hatch, not a tuning knob: operators can
disable without recompiling if the static analysis and race coverage
missed something. This addresses the safety concerns from prior CLs
while staying consistent with the preference against user-facing
performance knobs (this is purely a safety/compat escape).

Compatibility

  - No API change.
  - No change in public behavior; the read loop returns the same
    parsed frame values, only the per-call heap allocation is
    elided.
  - internal/http2 is unimportable from user code; the Framer type
    and SetReuseFrames method remain unreachable from outside the
    stdlib.

Updates #18502
Updates #68352

