### PR TITLE
internal/bytealg: use NEON for compare_arm64.s large-input path

### DIFF
--- a/src/internal/bytealg/compare_arm64.s
+++ b/src/internal/bytealg/compare_arm64.s
@@ -31,7 +31,7 @@ TEXT runtime·cmpstring<ABIInternal>(SB),NOSPLIT|NOFRAME,$0-40
 //
 // On exit:
 // R0 is the result
-// R4, R5, R6, R8, R9 and R10 are clobbered
+// R4, R5, R6, R8, R9, R10 and V0-V11 are clobbered
 TEXT cmpbody<>(SB),NOSPLIT|NOFRAME,$0-0
 	CMP	R0, R2
 	BEQ	samebytes         // same starting pointers; compare lengths
@@ -39,17 +39,40 @@ TEXT cmpbody<>(SB),NOSPLIT|NOFRAME,$0-0
 	CSEL	LT, R3, R1, R6    // R6 is min(R1, R3)
 
 	CBZ	R6, samebytes
-	BIC	$0x1f, R6, R10
-	CBZ	R10, chunk16      // length < 32, try single chunk16
-	ADD	R0, R10           // end of chunk32
-	// length >= 32
-chunk32_loop:
-	LDP.P	16(R0), (R4, R8)
-	LDP.P	16(R2), (R5, R9)
-	CMP	R4, R5
-	BNE	cmp
-	CMP	R8, R9
-	BNE	cmpnext
+	BIC	$0x3f, R6, R10
+	CBZ	R10, less_than_64 // length < 64, use scalar path
+	ADD	R0, R10           // end of 64-byte chunks
+
+	// Process 64 bytes per iteration using NEON.
+	// Compare 4x16-byte chunks and reduce the result to a single byte.
+	// On mismatch, rewind and fall back to the scalar path.
+	PCALIGN	$16
+chunk64_loop:
+	VLD1.P	(R0), [V0.D2, V1.D2, V2.D2, V3.D2]
+	VLD1.P	(R2), [V4.D2, V5.D2, V6.D2, V7.D2]
+	VCMEQ	V0.B16, V4.B16, V8.B16
+	VCMEQ	V1.B16, V5.B16, V9.B16
+	VCMEQ	V2.B16, V6.B16, V10.B16
+	VCMEQ	V3.B16, V7.B16, V11.B16
+	VAND	V8.B16, V9.B16, V8.B16
+	VAND	V10.B16, V11.B16, V10.B16
+	VAND	V8.B16, V10.B16, V8.B16
+	VUMINV	V8.B16, V8
+	VMOV	V8.B[0], R4
+	CBZ	R4, neon_mismatch
+	CMP	R10, R0
+	BNE	chunk64_loop
+
+	AND	$0x3f, R6, R6     // remaining 0-63 bytes
+	CBZ	R6, samebytes
+
+less_than_64:
+	// Scalar 16-byte loop for up to 63 bytes, then byte-level tail.
+	BIC	$0xf, R6, R10
+	CBZ	R10, small        // length < 16
+	ADD	R0, R10
+	PCALIGN	$16
+chunk16_loop:
 	LDP.P	16(R0), (R4, R8)
 	LDP.P	16(R2), (R5, R9)
 	CMP	R4, R5
@@ -57,20 +80,7 @@ chunk32_loop:
 	CMP	R8, R9
 	BNE	cmpnext
 	CMP	R10, R0
-	BNE	chunk32_loop
-	AND	$0x1f, R6, R6     // remaining 0-31 bytes
-	CBZ	R6, samebytes
-	// handle remaining 0-31 bytes: one possible 16-byte chunk then tail
-	TBZ	$4, R6, small_direct
-chunk16:
-	TBZ	$4, R6, small     // length < 16
-	LDP.P	16(R0), (R4, R8)
-	LDP.P	16(R2), (R5, R9)
-	CMP	R4, R5
-	BNE	cmp
-	CMP	R8, R9
-	BNE	cmpnext
-small_direct:
+	BNE	chunk16_loop
 	AND	$0xf, R6, R6
 	CBZ	R6, samebytes
 	SUBS	$8, R6
@@ -82,6 +92,8 @@ small_direct:
 	BNE	cmp
 	SUB	$8, R6
 	// compare last 8 bytes
+	// tail always reads the final 8-byte window at R0+R6. R6 may be
+	// negative here, overlapping already-verified bytes, which is harmless.
 tail:
 	MOVD	(R0)(R6), R4
 	MOVD	(R2)(R6), R5
@@ -95,6 +107,15 @@ ret:
 	MOVD	$1, R0
 	CNEG	HI, R0, R0
 	RET
+
+neon_mismatch:
+	// A mismatch was found in the last 64-byte NEON chunk. Rewind both
+	// pointers and let the scalar path locate the first differing byte.
+	SUB	$64, R0
+	SUB	$64, R2
+	MOVD	$64, R6
+	B	less_than_64
+
 small:
 	TBZ	$3, R6, lt_8
 	MOVD	(R0), R4
@@ -103,9 +124,6 @@ small:
 	BNE	cmp
 	SUBS	$8, R6
 	BEQ	samebytes
-	ADD	$8, R0
-	ADD	$8, R2
-	SUB	$8, R6
 	B	tail
 lt_8:
 	TBZ	$2, R6, lt_4


### PR DESCRIPTION
Replace the scalar chunk loop with a 64-byte/iter NEON loop.

For inputs >= 64 bytes, each iteration loads and compares 64 bytes from
both sides using NEON. The compare results are reduced to a single byte;
zero indicates a mismatch.

On mismatch, both pointers are rewound by 64 bytes and the existing
scalar chunk16 path locates the first differing byte pair and produces
the lexicographic result. This fallback is taken at most once.

Inputs < 64 bytes continue to use the existing scalar chunk16 and tail
paths unchanged.

This brings the overall structure closer to equal_arm64.s.

     goos: darwin
     goarch: arm64
     pkg: bytes
     cpu: Apple M3 Pro
                                              │   old.txt   │                new.txt                │
                                              │   sec/op    │   sec/op     vs base                  │
     CompareBytesBigUnaligned/offset=1-11       26.55µ ± 1%   19.21µ ± 1%  -27.63% (p=0.000 n=10)
     CompareBytesBigUnaligned/offset=2-11       26.83µ ± 3%   19.11µ ± 1%  -28.78% (p=0.000 n=10)
     CompareBytesBigUnaligned/offset=3-11       26.59µ ± 1%   19.28µ ± 2%  -27.50% (p=0.000 n=10)
     CompareBytesBigUnaligned/offset=4-11       26.49µ ± 1%   19.11µ ± 1%  -27.84% (p=0.000 n=10)
     CompareBytesBigUnaligned/offset=5-11       27.04µ ± 3%   19.05µ ± 1%  -29.54% (p=0.000 n=10)
     CompareBytesBigUnaligned/offset=6-11       27.12µ ± 1%   18.92µ ± 1%  -30.24% (p=0.000 n=10)
     CompareBytesBigUnaligned/offset=7-11       27.00µ ± 0%   18.90µ ± 0%  -30.01% (p=0.000 n=10)
     CompareBytesBigBothUnaligned/offset=0-11   26.56µ ± 1%   18.01µ ± 1%  -32.20% (p=0.000 n=10)
     CompareBytesBigBothUnaligned/offset=1-11   27.27µ ± 1%   19.43µ ± 0%  -28.77% (p=0.000 n=10)
     CompareBytesBigBothUnaligned/offset=2-11   26.83µ ± 2%   18.68µ ± 1%  -30.38% (p=0.000 n=10)
     CompareBytesBigBothUnaligned/offset=3-11   27.24µ ± 0%   19.45µ ± 0%  -28.62% (p=0.000 n=10)
     CompareBytesBigBothUnaligned/offset=4-11   27.07µ ± 1%   18.67µ ± 1%  -31.03% (p=0.000 n=7+10)
     geomean                                    26.88µ        10.82µ       -29.39%
    
                                              │   old.txt    │                new.txt                 │
                                              │     B/s      │     B/s       vs base                  │
     CompareBytesBigUnaligned/offset=1-11       36.78Gi ± 1%   50.82Gi ± 1%  +38.18% (p=0.000 n=10)
     CompareBytesBigUnaligned/offset=2-11       36.40Gi ± 3%   51.11Gi ± 1%  +40.41% (p=0.000 n=10)
     CompareBytesBigUnaligned/offset=3-11       36.73Gi ± 1%   50.66Gi ± 2%  +37.93% (p=0.000 n=10)
     CompareBytesBigUnaligned/offset=4-11       36.87Gi ± 1%   51.09Gi ± 1%  +38.59% (p=0.000 n=10)
     CompareBytesBigUnaligned/offset=5-11       36.12Gi ± 3%   51.27Gi ± 1%  +41.92% (p=0.000 n=10)
     CompareBytesBigUnaligned/offset=6-11       36.00Gi ± 1%   51.61Gi ± 1%  +43.35% (p=0.000 n=10)
     CompareBytesBigUnaligned/offset=7-11       36.17Gi ± 0%   51.68Gi ± 0%  +42.88% (p=0.000 n=10)
     CompareBytesBigBothUnaligned/offset=0-11   36.77Gi ± 1%   54.23Gi ± 1%  +47.48% (p=0.000 n=10)
     CompareBytesBigBothUnaligned/offset=1-11   35.81Gi ± 1%   50.27Gi ± 0%  +40.39% (p=0.000 n=10)
     CompareBytesBigBothUnaligned/offset=2-11   36.40Gi ± 2%   52.29Gi ± 1%  +43.64% (p=0.000 n=10)
     CompareBytesBigBothUnaligned/offset=3-11   35.85Gi ± 0%   50.22Gi ± 0%  +40.09% (p=0.000 n=10)
     CompareBytesBigBothUnaligned/offset=4-11   36.07Gi ± 1%   52.30Gi ± 1%  +45.00% (p=0.000 n=7+10)
     geomean                                    36.33Gi        90.30Gi       +41.63%