### PR TITLE
math/big: pool temporary variables to reduce allocations of Int.ModInverse

### DIFF
--- a/src/math/big/int.go
+++ b/src/math/big/int.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"math/rand"
 	"strings"
+	"sync"
 )
 
 // An Int represents a signed multi-precision integer.
@@ -829,6 +830,34 @@ func euclidUpdate(A, B, Ua, Ub, q, r *Int, extended bool) (nA, nB, nr, nUa, nUb 
 	return B, r, A, Ua, Ub
 }
 
+// sixIntPool is used to reduce allocation of limbs used in temporary integers
+// used to calculate lehmerGCD.
+type sixIntPool struct {
+	pool sync.Pool
+}
+
+func (t *sixIntPool) put(data *[6]Int) {
+	data[0].SetInt64(0)
+	data[1].SetInt64(0)
+	data[2].SetInt64(0)
+	data[3].SetInt64(0)
+	data[4].SetInt64(0)
+	data[5].SetInt64(0)
+	t.pool.Put(data)
+}
+
+func (t *sixIntPool) get() *[6]Int {
+	return t.pool.Get().(*[6]Int)
+}
+
+var sixIntP = sixIntPool{
+	sync.Pool{
+		New: func() any {
+			return &[6]Int{}
+		},
+	},
+}
+
 // lehmerGCD sets z to the greatest common divisor of a and b,
 // which both must be != 0, and returns z.
 // If x or y are not nil, their values are set such that z = a*x + b*y.
@@ -840,22 +869,25 @@ func euclidUpdate(A, B, Ua, Ub, q, r *Int, extended bool) (nA, nB, nr, nUa, nUb 
 // The cosequences are updated according to Algorithm 10.45 from
 // Cohen et al. "Handbook of Elliptic and Hyperelliptic Curve Cryptography" pp 192.
 func (z *Int) lehmerGCD(x, y, a, b *Int) *Int {
-	var A, B, Ua, Ub *Int
+	// recycle limbs to reduce allocations.
+	data := sixIntP.get()
+	defer sixIntP.put(data)
 
-	A = new(Int).Abs(a)
-	B = new(Int).Abs(b)
+	var A, B, Ua, Ub *Int = &data[0], &data[1], &data[2], &data[3]
+
+	A.Abs(a)
+	B.Abs(b)
 
 	extended := x != nil || y != nil
 
 	if extended {
 		// Ua (Ub) tracks how many times input a has been accumulated into A (B).
-		Ua = new(Int).SetInt64(1)
-		Ub = new(Int)
+		Ua.SetInt64(1)
 	}
 
 	// temp variables for multiprecision update
-	q := new(Int)
-	r := new(Int)
+	q := &data[4]
+	r := &data[5]
 
 	// ensure A >= B
 	if A.abs.cmp(B.abs) < 0 {
@@ -966,6 +998,30 @@ func (z *Int) Rand(rnd *rand.Rand, n *Int) *Int {
 	return z
 }
 
+// twoIntPool is used to reduce allocation of limbs used in temporary integers
+// used to calculate ModInverse.
+type twoIntPool struct {
+	pool sync.Pool
+}
+
+func (t *twoIntPool) put(data *[2]Int) {
+	data[0].SetInt64(0)
+	data[1].SetInt64(0)
+	t.pool.Put(data)
+}
+
+func (t *twoIntPool) get() *[2]Int {
+	return t.pool.Get().(*[2]Int)
+}
+
+var twoIntP = twoIntPool{
+	sync.Pool{
+		New: func() any {
+			return &[2]Int{}
+		},
+	},
+}
+
 // ModInverse sets z to the multiplicative inverse of g in the ring ℤ/nℤ
 // and returns z. If g and n are not relatively prime, g has no multiplicative
 // inverse in the ring ℤ/nℤ.  In this case, z is unchanged and the return value
@@ -980,8 +1036,13 @@ func (z *Int) ModInverse(g, n *Int) *Int {
 		var g2 Int
 		g = g2.Mod(g, n)
 	}
-	var d, x Int
-	d.GCD(&x, nil, g, n)
+
+	// recycle limbs to reduce allocations.
+	data := twoIntP.get()
+	defer twoIntP.put(data)
+
+	var d, x *Int = &data[0], &data[1]
+	d.GCD(x, nil, g, n)
 
 	// if and only if d==1, g and n are relatively prime
 	if d.Cmp(intOne) != 0 {
@@ -991,10 +1052,11 @@ func (z *Int) ModInverse(g, n *Int) *Int {
 	// x and y are such that g*x + n*y = 1, therefore x is the inverse element,
 	// but it may be negative, so convert to the range 0 <= z < |n|
 	if x.neg {
-		z.Add(&x, n)
+		z.Add(x, n)
 	} else {
-		z.Set(&x)
+		z.Set(x)
 	}
+
 	return z
 }
 


### PR DESCRIPTION
Before the changes, Int.ModInverse was doing several allocations for
temporary variables, this PR added pooling for those, effectively
reducing the total amount of allocations as the benchmarks below show.

goos: linux
goarch: amd64
pkg: math/big
cpu: Intel(R) Core(TM) i5-1031`0U CPU @ 1.70GHz
             │ /tmp/before │             /tmp/after              │
             │   sec/op    │   sec/op     vs base                │
ModInverse-8   815.9n ± 7%   450.6n ± 6%  -44.78% (p=0.000 n=10)

             │ /tmp/before  │              /tmp/after               │
             │     B/op     │     B/op      vs base                 │
ModInverse-8   1.055Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.000 n=10)

             │ /tmp/before │             /tmp/after             │
             │  allocs/op  │ allocs/op  vs base                 │
ModInverse-8    11.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)

As we can see, ModInverse is faster now.

Fixes #79707