### PR TITLE
internal/analysis/driverutil: report partial success in ApplyFixes

### DIFF
--- a/src/cmd/vendor/golang.org/x/tools/internal/analysis/driverutil/fix.go
+++ b/src/cmd/vendor/golang.org/x/tools/internal/analysis/driverutil/fix.go
@@ -308,16 +308,32 @@ fixloop:
 	//
 	// TODO(adonovan): should we log that n files were updated in case of total victory?
 	if badFixes > 0 || filesUpdated < totalFiles {
-		if printDiff {
-			return fmt.Errorf("%d of %s skipped (e.g. due to conflicts)",
+		var msg string
+		if filesUpdated < totalFiles {
+			msg = fmt.Sprintf("applied %d of %s; %s updated, but %d files failed to update",
+				goodFixes,
+				plural(len(fixes), "fix", "fixes"),
+				plural(filesUpdated, "file", "files"),
+				totalFiles-filesUpdated)
+		} else if printDiff {
+			msg = fmt.Sprintf("%d of %s skipped (e.g. due to conflicts)",
 				badFixes,
 				plural(len(fixes), "fix", "fixes"))
 		} else {
-			return fmt.Errorf("applied %d of %s; %s updated. (Re-run the command to apply more.)",
+			msg = fmt.Sprintf("applied %d of %s; %s updated. (Re-run the command to apply more.)",
 				goodFixes,
 				plural(len(fixes), "fix", "fixes"),
 				plural(filesUpdated, "file", "files"))
 		}
+
+		if goodFixes > 0 && filesUpdated == totalFiles {
+			// Partial success: report via log but return nil so the
+			// caller (like go fix) can apply the partial results.
+			log.Print(msg)
+			return nil
+		}
+		// Total failure or file write error: return as error.
+		return fmt.Errorf("%s", msg)
 	}
 
 	if verbose {


### PR DESCRIPTION
When the fix tool applies some suggested fixes but skips others due to
conflicts, it previously returned a non-zero exit code.

This caused the 'go fix' command to assume the tool failed, leading it
to discard the partial progress (the FixArchive) and not update the
source files. On subsequent runs, the tool would see the original code
again and repeat the same partial fixes, creating an infinite loop.

This change modifies ApplyFixes to return nil (success) if at least
one fix was applied and no I/O errors occurred. This ensures that
partial progress is saved to disk, breaking the non-convergence loop.

Fixes #78493