### PR TITLE
archive/tar: test tarinsecurepath behavior for link targets

### DIFF
--- a/src/archive/tar/reader.go
+++ b/src/archive/tar/reader.go
@@ -46,9 +46,9 @@ func NewReader(r io.Reader) *Reader {
 // At the end of the archive, Next returns the error io.EOF.
 //
 // If Next encounters a non-local file name (as defined by [filepath.IsLocal])
-// and the GODEBUG environment variable contains `tarinsecurepath=0`,
+// and the GODEBUG environment variable contains `tarinsecurepath=0`, Next
+// returns the header with an [ErrInsecurePath] error.
 // Only file names are validated, not link targets.
-// Next returns the header with an [ErrInsecurePath] error.
 // A future version of Go may introduce this behavior by default.
 // Programs that want to accept non-local names can ignore
 // the [ErrInsecurePath] error and use the returned header.

--- a/src/archive/tar/reader_test.go
+++ b/src/archive/tar/reader_test.go
@@ -1684,6 +1684,51 @@ func TestInsecurePaths(t *testing.T) {
 	}
 }
 
+func TestInsecureLinknames(t *testing.T) {
+	t.Setenv("GODEBUG", "tarinsecurepath=0")
+	for _, test := range []struct {
+		name     string
+		typeflag byte
+		linkname string
+	}{
+		{
+			name:     "hardlink",
+			typeflag: TypeLink,
+			linkname: "../target",
+		},
+		{
+			name:     "symlink",
+			typeflag: TypeSymlink,
+			linkname: "/target",
+		},
+	} {
+		var buf bytes.Buffer
+		tw := NewWriter(&buf)
+		if err := tw.WriteHeader(&Header{
+			Name:     test.name,
+			Typeflag: test.typeflag,
+			Linkname: test.linkname,
+		}); err != nil {
+			t.Fatalf("WriteHeader(%s): %v", test.name, err)
+		}
+		if err := tw.Close(); err != nil {
+			t.Fatalf("Close(%s): %v", test.name, err)
+		}
+
+		tr := NewReader(&buf)
+		h, err := tr.Next()
+		if err != nil {
+			t.Fatalf("Next(%s): got err %v, want nil", test.name, err)
+		}
+		if h.Name != test.name {
+			t.Errorf("Next(%s): got name %q, want %q", test.name, h.Name, test.name)
+		}
+		if h.Linkname != test.linkname {
+			t.Errorf("Next(%s): got linkname %q, want %q", test.name, h.Linkname, test.linkname)
+		}
+	}
+}
+
 func TestDisableInsecurePathCheck(t *testing.T) {
 	t.Setenv("GODEBUG", "tarinsecurepath=1")
 	var buf bytes.Buffer


### PR DESCRIPTION
Clarify the Reader.Next documentation for tarinsecurepath=0 and add
regression coverage for link targets.

The tarinsecurepath check reports ErrInsecurePath for non-local Header.Name
values, but it does not validate Header.Linkname. That distinction matters for
archive consumers that use archive/tar as part of extraction or policy
enforcement: link targets need to be handled by the extractor's own filesystem
policy.

This change preserves the current behavior. It rewords the Reader.Next comment
so the ErrInsecurePath behavior reads directly, keeps the existing statement
that only file names are validated, and adds tests for TypeLink and TypeSymlink
entries with non-local link targets while GODEBUG=tarinsecurepath=0.

The new test confirms that the tarinsecurepath check applies to the entry name
and not to the link target. This should help prevent future regressions or
ambiguous assumptions around link handling in archive/tar readers.

No issue: this is a documentation and test clarification for existing behavior.

Tests:
- go_bootstrap.exe test archive/tar
- go_bootstrap.exe test archive/...

Review requested. Please let me know if this should be adjusted to emphasize
the test coverage only, or if there is a preferred wording for the Reader.Next
documentation.