### PR TITLE
cmd/compile: fold redundant zero-extension after signed load on arm64

### DIFF
--- a/src/cmd/compile/internal/ssa/_gen/ARM64.rules
+++ b/src/cmd/compile/internal/ssa/_gen/ARM64.rules
@@ -956,6 +956,17 @@
 (MOVWstoreidx4 ptr idx (MOVWreg  x) mem) => (MOVWstoreidx4 ptr idx x mem)
 (MOVWstoreidx4 ptr idx (MOVWUreg x) mem) => (MOVWstoreidx4 ptr idx x mem)
 
+// Replace extend after sign-extending load with unsigned load,
+// so a following zero-extension is unnecessary.
+(MOVBUreg <t> x:(MOVBload      [off] {sym} ptr     mem)) && x.Uses == 1 && clobber(x) => @x.Block (MOVBUload      <t> [off] {sym} ptr     mem)
+(MOVHUreg <t> x:(MOVHload      [off] {sym} ptr     mem)) && x.Uses == 1 && clobber(x) => @x.Block (MOVHUload      <t> [off] {sym} ptr     mem)
+(MOVWUreg <t> x:(MOVWload      [off] {sym} ptr     mem)) && x.Uses == 1 && clobber(x) => @x.Block (MOVWUload      <t> [off] {sym} ptr     mem)
+(MOVBUreg <t> x:(MOVBloadidx               ptr idx mem)) && x.Uses == 1 && clobber(x) => @x.Block (MOVBUloadidx   <t>             ptr idx mem)
+(MOVHUreg <t> x:(MOVHloadidx               ptr idx mem)) && x.Uses == 1 && clobber(x) => @x.Block (MOVHUloadidx   <t>             ptr idx mem)
+(MOVWUreg <t> x:(MOVWloadidx               ptr idx mem)) && x.Uses == 1 && clobber(x) => @x.Block (MOVWUloadidx   <t>             ptr idx mem)
+(MOVHUreg <t> x:(MOVHloadidx2              ptr idx mem)) && x.Uses == 1 && clobber(x) => @x.Block (MOVHUloadidx2  <t>             ptr idx mem)
+(MOVWUreg <t> x:(MOVWloadidx4              ptr idx mem)) && x.Uses == 1 && clobber(x) => @x.Block (MOVWUloadidx4  <t>             ptr idx mem)
+
 // if a register move has only 1 use, just use the same register without emitting instruction
 // MOVDnop doesn't emit instruction, only for ensuring the type.
 (MOVDreg x) && x.Uses == 1 => (MOVDnop x)

--- a/src/cmd/compile/internal/ssa/rewriteARM64.go
+++ b/src/cmd/compile/internal/ssa/rewriteARM64.go
@@ -9028,6 +9028,52 @@ func rewriteValueARM64_OpARM64MOVBUloadidx(v *Value) bool {
 }
 func rewriteValueARM64_OpARM64MOVBUreg(v *Value) bool {
 	v_0 := v.Args[0]
+	b := v.Block
+	// match: (MOVBUreg <t> x:(MOVBload [off] {sym} ptr mem))
+	// cond: x.Uses == 1 && clobber(x)
+	// result: @x.Block (MOVBUload <t> [off] {sym} ptr mem)
+	for {
+		t := v.Type
+		x := v_0
+		if x.Op != OpARM64MOVBload {
+			break
+		}
+		off := auxIntToInt32(x.AuxInt)
+		sym := auxToSym(x.Aux)
+		mem := x.Args[1]
+		ptr := x.Args[0]
+		if !(x.Uses == 1 && clobber(x)) {
+			break
+		}
+		b = x.Block
+		v0 := b.NewValue0(x.Pos, OpARM64MOVBUload, t)
+		v.copyOf(v0)
+		v0.AuxInt = int32ToAuxInt(off)
+		v0.Aux = symToAux(sym)
+		v0.AddArg2(ptr, mem)
+		return true
+	}
+	// match: (MOVBUreg <t> x:(MOVBloadidx ptr idx mem))
+	// cond: x.Uses == 1 && clobber(x)
+	// result: @x.Block (MOVBUloadidx <t> ptr idx mem)
+	for {
+		t := v.Type
+		x := v_0
+		if x.Op != OpARM64MOVBloadidx {
+			break
+		}
+		mem := x.Args[2]
+		ptr := x.Args[0]
+		idx := x.Args[1]
+		if !(x.Uses == 1 && clobber(x)) {
+			break
+		}
+		b = x.Block
+		v0 := b.NewValue0(v.Pos, OpARM64MOVBUloadidx, t)
+		v.copyOf(v0)
+		v0.AddArg3(ptr, idx, mem)
+		return true
+	}
 	// match: (MOVBUreg (ANDconst [c] x))
 	// result: (ANDconst [c&(1<<8-1)] x)
 	for {
@@ -10313,6 +10359,73 @@ func rewriteValueARM64_OpARM64MOVHUloadidx2(v *Value) bool {
 }
 func rewriteValueARM64_OpARM64MOVHUreg(v *Value) bool {
 	v_0 := v.Args[0]
+	b := v.Block
+	// match: (MOVHUreg <t> x:(MOVHload [off] {sym} ptr mem))
+	// cond: x.Uses == 1 && clobber(x)
+	// result: @x.Block (MOVHUload <t> [off] {sym} ptr mem)
+	for {
+		t := v.Type
+		x := v_0
+		if x.Op != OpARM64MOVHload {
+			break
+		}
+		off := auxIntToInt32(x.AuxInt)
+		sym := auxToSym(x.Aux)
+		mem := x.Args[1]
+		ptr := x.Args[0]
+		if !(x.Uses == 1 && clobber(x)) {
+			break
+		}
+		b = x.Block
+		v0 := b.NewValue0(x.Pos, OpARM64MOVHUload, t)
+		v.copyOf(v0)
+		v0.AuxInt = int32ToAuxInt(off)
+		v0.Aux = symToAux(sym)
+		v0.AddArg2(ptr, mem)
+		return true
+	}
+	// match: (MOVHUreg <t> x:(MOVHloadidx ptr idx mem))
+	// cond: x.Uses == 1 && clobber(x)
+	// result: @x.Block (MOVHUloadidx <t> ptr idx mem)
+	for {
+		t := v.Type
+		x := v_0
+		if x.Op != OpARM64MOVHloadidx {
+			break
+		}
+		mem := x.Args[2]
+		ptr := x.Args[0]
+		idx := x.Args[1]
+		if !(x.Uses == 1 && clobber(x)) {
+			break
+		}
+		b = x.Block
+		v0 := b.NewValue0(v.Pos, OpARM64MOVHUloadidx, t)
+		v.copyOf(v0)
+		v0.AddArg3(ptr, idx, mem)
+		return true
+	}
+	// match: (MOVHUreg <t> x:(MOVHloadidx2 ptr idx mem))
+	// cond: x.Uses == 1 && clobber(x)
+	// result: @x.Block (MOVHUloadidx2 <t> ptr idx mem)
+	for {
+		t := v.Type
+		x := v_0
+		if x.Op != OpARM64MOVHloadidx2 {
+			break
+		}
+		mem := x.Args[2]
+		ptr := x.Args[0]
+		idx := x.Args[1]
+		if !(x.Uses == 1 && clobber(x)) {
+			break
+		}
+		b = x.Block
+		v0 := b.NewValue0(v.Pos, OpARM64MOVHUloadidx2, t)
+		v.copyOf(v0)
+		v0.AddArg3(ptr, idx, mem)
+		return true
+	}
 	// match: (MOVHUreg (ANDconst [c] x))
 	// result: (ANDconst [c&(1<<16-1)] x)
 	for {
@@ -11325,6 +11438,73 @@ func rewriteValueARM64_OpARM64MOVWUloadidx4(v *Value) bool {
 }
 func rewriteValueARM64_OpARM64MOVWUreg(v *Value) bool {
 	v_0 := v.Args[0]
+	b := v.Block
+	// match: (MOVWUreg <t> x:(MOVWload [off] {sym} ptr mem))
+	// cond: x.Uses == 1 && clobber(x)
+	// result: @x.Block (MOVWUload <t> [off] {sym} ptr mem)
+	for {
+		t := v.Type
+		x := v_0
+		if x.Op != OpARM64MOVWload {
+			break
+		}
+		off := auxIntToInt32(x.AuxInt)
+		sym := auxToSym(x.Aux)
+		mem := x.Args[1]
+		ptr := x.Args[0]
+		if !(x.Uses == 1 && clobber(x)) {
+			break
+		}
+		b = x.Block
+		v0 := b.NewValue0(x.Pos, OpARM64MOVWUload, t)
+		v.copyOf(v0)
+		v0.AuxInt = int32ToAuxInt(off)
+		v0.Aux = symToAux(sym)
+		v0.AddArg2(ptr, mem)
+		return true
+	}
+	// match: (MOVWUreg <t> x:(MOVWloadidx ptr idx mem))
+	// cond: x.Uses == 1 && clobber(x)
+	// result: @x.Block (MOVWUloadidx <t> ptr idx mem)
+	for {
+		t := v.Type
+		x := v_0
+		if x.Op != OpARM64MOVWloadidx {
+			break
+		}
+		mem := x.Args[2]
+		ptr := x.Args[0]
+		idx := x.Args[1]
+		if !(x.Uses == 1 && clobber(x)) {
+			break
+		}
+		b = x.Block
+		v0 := b.NewValue0(v.Pos, OpARM64MOVWUloadidx, t)
+		v.copyOf(v0)
+		v0.AddArg3(ptr, idx, mem)
+		return true
+	}
+	// match: (MOVWUreg <t> x:(MOVWloadidx4 ptr idx mem))
+	// cond: x.Uses == 1 && clobber(x)
+	// result: @x.Block (MOVWUloadidx4 <t> ptr idx mem)
+	for {
+		t := v.Type
+		x := v_0
+		if x.Op != OpARM64MOVWloadidx4 {
+			break
+		}
+		mem := x.Args[2]
+		ptr := x.Args[0]
+		idx := x.Args[1]
+		if !(x.Uses == 1 && clobber(x)) {
+			break
+		}
+		b = x.Block
+		v0 := b.NewValue0(v.Pos, OpARM64MOVWUloadidx4, t)
+		v.copyOf(v0)
+		v0.AddArg3(ptr, idx, mem)
+		return true
+	}
 	// match: (MOVWUreg (ANDconst [c] x))
 	// result: (ANDconst [c&(1<<32-1)] x)
 	for {

--- a/test/codegen/noextend.go
+++ b/test/codegen/noextend.go
@@ -6,7 +6,10 @@
 
 package codegen
 
-import "math/bits"
+import (
+	"math/bits"
+	"unsafe"
+)
 
 var sval64 [8]int64
 var sval32 [8]int32
@@ -282,4 +285,50 @@ func shouldSignEXT(x int) int64 {
 func noIntermediateExtension(a, b, c uint32) uint32 {
 	// arm64:-"MOVWU"
 	return a*b*9 + c
+}
+
+// When a sign-extending load feeds a single zero-extension, the load itself
+// can be switched to its unsigned form, eliminating the extension instruction.
+
+func zextSignLoadInt8(p *int8) bool {
+	// arm64:-`MOVBU\sR[0-9]+, R[0-9]+`
+	return *p == 0x5d
+}
+
+func zextSignLoadInt16(p *int16) bool {
+	// arm64:-`MOVHU\sR[0-9]+, R[0-9]+`
+	return *p == 0x5d
+}
+
+func zextSignLoadInt32(p *int32) uint64 {
+	// arm64:-`MOVWU\sR[0-9]+, R[0-9]+`
+	return uint64(uint32(*p))
+}
+
+func zextSignLoadIdxInt8(s []int8, i int) bool {
+	// arm64:-`MOVBU\sR[0-9]+, R[0-9]+`
+	return s[i] == 0x5d
+}
+
+func zextSignLoadIdxInt16(s []int16, i int) bool {
+	// arm64:-`MOVHU\sR[0-9]+, R[0-9]+`
+	return s[i] == 0x5d
+}
+
+func zextSignLoadIdxInt32(s []int32, i int) uint64 {
+	// arm64:-`MOVWU\sR[0-9]+, R[0-9]+`
+	return uint64(uint32(s[i]))
+}
+
+// Unscaled (byte-offset) indexed loads, which slice indexing does not
+// produce, cover the MOVHloadidx/MOVWloadidx variants of the rewrite.
+
+func zextSignLoadIdxUnscaledInt16(p *int16, i int) bool {
+	// arm64:-`MOVHU\sR[0-9]+, R[0-9]+`
+	return *(*int16)(unsafe.Add(unsafe.Pointer(p), i)) == 0x5d
+}
+
+func zextSignLoadIdxUnscaledInt32(p *int32, i int) uint64 {
+	// arm64:-`MOVWU\sR[0-9]+, R[0-9]+`
+	return uint64(uint32(*(*int32)(unsafe.Add(unsafe.Pointer(p), i))))
 }


### PR DESCRIPTION
When a sign-extending load (LDRSB/LDRSH/LDRSW) is followed by a single
zero-extension, the upper bits produced by the load are immediately
overwritten and the extension is dead. The load can be switched to its
unsigned form (LDRB/LDRH/LDR) and the extension elided.

For example, code like

	func F(s []int8, i int) bool { return s[i] == 0x5d }

previously generated

	ldrsb x4, [x1, x3]
	ubfx  x4, x4, #0, #8
	cmp   w4, #0x5d

and now generates

	ldrb  w4, [x1, x3]
	cmp   w4, #0x5d

RISCV64 (RISCV64.rules) and MIPS (MIPS.rules) already had the equivalent
rewrite; ARM64 was missing it, including the indexed (loadidx) variants.

Found via armlint: LDRSx + zero-extension findings drop from 40 -> 1 on
gofmt and 547 -> 8 on cmd/go. Text section shrinks by 144 bytes
(0.0121%) on gofmt and 2416 bytes (0.0363%) on cmd/go.