### PR TITLE
math: add Sum function for summing a slice of float64 values

### DIFF
--- a/src/math/all_test.go
+++ b/src/math/all_test.go
@@ -284,6 +284,23 @@ var fabs = []float64{
 	1.8253080916808550e+00,
 	8.6859247685756013e+00,
 }
+var fsum = 2.1089478335441655e+01
+
+var vffsumSC = [][]float64{
+	{Inf(1), 1},
+	{Inf(-1), 1},
+	{Inf(1), Inf(-1)},
+	{NaN(), 1},
+	{},
+}
+var fsumSC = []float64{
+	Inf(1),
+	Inf(-1),
+	NaN(),
+	NaN(),
+	0,
+}
+
 var fdim = []float64{
 	4.9790119248836735e+00,
 	7.7388724745781045e+00,
@@ -3043,6 +3060,17 @@ func TestSqrt(t *testing.T) {
 		}
 		if f := Sqrt(vfsqrtSC[i]); !alike(sqrtSC[i], f) {
 			t.Errorf("Sqrt(%g) = %g, want %g", vfsqrtSC[i], f, sqrtSC[i])
+		}
+	}
+}
+
+func TestSum(t *testing.T) {
+	if f := Sum(vf); !veryclose(fsum, f) {
+		t.Errorf("Sum(%v) = %g, want %g", vf, f, fsum)
+	}
+	for i, sc := range vffsumSC {
+		if f := Sum(sc); !alike(fsumSC[i], f) {
+			t.Errorf("Sum(%v) = %g, want %g", sc, f, fsumSC[i])
 		}
 	}
 }

--- a/src/math/sum.go
+++ b/src/math/sum.go
@@ -1,0 +1,22 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package math
+
+// Sum returns the sum of the values in x.
+//
+// Special cases are:
+//
+//	Sum([]) = 0
+//	Sum(x) = NaN if any x[i] is NaN
+//	Sum(x) = +Inf if sum overflows positive (no -Inf or NaN present)
+//	Sum(x) = -Inf if sum overflows negative (no +Inf or NaN present)
+//	Sum containing both +Inf and -Inf = NaN
+func Sum(x []float64) float64 {
+	s := 0.0
+	for _, v := range x {
+		s += v
+	}
+	return s
+}


### PR DESCRIPTION
Add math.Sum(x []float64) float64 to the standard library's math
package. The function returns the sum of all values in the slice,
returning 0 for an empty slice. 

Implements #80011