### PR TITLE
runtime: remove unused frag calculation in ASAN poisoning

### DIFF
--- a/src/runtime/malloc.go
+++ b/src/runtime/malloc.go
@@ -1180,10 +1180,6 @@ func mallocgc(size uintptr, typ *_type, needzero bool) unsafe.Pointer {
 	if asanenabled {
 		// Poison the space between the end of the requested size of x
 		// and the end of the slot. Unpoison the requested allocation.
-		frag := elemsize - size
-		if typ != nil && typ.Pointers() && !heapBitsInSpan(elemsize) && size <= maxSmallSize-gc.MallocHeaderSize {
-			frag -= gc.MallocHeaderSize
-		}
 		asanpoison(unsafe.Add(x, size-asanRZ), asanRZ)
 		asanunpoison(x, size-asanRZ)
 	}


### PR DESCRIPTION
The variable frag is computed but never used in the ASAN poisoning logic below. 
The code calculates the fragment size between the actual allocation slot and the requested size, optionally adjusting for the malloc header, but the result is discarded. 
Remove this dead code since asanpoison and asanunpoison only require size and asanRZ.