### PR TITLE
cmd/go: report an implicit go directive as upgraded from 1.16

### DIFF
--- a/src/cmd/go/internal/modget/get.go
+++ b/src/cmd/go/internal/modget/get.go
@@ -413,6 +413,12 @@ func runGet(ctx context.Context, cmd *base.Command, args []string) {
 
 	// Everything succeeded. Update go.mod.
 	oldReqs := reqsFromGoMod(modload.ModFile(moduleLoader))
+	// Record whether the main module's go.mod already had a go directive before
+	// WriteGoMod rewrites (and re-indexes) the file. If it did not, the go
+	// command synthesized the current version into oldReqs, which would
+	// otherwise make adding a go directive look like a downgrade.
+	// See go.dev/issue/63507.
+	mainHadGoDirective := modload.MainModuleHasGoDirective(moduleLoader)
 
 	if err := modload.WriteGoMod(moduleLoader, ctx, opts); err != nil {
 		// A TooNewError can happen for 'go get go@newversion'
@@ -424,7 +430,7 @@ func runGet(ctx context.Context, cmd *base.Command, args []string) {
 	}
 
 	newReqs := reqsFromGoMod(modload.ModFile(moduleLoader))
-	r.reportChanges(oldReqs, newReqs)
+	r.reportChanges(oldReqs, newReqs, mainHadGoDirective)
 
 	if gowork := moduleLoader.FindGoWork(base.Cwd()); gowork != "" {
 		wf, err := modload.ReadWorkFile(gowork)
@@ -1855,7 +1861,7 @@ func (r *resolver) checkPackageProblems(ld *modload.Loader, ctx context.Context,
 // are not relevant to the user and are not logged.
 //
 // reportChanges should be called after WriteGoMod.
-func (r *resolver) reportChanges(oldReqs, newReqs []module.Version) {
+func (r *resolver) reportChanges(oldReqs, newReqs []module.Version, mainHadGoDirective bool) {
 	type change struct {
 		path, old, new string
 	}
@@ -1912,6 +1918,13 @@ func (r *resolver) reportChanges(oldReqs, newReqs []module.Version) {
 	oldGo, oldToolchain := toolchainVersions(oldReqs)
 	newGo, newToolchain := toolchainVersions(newReqs)
 	if oldGo != newGo {
+		// If the main module's go.mod had no go directive, the go command
+		// synthesized the current version into oldGo. Report the directive as
+		// added rather than as a spurious up/downgrade from that synthesized
+		// version. See go.dev/issue/63507.
+		if !mainHadGoDirective {
+			oldGo = ""
+		}
 		changes["go"] = change{"go", oldGo, newGo}
 	}
 	if oldToolchain != newToolchain {

--- a/src/cmd/go/internal/modget/get.go
+++ b/src/cmd/go/internal/modget/get.go
@@ -413,6 +413,12 @@ func runGet(ctx context.Context, cmd *base.Command, args []string) {
 
 	// Everything succeeded. Update go.mod.
 	oldReqs := reqsFromGoMod(modload.ModFile(moduleLoader))
+	// Record whether the main module's go.mod already had a go directive before
+	// WriteGoMod rewrites (and re-indexes) the file. If it did not, the go
+	// command synthesized the current version into oldReqs, which would
+	// otherwise make adding a go directive look like a downgrade.
+	// See go.dev/issue/63507.
+	mainHadGoDirective := modload.MainModuleHasGoDirective(moduleLoader)
 
 	if err := modload.WriteGoMod(moduleLoader, ctx, opts); err != nil {
 		// A TooNewError can happen for 'go get go@newversion'
@@ -424,7 +430,7 @@ func runGet(ctx context.Context, cmd *base.Command, args []string) {
 	}
 
 	newReqs := reqsFromGoMod(modload.ModFile(moduleLoader))
-	r.reportChanges(oldReqs, newReqs)
+	r.reportChanges(oldReqs, newReqs, mainHadGoDirective)
 
 	if gowork := moduleLoader.FindGoWork(base.Cwd()); gowork != "" {
 		wf, err := modload.ReadWorkFile(gowork)
@@ -1847,7 +1853,7 @@ func (r *resolver) checkPackageProblems(ld *modload.Loader, ctx context.Context,
 // are not relevant to the user and are not logged.
 //
 // reportChanges should be called after WriteGoMod.
-func (r *resolver) reportChanges(oldReqs, newReqs []module.Version) {
+func (r *resolver) reportChanges(oldReqs, newReqs []module.Version, mainHadGoDirective bool) {
 	type change struct {
 		path, old, new string
 	}
@@ -1903,6 +1909,16 @@ func (r *resolver) reportChanges(oldReqs, newReqs []module.Version) {
 	}
 	oldGo, oldToolchain := toolchainVersions(oldReqs)
 	newGo, newToolchain := toolchainVersions(newReqs)
+	// A go.mod with no go directive leaves the main module at the implicit
+	// gover.DefaultGoModVersion. The go command synthesizes its own version
+	// into the in-memory go.mod before this point, so without this oldGo would
+	// make a newly written directive look like an up- or downgrade from
+	// whichever version of the go command happened to run.
+	// See go.dev/issue/63507.
+	goImplicit := !mainHadGoDirective
+	if goImplicit {
+		oldGo = gover.DefaultGoModVersion
+	}
 	if oldGo != newGo {
 		changes["go"] = change{"go", oldGo, newGo}
 	}
@@ -1935,18 +1951,24 @@ func (r *resolver) reportChanges(oldReqs, newReqs []module.Version) {
 	})
 
 	for _, c := range sortedChanges {
+		// An implicit go version was never written in go.mod, so say so rather
+		// than let it read as a version the module used to declare.
+		what := c.path
+		if c.path == "go" && goImplicit {
+			what = "implicit go"
+		}
 		if c.old == "" {
-			fmt.Fprintf(os.Stderr, "go: added %s %s\n", c.path, c.new)
+			fmt.Fprintf(os.Stderr, "go: added %s %s\n", what, c.new)
 		} else if c.new == "none" || c.new == "" {
-			fmt.Fprintf(os.Stderr, "go: removed %s %s\n", c.path, c.old)
+			fmt.Fprintf(os.Stderr, "go: removed %s %s\n", what, c.old)
 		} else if gover.ModCompare(c.path, c.new, c.old) > 0 {
-			fmt.Fprintf(os.Stderr, "go: upgraded %s %s => %s\n", c.path, c.old, c.new)
+			fmt.Fprintf(os.Stderr, "go: upgraded %s %s => %s\n", what, c.old, c.new)
 			if c.path == "go" && gover.Compare(c.old, gover.ExplicitIndirectVersion) < 0 && gover.Compare(c.new, gover.ExplicitIndirectVersion) >= 0 {
 				fmt.Fprintf(os.Stderr, "\tnote: expanded dependencies to upgrade to go %s or higher; run 'go mod tidy' to clean up\n", gover.ExplicitIndirectVersion)
 			}
 
 		} else {
-			fmt.Fprintf(os.Stderr, "go: downgraded %s %s => %s\n", c.path, c.old, c.new)
+			fmt.Fprintf(os.Stderr, "go: downgraded %s %s => %s\n", what, c.old, c.new)
 		}
 	}
 

--- a/src/cmd/go/internal/modload/init.go
+++ b/src/cmd/go/internal/modload/init.go
@@ -324,6 +324,28 @@ func ModFile(ld *Loader) *modfile.File {
 	return modFile
 }
 
+// MainModuleHasGoDirective reports whether the main module's go.mod file
+// declared a go directive as originally loaded from disk. It reads the parsed
+// module index, which preserves that original state, rather than the in-memory
+// go.mod, into which the go command synthesizes a version for a module that
+// omits one. It must therefore be called after the main module is loaded and
+// before WriteGoMod rewrites (and re-indexes) the file; afterward the index
+// reflects the rewritten go.mod instead.
+//
+// In workspace mode, or when there is not exactly one main module, it
+// conservatively reports true.
+func MainModuleHasGoDirective(ld *Loader) bool {
+	Init(ld)
+	if ld.inWorkspaceMode() || ld.MainModules.Len() != 1 {
+		return true
+	}
+	idx := ld.MainModules.GetSingleIndexOrNil(ld)
+	if idx == nil {
+		return true
+	}
+	return idx.goVersion != ""
+}
+
 func BinDir(ld *Loader) string {
 	Init(ld)
 	if cfg.GOBIN != "" {

--- a/src/cmd/go/internal/modload/init.go
+++ b/src/cmd/go/internal/modload/init.go
@@ -330,6 +330,28 @@ func ModFile(ld *Loader) *modfile.File {
 	return modFile
 }
 
+// MainModuleHasGoDirective reports whether the main module's go.mod file
+// declared a go directive as originally loaded from disk. It reads the parsed
+// module index, which preserves that original state, rather than the in-memory
+// go.mod, into which the go command synthesizes a version for a module that
+// omits one. It must therefore be called after the main module is loaded and
+// before WriteGoMod rewrites (and re-indexes) the file; afterward the index
+// reflects the rewritten go.mod instead.
+//
+// In workspace mode, or when there is not exactly one main module, it
+// conservatively reports true.
+func MainModuleHasGoDirective(ld *Loader) bool {
+	Init(ld)
+	if ld.inWorkspaceMode() || ld.MainModules.Len() != 1 {
+		return true
+	}
+	idx := ld.MainModules.GetSingleIndexOrNil(ld)
+	if idx == nil {
+		return true
+	}
+	return idx.goVersion != ""
+}
+
 func BinDir(ld *Loader) string {
 	Init(ld)
 	if cfg.GOBIN != "" {

--- a/src/cmd/go/testdata/script/mod_get_go_directive_added.txt
+++ b/src/cmd/go/testdata/script/mod_get_go_directive_added.txt
@@ -1,0 +1,48 @@
+# go.dev/issue/63507: in a module whose go.mod has no go directive,
+# 'go get go@version' synthesizes the current version internally. The change
+# must be reported as the directive being added, not as a spurious downgrade
+# from the go command's own version.
+
+env TESTGO_VERSION=go1.99
+
+# No go directive: 'go get go@1.20' adds one. It must not look like a downgrade
+# from go1.99.
+go get go@1.20
+stderr '^go: added go 1.20$'
+! stderr 'downgraded'
+grep '^go 1.20$' go.mod
+
+# No go directive + 'go get go@<current>': the go command would write the same
+# synthesized version, so this is a no-op change and must stay silent rather
+# than report a spurious "added"/"upgraded"/"downgraded" go line. The matching
+# toolchain is implicit, so no toolchain line is written or reported either.
+cp go.mod.none go.mod
+go get go@1.99
+! stderr 'go: (added|upgraded|downgraded) go'
+! stderr 'toolchain'
+grep '^go 1.99$' go.mod
+! grep '^toolchain' go.mod
+
+# An existing, higher go directive is still reported as a real downgrade.
+cp go.mod.high go.mod
+go get go@1.20
+stderr '^go: downgraded go 1.25 => 1.20$'
+
+# An existing, lower go directive is still reported as a real upgrade.
+cp go.mod.low go.mod
+go get go@1.20
+stderr '^go: upgraded go 1.18 => 1.20$'
+
+-- go.mod --
+module example.com/m
+
+-- go.mod.none --
+module example.com/m
+
+-- go.mod.high --
+module example.com/m
+go 1.25
+
+-- go.mod.low --
+module example.com/m
+go 1.18

--- a/src/cmd/go/testdata/script/mod_get_go_directive_implicit.txt
+++ b/src/cmd/go/testdata/script/mod_get_go_directive_implicit.txt
@@ -1,0 +1,75 @@
+# go.dev/issue/63507: in a module whose go.mod has no go directive, 'go get'
+# synthesizes the version of the go command itself internally. The change must
+# be reported against the version the module implicitly had, go 1.16, not
+# against whichever go command happened to run.
+
+env TESTGO_VERSION=go1.99
+
+# No go directive: 'go get go@1.20' writes one. The module was implicitly at
+# go 1.16, so this is an upgrade from 1.16, not a downgrade from go1.99.
+# Moving past 1.17 expands the requirements, so the existing note applies.
+go get go@1.20
+stderr '^go: upgraded implicit go 1.16 => 1.20$'
+stderr 'note: expanded dependencies to upgrade to go 1.17 or higher'
+! stderr 'downgraded'
+grep '^go 1.20$' go.mod
+
+# The same holds when the new version is the version of the go command: the
+# module still moves from the implicit go 1.16, so the change is reported.
+cp go.mod.none go.mod
+go get go@1.99
+stderr '^go: upgraded implicit go 1.16 => 1.99$'
+grep '^go 1.99$' go.mod
+! grep '^toolchain' go.mod
+
+# Below the implicit version is a real downgrade.
+cp go.mod.none go.mod
+go get go@1.15
+stderr '^go: downgraded implicit go 1.16 => 1.15$'
+grep '^go 1.15$' go.mod
+
+# Writing the implicit version explicitly changes nothing, so it stays silent.
+cp go.mod.none go.mod
+go get go@1.16
+! stderr 'implicit'
+! stderr 'go: (added|upgraded|downgraded) go'
+grep '^go 1.16$' go.mod
+
+# A version go.mod really declared is reported without 'implicit', including
+# when it declares the same 1.16 that the implicit version would have been.
+cp go.mod.116 go.mod
+go get go@1.20
+stderr '^go: upgraded go 1.16 => 1.20$'
+! stderr 'implicit'
+
+cp go.mod.high go.mod
+go get go@1.20
+stderr '^go: downgraded go 1.25 => 1.20$'
+
+cp go.mod.low go.mod
+go get go@1.20
+stderr '^go: upgraded go 1.18 => 1.20$'
+
+# This is not specific to 'go get go@version'. Getting a package writes the
+# directive as a side effect, and that is now reported too.
+cp go.mod.none go.mod
+go get rsc.io/quote@v1.5.2
+stderr '^go: upgraded implicit go 1.16 => 1.99$'
+
+-- go.mod --
+module example.com/m
+
+-- go.mod.none --
+module example.com/m
+
+-- go.mod.116 --
+module example.com/m
+go 1.16
+
+-- go.mod.high --
+module example.com/m
+go 1.25
+
+-- go.mod.low --
+module example.com/m
+go 1.18


### PR DESCRIPTION
When 'go get' runs in a module whose go.mod has no go directive, the
go command synthesizes its own version into the in-memory requirements
before writing the file. reportChanges then compared the requested
version against that synthesized version and printed a misleading
message, for example:

	go: downgraded go 1.27 => 1.20

even though the module never declared go 1.27. A go.mod with no go
directive leaves the module at the implicit go 1.16, so report the
change from there:

	go: upgraded implicit go 1.16 => 1.20

Determine whether the go.mod originally declared a go directive from
the main module's index, which is not affected by the synthesized
directive, and use gover.DefaultGoModVersion as the old version when
it did not. A version the go.mod really declared is still reported as
a plain upgrade or downgrade.

Measuring from 1.16 has two visible consequences. A 'go get' that
writes a directive of go 1.17 or higher now also prints the existing
note about expanded dependencies, which applies because the module
really does cross the graph pruning boundary. And a 'go get' that
writes the directive at all now reports it, where before it was
reported only when the version differed from the version of the go
command. That includes getting a package in a module with no go
directive, which used to write the go line silently.

Fixes #63507
Fixes #70090

