### PR TITLE
net/smtp: parse EHLO extension keywords case-insensitively

### DIFF
--- a/src/net/smtp/smtp.go
+++ b/src/net/smtp/smtp.go
@@ -139,7 +139,7 @@ func (c *Client) ehlo() error {
 		extList = extList[1:]
 		for _, line := range extList {
 			k, v, _ := strings.Cut(line, " ")
-			ext[k] = v
+			ext[strings.ToUpper(k)] = v
 		}
 	}
 	if mechs, ok := ext["AUTH"]; ok {

--- a/src/net/smtp/smtp_test.go
+++ b/src/net/smtp/smtp_test.go
@@ -530,6 +530,26 @@ QUIT
 			t.Fatalf("Got:\n%s\nExpected:\n%s", actualcmds, client)
 		}
 	})
+
+	t.Run("ehlo mixed case extensions", func(t *testing.T) {
+		const basicServer = `250-mx.google.com at your service
+250-starttls
+250-aUtH LOGIN PLAIN
+250 Ok
+`
+
+		c, _, _ := fake(basicServer)
+
+		if err := c.Hello("localhost"); err != nil {
+			t.Fatalf("EHLO failed: %s", err)
+		}
+		if ok, _ := c.Extension("STARTTLS"); !ok {
+			t.Fatalf("Should support STARTTLS")
+		}
+		if ok, args := c.Extension("auth"); !ok || args != "LOGIN PLAIN" {
+			t.Fatalf("Should support AUTH, got ok=%v args=%q", ok, args)
+		}
+	})
 }
 
 func TestNewClient(t *testing.T) {


### PR DESCRIPTION
RFC 5321 requires EHLO keywords to be recognized case-insensitively. Normalize extension names to upper case when parsing the EHLO response so Extension, StartTLS, and other callers detect capabilities advertised with mixed case (for example "starttls").

Fixes golang/go#78749

Change-Id: I72350651fe8bc8508c075e60bfa0eb884ac75de9

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://go.dev/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible, ideally 72 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at around 72 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/vscode-go#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
