### PR TITLE
runtime: add opt-in epoll_pwait2 for sub-ms netpoll timeouts

### DIFF
--- a/doc/godebug.md
+++ b/doc/godebug.md
@@ -154,6 +154,22 @@ for example,
 see the [runtime documentation](/pkg/runtime#hdr-Environment_Variables)
 and the [go command documentation](/cmd/go#hdr-Build_and_test_caching).
 
+### Go 1.28
+
+Go 1.28 added a new `epollpwait2` setting on Linux that controls whether the
+network poller uses the `epoll_pwait2` system call, when available (Linux 5.11+
+and not blocked by seccomp), instead of `epoll_wait`. The `epoll_pwait2` call
+accepts a nanosecond-precision timeout, removing the implicit 1ms rounding that
+`epoll_wait` applies to sub-millisecond deadlines. To limit the increase in
+wakeup frequency that would otherwise result from losing `epoll_wait`'s implicit
+1ms coalescing, the runtime applies graduated bucketing: delays under 1ms
+round up to the nearest 10µs, under 10ms to the nearest 100µs, and longer
+delays to the nearest millisecond, so that timers within the same bucket
+share a single wakeup. The default
+`epollpwait2=0` retains the existing `epoll_wait` behavior. Setting
+`epollpwait2=1` opts in to nanosecond-precision wakeups. This setting has no
+effect on non-Linux platforms or when running on Linux kernels older than 5.11.
+
 ### Go 1.27
 
 Go 1.27 removed the `gotypesalias` setting, as noted in the [Go 1.22](#go-122) section.

--- a/src/internal/godebugs/table.go
+++ b/src/internal/godebugs/table.go
@@ -32,6 +32,7 @@ var All = []Info{
 	{Name: "dataindependenttiming", Package: "crypto/subtle", Opaque: true},
 	{Name: "decoratemappings", Package: "runtime", Opaque: true, Changed: 25, Old: "0"},
 	{Name: "embedfollowsymlinks", Package: "cmd/go"},
+	{Name: "epollpwait2", Package: "runtime", Opaque: true},
 	{Name: "execerrdot", Package: "os/exec"},
 	{Name: "fips140", Package: "crypto/fips140", Opaque: true, Immutable: true},
 	{Name: "gocachehash", Package: "cmd/go"},

--- a/src/internal/runtime/syscall/linux/syscall_linux.go
+++ b/src/internal/runtime/syscall/linux/syscall_linux.go
@@ -33,6 +33,32 @@ func EpollWait(epfd int32, events []EpollEvent, maxev, waitms int32) (n int32, e
 	return int32(r1), e
 }
 
+// KernelTimespec is the __kernel_timespec type. Unlike the C struct timespec on
+// 32-bit systems, __kernel_timespec always uses 64-bit fields.
+type KernelTimespec struct {
+	Sec  int64
+	Nsec int64
+}
+
+// SetNsec sets the timespec to the given nanosecond count.
+func (ts *KernelTimespec) SetNsec(nsec int64) {
+	ts.Sec = nsec / 1e9
+	ts.Nsec = nsec % 1e9
+}
+
+// EpollPwait2 calls epoll_pwait2(2), which supports nanosecond-precision
+// timeouts. timeout may be nil to block indefinitely. Requires Linux 5.11+.
+func EpollPwait2(epfd int32, events []EpollEvent, maxev int32, timeout *KernelTimespec) (n int32, errno uintptr) {
+	var ev unsafe.Pointer
+	if len(events) > 0 {
+		ev = unsafe.Pointer(&events[0])
+	} else {
+		ev = unsafe.Pointer(&_zero)
+	}
+	r1, _, e := Syscall6(SYS_EPOLL_PWAIT2, uintptr(epfd), uintptr(ev), uintptr(maxev), uintptr(unsafe.Pointer(timeout)), 0, 0)
+	return int32(r1), e
+}
+
 func EpollCtl(epfd, op, fd int32, event *EpollEvent) (errno uintptr) {
 	_, _, e := Syscall6(SYS_EPOLL_CTL, uintptr(epfd), uintptr(op), uintptr(fd), uintptr(unsafe.Pointer(event)), 0, 0)
 	return e

--- a/src/runtime/export_linux_test.go
+++ b/src/runtime/export_linux_test.go
@@ -12,6 +12,5 @@ const SigeventMaxSize = _sigev_max_size
 var NewOSProc0 = newosproc0
 var Mincore = mincore
 var ParseRelease = parseRelease
-
 type Siginfo siginfo
 type Sigevent sigevent

--- a/src/runtime/extern.go
+++ b/src/runtime/extern.go
@@ -95,6 +95,18 @@ It is a comma-separated list of name=val pairs setting these named variables:
 	where each object is allocated on a unique page and addresses are
 	never recycled.
 
+	epollpwait2: setting epollpwait2=1 on Linux makes the network poller use the
+	epoll_pwait2 system call, when available (Linux 5.11+, and not blocked by
+	seccomp), to wait for I/O with nanosecond-resolution timeouts instead of
+	epoll_wait's millisecond-rounded ones. This gives goroutines waiting on
+	sub-millisecond deadlines more precise wakeups. To limit the increase in
+	wakeup frequency that would otherwise result from losing epoll_wait's
+	implicit 1ms coalescing, the runtime applies graduated bucketing:
+	delays under 1ms round up to the nearest 10µs, under 10ms to the
+	nearest 100µs, and longer delays to the nearest millisecond. Timers
+	within the same bucket share a single wakeup.
+	It defaults to epollpwait2=0. It has no effect on other platforms.
+
 	gccheckmark: setting gccheckmark=1 enables verification of the
 	garbage collector's concurrent mark phase by performing a
 	second mark pass while the world is stopped.  If the second

--- a/src/runtime/netpoll_epoll.go
+++ b/src/runtime/netpoll_epoll.go
@@ -13,10 +13,31 @@ import (
 )
 
 var (
-	epfd           int32         = -1 // epoll descriptor
-	netpollEventFd uintptr            // eventfd for netpollBreak
-	netpollWakeSig atomic.Uint32      // used to avoid duplicate calls of netpollBreak
+	epfd             int32         = -1 // epoll descriptor
+	netpollEventFd   uintptr            // eventfd for netpollBreak
+	netpollWakeSig   atomic.Uint32      // used to avoid duplicate calls of netpollBreak
+	epollpwait2Avail bool               // true if epoll_pwait2 is available (Linux 5.11+)
 )
+
+// netpollEpollPwait2Init decides whether epoll_pwait2 is available.
+// Opt-in via GODEBUG=epollpwait2=1: precise per-timer wakeups can
+// measurably increase wakeup frequency and CPU usage for workloads
+// with many similar short-lived timers. Must run after parsedebugvars.
+//
+// Check the kernel version first. Even on a new-enough kernel, probe
+// the syscall since seccomp may block it. The probe expects EBADF from
+// an invalid epfd, treating any other result as unavailable.
+func netpollEpollPwait2Init() {
+	if debug.epollpwait2 == 0 {
+		return
+	}
+	if kv, ok := getKernelVersion(); ok && !kv.GE(5, 11) {
+		return
+	}
+	_, errno := linux.EpollPwait2(-1, nil, 0, nil)
+	const badf = 9 // EBADF
+	epollpwait2Avail = errno == badf
+}
 
 func netpollinit() {
 	var errno uintptr
@@ -88,6 +109,32 @@ func netpollBreak() {
 	}
 }
 
+// netpollCoalesceDelay rounds delay up to the nearest coalescing bucket.
+// epoll_wait's 1ms floor implicitly batches timers with nearby deadlines
+// into a single wakeup; epoll_pwait2 does not. Rounding up to a bucket
+// boundary recovers that batching: timers within the same bucket share a
+// wakeup. Delay is always rounded up, never down, so no timer fires early.
+//
+// The minimum bucket is 10µs, which matches the scheduling latency floor
+// on Linux: any sleep shorter than ~10µs is delivered at ~10µs regardless,
+// so finer buckets would claim precision the OS cannot provide.
+func netpollCoalesceDelay(delay int64) int64 {
+	// Cap at ~11.5 days, matching the epoll_wait path, to prevent
+	// arithmetic overflow in the rounding below for very large delays.
+	const maxDelay = 1_000_000_000_000_000 // 1e15 ns
+	if delay > maxDelay {
+		delay = maxDelay
+	}
+	switch {
+	case delay < 1_000_000: // <1ms: 10µs buckets
+		return ((delay + 9_999) / 10_000) * 10_000
+	case delay < 10_000_000: // <10ms: 100µs buckets
+		return ((delay + 99_999) / 100_000) * 100_000
+	default: // ≥10ms: 1ms buckets, same as epoll_wait
+		return ((delay + 999_999) / 1_000_000) * 1_000_000
+	}
+}
+
 // netpoll checks for ready network connections.
 // Returns a list of goroutines that become runnable,
 // and a delta to add to netpollWaiters.
@@ -100,23 +147,44 @@ func netpoll(delay int64) (gList, int32) {
 	if epfd == -1 {
 		return gList{}, 0
 	}
-	var waitms int32
-	if delay < 0 {
-		waitms = -1
-	} else if delay == 0 {
-		waitms = 0
-	} else if delay < 1e6 {
-		waitms = 1
-	} else if delay < 1e15 {
-		waitms = int32(delay / 1e6)
-	} else {
-		// An arbitrary cap on how long to wait for a timer.
-		// 1e9 ms == ~11.5 days.
-		waitms = 1e9
-	}
 	var events [128]linux.EpollEvent
+	var n int32
+	var errno uintptr
 retry:
-	n, errno := linux.EpollWait(epfd, events[:], int32(len(events)), waitms)
+	if epollpwait2Avail && delay != 0 {
+		// Use epoll_pwait2 for nanosecond-precision timeouts (Linux 5.11+).
+		// This eliminates the 1ms rounding applied by epoll_wait, improving
+		// deadline accuracy for sub-millisecond timeouts. Apply graduated
+		// coalescing to recover the wakeup batching that epoll_wait's 1ms
+		// floor provided: nearby timers round into the same bucket and share
+		// a single wakeup, bounding the per-timer wakeup regression.
+		var ts *linux.KernelTimespec
+		if delay > 0 {
+			var timeout linux.KernelTimespec
+			timeout.SetNsec(netpollCoalesceDelay(delay))
+			ts = &timeout
+		}
+		// delay < 0: ts == nil, blocks indefinitely.
+		n, errno = linux.EpollPwait2(epfd, events[:], int32(len(events)), ts)
+	} else {
+		// epoll_pwait2 unavailable or delay == 0 (non-blocking): use epoll_wait.
+		// Convert delay to milliseconds for epoll_wait.
+		var waitms int32
+		if delay < 0 {
+			waitms = -1
+		} else if delay == 0 {
+			waitms = 0
+		} else if delay < 1e6 {
+			waitms = 1
+		} else if delay < 1e15 {
+			waitms = int32(delay / 1e6)
+		} else {
+			// An arbitrary cap on how long to wait for a timer.
+			// 1e9 ms == ~11.5 days.
+			waitms = 1e9
+		}
+		n, errno = linux.EpollWait(epfd, events[:], int32(len(events)), waitms)
+	}
 	if errno != 0 {
 		if errno != _EINTR {
 			println("runtime: epollwait on fd", epfd, "failed with", errno)
@@ -124,7 +192,7 @@ retry:
 		}
 		// If a timed sleep was interrupted, just return to
 		// recalculate how long we should sleep now.
-		if waitms > 0 {
+		if delay > 0 {
 			return gList{}, 0
 		}
 		goto retry

--- a/src/runtime/netpoll_epoll_pwait2_stub.go
+++ b/src/runtime/netpoll_epoll_pwait2_stub.go
@@ -1,0 +1,10 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !linux
+
+package runtime
+
+// netpollEpollPwait2Init is a no-op on platforms that do not support epoll_pwait2.
+func netpollEpollPwait2Init() {}

--- a/src/runtime/netpoll_epoll_test.go
+++ b/src/runtime/netpoll_epoll_test.go
@@ -1,0 +1,51 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux
+
+package runtime_test
+
+import (
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func cpuNanos() int64 {
+	var ru syscall.Rusage
+	syscall.Getrusage(syscall.RUSAGE_SELF, &ru)
+	return ru.Utime.Sec*1e9 + ru.Utime.Usec*1e3 +
+		ru.Stime.Sec*1e9 + ru.Stime.Usec*1e3
+}
+
+// BenchmarkSpreadSubMsTimers measures the cost of waking many goroutines
+// with staggered sub-millisecond sleep intervals. With epoll_wait these
+// deadlines collapse into the same 1ms bucket (one wakeup); with
+// epoll_pwait2 each gets its own wakeup unless coalescing absorbs them.
+// Run with GODEBUG=epollpwait2=0 (default) and GODEBUG=epollpwait2=1
+// to compare. cpu-ns/wakeup uses RUSAGE_SELF to measure actual process
+// CPU time, not wall time.
+func BenchmarkSpreadSubMsTimers(b *testing.B) {
+	const nGoroutines = 50
+	var wg sync.WaitGroup
+	cpu0 := cpuNanos()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		wg.Add(nGoroutines)
+		for j := 0; j < nGoroutines; j++ {
+			d := time.Duration(20+j*20) * time.Microsecond
+			go func(d time.Duration) {
+				time.Sleep(d)
+				wg.Done()
+			}(d)
+		}
+		wg.Wait()
+	}
+	b.StopTimer()
+	cpuElapsed := cpuNanos() - cpu0
+	wakeups := b.N * nGoroutines
+	b.ReportMetric(float64(cpuElapsed)/float64(wakeups), "cpu-ns/wakeup")
+	b.ReportMetric(float64(wakeups)/b.Elapsed().Seconds(), "wakeups/s")
+}

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -928,6 +928,7 @@ func schedinit() {
 	// mcommoninit runs before parsedebugvars, so init profstacks again.
 	mProfStackInit(gp.m)
 	defaultGOMAXPROCSInit()
+	netpollEpollPwait2Init()
 
 	lock(&sched.lock)
 	sched.lastpoll.Store(nanotime())

--- a/src/runtime/runtime1.go
+++ b/src/runtime/runtime1.go
@@ -309,6 +309,7 @@ var debug struct {
 	disablethp               int32
 	dontfreezetheworld       int32
 	efence                   int32
+	epollpwait2              int32
 	gccheckmark              int32
 	gcpacertrace             int32
 	gcshrinkstackoff         int32
@@ -366,6 +367,7 @@ var dbgvars = []*dbgVar{
 	{name: "dontfreezetheworld", value: &debug.dontfreezetheworld},
 	{name: "checkfinalizers", value: &debug.checkfinalizers},
 	{name: "efence", value: &debug.efence},
+	{name: "epollpwait2", value: &debug.epollpwait2},
 	{name: "gccheckmark", value: &debug.gccheckmark},
 	{name: "gcpacertrace", value: &debug.gcpacertrace},
 	{name: "gcshrinkstackoff", value: &debug.gcshrinkstackoff},

--- a/src/time/sleep_test.go
+++ b/src/time/sleep_test.go
@@ -976,10 +976,19 @@ func BenchmarkStaggeredTickerLatency(b *testing.B) {
 		b.Skip("skipping with GOMAXPROCS < 2 or NumCPU < GOMAXPROCS")
 	}
 
-	const delay = 3 * Millisecond
+	type tickerCase struct {
+		delay   Duration
+		workDur Duration
+	}
+	cases := []tickerCase{
+		{300 * Microsecond, 30 * Microsecond},
+		{3 * Millisecond, 300 * Microsecond},
+		{3 * Millisecond, 2 * Millisecond},
+	}
 
-	for _, dur := range []Duration{300 * Microsecond, 2 * Millisecond} {
-		b.Run(fmt.Sprintf("work-dur=%s", dur), func(b *testing.B) {
+	for _, tc := range cases {
+		delay, dur := tc.delay, tc.workDur
+		b.Run(fmt.Sprintf("delay=%s/work-dur=%s", delay, dur), func(b *testing.B) {
 			for tickersPerP := 1; tickersPerP < int(delay/dur)+1; tickersPerP++ {
 				tickerCount := gmp * tickersPerP
 				b.Run(fmt.Sprintf("tickers-per-P=%d", tickersPerP), func(b *testing.B) {


### PR DESCRIPTION
runtime: add opt-in epoll_pwait2 for sub-ms netpoll timeouts

epoll_wait only supports millisecond timeout granularity, requiring
the runtime to round positive delays below 1 ms up to 1 ms. This can
cause sub-millisecond deadlines and timers to overshoot by hundreds
of microseconds.

Use epoll_pwait2 when available (Linux 5.11+) to let netpoll wait
with nanosecond-resolution timeouts instead of epoll_wait's
millisecond-rounded ones. The feature is disabled by default and can
be enabled with GODEBUG=epollpwait2=1.

With this little program:

	package main

	import (
		"fmt"
		"time"

		"github.com/loov/hrtime"
	)

	func main() {
		b := hrtime.NewBenchmark(100)
		for b.Next() {
			time.Sleep(50 * time.Microsecond)
		}
		fmt.Println(b.Histogram(10))
	}

before (GODEBUG=epollpwait2=0, the default):

	avg 1ms;  min 1ms;  p50 1ms;  max 1.03ms;

after (GODEBUG=epollpwait2=1):

	avg 53.8µs;  min 51.9µs;  p50 52.7µs;  max 65.6µs;

Giving every timer its own precise wakeup also removes the coalescing
that millisecond rounding provided. This CL recovers that batching by
rounding the epoll_pwait2 timeout up to the nearest bucket boundary
before the syscall: timers whose rounded deadlines land in the same
bucket share a single wakeup. Bucket size scales with the delay:

	<  1ms:  10µs buckets
	< 10ms: 100µs buckets
	>= 10ms:  1ms buckets (same as epoll_wait)

The 10µs minimum matches the scheduling latency floor on Linux: any
sleep shorter than ~10µs is delivered at ~10µs regardless of the
requested duration, so finer buckets would claim precision the OS
cannot provide. Delays >= 10ms use the same 1ms rounding that
epoll_wait applies, so programs with only supra-10ms timers see no
change in behavior. The delay is always rounded up so no timer fires
early.

The remaining CPU amplification is bounded to workloads with genuinely
distinct sub-ms deadlines. BenchmarkSpreadSubMsTimers (50 goroutines
sleeping at staggered 20-1000µs intervals, no two in the same 10µs
bucket) measures the worst case. Run with -count=10 -benchtime=3s on
linux/amd64 (AMD Ryzen 9 9950X3D):

	goos: linux
	goarch: amd64
	pkg: runtime
	cpu: AMD Ryzen 9 9950X3D 16-Core Processor
	                     │  epoll_wait   │        epollpwait2=1         │
	                     │    sec/op     │    sec/op       vs base       │
	SpreadSubMsTimers-32   1.064m ± 0%    1.019m ± 0%  -4.22% (p=0.000 n=10)

	                     │ cpu-ns/wakeup │  cpu-ns/wakeup    vs base    │
	SpreadSubMsTimers-32   2.089µ ± 3%    7.182µ ± 2%  +243.86% (p=0.000 n=10)

	                     │  wakeups/s   │   wakeups/s       vs base     │
	SpreadSubMsTimers-32   46.99k ± 0%   49.06k ± 0%  +4.40% (p=0.000 n=10)

	                     │    B/op      │      B/op         vs base     │
	SpreadSubMsTimers-32   6.642Ki ± 0%   6.642Ki ± 0%  ~ (p=0.889 n=10)

	                     │  allocs/op   │   allocs/op       vs base     │
	SpreadSubMsTimers-32    150.0 ± 0%     150.0 ± 0%  ~ (p=1.000 n=10)

The cpu/wakeup cost is 3.4 times higher in this adversarial case
because each goroutine wakes on its own syscall. Wall time improves by
4.22% and throughput by 4.40% because the last goroutine no longer
waits for epoll_wait's 1ms ceiling. Allocations are unaffected;
KernelTimespec is stack-allocated.

Detection first checks the kernel version and then probes for EBADF
on an invalid fd. The extra probe handles seccomp filters, which can
block epoll_pwait2 independently of kernel version, returning EPERM
instead of ENOSYS.

For #53824