### PR TITLE
crypto/tls: document that ConnectionState is valid only after handshake

### DIFF
--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -1604,6 +1604,12 @@ func (c *Conn) handshakeContext(ctx context.Context) (ret error) {
 }
 
 // ConnectionState returns basic TLS details about the connection.
+//
+// The returned [ConnectionState] is only meaningful after the handshake has
+// completed, as reported by [ConnectionState.HandshakeComplete]; before then
+// its fields are not populated. The handshake is run automatically by the
+// first [Conn.Read] or [Conn.Write], or it can be triggered explicitly with
+// [Conn.Handshake].
 func (c *Conn) ConnectionState() ConnectionState {
 	c.handshakeMutex.Lock()
 	defer c.handshakeMutex.Unlock()


### PR DESCRIPTION
Conn.ConnectionState reports details that are only populated once the
TLS handshake has completed. Callers that read it immediately after
Accept (for example via tls.NewListener) instead observe an
unpopulated ConnectionState whose HandshakeComplete field is false.

Document this precondition on Conn.ConnectionState and point to
ConnectionState.HandshakeComplete and Conn.Handshake, which the first
Conn.Read or Conn.Write runs automatically.

Fixes #79828.
