### PR TITLE
cmd/compile/internal/arm64: fuse adjacent spill/reload STR/LDR into STP/LDP

### DIFF
--- a/src/cmd/compile/internal/arm64/galign.go
+++ b/src/cmd/compile/internal/arm64/galign.go
@@ -24,4 +24,5 @@ func Init(arch *ssagen.ArchInfo) {
 	arch.SSAGenBlock = ssaGenBlock
 	arch.LoadRegResult = loadRegResult
 	arch.SpillArgReg = spillArgReg
+	arch.SSAGenFinish = ssaGenFinish
 }

--- a/src/cmd/compile/internal/arm64/pair.go
+++ b/src/cmd/compile/internal/arm64/pair.go
@@ -1,0 +1,194 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package arm64
+
+import (
+	"cmd/compile/internal/base"
+	"cmd/compile/internal/objw"
+	"cmd/internal/obj"
+	"cmd/internal/obj/arm64"
+	"cmd/internal/src"
+)
+
+// movdImmMemInfo describes a plain "MOVD reg, off(base)" or "MOVD off(base), reg"
+// instruction. base, off, name, and sym record the memory operand's base
+// register, offset, addressing class (NAME_AUTO or NAME_PARAM), and symbol;
+// reg is the register stored or loaded, and isLoad distinguishes the two
+// forms.
+type movdImmMemInfo struct {
+	base, reg int16
+	off       int64
+	name      obj.AddrName
+	sym       *obj.LSym
+	isLoad    bool
+}
+
+// movdImmMem decodes p into a movdImmMemInfo. ok reports whether p is a
+// plain MOVD load or store using an immediate-offset addressing form
+// suitable for LDP/STP coalescing.
+func movdImmMem(p *obj.Prog) (info movdImmMemInfo, ok bool) {
+	if p.As != arm64.AMOVD || p.Scond != 0 || p.Reg != 0 {
+		return movdImmMemInfo{}, false
+	}
+	var a *obj.Addr
+	switch {
+	case p.From.Type == obj.TYPE_MEM && p.To.Type == obj.TYPE_REG:
+		// Plain load: MOVD mem, reg.
+		a = &p.From
+		info.reg = p.To.Reg
+		info.isLoad = true
+	case p.From.Type == obj.TYPE_REG && p.To.Type == obj.TYPE_MEM:
+		// Plain store: MOVD reg, mem.
+		a = &p.To
+		info.reg = p.From.Reg
+	default:
+		return movdImmMemInfo{}, false
+	}
+	if a.Index != 0 || (a.Name != obj.NAME_AUTO && a.Name != obj.NAME_PARAM) {
+		return movdImmMemInfo{}, false
+	}
+	info.base, info.off, info.name, info.sym = a.Reg, a.Offset, a.Name, a.Sym
+	return info, true
+}
+
+// ssaGenFinish runs after genssa has emitted all of a function's Progs,
+// resolved its branch and jump-table targets, and finalized the frame size
+// in defframe.
+func ssaGenFinish(pp *objw.Progs) {
+	if base.Flag.N != 0 {
+		// Keep unoptimized builds unoptimized.
+		return
+	}
+	pairSpills(pp.Text, pp.Text.To.Offset, pp.CurFunc.LSym.Func().JumpTables)
+}
+
+// pairSpills fuses strictly-adjacent MOVD load or store pairs that target the
+// same base register at consecutive 8-byte offsets into a single LDP or STP.
+// text is the function's first Prog, framesize its final frame size, and
+// jumpTables its resolved jump tables.
+//
+// This recovers spill/reload pairings that the SSA-level pair pass
+// (cmd/compile/internal/ssa/pair.go) cannot perform: that pass runs before
+// regalloc and only sees source-level loads/stores, so the STR/LDR pairs that
+// regalloc later inserts for OpStoreReg/OpLoadReg never get a chance to be
+// paired. Doing the fusion here, as the last step of code generation, keeps the
+// optimization in the compiler so the assembler can stay a simple translator.
+func pairSpills(text *obj.Prog, framesize int64, jumpTables []obj.JumpTable) {
+	// Branch and jump-table targets, collected lazily once a candidate pair
+	// survives the cheaper checks; most functions have no candidates.
+	// Fusing into the first of a pair whose second instruction is a target
+	// would silently change control flow: paths that jump directly to the
+	// second instruction would skip the work the LDP/STP now does at the
+	// first instruction's position.
+	var isTarget map[*obj.Prog]bool
+	targets := func() map[*obj.Prog]bool {
+		if isTarget == nil {
+			isTarget = map[*obj.Prog]bool{}
+			for p := text; p != nil; p = p.Link {
+				if t := p.To.Target(); t != nil {
+					isTarget[t] = true
+				}
+			}
+			for _, jt := range jumpTables {
+				for _, t := range jt.Targets {
+					isTarget[t] = true
+				}
+			}
+		}
+		return isTarget
+	}
+	for p := text; p != nil; p = p.Link {
+		q := p.Link
+		if q == nil {
+			continue
+		}
+		a, ok := movdImmMem(p)
+		if !ok {
+			continue
+		}
+		b, ok := movdImmMem(q)
+		if !ok || a.isLoad != b.isLoad {
+			continue
+		}
+		if a.base != b.base || a.name != b.name {
+			continue
+		}
+		if a.reg == b.reg {
+			// LDP with Rt1 == Rt2 is CONSTRAINED UNPREDICTABLE. (STP with
+			// identical source registers would be fine, but spills never
+			// store the same register twice, so don't bother.)
+			continue
+		}
+		if a.isLoad && a.reg == a.base {
+			// The first load overwrites the base register: executed
+			// sequentially, the second load computes its address from the
+			// just-loaded value, while LDP computes both addresses from
+			// the original base. (The second load overwriting the base is
+			// fine; no address depends on it.)
+			continue
+		}
+		if q.Pos.IsStmt() == src.PosIsStmt {
+			// q carries a statement boundary, and may also be registered
+			// as an inline mark: genssa promotes instructions it reuses
+			// as inline marks to statements. Reducing q to a 0-byte ANOP
+			// would drop the statement from the line tables and violate
+			// the invariant that inline marks are never zero-sized (they
+			// are identified by PC).
+			continue
+		}
+		lo, hi := a, b
+		if lo.off > hi.off {
+			lo, hi = hi, lo
+		}
+		if hi.off != lo.off+8 {
+			continue
+		}
+		// Fuse only when the result will encode as a single LDP/STP, whose
+		// signed 7-bit immediate scaled by 8 covers offsets [-512, 504].
+		// The assembler resolves a NAME_AUTO offset to off+framesize+8
+		// (the 8 is the saved LR) and a NAME_PARAM offset to
+		// off+framesize+24 or +32 depending on frame alignment padding —
+		// or off+8 in a frameless leaf, which is not decided until
+		// assembly, so a frameless PARAM must fit both. An out-of-range
+		// LDP/STP needs an assembler-synthesized address (ADD + LDP),
+		// which is no smaller than the original pair and serializes the
+		// accesses through REGTMP.
+		var biasLo, biasHi int64
+		switch {
+		case lo.name == obj.NAME_AUTO:
+			// Autos exist only in functions with a frame, and their offsets
+			// are negative from FP, so framesize+8 rebases them onto the
+			// non-negative SP-relative range the LDP/STP immediate must reach.
+			biasLo = framesize + 8
+			biasHi = biasLo
+		case framesize == 0:
+			biasLo, biasHi = 8, 24
+		case framesize%16 == 0:
+			biasLo = framesize + 24
+			biasHi = biasLo
+		default:
+			biasLo = framesize + 32
+			biasHi = biasLo
+		}
+		if lo.off%8 != 0 || lo.off+biasLo < -512 || lo.off+biasHi > 504 {
+			continue
+		}
+		if targets()[q] {
+			continue
+		}
+		mem := obj.Addr{Type: obj.TYPE_MEM, Reg: lo.base, Offset: lo.off, Name: lo.name, Sym: lo.sym}
+		regs := obj.Addr{Type: obj.TYPE_REGREG, Reg: lo.reg, Offset: int64(hi.reg)}
+		if a.isLoad {
+			p.As = arm64.ALDP
+			p.From, p.To = mem, regs
+		} else {
+			p.As = arm64.ASTP
+			p.From, p.To = regs, mem
+		}
+		// Reduce q to a 0-byte ANOP rather than unlinking it so that
+		// branch targets referencing q remain valid.
+		obj.Nopout(q)
+	}
+}

--- a/src/cmd/compile/internal/arm64/pair_test.go
+++ b/src/cmd/compile/internal/arm64/pair_test.go
@@ -1,0 +1,419 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package arm64
+
+import (
+	"cmd/internal/obj"
+	"cmd/internal/obj/arm64"
+	"cmd/internal/src"
+	"testing"
+)
+
+func TestPairSpills(t *testing.T) {
+	movdLoad := func(dst, base int16, off int64) *obj.Prog {
+		return &obj.Prog{
+			As:   arm64.AMOVD,
+			From: obj.Addr{Type: obj.TYPE_MEM, Reg: base, Offset: off, Name: obj.NAME_AUTO},
+			To:   obj.Addr{Type: obj.TYPE_REG, Reg: dst},
+		}
+	}
+	movdStore := func(src, base int16, off int64) *obj.Prog {
+		return &obj.Prog{
+			As:   arm64.AMOVD,
+			From: obj.Addr{Type: obj.TYPE_REG, Reg: src},
+			To:   obj.Addr{Type: obj.TYPE_MEM, Reg: base, Offset: off, Name: obj.NAME_AUTO},
+		}
+	}
+	// param rewrites p's memory operand to NAME_PARAM.
+	param := func(p *obj.Prog) *obj.Prog {
+		if p.From.Type == obj.TYPE_MEM {
+			p.From.Name = obj.NAME_PARAM
+		} else {
+			p.To.Name = obj.NAME_PARAM
+		}
+		return p
+	}
+	chain := func(progs ...*obj.Prog) *obj.Prog {
+		for i := 0; i < len(progs)-1; i++ {
+			progs[i].Link = progs[i+1]
+		}
+		return progs[0]
+	}
+	countAs := func(head *obj.Prog) map[obj.As]int {
+		m := map[obj.As]int{}
+		for p := head; p != nil; p = p.Link {
+			m[p.As]++
+		}
+		return m
+	}
+
+	// pairWant describes the expected operands of the fused LDP/STP:
+	// MOVDs of lo and hi (lo at the lower address off, hi at off+8)
+	// against base, with the memory operand's addressing class name.
+	type pairWant struct {
+		as     obj.As
+		base   int16
+		off    int64
+		lo, hi int16
+		name   obj.AddrName
+	}
+
+	tests := []struct {
+		name      string
+		framesize int64
+		setup     func() (*obj.Prog, []obj.JumpTable)
+		wantLDP   int
+		wantSTP   int
+		wantMOVD  int
+		wantNOP   int
+		wantPair  *pairWant
+	}{
+		{
+			name: "adjacent LDRs fuse to LDP",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				return chain(
+					movdLoad(arm64.REG_R0, arm64.REGSP, 16),
+					movdLoad(arm64.REG_R1, arm64.REGSP, 24),
+				), nil
+			},
+			wantLDP: 1, wantNOP: 1,
+			wantPair: &pairWant{arm64.ALDP, arm64.REGSP, 16, arm64.REG_R0, arm64.REG_R1, obj.NAME_AUTO},
+		},
+		{
+			name: "adjacent STRs fuse to STP",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				return chain(
+					movdStore(arm64.REG_R0, arm64.REGSP, 16),
+					movdStore(arm64.REG_R1, arm64.REGSP, 24),
+				), nil
+			},
+			wantSTP: 1, wantNOP: 1,
+			wantPair: &pairWant{arm64.ASTP, arm64.REGSP, 16, arm64.REG_R0, arm64.REG_R1, obj.NAME_AUTO},
+		},
+		{
+			name: "reverse-order LDRs fuse to LDP",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				// p loads from the higher address, q from the lower.
+				return chain(
+					movdLoad(arm64.REG_R0, arm64.REGSP, 24),
+					movdLoad(arm64.REG_R1, arm64.REGSP, 16),
+				), nil
+			},
+			wantLDP: 1, wantNOP: 1,
+			wantPair: &pairWant{arm64.ALDP, arm64.REGSP, 16, arm64.REG_R1, arm64.REG_R0, obj.NAME_AUTO},
+		},
+		{
+			name: "reverse-order STRs fuse to STP",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				// p stores to the higher address, q to the lower.
+				return chain(
+					movdStore(arm64.REG_R0, arm64.REGSP, 24),
+					movdStore(arm64.REG_R1, arm64.REGSP, 16),
+				), nil
+			},
+			wantSTP: 1, wantNOP: 1,
+			wantPair: &pairWant{arm64.ASTP, arm64.REGSP, 16, arm64.REG_R1, arm64.REG_R0, obj.NAME_AUTO},
+		},
+		{
+			name: "PARAM pair fuses",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				return chain(
+					param(movdLoad(arm64.REG_R0, arm64.REGSP, 16)),
+					param(movdLoad(arm64.REG_R1, arm64.REGSP, 24)),
+				), nil
+			},
+			wantLDP: 1, wantNOP: 1,
+			wantPair: &pairWant{arm64.ALDP, arm64.REGSP, 16, arm64.REG_R0, arm64.REG_R1, obj.NAME_PARAM},
+		},
+		{
+			name: "mixed AUTO and PARAM do not fuse",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				return chain(
+					movdLoad(arm64.REG_R0, arm64.REGSP, 16),
+					param(movdLoad(arm64.REG_R1, arm64.REGSP, 24)),
+				), nil
+			},
+			wantMOVD: 2,
+		},
+		{
+			name: "non-adjacent offsets do not fuse",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				return chain(
+					movdLoad(arm64.REG_R0, arm64.REGSP, 16),
+					movdLoad(arm64.REG_R1, arm64.REGSP, 32),
+				), nil
+			},
+			wantMOVD: 2,
+		},
+		{
+			name: "different base registers do not fuse",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				return chain(
+					movdLoad(arm64.REG_R0, arm64.REGSP, 16),
+					movdLoad(arm64.REG_R1, arm64.REG_R28, 24),
+				), nil
+			},
+			wantMOVD: 2,
+		},
+		{
+			name: "load followed by store does not fuse",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				return chain(
+					movdLoad(arm64.REG_R0, arm64.REGSP, 16),
+					movdStore(arm64.REG_R1, arm64.REGSP, 24),
+				), nil
+			},
+			wantMOVD: 2,
+		},
+		{
+			name: "same destination register does not fuse",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				return chain(
+					movdLoad(arm64.REG_R0, arm64.REGSP, 16),
+					movdLoad(arm64.REG_R0, arm64.REGSP, 24),
+				), nil
+			},
+			wantMOVD: 2,
+		},
+		{
+			name: "first load writing the second's base does not fuse",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				// Executed sequentially, the second load computes its
+				// address from the value the first load just wrote into
+				// R1; LDP would compute both addresses from the original
+				// R1.
+				return chain(
+					movdLoad(arm64.REG_R1, arm64.REG_R1, 16),
+					movdLoad(arm64.REG_R2, arm64.REG_R1, 24),
+				), nil
+			},
+			wantMOVD: 2,
+		},
+		{
+			name: "second load writing the base fuses",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				// No address depends on the base after the second load
+				// overwrites it, so LDP has identical semantics.
+				return chain(
+					movdLoad(arm64.REG_R0, arm64.REG_R5, 16),
+					movdLoad(arm64.REG_R5, arm64.REG_R5, 24),
+				), nil
+			},
+			wantLDP: 1, wantNOP: 1,
+			wantPair: &pairWant{arm64.ALDP, arm64.REG_R5, 16, arm64.REG_R0, arm64.REG_R5, obj.NAME_AUTO},
+		},
+		{
+			name: "store whose source is the base fuses",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				// Stores never write registers, so there is no base
+				// hazard for STP.
+				return chain(
+					movdStore(arm64.REG_R5, arm64.REG_R5, 16),
+					movdStore(arm64.REG_R1, arm64.REG_R5, 24),
+				), nil
+			},
+			wantSTP: 1, wantNOP: 1,
+			wantPair: &pairWant{arm64.ASTP, arm64.REG_R5, 16, arm64.REG_R5, arm64.REG_R1, obj.NAME_AUTO},
+		},
+		{
+			name: "skip when second instruction is a branch target",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				p1 := movdLoad(arm64.REG_R0, arm64.REGSP, 16)
+				p2 := movdLoad(arm64.REG_R1, arm64.REGSP, 24)
+				br := &obj.Prog{As: arm64.AB, To: obj.Addr{Type: obj.TYPE_BRANCH}}
+				br.To.SetTarget(p2)
+				return chain(br, p1, p2), nil
+			},
+			wantMOVD: 2,
+		},
+		{
+			name: "skip when second instruction is a backward-branch target",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				// The branch sits after the pair, so target collection
+				// must consider the whole Prog list, not just what
+				// precedes the pair.
+				p1 := movdLoad(arm64.REG_R0, arm64.REGSP, 16)
+				p2 := movdLoad(arm64.REG_R1, arm64.REGSP, 24)
+				br := &obj.Prog{As: arm64.AB, To: obj.Addr{Type: obj.TYPE_BRANCH}}
+				br.To.SetTarget(p2)
+				return chain(p1, p2, br), nil
+			},
+			wantMOVD: 2,
+		},
+		{
+			name: "skip when second instruction is a jump-table target",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				p1 := movdLoad(arm64.REG_R0, arm64.REGSP, 16)
+				p2 := movdLoad(arm64.REG_R1, arm64.REGSP, 24)
+				return chain(p1, p2), []obj.JumpTable{{Targets: []*obj.Prog{p2}}}
+			},
+			wantMOVD: 2,
+		},
+		{
+			name: "skip when second instruction is a statement boundary",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				// Statement-marked instructions (including those genssa
+				// reuses as inline marks, which it promotes to
+				// statements) must not become zero-sized. The statement
+				// bit needs a known position to stick to.
+				var tab src.PosTable
+				pos := tab.XPos(src.MakePos(src.NewFileBase("f.go", "f.go"), 1, 1))
+				p1 := movdLoad(arm64.REG_R0, arm64.REGSP, 16)
+				p2 := movdLoad(arm64.REG_R1, arm64.REGSP, 24)
+				p2.Pos = pos.WithIsStmt()
+				return chain(p1, p2), nil
+			},
+			wantMOVD: 2,
+		},
+		{
+			name: "at the encodable bound fuses",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				// Resolved offset 496+0+8 = 504, LDP's maximum.
+				return chain(
+					movdLoad(arm64.REG_R0, arm64.REGSP, 496),
+					movdLoad(arm64.REG_R1, arm64.REGSP, 504),
+				), nil
+			},
+			wantLDP: 1, wantNOP: 1,
+			wantPair: &pairWant{arm64.ALDP, arm64.REGSP, 496, arm64.REG_R0, arm64.REG_R1, obj.NAME_AUTO},
+		},
+		{
+			name: "resolved offset out of LDP range does not fuse",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				// Resolved offset 504+0+8 = 512, just past the bound.
+				return chain(
+					movdLoad(arm64.REG_R0, arm64.REGSP, 504),
+					movdLoad(arm64.REG_R1, arm64.REGSP, 512),
+				), nil
+			},
+			wantMOVD: 2,
+		},
+		{
+			name:      "large frame pushes resolved offset out of range",
+			framesize: 1024,
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				// 16+1024+8 = 1048: fusing would force an
+				// assembler-synthesized address, no smaller than the
+				// original pair.
+				return chain(
+					movdLoad(arm64.REG_R0, arm64.REGSP, 16),
+					movdLoad(arm64.REG_R1, arm64.REGSP, 24),
+				), nil
+			},
+			wantMOVD: 2,
+		},
+		{
+			name:      "deep spill slots fuse in a large frame",
+			framesize: 1024,
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				// -528+1024+8 = 504: encodable even though the
+				// pre-resolution offset is far below -512.
+				return chain(
+					movdLoad(arm64.REG_R0, arm64.REGSP, -528),
+					movdLoad(arm64.REG_R1, arm64.REGSP, -520),
+				), nil
+			},
+			wantLDP: 1, wantNOP: 1,
+			wantPair: &pairWant{arm64.ALDP, arm64.REGSP, -528, arm64.REG_R0, arm64.REG_R1, obj.NAME_AUTO},
+		},
+		{
+			name: "misaligned offsets do not fuse",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				return chain(
+					movdLoad(arm64.REG_R0, arm64.REGSP, -12),
+					movdLoad(arm64.REG_R1, arm64.REGSP, -4),
+				), nil
+			},
+			wantMOVD: 2,
+		},
+		{
+			name: "three adjacent loads fuse greedily",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				return chain(
+					movdLoad(arm64.REG_R0, arm64.REGSP, 16),
+					movdLoad(arm64.REG_R1, arm64.REGSP, 24),
+					movdLoad(arm64.REG_R2, arm64.REGSP, 32),
+				), nil
+			},
+			wantLDP: 1, wantNOP: 1, wantMOVD: 1,
+		},
+		{
+			name: "intervening instruction blocks fusion",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				return chain(
+					movdLoad(arm64.REG_R0, arm64.REGSP, 16),
+					&obj.Prog{As: arm64.AHINT},
+					movdLoad(arm64.REG_R1, arm64.REGSP, 24),
+				), nil
+			},
+			wantMOVD: 2,
+		},
+		{
+			name: "pre-indexed addressing does not fuse",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				p1 := movdLoad(arm64.REG_R0, arm64.REGSP, 16)
+				p1.Scond = arm64.C_XPRE
+				return chain(p1, movdLoad(arm64.REG_R1, arm64.REGSP, 24)), nil
+			},
+			wantMOVD: 2,
+		},
+		{
+			name: "post-indexed addressing does not fuse",
+			setup: func() (*obj.Prog, []obj.JumpTable) {
+				p1 := movdLoad(arm64.REG_R0, arm64.REGSP, 16)
+				p1.Scond = arm64.C_XPOST
+				return chain(p1, movdLoad(arm64.REG_R1, arm64.REGSP, 24)), nil
+			},
+			wantMOVD: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			head, jumpTables := tt.setup()
+			pairSpills(head, tt.framesize, jumpTables)
+			got := countAs(head)
+			if got[arm64.ALDP] != tt.wantLDP {
+				t.Errorf("ALDP count = %d, want %d", got[arm64.ALDP], tt.wantLDP)
+			}
+			if got[arm64.ASTP] != tt.wantSTP {
+				t.Errorf("ASTP count = %d, want %d", got[arm64.ASTP], tt.wantSTP)
+			}
+			if got[arm64.AMOVD] != tt.wantMOVD {
+				t.Errorf("AMOVD count = %d, want %d", got[arm64.AMOVD], tt.wantMOVD)
+			}
+			if got[obj.ANOP] != tt.wantNOP {
+				t.Errorf("ANOP count = %d, want %d", got[obj.ANOP], tt.wantNOP)
+			}
+			if w := tt.wantPair; w != nil {
+				var fused *obj.Prog
+				for p := head; p != nil; p = p.Link {
+					if p.As == arm64.ALDP || p.As == arm64.ASTP {
+						fused = p
+						break
+					}
+				}
+				if fused == nil {
+					t.Fatal("no LDP/STP emitted")
+				}
+				mem, regs := &fused.From, &fused.To // LDP order
+				if fused.As == arm64.ASTP {
+					regs, mem = &fused.From, &fused.To
+				}
+				if fused.As != w.as {
+					t.Errorf("fused As = %v, want %v", fused.As, w.as)
+				}
+				if mem.Type != obj.TYPE_MEM || mem.Reg != w.base || mem.Offset != w.off || mem.Name != w.name {
+					t.Errorf("memory operand = {Type %v, Reg %v, Offset %d, Name %v}, want {TYPE_MEM, %v, %d, %v}",
+						mem.Type, mem.Reg, mem.Offset, mem.Name, w.base, w.off, w.name)
+				}
+				if regs.Type != obj.TYPE_REGREG || regs.Reg != w.lo || regs.Offset != int64(w.hi) {
+					t.Errorf("register pair = {Type %v, Reg %v, Offset %v}, want {TYPE_REGREG, %v, %v}",
+						regs.Type, regs.Reg, regs.Offset, w.lo, w.hi)
+				}
+			}
+		})
+	}
+}

--- a/src/cmd/compile/internal/ssagen/arch.go
+++ b/src/cmd/compile/internal/ssagen/arch.go
@@ -53,4 +53,11 @@ type ArchInfo struct {
 
 	// SpillArgReg emits instructions that spill reg to n+off.
 	SpillArgReg func(pp *objw.Progs, p *obj.Prog, f *ssa.Func, t *types.Type, reg int16, n *ir.Name, off int64) *obj.Prog
+
+	// SSAGenFinish, if non-nil, is called after all of a function's Progs
+	// have been generated and defframe has run: branch and jump-table
+	// targets are resolved and the frame size is final. It allows the
+	// backend to run a last Prog-level pass. Used on arm64 to fuse adjacent
+	// spill/reload MOVDs into STP/LDP.
+	SSAGenFinish func(pp *objw.Progs)
 }

--- a/src/cmd/compile/internal/ssagen/ssa.go
+++ b/src/cmd/compile/internal/ssagen/ssa.go
@@ -7397,6 +7397,18 @@ func genssa(f *ssa.Func, pp *objw.Progs) {
 		fi.JumpTables = append(fi.JumpTables, obj.JumpTable{Sym: jt.Aux.(*obj.LSym), Targets: targets})
 	}
 
+	// Finalize the frame, then let the backend run a final pass over the
+	// generated Progs (e.g. arm64 fuses adjacent spill/reload MOVDs into
+	// STP/LDP). Branch and jump-table targets are resolved at this point.
+	// Doing this before the debug dumps below means -S and GOSSAFUNC's genssa
+	// output reflect the instructions that are actually assembled. defframe
+	// must run first: it finalizes the frame size, which the backend pass
+	// depends on.
+	defframe(&s, e, f)
+	if Arch.SSAGenFinish != nil {
+		Arch.SSAGenFinish(s.pp)
+	}
+
 	if e.log { // spew to stdout
 		filename := ""
 		for p := s.pp.Text; p != nil; p = p.Link {
@@ -7515,8 +7527,6 @@ func genssa(f *ssa.Func, pp *objw.Progs) {
 			fi.Close()
 		}
 	}
-
-	defframe(&s, e, f)
 
 	f.HTMLWriter.Close()
 	f.HTMLWriter = nil

--- a/src/cmd/compile/internal/test/bench_test.go
+++ b/src/cmd/compile/internal/test/bench_test.go
@@ -204,6 +204,37 @@ func containsLeft(strs []string, str string) bool {
 	return false
 }
 
+//go:noinline
+func benchSpillReloadSink() {}
+
+// benchSpillReloadDistinctAutos loads two values from independent pointers,
+// spills both across a call, and returns them as a pair. The spills and
+// reloads do not exist when the SSA pair pass runs (regalloc inserts them
+// later), so only the late pair pass in cmd/compile/internal/arm64 can fuse
+// the reloads into a single LDP.
+//
+//go:noinline
+func benchSpillReloadDistinctAutos(p, q *int) (int, int) {
+	a := *p
+	b := *q
+	benchSpillReloadSink()
+	return a, b
+}
+
+// BenchmarkSpillReloadPair exercises the spill/reload pattern the late
+// arm64 pair pass fuses but the SSA pair pass cannot. The numbers are not
+// meaningful in absolute terms; the benchmark exists so builds with and
+// without the pass can be compared.
+func BenchmarkSpillReloadPair(b *testing.B) {
+	x, y := 1, 2
+	var s int
+	for b.Loop() {
+		a, c := benchSpillReloadDistinctAutos(&x, &y)
+		s += a + c
+	}
+	globl = int64(s)
+}
+
 // BenchmarkStringEqParamOrder tests that the operand order of string
 // equality comparisons does not affect performance. See issue #74471.
 func BenchmarkStringEqParamOrder(b *testing.B) {

--- a/test/codegen/memcombine.go
+++ b/test/codegen/memcombine.go
@@ -1104,3 +1104,28 @@ func dwstoreOrder(p *struct {
 	p.e = true
 	p.b = b
 }
+
+// --------------------------------------------------- //
+//    arm64 spill/reload pair coalescing               //
+// --------------------------------------------------- //
+
+// Spills and reloads do not exist when the SSA pair pass runs: regalloc
+// inserts them later, so they never get a chance to be fused by that pass.
+// A late Prog-level pass in cmd/compile/internal/arm64 catches adjacent
+// spill/reload pairs that target the same base register at consecutive
+// 8-byte offsets. These tests pin down that behavior.
+
+//go:noinline
+func dwpairClobber() {}
+
+// Two distinct values that need to survive a call: regalloc spills both,
+// and the late pass coalesces the adjacent reloads into a single LDP. The
+// pattern requires a spill-slot (SP) base so that a frame-pointer epilogue
+// LDP, which uses (RSP), cannot satisfy it.
+func dwpairSpillReloadDistinct(p, q *int) (int, int) {
+	a := *p
+	b := *q
+	dwpairClobber()
+	// arm64:`LDP\s.+\(SP\), \(R[0-9]+, R[0-9]+\)`
+	return a, b
+}

--- a/test/fixedbugs/spillreload_arm64_pair.go
+++ b/test/fixedbugs/spillreload_arm64_pair.go
@@ -1,0 +1,106 @@
+// run
+
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Regression coverage for the late spill/reload pair coalescer on arm64
+// (cmd/compile/internal/arm64.pairSpills). When the coalescer fused two
+// adjacent AMOVD reloads into a single LDP, paths that branched directly to
+// the second reload would silently skip the fused load and observe a stale
+// or uninitialized register. The fix records branch and jump-table targets
+// before fusing and refuses to fuse when the second instruction is one.
+// These functions exercise patterns that produce strictly-adjacent reloads
+// and conditional branches over calls, including the shape from
+// runtime.schedule.
+//
+// The check is end-to-end: each function returns a value that depends on
+// every spilled variable, so a missing reload produces a wrong result and
+// the program panics.
+
+package main
+
+import "fmt"
+
+//go:noinline
+func sink(int) {}
+
+//go:noinline
+func sink2(int, int) {}
+
+func callTwoVars(p, q *int) (int, int) {
+	a := *p
+	b := *q
+	sink(0)
+	return a, b
+}
+
+func condCallTwoVars(c bool, p, q *int) (int, int) {
+	a := *p
+	b := *q
+	if c {
+		sink(0)
+	}
+	return a, b
+}
+
+// condCallThreeVars mimics the shape that produced the original
+// miscompile: a conditional call surrounded by values that need to
+// survive it, with the join landing on the second of two adjacent
+// reloads.
+func condCallThreeVars(c bool, p, q, r *int) (int, int, int) {
+	a := *p
+	b := *q
+	d := *r
+	if c {
+		sink2(a, b)
+	}
+	return a, b, d
+}
+
+func loopReload(p []int) int {
+	s := 0
+	for _, v := range p {
+		sink(v)
+		s += v
+	}
+	return s
+}
+
+func nestedConds(c1, c2 bool, p, q, r *int) (int, int, int) {
+	a := *p
+	b := *q
+	d := *r
+	if c1 {
+		sink(a)
+		if c2 {
+			sink(b)
+		}
+	}
+	return a, b, d
+}
+
+func main() {
+	x, y, z := 7, 11, 13
+	if a, b := callTwoVars(&x, &y); a != 7 || b != 11 {
+		panic(fmt.Sprintf("callTwoVars = %d, %d", a, b))
+	}
+	for _, c := range []bool{false, true} {
+		if a, b := condCallTwoVars(c, &x, &y); a != 7 || b != 11 {
+			panic(fmt.Sprintf("condCallTwoVars(%v) = %d, %d", c, a, b))
+		}
+		if a, b, d := condCallThreeVars(c, &x, &y, &z); a != 7 || b != 11 || d != 13 {
+			panic(fmt.Sprintf("condCallThreeVars(%v) = %d, %d, %d", c, a, b, d))
+		}
+	}
+	for _, c1 := range []bool{false, true} {
+		for _, c2 := range []bool{false, true} {
+			if a, b, d := nestedConds(c1, c2, &x, &y, &z); a != 7 || b != 11 || d != 13 {
+				panic(fmt.Sprintf("nestedConds(%v,%v) = %d, %d, %d", c1, c2, a, b, d))
+			}
+		}
+	}
+	if s := loopReload([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}); s != 55 {
+		panic(fmt.Sprintf("loopReload = %d", s))
+	}
+}


### PR DESCRIPTION
The SSA pair pass (cmd/compile/internal/ssa/pair.go) runs before regalloc
and only sees source-level loads and stores. Spill/reload code that
regalloc inserts later for OpStoreReg/OpLoadReg becomes individual STR/LDR
instructions that never get a chance to be paired, even when two spills
target adjacent 8-byte stack slots.

Fuse those pairs as the final step of code generation, in the compiler
rather than the assembler. A new ssagen.ArchInfo.SSAGenFinish hook runs
after genssa has emitted all of a function's Progs, resolved its branch
and jump-table targets, and finalized the frame size in defframe (so the
register-argument spills defframe inserts participate too); on arm64 it
walks the Prog list and rewrites strictly-adjacent AMOVD spill pairs that
share a base register and have consecutive 8-byte offsets into a single
ASTP/ALDP. The second Prog is reduced to a 0-byte ANOP rather than
unlinked so that branch targets referencing it remain valid. The pass is
skipped under -N to keep unoptimized builds unoptimized. Doing this in
the compiler keeps the assembler a simple translator.

Fusion is gated on several safety and profitability conditions:
  - same base register and same Addr.Name (AUTO or PARAM, the only
    classes spill slots use), distinct destination registers (LDP with
    Rt1 == Rt2 is CONSTRAINED UNPREDICTABLE), and no pre/post-index or
    register-offset addressing
  - the resolved offset must encode in LDP/STP's signed 7-bit scaled
    immediate, [-512, 504]: the assembler rewrites an AUTO offset to
    off+framesize+8 and a PARAM offset to off+framesize+24 or +32
    depending on frame alignment (off+8 in a frameless leaf, which is
    not decided until assembly, so a frameless PARAM must fit both).
    Checking the resolved value against the final frame size both
    admits deep spill slots in large frames, where spills are most
    common, and refuses fusions that would need an
    assembler-synthesized address (ADD + LDP), which is no smaller
    than the original pair and serializes through REGTMP
  - the first load of a pair must not write the base register: executed
    sequentially, the second load computes its address from the
    just-loaded value, while LDP computes both addresses from the
    original base
  - the second instruction is not a branch or jump-table target
    (otherwise paths that jump directly to it would skip the work the
    LDP/STP now does at the first instruction's position) and does not
    carry a statement boundary: genssa promotes instructions it reuses
    as inline marks to statements, and inline marks must never become
    zero-sized, while plain statement boundaries must keep their line
    table entries

The prologue's register-argument spills around morestack, which the
assembler inserts during preprocess, are already emitted as STP/LDP
pairs (CL 621556).

TestPairSpills in cmd/compile/internal/arm64 drives pairSpills directly
with hand-constructed Prog chains, asserting the fused operands and
covering each fusion path and each gating condition.
test/codegen/memcombine.go pins down the spill/reload pattern that the
SSA pair pass misses but this pass catches.
test/fixedbugs/spillreload_arm64_pair.go exercises the conditional-call-
with-adjacent-reloads pattern from runtime.schedule that miscompiled
before the branch-target check was added. BenchmarkSpillReloadPair in
cmd/compile/internal/test improves from about 1.92 to 1.78 ns/op on an
Apple M4 Max (~7%).

armlint reports that adjacent STR/LDR pairings drop from 4354 -> 235 on
gofmt (94.6% reduction) and 26022 -> 772 on cmd/go (97.0% reduction).
The text section shrinks by 16720 bytes (1.40%) on gofmt and 101312
bytes (1.52%) on cmd/go.