### PR TITLE
internal/bytealg: optimize memequal

### DIFF
--- a/src/internal/bytealg/equal_riscv64.s
+++ b/src/internal/bytealg/equal_riscv64.s
@@ -26,14 +26,17 @@ TEXT runtime·memequal<ABIInternal>(SB),NOSPLIT|NOFRAME,$0-25
 length_check:
 	BEQZ	X12, done
 
+#ifndef EnableSmallSizeMemVector
 	MOV	$32, X23
 	BLT	X12, X23, loop4_check
+#endif
 
 #ifndef hasV
 	MOVB	internal∕cpu·RISCV64+const_offsetRISCV64HasV(SB), X5
 	BEQZ	X5, equal_scalar
 #endif
 
+#ifndef EnableSmallSizeMemVector
 	// Use vector if not 8 byte aligned.
 	OR	X10, X11, X5
 	AND	$7, X5
@@ -42,7 +45,52 @@ length_check:
 	// Use scalar if 8 byte aligned and <= 64 bytes.
 	SUB	$64, X12, X6
 	BLEZ	X6, loop32_check
+#endif
 
+#ifdef EnableSmallSizeMemVector
+f_vector_dispatch:
+	MOV $16, X6
+#ifdef VLen_256
+	SLLI	$1, X6
+#endif
+#ifdef VLen_512
+	SLLI	$2, X6
+#endif
+	BGEU	X6, X12, vector_single
+	SLLI	$2, X6
+	BGTU	X12, X6, vector_loop
+	SRLI	$1, X6
+	BGTU	X12, X6, vector_quarter
+
+// (vlen+1)..(2*vlen) bytes
+	PCALIGN	$16
+vector_double:
+	VSETVLI	X12, E8, M2, TA, MA, X5
+	JMP vector
+
+// 1..(vlen) bytes
+	PCALIGN	$16
+vector_single:
+	VSETVLI	X12, E8, M1, TA, MA, X5
+	JMP vector
+
+// (2*vlen+1)..(4*vlen) bytes
+	PCALIGN	$16
+vector_quarter:
+	VSETVLI	X12, E8, M4, TA, MA, X5
+	JMP vector
+
+vector:
+	VLE8V	(X10), V8
+	VLE8V	(X11), V16
+	VMSNEVV	V8, V16, V0
+	VFIRSTM	V0, X6
+	BGEZ	X6, done
+	SUB	X5, X12
+	JMP	done
+#endif
+
+// (4*vlen+1).. bytes
 	PCALIGN	$16
 vector_loop:
 	VSETVLI	X12, E8, M8, TA, MA, X5
@@ -57,6 +105,7 @@ vector_loop:
 	BNEZ	X12, vector_loop
 	JMP	done
 
+#ifndef hasV
 equal_scalar:
 	// Check alignment - if alignment differs we have to do one byte at a time.
 	AND	$7, X10, X9
@@ -76,7 +125,9 @@ align:
 	ADD	$1, X10
 	ADD	$1, X11
 	BNEZ	X9, align
+#endif
 
+#ifndef EnableSmallSizeMemVector
 loop32_check:
 	MOV	$32, X9
 	BLT	X12, X9, loop16_check
@@ -145,6 +196,7 @@ loop1:
 	ADD	$1, X11
 	SUB	$1, X12
 	JMP	loop1
+#endif
 
 done:
 	// If X12 is zero then memory is equivalent.


### PR DESCRIPTION
Implement vectorization optimization for small size memory comparing.

goos: linux
goarch: riscv64
cpu: SG2044
pkg: bytes
                              │  sg_old.txt  │             sg_new.txt              │
                              │    sec/op    │    sec/op     vs base               │
Equal/0                         0.3903n ± 2%   0.3903n ± 1%        ~ (p=0.853 n=6)
Equal/same/1                     5.039n ± 0%    5.037n ± 0%        ~ (p=0.381 n=6)
Equal/same/6                     5.040n ± 0%    5.037n ± 0%        ~ (p=0.472 n=6)
Equal/same/9                     5.037n ± 0%    5.039n ± 0%        ~ (p=0.277 n=6)
Equal/same/15                    5.034n ± 0%    5.036n ± 0%        ~ (p=0.935 n=6)
Equal/same/16                    5.037n ± 0%    5.038n ± 0%        ~ (p=0.602 n=6)
Equal/same/20                    5.039n ± 1%    5.037n ± 0%        ~ (p=0.818 n=6)
Equal/same/32                    5.040n ± 0%    5.037n ± 0%        ~ (p=0.422 n=6)
Equal/same/4K                    5.039n ± 0%    5.041n ± 0%        ~ (p=0.725 n=6)
Equal/same/4M                    5.038n ± 0%    5.042n ± 0%        ~ (p=0.212 n=6)
Equal/same/64M                   5.043n ± 0%    5.038n ± 0%        ~ (p=0.069 n=6)
Equal/1                          12.45n ± 1%    11.45n ± 0%   -8.07% (p=0.002 n=6)
Equal/6                          15.83n ± 0%    11.46n ± 0%  -27.64% (p=0.002 n=6)
Equal/9                          16.92n ± 0%    11.74n ± 0%  -30.62% (p=0.002 n=6)
Equal/15                         22.65n ± 1%    11.73n ± 0%  -48.21% (p=0.002 n=6)
Equal/16                         22.33n ± 0%    11.14n ± 0%  -50.11% (p=0.002 n=6)
Equal/20                         25.41n ± 0%    15.06n ± 0%  -40.72% (p=0.002 n=6)
Equal/32                         14.19n ± 0%    12.29n ± 0%  -13.42% (p=0.002 n=6)
Equal/4K                         232.7n ± 0%    231.9n ± 0%   -0.30% (p=0.004 n=6)
Equal/4M                         240.7µ ± 0%    240.5µ ± 0%   -0.10% (p=0.026 n=6)
Equal/64M                        3.895m ± 0%    3.883m ± 0%   -0.31% (p=0.004 n=6)
EqualBothUnaligned/64_0         14.295n ± 0%    9.486n ± 0%  -33.64% (p=0.002 n=6)
EqualBothUnaligned/64_1          13.24n ± 1%    11.94n ± 0%   -9.82% (p=0.002 n=6)
EqualBothUnaligned/64_4          13.26n ± 1%    11.92n ± 0%  -10.14% (p=0.002 n=6)
EqualBothUnaligned/64_7          13.22n ± 1%    11.93n ± 0%   -9.79% (p=0.002 n=6)
EqualBothUnaligned/4096_0        380.8n ± 0%    374.2n ± 0%   -1.73% (p=0.002 n=6)
EqualBothUnaligned/4096_1        488.0n ± 0%    459.5n ± 0%   -5.84% (p=0.002 n=6)
EqualBothUnaligned/4096_4        488.6n ± 0%    459.7n ± 0%   -5.91% (p=0.002 n=6)
EqualBothUnaligned/4096_7        488.5n ± 0%    459.6n ± 0%   -5.91% (p=0.002 n=6)
EqualBothUnaligned/4194304_0     399.9µ ± 0%    400.8µ ± 0%   +0.22% (p=0.002 n=6)
EqualBothUnaligned/4194304_1     471.0µ ± 0%    472.1µ ± 0%   +0.23% (p=0.002 n=6)
EqualBothUnaligned/4194304_4     471.4µ ± 0%    472.8µ ± 0%   +0.30% (p=0.002 n=6)
EqualBothUnaligned/4194304_7     471.8µ ± 0%    472.1µ ± 0%   +0.06% (p=0.026 n=6)
EqualBothUnaligned/67108864_0    6.404m ± 0%    6.402m ± 0%        ~ (p=0.699 n=6)
EqualBothUnaligned/67108864_1    7.569m ± 0%    7.577m ± 2%   +0.12% (p=0.002 n=6)
EqualBothUnaligned/67108864_4    7.577m ± 0%    7.574m ± 0%        ~ (p=0.818 n=6)
EqualBothUnaligned/67108864_7    7.577m ± 0%    7.577m ± 0%        ~ (p=1.000 n=6)
geomean                          368.8n         333.6n        -9.55%

                              │   sg_old.txt   │               sg_new.txt               │
                              │      B/s       │      B/s        vs base                │
Equal/same/1                      189.3Mi ± 0%     189.3Mi ± 0%         ~ (p=0.461 n=6)
Equal/same/6                      1.109Gi ± 0%     1.109Gi ± 0%         ~ (p=0.485 n=6)
Equal/same/9                      1.664Gi ± 0%     1.663Gi ± 0%         ~ (p=0.240 n=6)
Equal/same/15                     2.775Gi ± 0%     2.774Gi ± 0%         ~ (p=0.937 n=6)
Equal/same/16                     2.959Gi ± 0%     2.958Gi ± 0%         ~ (p=0.485 n=6)
Equal/same/20                     3.697Gi ± 1%     3.698Gi ± 0%         ~ (p=0.818 n=6)
Equal/same/32                     5.914Gi ± 0%     5.917Gi ± 0%         ~ (p=0.394 n=6)
Equal/same/4K                     757.1Gi ± 0%     756.7Gi ± 0%         ~ (p=0.818 n=6)
Equal/same/4M                     757.1Ti ± 0%     756.6Ti ± 0%         ~ (p=0.180 n=6)
Equal/same/64M                  12103.9Ti ± 0%   12113.8Ti ± 0%         ~ (p=0.093 n=6)
Equal/1                           76.59Mi ± 1%     83.33Mi ± 0%    +8.80% (p=0.002 n=6)
Equal/6                           361.5Mi ± 0%     499.7Mi ± 0%   +38.23% (p=0.002 n=6)
Equal/9                           507.4Mi ± 0%     731.6Mi ± 0%   +44.19% (p=0.002 n=6)
Equal/15                          631.7Mi ± 1%    1219.2Mi ± 0%   +93.02% (p=0.002 n=6)
Equal/16                          683.4Mi ± 0%    1369.6Mi ± 0%  +100.39% (p=0.002 n=6)
Equal/20                          750.7Mi ± 0%    1266.5Mi ± 0%   +68.70% (p=0.002 n=6)
Equal/32                          2.100Gi ± 0%     2.426Gi ± 0%   +15.53% (p=0.002 n=6)
Equal/4K                          16.40Gi ± 0%     16.45Gi ± 0%    +0.29% (p=0.004 n=6)
Equal/4M                          16.23Gi ± 0%     16.24Gi ± 0%    +0.10% (p=0.026 n=6)
Equal/64M                         16.05Gi ± 0%     16.10Gi ± 0%    +0.31% (p=0.004 n=6)
EqualBothUnaligned/64_0           4.170Gi ± 0%     6.283Gi ± 0%   +50.69% (p=0.002 n=6)
EqualBothUnaligned/64_1           4.505Gi ± 1%     4.994Gi ± 0%   +10.86% (p=0.002 n=6)
EqualBothUnaligned/64_4           4.492Gi ± 1%     5.001Gi ± 0%   +11.33% (p=0.002 n=6)
EqualBothUnaligned/64_7           4.507Gi ± 1%     4.995Gi ± 0%   +10.83% (p=0.002 n=6)
EqualBothUnaligned/4096_0         10.02Gi ± 0%     10.19Gi ± 0%    +1.75% (p=0.002 n=6)
EqualBothUnaligned/4096_1         7.816Gi ± 0%     8.302Gi ± 0%    +6.21% (p=0.002 n=6)
EqualBothUnaligned/4096_4         7.808Gi ± 0%     8.298Gi ± 0%    +6.28% (p=0.002 n=6)
EqualBothUnaligned/4096_7         7.809Gi ± 0%     8.299Gi ± 0%    +6.28% (p=0.002 n=6)
EqualBothUnaligned/4194304_0      9.768Gi ± 0%     9.747Gi ± 0%    -0.22% (p=0.002 n=6)
EqualBothUnaligned/4194304_1      8.293Gi ± 0%     8.274Gi ± 0%    -0.23% (p=0.002 n=6)
EqualBothUnaligned/4194304_4      8.287Gi ± 0%     8.262Gi ± 0%    -0.30% (p=0.002 n=6)
EqualBothUnaligned/4194304_7      8.279Gi ± 0%     8.275Gi ± 0%    -0.06% (p=0.026 n=6)
EqualBothUnaligned/67108864_0     9.759Gi ± 0%     9.762Gi ± 0%         ~ (p=0.699 n=6)
EqualBothUnaligned/67108864_1     8.258Gi ± 0%     8.248Gi ± 2%    -0.12% (p=0.002 n=6)
EqualBothUnaligned/67108864_4     8.249Gi ± 0%     8.252Gi ± 0%         ~ (p=0.818 n=6)
EqualBothUnaligned/67108864_7     8.249Gi ± 0%     8.249Gi ± 0%         ~ (p=1.000 n=6)
geomean                           8.223Gi          9.117Gi        +10.87%