### PR TITLE
crypto/tls: only set LocalCertificate when a certificate is presented

### DIFF
--- a/src/crypto/tls/handshake_server.go
+++ b/src/crypto/tls/handshake_server.go
@@ -280,10 +280,6 @@ func (hs *serverHandshakeState) processClientHello() error {
 		return err
 	}
 
-	if hs.cert != nil {
-		hs.c.localCertificate = hs.cert.Certificate
-	}
-
 	if hs.clientHello.scts {
 		hs.hello.scts = hs.cert.SignedCertificateTimestamps
 	}
@@ -618,6 +614,10 @@ func (hs *serverHandshakeState) doFullHandshake() error {
 
 	certMsg := new(certificateMsg)
 	certMsg.certificates = hs.cert.Certificate
+	// Set localCertificate here, rather than at certificate selection time, so
+	// that it is only populated when a certificate is actually presented to the
+	// peer, and not on resumed connections.
+	c.localCertificate = hs.cert.Certificate
 	if _, err := hs.c.writeHandshakeRecord(certMsg, &hs.finishedHash); err != nil {
 		return err
 	}

--- a/src/crypto/tls/tls_test.go
+++ b/src/crypto/tls/tls_test.go
@@ -2953,6 +2953,9 @@ func testLocalCertificate(t *testing.T, version uint16, callback bool) {
 
 	clientConfig.MinVersion, serverConfig.MinVersion = version, version
 	clientConfig.MaxVersion, serverConfig.MaxVersion = version, version
+	if version < VersionTLS12 {
+		skipFIPS(t)
+	}
 	serverConfig.ClientAuth = RequestClientCert
 
 	serverCert, clientCert := testConfigServer.Certificates[0], testConfigClient.Certificates[0]
@@ -3009,6 +3012,9 @@ func testLocalCertificateResumption(t *testing.T, version uint16, callback bool)
 
 	clientConfig.MinVersion, serverConfig.MinVersion = version, version
 	clientConfig.MaxVersion, serverConfig.MaxVersion = version, version
+	if version < VersionTLS12 {
+		skipFIPS(t)
+	}
 	clientConfig.ClientSessionCache = NewLRUClientSessionCache(1)
 	serverConfig.ClientAuth = RequestClientCert
 

--- a/src/crypto/tls/tls_test.go
+++ b/src/crypto/tls/tls_test.go
@@ -2952,6 +2952,7 @@ func testLocalCertificate(t *testing.T, version uint16, callback bool) {
 	clientConfig, serverConfig := testConfigClient.Clone(), testConfigServer.Clone()
 
 	clientConfig.MinVersion, serverConfig.MinVersion = version, version
+	clientConfig.MaxVersion, serverConfig.MaxVersion = version, version
 	serverConfig.ClientAuth = RequestClientCert
 
 	serverCert, clientCert := testConfigServer.Certificates[0], testConfigClient.Certificates[0]
@@ -3007,6 +3008,7 @@ func testLocalCertificateResumption(t *testing.T, version uint16, callback bool)
 	clientConfig, serverConfig := testConfigClient.Clone(), testConfigServer.Clone()
 
 	clientConfig.MinVersion, serverConfig.MinVersion = version, version
+	clientConfig.MaxVersion, serverConfig.MaxVersion = version, version
 	clientConfig.ClientSessionCache = NewLRUClientSessionCache(1)
 	serverConfig.ClientAuth = RequestClientCert
 


### PR DESCRIPTION
ConnectionState.LocalCertificate is documented to be populated only for
connections which are not resumed. However, the TLS 1.0-1.2 server
handshake set it in processClientHello, which runs before
checkForResumption, and nothing cleared it on the abbreviated handshake
path. Resumed pre-1.3 server connections therefore reported a
certificate chain that was never presented to the peer (also visible to
VerifyConnection and WrapSession during the handshake).

Set the field in doFullHandshake, where the Certificate message is
actually written, so it is populated if and only if a chain was
presented. TLS 1.3 is unaffected because pickCertificate already returns
early for PSK resumption.

Also pin MaxVersion in TestLocalCertificate and
TestLocalCertificateResumption: they previously set only MinVersion, so
every pre-1.3 subtest silently negotiated TLS 1.3 and the broken path
had no coverage. With MaxVersion pinned, the resumption test fails
without this fix at TLS 1.0-1.2.

Verified: strengthened resumption test fails on unpatched master at TLS
1.0/1.1/1.2 and passes with the fix; full `go test crypto/tls` passes;
standalone repro from the issue prints len(LocalCertificate)=0 for
resumed TLS 1.2 connections.

Fixes #79967