### PR TITLE
net/http/internal/http2: optimize Date header generation

### DIFF
--- a/src/net/http/internal/http2/cached_date.go
+++ b/src/net/http/internal/http2/cached_date.go
@@ -1,0 +1,30 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package http2
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+type dateCache struct {
+	sec int64
+	str string
+}
+
+var globalDateCache atomic.Pointer[dateCache]
+
+// cachedDate returns the current time in [TimeFormat], updating at most once
+// per UTC second. The returned string is shared and must not be mutated.
+func cachedDate() string {
+	now := time.Now()
+	sec := now.Unix()
+	if c := globalDateCache.Load(); c != nil && c.sec == sec {
+		return c.str
+	}
+	s := now.UTC().Format(TimeFormat)
+	globalDateCache.Store(&dateCache{sec: sec, str: s})
+	return s
+}

--- a/src/net/http/internal/http2/cached_date_test.go
+++ b/src/net/http/internal/http2/cached_date_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package http2
+
+import (
+	"testing"
+	"time"
+)
+
+// restoreGlobalDateCache saves globalDateCache and restores it when t finishes.
+// These tests mutate package-global state and must not call t.Parallel().
+func restoreGlobalDateCache(t *testing.T) {
+	t.Helper()
+	orig := globalDateCache.Load()
+	t.Cleanup(func() {
+		globalDateCache.Store(orig)
+	})
+}
+
+func TestCachedDate(t *testing.T) {
+	restoreGlobalDateCache(t)
+
+	// Warm the cache so consecutive calls compare against a populated entry.
+	cachedDate()
+
+	d1 := cachedDate()
+	d2 := cachedDate()
+
+	if _, err := time.Parse(TimeFormat, d1); err != nil {
+		t.Fatalf("d1 = %q not a valid date: %v", d1, err)
+	}
+	if _, err := time.Parse(TimeFormat, d2); err != nil {
+		t.Fatalf("d2 = %q not a valid date: %v", d2, err)
+	}
+
+	// Allow up to 3 seconds of scheduling delay to avoid flaky failures in CI.
+	now := time.Now().UTC()
+	matched := false
+	for i := 0; i <= 3; i++ {
+		want := now.Add(-time.Duration(i) * time.Second).Format(TimeFormat)
+		if d2 == want {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		t.Fatalf("cachedDate() = %q; want a formatted time within 3 seconds before %q", d2, now.Format(TimeFormat))
+	}
+}
+
+func TestCachedDateUpdatesAfterExpiry(t *testing.T) {
+	restoreGlobalDateCache(t)
+
+	staleSec := time.Now().Unix() - 10
+	const stale = "stale"
+	globalDateCache.Store(&dateCache{sec: staleSec, str: stale})
+
+	got := cachedDate()
+
+	if got == stale {
+		t.Fatal("cachedDate did not refresh stale cache")
+	}
+	if _, err := time.Parse(TimeFormat, got); err != nil {
+		t.Fatalf("cachedDate() = %q: %v", got, err)
+	}
+
+	c := globalDateCache.Load()
+	if c == nil {
+		t.Fatal("globalDateCache does not contain a dateCache")
+	}
+	if c.str == stale {
+		t.Fatal("expected cached date to update after expiry")
+	}
+	if c.sec <= staleSec {
+		t.Fatalf("expected refreshed cache sec (%d) to be newer than stale sec (%d)", c.sec, staleSec)
+	}
+}
+
+func TestCachedDateInitializesWhenEmpty(t *testing.T) {
+	restoreGlobalDateCache(t)
+
+	// Use nil to represent the empty/initial state for atomic.Pointer
+	globalDateCache.Store(nil)
+
+	got := cachedDate()
+
+	if got == "" {
+		t.Fatal("cachedDate returned empty string on cold start")
+	}
+	if _, err := time.Parse(TimeFormat, got); err != nil {
+		t.Fatalf("cachedDate() = %q: %v", got, err)
+	}
+
+	c := globalDateCache.Load()
+	if c == nil {
+		t.Fatal("globalDateCache does not contain a dateCache after cold start")
+	}
+	if c.str == "" {
+		t.Fatal("expected cached date to be populated after cold start")
+	}
+	if c.sec == 0 {
+		t.Fatalf("expected initialized cache sec to be non-zero, got %d", c.sec)
+	}
+}

--- a/src/net/http/internal/http2/server.go
+++ b/src/net/http/internal/http2/server.go
@@ -2588,8 +2588,7 @@ func (rws *responseWriterState) writeChunk(p []byte) (n int, err error) {
 		}
 		var date string
 		if _, ok := rws.snapHeader["Date"]; !ok {
-			// TODO(bradfitz): be faster here, like net/http? measure.
-			date = time.Now().UTC().Format(TimeFormat)
+			date = cachedDate()
 		}
 
 		for _, v := range rws.snapHeader["Trailer"] {


### PR DESCRIPTION
Replace the per-request time.Now().UTC().Format() call
in writeChunk with a cached string that updates at most
once per UTC second.

This eliminates redundant time formatting overhead in
high-concurrency HTTP/2 workloads by using an atomic
cache for the formatted date string.

Fixes #79914