### PR TITLE
cmd/go: avoid ImportMap panic for synthetic imports

### DIFF
--- a/src/cmd/go/internal/list/list.go
+++ b/src/cmd/go/internal/list/list.go
@@ -875,30 +875,42 @@ func runList(ctx context.Context, cmd *base.Command, args []string) {
 
 	// Record non-identity import mappings in p.ImportMap.
 	for _, p := range pkgs {
-		nRaw := len(p.Internal.RawImports)
-		for i, path := range p.Imports {
-			var srcPath string
-			if i < nRaw {
-				srcPath = p.Internal.RawImports[i]
-			} else {
-				// This path is not within the raw imports, so it must be an import
-				// found only within CompiledGoFiles. Those paths are found in
-				// CompiledImports.
-				srcPath = p.Internal.CompiledImports[i-nRaw]
-			}
-
-			if path != srcPath {
-				if p.ImportMap == nil {
-					p.ImportMap = make(map[string]string)
-				}
-				p.ImportMap[srcPath] = path
-			}
-		}
+		p.ImportMap = packageImportMap(p.Imports, p.Internal.RawImports, p.Internal.CompiledImports)
 	}
 
 	for _, p := range pkgs {
 		do(&p.PackagePublic)
 	}
+}
+
+func packageImportMap(imports, rawImports, compiledImports []string) map[string]string {
+	var importMap map[string]string
+	compiledStart := len(imports) - len(compiledImports)
+
+	for i, path := range imports {
+		var srcPath string
+		switch {
+		case i < len(rawImports):
+			srcPath = rawImports[i]
+		case i >= compiledStart && i-compiledStart < len(compiledImports):
+			// This path is not within the raw imports, so it must be an import
+			// found only within CompiledGoFiles. Those paths are found at the
+			// end of the package imports list.
+			srcPath = compiledImports[i-compiledStart]
+		default:
+			// Synthetic imports, such as linker-induced dependencies, do not
+			// have a source import path to record in ImportMap.
+			continue
+		}
+
+		if path != srcPath {
+			if importMap == nil {
+				importMap = make(map[string]string)
+			}
+			importMap[srcPath] = path
+		}
+	}
+	return importMap
 }
 
 // loadPackageList is like load.PackageList, but prints error messages and exits

--- a/src/cmd/go/internal/list/list.go
+++ b/src/cmd/go/internal/list/list.go
@@ -928,15 +928,17 @@ func runList(ctx context.Context, cmd *base.Command, args []string) {
 	// Record non-identity import mappings in p.ImportMap.
 	for _, p := range pkgs {
 		nRaw := len(p.Internal.RawImports)
+		nCompiled := len(p.Internal.CompiledImports)
 		for i, path := range p.Imports {
 			var srcPath string
 			if i < nRaw {
 				srcPath = p.Internal.RawImports[i]
+			} else if i < len(p.Imports)-nCompiled {
+				// This is an implicitly added import with no corresponding source path.
+				continue
 			} else {
-				// This path is not within the raw imports, so it must be an import
-				// found only within CompiledGoFiles. Those paths are found in
-				// CompiledImports.
-				srcPath = p.Internal.CompiledImports[i-nRaw]
+				// CompiledImports is 1:1 with the end of Imports.
+				srcPath = p.Internal.CompiledImports[i-(len(p.Imports)-nCompiled)]
 			}
 
 			if path != srcPath {

--- a/src/cmd/go/internal/list/list_test.go
+++ b/src/cmd/go/internal/list/list_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package list
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPackageImportMap(t *testing.T) {
+	tests := []struct {
+		name            string
+		imports         []string
+		rawImports      []string
+		compiledImports []string
+		want            map[string]string
+	}{
+		{
+			name:       "raw import",
+			imports:    []string{"vendor/foo", "bar"},
+			rawImports: []string{"foo", "bar"},
+			want:       map[string]string{"foo": "vendor/foo"},
+		},
+		{
+			name:            "compiled import",
+			imports:         []string{"sync [runtime.test]", "runtime/cgo [runtime.test]"},
+			rawImports:      []string{"sync"},
+			compiledImports: []string{"runtime/cgo"},
+			want: map[string]string{
+				"sync":        "sync [runtime.test]",
+				"runtime/cgo": "runtime/cgo [runtime.test]",
+			},
+		},
+		{
+			name:            "synthetic import before compiled imports",
+			imports:         []string{"resolved/a", "runtime", "runtime/cgo [runtime.test]"},
+			rawImports:      []string{"a"},
+			compiledImports: []string{"runtime/cgo"},
+			want: map[string]string{
+				"a":           "resolved/a",
+				"runtime/cgo": "runtime/cgo [runtime.test]",
+			},
+		},
+		{
+			name:       "synthetic import without compiled imports",
+			imports:    []string{"testing", "runtime"},
+			rawImports: []string{"testing"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := packageImportMap(tt.imports, tt.rawImports, tt.compiledImports)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("packageImportMap(%q, %q, %q) = %v; want %v", tt.imports, tt.rawImports, tt.compiledImports, got, tt.want)
+			}
+		})
+	}
+}

--- a/src/cmd/go/testdata/script/list_importmap_implicit.txt
+++ b/src/cmd/go/testdata/script/list_importmap_implicit.txt
@@ -1,0 +1,9 @@
+# Exercise go list with a test variant that gains an implicit SIMD bridge
+# import. This used to panic while constructing ImportMap (golang.org/issue/79749).
+
+env GOOS=linux
+env GOARCH=amd64
+env CGO_ENABLED=0
+env GOEXPERIMENT=simd
+
+go list -compiled -test simd


### PR DESCRIPTION
The ImportMap construction assumed that every import path after RawImports was backed by CompiledImports.
Some packages can also contain synthetic imports that have no source import string, so go list could index past CompiledImports while preparing ImportMap.

Match raw imports from the front of Imports and compiled imports from the end, and skip imports that have no source or compiled-file counterpart.
This preserves ImportMap entries for rewritten source imports and compiled imports while avoiding the panic.

Fixes #79749