### PR TITLE
cmd/gofmt: correctly truncate symlinks instead of buggy mangling

### DIFF
--- a/src/cmd/go/testdata/script/gofmt_with_symlink.txt
+++ b/src/cmd/go/testdata/script/gofmt_with_symlink.txt
@@ -1,0 +1,31 @@
+# Test that gofmt-ing a symlink works correctly. See #79735.
+
+# Skip on systems without unix-style symlinks
+[GOOS:windows] skip
+
+cd $WORK/a
+cp issue-original.go issue-expected.go
+exec go fmt issue-expected.go
+! cmp -q issue-expected.go issue-original.go
+
+# Create that symlink.
+exec ln -s issue-original.go issue-symlink.go
+
+# Now go fmt it.
+exec go fmt issue-symlink.go
+
+# Ensure that the symlinked file is equal to the expected.
+cmp issue-expected.go issue-symlink.go
+
+# Our source code and setup.
+-- $WORK/a/go.mod --
+module gofmt_symlink
+
+-- $WORK/a/issue-original.go --
+package main;
+
+import "fmt"
+
+func main() {
+       fmt.Println(  "Hello, world!!!"  )
+}

--- a/src/cmd/gofmt/gofmt.go
+++ b/src/cmd/gofmt/gofmt.go
@@ -280,7 +280,7 @@ func processFile(filename string, info fs.FileInfo, in io.Reader, r *reporter) e
 			}
 
 			perm := info.Mode().Perm()
-			if err := writeFile(filename, src, res, perm, info.Size()); err != nil {
+			if err := writeFile(filename, src, res, perm); err != nil {
 				return err
 			}
 		}
@@ -465,7 +465,7 @@ func fileWeight(path string, info fs.FileInfo) int64 {
 }
 
 // writeFile updates a file with the new formatted data.
-func writeFile(filename string, orig, formatted []byte, perm fs.FileMode, size int64) error {
+func writeFile(filename string, orig, formatted []byte, perm fs.FileMode) error {
 	// Make a temporary backup file before rewriting the original file.
 	bakname, err := backupFile(filename, orig, perm)
 	if err != nil {
@@ -489,7 +489,7 @@ func writeFile(filename string, orig, formatted []byte, perm fs.FileMode, size i
 	}
 
 	n, err := fout.Write(formatted)
-	if err == nil && int64(n) < size {
+	if err == nil {
 		err = fout.Truncate(int64(n))
 	}
 


### PR DESCRIPTION
Currenty `go fmt` does not truncate the symlinked file, as it compares
the size of the recorded data not with the real file size, but with
the symlink reference path length.

Fixes #79735