### PR TITLE
regexp: re-order short input fast path

### DIFF
--- a/src/regexp/exec.go
+++ b/src/regexp/exec.go
@@ -519,13 +519,13 @@ func (re *Regexp) doMatch(r io.RuneReader, b []byte, s string) bool {
 //
 // nil is returned if no matches are found and non-nil if matches are found.
 func (re *Regexp) find(r io.RuneReader, b []byte, s string, pos int, ncap int, dstCap []int) []int {
+	if r == nil && len(b)+len(s) < re.minInputLen {
+		return nil
+	}
+
 	if dstCap == nil {
 		// Make sure 'return dstCap' is non-nil.
 		dstCap = arrayNoInts[:0:0]
-	}
-
-	if r == nil && len(b)+len(s) < re.minInputLen {
-		return nil
 	}
 
 	if re.onepass != nil {


### PR DESCRIPTION
Input len is less than regexp min len will not rely on dstCap not nil.