### PR TITLE
internal/refactor/inline: always retain braces for binding declarations

### DIFF
--- a/src/cmd/vendor/golang.org/x/tools/internal/refactor/inline/inline.go
+++ b/src/cmd/vendor/golang.org/x/tools/internal/refactor/inline/inline.go
@@ -193,6 +193,8 @@ func (st *state) inline() (*Result, error) {
 					logf("keeping block braces: caller uses control labels")
 				} else if intersects(declares(newBlock.List), callerNames) {
 					logf("keeping block braces: avoids name conflict")
+				} else if res.bindingDecl {
+					logf("keeping block braces: avoids potential conflict with other inlinings")
 				} else {
 					elideBraces = true
 				}
@@ -1144,6 +1146,7 @@ func (st *state) inlineCall() (*inlineCallResult, error) {
 		var repl ast.Stmt = body
 		clearPositions(repl)
 		if needBindingDecl {
+			res.bindingDecl = true
 			body.List = prepend(bindingDecl.stmt, body.List...)
 		}
 		res.old = stmt


### PR DESCRIPTION
When inlining a function that requires a binding declaration (e.g.,
'var p = arg'), the inliner must ensure that the new variable does
not collide with other declarations in the same scope.

Previously, the inliner would often elide the braces around the
inlined body if the chosen variable name (the parameter name) was
not yet present in the caller's scope. However, when multiple calls
are inlined into the same block, independent inlining passes may
choose the same name, leading to a redeclaration error.

This change modifies Go to always retain block braces whenever a
binding declaration is introduced. This provides guaranteed scope
isolation for the new variables and prevents redeclaration conflicts
between multiple concurrent inlinings.

Additionally, this fix adds a missing 'res.bindingDecl = true' flag 
in the void-function inlining strategy, which was previously causing 
some inlinings to incorrectly elide braces even when variables were 
introduced.

Fixes #79813