### PR TITLE
unicode: avoid divide by zero in is16/is32 for zero-stride ranges

### DIFF
--- a/src/unicode/letter.go
+++ b/src/unicode/letter.go
@@ -96,7 +96,7 @@ func is16(ranges []Range16, r uint16) bool {
 				return false
 			}
 			if r <= range_.Hi {
-				return range_.Stride == 1 || (r-range_.Lo)%range_.Stride == 0
+				return range_.Stride <= 1 || (r-range_.Lo)%range_.Stride == 0
 			}
 		}
 		return false
@@ -109,7 +109,7 @@ func is16(ranges []Range16, r uint16) bool {
 		m := int(uint(lo+hi) >> 1)
 		range_ := &ranges[m]
 		if range_.Lo <= r && r <= range_.Hi {
-			return range_.Stride == 1 || (r-range_.Lo)%range_.Stride == 0
+			return range_.Stride <= 1 || (r-range_.Lo)%range_.Stride == 0
 		}
 		if r < range_.Lo {
 			hi = m
@@ -129,7 +129,7 @@ func is32(ranges []Range32, r uint32) bool {
 				return false
 			}
 			if r <= range_.Hi {
-				return range_.Stride == 1 || (r-range_.Lo)%range_.Stride == 0
+				return range_.Stride <= 1 || (r-range_.Lo)%range_.Stride == 0
 			}
 		}
 		return false
@@ -142,7 +142,7 @@ func is32(ranges []Range32, r uint32) bool {
 		m := int(uint(lo+hi) >> 1)
 		range_ := ranges[m]
 		if range_.Lo <= r && r <= range_.Hi {
-			return range_.Stride == 1 || (r-range_.Lo)%range_.Stride == 0
+			return range_.Stride <= 1 || (r-range_.Lo)%range_.Stride == 0
 		}
 		if r < range_.Lo {
 			hi = m

--- a/src/unicode/letter_test.go
+++ b/src/unicode/letter_test.go
@@ -271,6 +271,14 @@ func TestIsUpper(t *testing.T) {
 	}
 }
 
+func TestIsZeroStride(t *testing.T) {
+	// A RangeTable range with Stride == 0 must not cause Is to divide by zero.
+	tab := &RangeTable{R16: []Range16{{Lo: 'A', Hi: 'A', Stride: 0}}}
+	if !Is(tab, 'A') {
+		t.Errorf("Is(tab, 'A') = false, want true")
+	}
+}
+
 func caseString(c int) string {
 	switch c {
 	case UpperCase:


### PR DESCRIPTION
unicode: avoid divide by zero in is16/is32 for zero-stride ranges - closes #80269