### PR TITLE
net/http: reject userinfo in CrossOriginProtection

### DIFF
--- a/src/net/http/csrf.go
+++ b/src/net/http/csrf.go
@@ -65,8 +65,8 @@ func (c *CrossOriginProtection) AddTrustedOrigin(origin string) error {
 	if u.Host == "" {
 		return fmt.Errorf("invalid origin %q: host is required", origin)
 	}
-	if u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
-		return fmt.Errorf("invalid origin %q: path, query, and fragment are not allowed", origin)
+	if u.User != nil || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("invalid origin %q: userinfo, path, query, and fragment are not allowed", origin)
 	}
 	c.trustedMu.Lock()
 	defer c.trustedMu.Unlock()

--- a/src/net/http/csrf_test.go
+++ b/src/net/http/csrf_test.go
@@ -235,6 +235,8 @@ func TestCrossOriginProtectionAddTrustedOriginErrors(t *testing.T) {
 		{"http origin", "http://example.com", false},
 		{"missing scheme", "example.com", true},
 		{"missing host", "https://", true},
+		{"with empty userinfo", "https://@example.com", true},
+		{"with nonempty userinfo", "https://foo:bar@example.com", true},
 		{"trailing slash", "https://example.com/", true},
 		{"with path", "https://example.com/path", true},
 		{"with query", "https://example.com?query=value", true},


### PR DESCRIPTION
(*CrossOriginProtection).AddTrustedOrigin fails if its argument contains
a path, a query, and/or a fragment, but it doesn't check for the
presence of a userinfo part. Such an omission doesn't affect security
(because serialized origins don't contain any userinfo part), but it
causes invalid origins to be silently accepted, which could create some
confusion.

With this CL, the method now also fails if its argument contains a
userinfo part (even if it's empty).
