### PR TITLE
encoding/ascii85: fix Decode with exact-size destination buffer

### DIFF
--- a/src/encoding/ascii85/ascii85.go
+++ b/src/encoding/ascii85/ascii85.go
@@ -187,9 +187,6 @@ func Decode(dst, src []byte, flush bool) (ndst, nsrc int, err error) {
 	var v uint32
 	var nb int
 	for i, b := range src {
-		if len(dst)-ndst < 4 {
-			return
-		}
 		switch {
 		case b <= ' ':
 			continue
@@ -203,6 +200,9 @@ func Decode(dst, src []byte, flush bool) (ndst, nsrc int, err error) {
 			return 0, 0, CorruptInputError(i)
 		}
 		if nb == 5 {
+			if len(dst)-ndst < 4 {
+				return
+			}
 			nsrc = i + 1
 			dst[ndst] = byte(v >> 24)
 			dst[ndst+1] = byte(v >> 16)
@@ -222,6 +222,10 @@ func Decode(dst, src []byte, flush bool) (ndst, nsrc int, err error) {
 			// the inefficiency of the encoding for the block.
 			if nb == 1 {
 				return 0, 0, CorruptInputError(len(src))
+			}
+			need := nb - 1
+			if len(dst)-ndst < need {
+				return
 			}
 			for i := nb; i < 5; i++ {
 				// The short encoding truncated the output value.

--- a/src/encoding/ascii85/ascii85_test.go
+++ b/src/encoding/ascii85/ascii85_test.go
@@ -209,3 +209,46 @@ func TestDecoderInternalWhitespace(t *testing.T) {
 		t.Errorf("Decode failed: got %v, want %v", decoded, want)
 	}
 }
+
+func TestDecodeExactDstSize(t *testing.T) {
+	for _, src := range [][]byte{
+		[]byte("Q"),
+		[]byte("ABCDE"),
+	} {
+		enc := make([]byte, MaxEncodedLen(len(src)))
+		nenc := Encode(enc, src)
+		dec := make([]byte, len(src))
+		ndst, _, err := Decode(dec, enc[:nenc], true)
+		if err != nil {
+			t.Fatalf("Decode(%q): %v", enc[:nenc], err)
+		}
+		if ndst != len(src) {
+			t.Fatalf("Decode(%q) wrote %d bytes, want %d", enc[:nenc], ndst, len(src))
+		}
+		if !bytes.Equal(src, dec) {
+			t.Fatalf("Decode(%q) = %x, want %x", enc[:nenc], dec, src)
+		}
+	}
+}
+
+func TestDecodeRandomRoundTrip(t *testing.T) {
+	const supLen = 100
+	srcBuf := make([]byte, supLen)
+	encBuf := make([]byte, MaxEncodedLen(supLen))
+	decBuf := make([]byte, supLen)
+	for i := 0; i < 1000; i++ {
+		srcLen := 1 + i%(supLen)
+		src := srcBuf[:srcLen]
+		for j := range src {
+			src[j] = byte(i + j)
+		}
+		nenc := Encode(encBuf[:MaxEncodedLen(srcLen)], src)
+		ndst, _, err := Decode(decBuf[:srcLen], encBuf[:nenc], true)
+		if err != nil {
+			t.Fatalf("Decode failed: %v", err)
+		}
+		if ndst != srcLen || !bytes.Equal(src, decBuf[:ndst]) {
+			t.Fatalf("round-trip failed for len %d: got %x want %x", srcLen, decBuf[:ndst], src)
+		}
+	}
+}


### PR DESCRIPTION
Decode required four spare bytes in dst before processing each input byte, which caused flush of a final short block to fail when dst was sized to the decoded output length. Check available space only when writing output bytes.

Fixes golang/go#75590

Change-Id: I1e4794405f4b16126b50891e792ff61a773ca9c9

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://go.dev/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible, ideally 72 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at around 72 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/vscode-go#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
