### PR TITLE
net/http: do not copy Proxy-Authorization on redirects

### DIFF
--- a/src/net/http/client.go
+++ b/src/net/http/client.go
@@ -823,8 +823,11 @@ func (c *Client) makeHeadersCopier(ireq *Request) func(req *Request, stripSensit
 			sensitive := false
 			body := false
 			switch CanonicalHeaderKey(k) {
+			case "Proxy-Authorization":
+				continue
+
 			case "Authorization", "Www-Authenticate", "Cookie", "Cookie2",
-				"Proxy-Authorization", "Proxy-Authenticate":
+				"Proxy-Authenticate":
 				sensitive = true
 
 			case "Content-Encoding", "Content-Language", "Content-Location",

--- a/src/net/http/client_test.go
+++ b/src/net/http/client_test.go
@@ -1576,6 +1576,56 @@ func testClientCopyHeadersOnRedirect(t *testing.T, mode testMode) {
 	}
 }
 
+// Proxy-Authorization is scoped to the proxy connection, so the client
+// should not copy a caller-supplied value when constructing redirect requests.
+func TestClientStripProxyAuthorizationOnRedirect(t *testing.T) {
+	run(t, testClientStripProxyAuthorizationOnRedirect, http3SkippedMode)
+}
+func testClientStripProxyAuthorizationOnRedirect(t *testing.T, mode testMode) {
+	var proto string
+	ts := newClientServerTest(t, mode, HandlerFunc(func(w ResponseWriter, r *Request) {
+		switch r.Host + r.URL.Path {
+		case "example.com/":
+			if h := r.Header.Get("Proxy-Authorization"); h != "secretpassword" {
+				t.Errorf("initial request Proxy-Authorization=%q, want secretpassword", h)
+			}
+			Redirect(w, r, proto+"://sub.example.com/redirect", StatusFound)
+		case "sub.example.com/redirect":
+			if h := r.Header.Get("Authorization"); h != "secretpassword" {
+				t.Errorf("redirected request Authorization=%q, want secretpassword", h)
+			}
+			if h := r.Header.Get("Cookie"); h != "foo=bar" {
+				t.Errorf("redirected request Cookie=%q, want foo=bar", h)
+			}
+			if h := r.Header.Get("Proxy-Authorization"); h != "" {
+				t.Errorf("redirected request Proxy-Authorization=%q, want no header", h)
+			}
+			w.Header().Set("X-Done", "true")
+		default:
+			t.Errorf("unexpected request to %v%v", r.Host, r.URL.Path)
+		}
+	})).ts
+	proto, _, _ = strings.Cut(ts.URL, ":")
+
+	c := ts.Client()
+	c.Transport.(*Transport).Dial = func(_ string, _ string) (net.Conn, error) {
+		return net.Dial("tcp", ts.Listener.Addr().String())
+	}
+
+	req, _ := NewRequest("GET", proto+"://example.com/", nil)
+	req.Header.Add("Cookie", "foo=bar")
+	req.Header.Add("Authorization", "secretpassword")
+	req.Header.Add("Proxy-Authorization", "secretpassword")
+	res, err := c.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.Header.Get("X-Done") != "true" {
+		t.Fatalf("response missing expected header: X-Done=true")
+	}
+}
+
 // Issue #70530: Once we strip a header on a redirect to a different host,
 // the header should stay stripped across any further redirects.
 func TestClientStripHeadersOnRepeatedRedirect(t *testing.T) {


### PR DESCRIPTION
This change stops http.Client redirect handling from copying
caller-supplied Proxy-Authorization headers onto redirect requests.

Proxy-Authorization authenticates the client to a proxy. It is scoped to
the proxy hop, not to the origin server. That makes it different from
origin-scoped headers such as Authorization and Cookie, which keep their
existing same-site redirect behavior in this change.

Transport-injected proxy credentials from proxy URL userinfo are unchanged.
Those credentials are still added per selected proxy connection by the
transport, rather than inherited from an earlier request.

Issue #79792 describes a same-site redirect case where a caller-supplied
Proxy-Authorization header can be copied to a redirected request. If the
redirected hop is sent directly because proxy selection changes, the direct
origin can receive a credential intended for the proxy.

This CL keeps the scope narrow. It skips Proxy-Authorization in the
redirect header copier, adds a regression test for a same-site subdomain
redirect, and verifies that Authorization and Cookie are still preserved
there. Broader 307 and 308 body and custom-header behavior is intentionally
left out of scope.

Callers that intentionally need Proxy-Authorization on a redirected request
can still add it in CheckRedirect.

Tests: repo-local bootstrap toolchain, net/http package tests.

Please review whether always dropping caller-supplied Proxy-Authorization
on redirects is the right compatibility tradeoff.

Fixes #79792
