### PR TITLE
uuid: randomize NewV7 rand_a when sub-ms time is unavailable

### DIFF
--- a/src/uuid/uuid.go
+++ b/src/uuid/uuid.go
@@ -23,6 +23,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"runtime"
 	"sync"
 	"time"
 )
@@ -222,8 +223,9 @@ func NewV7() UUID {
 	// |                            rand_b                             |
 	// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 	//
-	// We store a 12 bit sub-millisecond timestamp fraction in the rand_a section,
-	// as optionally permitted by the RFC.
+	// We store a 12 bit sub-millisecond timestamp fraction in the rand_a section
+	// where available. On platforms without sub-millisecond time precision,
+	// rand_a is seeded with random bits instead, as permitted by the RFC.
 	v7mu.Lock()
 
 	// Generate our 60-bit timestamp: 48 bits of millisecond-resolution,
@@ -233,8 +235,21 @@ func NewV7() UUID {
 	nanos := uint64(now.Nanosecond())
 	msecs := nanos / 1000000
 	frac := nanos - (1000000 * msecs)
+
+	subms := (frac * 4096) / 1000000 // ns converted to 1/4096-ms units
+	if runtime.GOOS == "js" {
+		// On js/wasm, time.Now has only millisecond precision.
+		// In that case the sub-millisecond fraction would always be zero.
+		// Seed it with random bits instead; the monotonic adjustment below
+		// still preserves increasing order for UUIDs generated in the same
+		// millisecond.
+		var b [2]byte
+		rand.Read(b[:])
+		subms = uint64(binary.BigEndian.Uint16(b[:]) & 0x0fff)
+	}
+
 	timestamp := (1000*secs + msecs) << 12 // ms shifted into position
-	timestamp += (frac * 4096) / 1000000   // ns converted to 1/4096-ms units
+	timestamp += subms
 
 	if v7lastSecs > secs {
 		// Time has gone backwards.

--- a/src/uuid/uuid_js_wasm_test.go
+++ b/src/uuid/uuid_js_wasm_test.go
@@ -1,0 +1,27 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build js && wasm
+
+package uuid
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewV7SubmillisecondBitsOnWasm(t *testing.T) {
+	allZero := true
+	for range 20 {
+		u := NewV7()
+		if u[6]&0x0f != 0 || u[7] != 0 {
+			allZero = false
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if allZero {
+		t.Fatal("NewV7 sub-millisecond bits are always zero on js/wasm")
+	}
+}


### PR DESCRIPTION
On js/wasm, time.Now only reports time with millisecond precision. NewV7
uses the sub-millisecond part of the current time for rand_a, so that value
ends up being zero on js/wasm. This makes generated UUIDs consistently
contain 7000 in the third group.

When sub-millisecond time is not available, use random bits for rand_a
instead. The existing monotonic adjustment still keeps UUIDs ordered when
multiple UUIDs are generated in the same millisecond.

Fixes #80084