### PR TITLE
go/types, types2: add user-friendly panics in Instantiate

### DIFF
--- a/src/cmd/compile/internal/types2/instantiate.go
+++ b/src/cmd/compile/internal/types2/instantiate.go
@@ -49,15 +49,22 @@ type genericType interface {
 // count is incorrect; for *Named types, a panic may occur later inside the
 // *Named API.
 func Instantiate(ctxt *Context, orig Type, targs []Type, validate bool) (Type, error) {
-	assert(len(targs) > 0)
+	if len(targs) == 0 {
+		panic(sprintf(nil, false, "cannot instantiate %v: empty type argument list", orig))
+	}
 	if ctxt == nil {
 		ctxt = NewContext()
 	}
-	orig_ := orig.(genericType) // signature of Instantiate must not change for backward-compatibility
+	orig_, ok := orig.(genericType) // signature of Instantiate must not change for backward-compatibility
+	if !ok {
+		panic(sprintf(nil, false, "cannot instantiate %v: non-generic type %T supplied, expected *Named, *Alias, or *Signature", orig, orig))
+	}
 
 	if validate {
 		tparams := orig_.TypeParams().list()
-		assert(len(tparams) > 0)
+		if len(tparams) == 0 {
+			panic(sprintf(nil, false, "cannot instantiate %v: has no type parameters", orig))
+		}
 		if len(targs) != len(tparams) {
 			return nil, fmt.Errorf("got %d type arguments but %s has %d type parameters", len(targs), orig, len(tparams))
 		}

--- a/src/go/types/instantiate.go
+++ b/src/go/types/instantiate.go
@@ -52,15 +52,22 @@ type genericType interface {
 // count is incorrect; for *Named types, a panic may occur later inside the
 // *Named API.
 func Instantiate(ctxt *Context, orig Type, targs []Type, validate bool) (Type, error) {
-	assert(len(targs) > 0)
+	if len(targs) == 0 {
+		panic(sprintf(nil, nil, false, "cannot instantiate %v: empty type argument list", orig))
+	}
 	if ctxt == nil {
 		ctxt = NewContext()
 	}
-	orig_ := orig.(genericType) // signature of Instantiate must not change for backward-compatibility
+	orig_, ok := orig.(genericType) // signature of Instantiate must not change for backward-compatibility
+	if !ok {
+		panic(sprintf(nil, nil, false, "cannot instantiate %v: non-generic type %T supplied, expected *Named, *Alias, or *Signature", orig, orig))
+	}
 
 	if validate {
 		tparams := orig_.TypeParams().list()
-		assert(len(tparams) > 0)
+		if len(tparams) == 0 {
+			panic(sprintf(nil, nil, false, "cannot instantiate %v: has no type parameters", orig))
+		}
 		if len(targs) != len(tparams) {
 			return nil, fmt.Errorf("got %d type arguments but %s has %d type parameters", len(targs), orig, len(tparams))
 		}


### PR DESCRIPTION
Replace opaque assert() calls and a bare type assertion in the exported
Instantiate function with explicit panics that name the package, the
function, and the violated precondition. Internal assertions in
instance() are unchanged since they guard invariants unreachable from
the public API.

Fixes #79709