### PR TITLE
cmd/gofmt: fix symlink file truncation

### DIFF
--- a/src/cmd/gofmt/gofmt.go
+++ b/src/cmd/gofmt/gofmt.go
@@ -280,7 +280,7 @@ func processFile(filename string, info fs.FileInfo, in io.Reader, r *reporter) e
 			}
 
 			perm := info.Mode().Perm()
-			if err := writeFile(filename, src, res, perm, info.Size()); err != nil {
+			if err := writeFile(filename, src, res, perm, fileWeight(filename, info)); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Currenty `go fmt` does not truncate the symlinked file, as it compares the size of the recorded data not with the real file size, but with the symlink reference path length.

Fixes #79735