### PR TITLE
runtime: fix softfloat64 add/sub for normal operands cancelling to subnormal

### DIFF
--- a/src/runtime/softfloat64.go
+++ b/src/runtime/softfloat64.go
@@ -91,7 +91,6 @@ func funpack32(f uint32) (sign, mant uint32, exp int, inf, nan bool) {
 }
 
 func fpack64(sign, mant uint64, exp int, trunc uint64) uint64 {
-	mant0, exp0, trunc0 := mant, exp, trunc
 	if mant == 0 {
 		return sign
 	}
@@ -99,6 +98,11 @@ func fpack64(sign, mant uint64, exp int, trunc uint64) uint64 {
 		mant <<= 1
 		exp--
 	}
+	// Save the normalized mantissa; the denormal path below restores it and
+	// re-aligns to the subnormal exponent. Saving before this loop (as the
+	// code originally did) left a heavily-cancelled add/sub mantissa
+	// un-normalized, which that path then shifted the wrong way. See #79964.
+	mant0, exp0, trunc0 := mant, exp, trunc
 	for mant >= 4<<mantbits64 {
 		trunc |= mant & 1
 		mant >>= 1
@@ -124,17 +128,6 @@ func fpack64(sign, mant uint64, exp int, trunc uint64) uint64 {
 		}
 		// repeat expecting denormal
 		mant, exp, trunc = mant0, exp0, trunc0
-		// Re-normalize the mantissa before aligning it to the subnormal
-		// exponent. When the caller passed a mantissa that was heavily
-		// cancelled (fadd64 subtracting two near-equal operands), mant0 can be
-		// far below 1<<mantbits64 while exp0 is still a normal-range exponent;
-		// without this the loop below would shift right (the wrong direction)
-		// and return a wrongly scaled subnormal. No-op for already-normalized
-		// callers (fmul64/fdiv64/conversions).
-		for mant < 1<<mantbits64 {
-			mant <<= 1
-			exp--
-		}
 		for exp < bias64 {
 			trunc |= mant & 1
 			mant >>= 1
@@ -153,7 +146,6 @@ func fpack64(sign, mant uint64, exp int, trunc uint64) uint64 {
 }
 
 func fpack32(sign, mant uint32, exp int, trunc uint32) uint32 {
-	mant0, exp0, trunc0 := mant, exp, trunc
 	if mant == 0 {
 		return sign
 	}
@@ -161,6 +153,8 @@ func fpack32(sign, mant uint32, exp int, trunc uint32) uint32 {
 		mant <<= 1
 		exp--
 	}
+	// See fpack64: save the normalized mantissa for the denormal path below.
+	mant0, exp0, trunc0 := mant, exp, trunc
 	for mant >= 4<<mantbits32 {
 		trunc |= mant & 1
 		mant >>= 1
@@ -186,11 +180,6 @@ func fpack32(sign, mant uint32, exp int, trunc uint32) uint32 {
 		}
 		// repeat expecting denormal
 		mant, exp, trunc = mant0, exp0, trunc0
-		// Re-normalize before aligning to the subnormal exponent; see fpack64.
-		for mant < 1<<mantbits32 {
-			mant <<= 1
-			exp--
-		}
 		for exp < bias32 {
 			trunc |= mant & 1
 			mant >>= 1

--- a/src/runtime/softfloat64.go
+++ b/src/runtime/softfloat64.go
@@ -124,6 +124,17 @@ func fpack64(sign, mant uint64, exp int, trunc uint64) uint64 {
 		}
 		// repeat expecting denormal
 		mant, exp, trunc = mant0, exp0, trunc0
+		// Re-normalize the mantissa before aligning it to the subnormal
+		// exponent. When the caller passed a mantissa that was heavily
+		// cancelled (fadd64 subtracting two near-equal operands), mant0 can be
+		// far below 1<<mantbits64 while exp0 is still a normal-range exponent;
+		// without this the loop below would shift right (the wrong direction)
+		// and return a wrongly scaled subnormal. No-op for already-normalized
+		// callers (fmul64/fdiv64/conversions).
+		for mant < 1<<mantbits64 {
+			mant <<= 1
+			exp--
+		}
 		for exp < bias64 {
 			trunc |= mant & 1
 			mant >>= 1
@@ -175,6 +186,11 @@ func fpack32(sign, mant uint32, exp int, trunc uint32) uint32 {
 		}
 		// repeat expecting denormal
 		mant, exp, trunc = mant0, exp0, trunc0
+		// Re-normalize before aligning to the subnormal exponent; see fpack64.
+		for mant < 1<<mantbits32 {
+			mant <<= 1
+			exp--
+		}
 		for exp < bias32 {
 			trunc |= mant & 1
 			mant >>= 1

--- a/src/runtime/softfloat64_test.go
+++ b/src/runtime/softfloat64_test.go
@@ -40,6 +40,10 @@ func TestFloat64(t *testing.T) {
 		1.3333333333333333,     // 1.010101010101...
 		1.1428571428571428,     // 1.001001001001...
 		1.112536929253601e-308, // first normal
+		// Two near-equal opposite-sign normals whose sum cancels into a
+		// subnormal; exercises the fpack64 denormal path.
+		math.Float64frombits(9333378022939403091),
+		math.Float64frombits(110005986185704326),
 		2,
 		4,
 		8,

--- a/src/runtime/softfloat64_test.go
+++ b/src/runtime/softfloat64_test.go
@@ -36,14 +36,12 @@ func TestFloat64(t *testing.T) {
 		math.Inf(-1),
 		0.1,
 		1.5,
-		1.9999999999999998,     // all 1s mantissa
-		1.3333333333333333,     // 1.010101010101...
-		1.1428571428571428,     // 1.001001001001...
-		1.112536929253601e-308, // first normal
-		// Two near-equal opposite-sign normals whose sum cancels into a
-		// subnormal; exercises the fpack64 denormal path.
-		math.Float64frombits(9333378022939403091),
-		math.Float64frombits(110005986185704326),
+		1.9999999999999998,      // all 1s mantissa
+		1.3333333333333333,      // 1.010101010101...
+		1.1428571428571428,      // 1.001001001001...
+		1.112536929253601e-308,  // first normal
+		-2.662107816930723e-301, // #79964: two near-equal opposite-sign
+		2.662107858822336e-301,  // normals cancelling to a subnormal
 		2,
 		4,
 		8,


### PR DESCRIPTION
When fadd64/fsub64 cancel two near-equal, opposite-sign normal operands
into a subnormal result, fpack64 is handed a mantissa far below
1<<mantbits64 while exp is still a normal-range exponent. fpack64 saved
mant0/exp0/trunc0 before its normalization loop, so the denormal branch
restored an un-normalized mantissa and right-shifted it to align to the
subnormal exponent (the wrong direction here), returning the
un-normalized cancellation mantissa at the wrong scale instead of the
correctly rounded subnormal.

Save mant0/exp0/trunc0 after the normalization loop so the denormal path
restores a normalized mantissa and aligns correctly. This is a no-op for
callers that already pass a normalized mantissa (fmul64, fdiv64,
conversions). fpack32 is updated identically for parity, though its
denormal branch is not reachable with an un-normalized mantissa through
any current caller.

This only manifests on softfloat targets (e.g. GOMIPS=softfloat), which
is why it has gone unnoticed on hardware-float platforms. A randomized
differential check against hardware found the previous code wrong on
>50% of normal pairs that cancel into a subnormal; with this change
those cases match hardware.

Fixes #79964
