### PR TITLE
fmt: use type assertion to avoid reflection in doPrint

### DIFF
--- a/src/fmt/print.go
+++ b/src/fmt/print.go
@@ -1185,7 +1185,11 @@ formatLoop:
 func (p *pp) doPrint(a []any) {
 	prevString := false
 	for argNum, arg := range a {
-		isString := arg != nil && reflect.TypeOf(arg).Kind() == reflect.String
+		_, isString := arg.(string)
+		if !isString && arg != nil {
+			isString = reflect.TypeOf(arg).Kind() == reflect.String
+		}
+
 		// Add a space between two non-string arguments.
 		if argNum > 0 && !isString && !prevString {
 			p.buf.writeByte(' ')

--- a/src/fmt/print_bench_test.go
+++ b/src/fmt/print_bench_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fmt_test
+
+import (
+	. "fmt"
+	"io"
+	"testing"
+)
+
+// BenchmarkSprint exercises doPrint (no format string path).
+func BenchmarkSprintInts(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = Sprint(1, 2, 3, 4, 5)
+	}
+}
+
+func BenchmarkSprintlnInts(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = Sprintln(1, 2, 3, 4, 5)
+	}
+}
+
+func BenchmarkSprintStrings(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = Sprint("a", "b", "c", "d", "e")
+	}
+}
+
+func BenchmarkSprintMixed(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = Sprint(1, "hello", 3.14, true, "world")
+	}
+}
+
+func BenchmarkPrintInts(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Print(1, 2, 3, 4, 5)
+	}
+}
+
+func BenchmarkPrintlnInts(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Println(1, 2, 3, 4, 5)
+	}
+}
+
+// discard is a Writer that discards all writes.
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }
+
+func BenchmarkFprintInts(b *testing.B) {
+	w := io.Writer(discard{})
+	for i := 0; i < b.N; i++ {
+		Fprint(w, 1, 2, 3, 4, 5)
+	}
+}
+
+func BenchmarkFprintlnInts(b *testing.B) {
+	w := io.Writer(discard{})
+	for i := 0; i < b.N; i++ {
+		Fprintln(w, 1, 2, 3, 4, 5)
+	}
+}

--- a/src/fmt/print_space_test.go
+++ b/src/fmt/print_space_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fmt_test
+
+import (
+	"bytes"
+	. "fmt"
+	"testing"
+)
+
+// customString is a renamed string type for testing the reflect fallback path.
+type customString string
+
+// TestDoPrintSpacing checks that Sprint (and hence Print, Fprint) adds a space
+// between adjacent non-string arguments, including the fast path for built-in
+// string (type assertion) and the reflect fallback for renamed string types.
+func TestDoPrintSpacing(t *testing.T) {
+	cs := customString("custom")
+	tests := []struct {
+		name string
+		args []any
+		want string
+	}{
+		// Built-in string: fast path via type assertion.
+		{"string_string", []any{"a", "b"}, "ab"},
+		{"string_nonstring", []any{"a", 1}, "a1"},
+		{"nonstring_string", []any{1, "a"}, "1a"},
+		{"nonstring_nonstring", []any{1, 2}, "1 2"},
+
+		// Custom string: reflect.Kind fallback path.
+		{"customString_string", []any{cs, "b"}, "customb"},
+		{"string_customString", []any{"a", cs}, "acustom"},
+		{"customString_customString", []any{cs, customString("d")}, "customd"},
+		{"customString_nonstring", []any{cs, 1}, "custom1"},
+		{"nonstring_customString", []any{1, cs}, "1custom"},
+
+		// nil must not panic and is treated as non-string.
+		{"nil_nonstring", []any{nil, 1}, "<nil> 1"},
+		{"string_nil", []any{"a", nil}, "a<nil>"},
+		{"nil_string", []any{nil, "a"}, "<nil>a"},
+		{"customString_nil", []any{cs, nil}, "custom<nil>"},
+		{"nil_customString", []any{nil, cs}, "<nil>custom"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Sprint(tt.args...)
+			if got != tt.want {
+				t.Errorf("Sprint(%v) = %q, want %q", tt.args, got, tt.want)
+			}
+
+			var buf bytes.Buffer
+			if _, err := Fprint(&buf, tt.args...); err != nil {
+				t.Fatalf("Fprint(%v) returned error: %v", tt.args, err)
+			}
+			if got := buf.String(); got != tt.want {
+				t.Errorf("Fprint(%v) = %q, want %q", tt.args, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In doPrint, the isString check currently always uses
reflect.TypeOf(arg).Kind() to determine if an argument is a string,
even for plain string values. This change tries a direct type
assertion arg.(string) first, falling back to reflection only for
non-nil, non-plain-string arguments such as named string types.

This avoids a reflect call in the common case without any change in
behavior: nil is not considered a string, named string types are
still recognized, and spacing between non-string arguments is
unaffected.