### PR TITLE
fmt: clarify %q verb uses rune literal not character literal

### DIFF
--- a/src/fmt/doc.go
+++ b/src/fmt/doc.go
@@ -43,7 +43,7 @@ Integer:
 	%d	base 10
 	%o	base 8
 	%O	base 8 with 0o prefix
-	%q	a single-quoted character literal safely escaped with Go syntax.
+	%q	a single-quoted rune literal safely escaped with Go syntax.
 	%x	base 16, with lower-case letters for a-f
 	%X	base 16, with upper-case letters for A-F
 	%U	Unicode format: U+1234; same as "U+%04X"


### PR DESCRIPTION
The %q verb in the Integer section was documented as formatting a "character literal", which incorrectly suggests that values such as plain int are valid arguments. Clarify that it formats a rune literal, matching Go spec terminology.

Fixes golang/go#78486

Change-Id: Ibe5ec34d1912ce860aa956ec8ad3b1f369ac10ff

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://go.dev/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible, ideally 72 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at around 72 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/vscode-go#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
