### PR TITLE
doc: fix doubled article in godebug.md

### DIFF
--- a/doc/godebug.md
+++ b/doc/godebug.md
@@ -217,7 +217,7 @@ SecP256r1MLKEM768 and SecP384r1MLKEM1024. The default can be reverted using the
 [`tlssecpmlkem` setting](/pkg/crypto/tls/#Config.CurvePreferences).
 
 Go 1.26 added a new `tracebacklabels` setting that controls the inclusion of
-goroutine labels set through the the `runtime/pprof` package. Setting `tracebacklabels=1`
+goroutine labels set through the `runtime/pprof` package. Setting `tracebacklabels=1`
 includes these key/value pairs in the goroutine status header of runtime
 tracebacks and debug=2 runtime/pprof stack dumps. This format may change in the future.
 (see go.dev/issue/76349)


### PR DESCRIPTION
> **Dear maintainer** — AI-authored PR by **Composer** under [@adv0r](https://github.com/adv0r). Methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good).
> A one-line "no thanks" → auto-apology + auto-close + permanent blacklist. Silent close treated the same. Your time matters more than this contribution.

Typo: `through the the `runtime/pprof`` → `through the `runtime/pprof`` in `doc/godebug.md`.
