### PR TITLE
internal/bytealg: optimize indexbyte_riscv64.s

### DIFF
--- a/src/internal/bytealg/indexbyte_riscv64.s
+++ b/src/internal/bytealg/indexbyte_riscv64.s
@@ -13,6 +13,11 @@ TEXT ·IndexByte<ABIInternal>(SB),NOSPLIT,$0-40
 	// X13 = byte to find
 	AND	$0xff, X13, X12		// x12 byte to look for
 
+#ifdef EnableSmallSizeMemVector
+	JMP	indexByteVector<>(SB)
+#endif
+
+#ifndef EnableSmallSizeMemVector
 	SLTI	$24, X11, X14
 	BNEZ	X14, small
 	JMP	indexByteBig<>(SB)
@@ -33,6 +38,7 @@ loop:
 notfound:
 	MOV	$-1, X10
 	RET
+#endif
 
 TEXT ·IndexByteString<ABIInternal>(SB),NOSPLIT,$0-32
 	// X10 = b_base
@@ -40,6 +46,11 @@ TEXT ·IndexByteString<ABIInternal>(SB),NOSPLIT,$0-32
 	// X12 = byte to find
 	AND	$0xff, X12		// x12 byte to look for
 
+#ifdef EnableSmallSizeMemVector
+	JMP	indexByteVector<>(SB)
+#endif
+
+#ifndef EnableSmallSizeMemVector
 	SLTI	$24, X11, X14
 	BNEZ	X14, small
 	JMP	indexByteBig<>(SB)
@@ -55,6 +66,62 @@ loop:
 	BNE	X12, X14, loop
 
 	SUB	X13, X10		// remove base
+	RET
+
+notfound:
+	MOV	$-1, X10
+	RET
+#endif
+
+TEXT indexByteVector<>(SB),NOSPLIT|NOFRAME,$0
+	// On entry:
+	// X10 = b_base
+	// X11 = b_len
+	// X12 = byte to find
+	// On exit:
+	// X10 = index of first instance of sought byte, if found, or -1 otherwise
+
+	MOV $16, X13
+#ifdef VLen_256
+	SLLI	$1, X13
+#endif
+#ifdef VLen_512
+	SLLI	$2, X13
+#endif
+	BGEU	X13, X11, vector_single
+	SLLI	$1, X13
+	BGEU	X13, X11, vector_double
+	SLLI	$1, X13
+	BGEU	X13, X11, vector_quarter
+	JMP	indexByteBig<>(SB)
+
+// 1..(vlen) bytes
+	PCALIGN	$16
+vector_single:
+	VSETVLI	X11, E8, M1, TA, MA, X5
+	JMP vector
+
+// (vlen+1)..(2*vlen) bytes
+	PCALIGN	$16
+vector_double:
+	VSETVLI	X11, E8, M2, TA, MA, X5
+	JMP vector
+
+// (2*vlen+1)..(4*vlen) bytes
+	PCALIGN	$16
+vector_quarter:
+	VSETVLI	X11, E8, M4, TA, MA, X5
+	JMP vector
+
+vector:
+	VLE8V	(X10), V8
+	VMSEQVX	X12, V8, V0
+	VFIRSTM	V0, X6
+	BGEZ	X6, found
+	JMP	notfound
+
+found:
+	MOV	X6, X10
 	RET
 
 notfound:
@@ -93,6 +160,7 @@ vector_found:
 	ADD	X6, X10
 	RET
 
+#ifndef hasV
 indexbyte_scalar:
 	ADD	X10, X11		// end
 
@@ -155,7 +223,7 @@ loop:
 found:
 	SUB	X13, X10		// remove base
 	RET
+#endif
 
 notfound:
 	MOV	$-1, X10
-	RET


### PR DESCRIPTION
Implement vectorization optimization for indexbyte.

goos: linux
goarch: riscv64
cpu: SG2044
pkg: bytes
                      │ sg_old.txt  │             sg_new.txt             │
                      │   sec/op    │   sec/op     vs base               │
IndexByte/10            15.21n ± 1%   14.34n ± 4%   -5.72% (p=0.002 n=6)
IndexByte/32            17.45n ± 0%   13.94n ± 6%  -20.09% (p=0.002 n=6)
IndexByte/4K            187.1n ± 0%   187.4n ± 0%        ~ (p=0.286 n=6)
IndexByte/4M            697.2µ ± 1%   683.7µ ± 0%   -1.93% (p=0.002 n=6)
IndexByte/64M           2.951m ± 1%   2.922m ± 0%   -0.99% (p=0.002 n=6)
IndexBytePortable/10    25.79n ± 1%   24.75n ± 2%   -4.07% (p=0.002 n=6)
IndexBytePortable/32    47.37n ± 1%   48.33n ± 0%   +2.03% (p=0.002 n=6)
IndexBytePortable/4K    4.798µ ± 1%   4.757µ ± 0%   -0.86% (p=0.048 n=6)
IndexBytePortable/4M    4.893m ± 1%   4.870m ± 0%        ~ (p=0.310 n=6)
IndexBytePortable/64M   78.17m ± 0%   78.06m ± 0%        ~ (p=0.394 n=6)
geomean                 6.855µ        6.621µ        -3.41%

                      │  sg_old.txt  │             sg_new.txt              │
                      │     B/s      │     B/s       vs base               │
IndexByte/10            627.1Mi ± 1%   665.2Mi ± 4%   +6.07% (p=0.002 n=6)
IndexByte/32            1.708Gi ± 0%   2.137Gi ± 6%  +25.16% (p=0.002 n=6)
IndexByte/4K            20.39Gi ± 0%   20.35Gi ± 0%        ~ (p=0.394 n=6)
IndexByte/4M            5.603Gi ± 1%   5.713Gi ± 0%   +1.97% (p=0.002 n=6)
IndexByte/64M           21.18Gi ± 1%   21.39Gi ± 0%   +1.00% (p=0.002 n=6)
IndexBytePortable/10    369.7Mi ± 1%   385.4Mi ± 2%   +4.24% (p=0.002 n=6)
IndexBytePortable/32    644.2Mi ± 1%   631.5Mi ± 0%   -1.98% (p=0.002 n=6)
IndexBytePortable/4K    814.1Mi ± 1%   821.1Mi ± 0%        ~ (p=0.058 n=6)
IndexBytePortable/4M    817.6Mi ± 1%   821.3Mi ± 0%        ~ (p=0.310 n=6)
IndexBytePortable/64M   818.8Mi ± 0%   819.8Mi ± 0%        ~ (p=0.394 n=6)
geomean                 1.764Gi        1.826Gi        +3.53%