### PR TITLE
runtime: cache grown goroutine stacks to reduce stack-growth cost

### DIFF
--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -5511,6 +5511,12 @@ func saveAncestors(callergp *g) *[]ancestorInfo {
 	return ancestorsp
 }
 
+// maxCachedStackSize bounds the size of a dead goroutine's stack that we keep
+// on the free-g list for reuse instead of freeing. Stacks larger than this are
+// freed. The per-P free-g list is already capped at 64 entries, so the extra
+// memory retained is bounded at 64*maxCachedStackSize per P (~8 MiB at 128 KiB).
+const maxCachedStackSize = 128 << 10 // 128 KiB
+
 // Put on gfree list.
 // If local list is too long, transfer a batch to the global list.
 func gfput(pp *p, gp *g) {
@@ -5520,8 +5526,16 @@ func gfput(pp *p, gp *g) {
 
 	stksize := gp.stack.hi - gp.stack.lo
 
-	if stksize != uintptr(startingStackSize) {
-		// non-standard stack size - free it.
+	// When GC stack shrinking is disabled (GODEBUG=gcshrinkstackoff=1) a cached
+	// grown stack can never be reclaimed, so cap the limit at startingStackSize.
+	limit := uintptr(maxCachedStackSize)
+	if debug.gcshrinkstackoff != 0 {
+		limit = uintptr(startingStackSize)
+	}
+	if stksize > limit {
+		// Free stacks larger than the limit. Smaller (possibly grown) stacks are
+		// retained on the free-g list so a future goroutine can reuse them
+		// instead of paying to grow again.
 		stackfree(gp.stack)
 		gp.stack.lo = 0
 		gp.stack.hi = 0
@@ -5578,23 +5592,8 @@ retry:
 	if gp == nil {
 		return nil
 	}
-	if gp.stack.lo != 0 && gp.stack.hi-gp.stack.lo != uintptr(startingStackSize) {
-		// Deallocate old stack. We kept it in gfput because it was the
-		// right size when the goroutine was put on the free list, but
-		// the right size has changed since then.
-		systemstack(func() {
-			stackfree(gp.stack)
-			gp.stack.lo = 0
-			gp.stack.hi = 0
-			gp.stackguard0 = 0
-			if valgrindenabled {
-				valgrindDeregisterStack(gp.valgrindStackID)
-				gp.valgrindStackID = 0
-			}
-		})
-	}
 	if gp.stack.lo == 0 {
-		// Stack was deallocated in gfput or just above. Allocate a new one.
+		// Stack was deallocated in gfput. Allocate a new one.
 		systemstack(func() {
 			gp.stack = stackalloc(startingStackSize)
 			if valgrindenabled {

--- a/src/runtime/stack_test.go
+++ b/src/runtime/stack_test.go
@@ -598,20 +598,30 @@ func BenchmarkStackCopyWithStkobj(b *testing.B) {
 }
 
 func BenchmarkIssue18138(b *testing.B) {
-	// Channel with N "can run a goroutine" tokens
-	const N = 10
-	c := make(chan []byte, N)
-	for i := 0; i < N; i++ {
-		c <- make([]byte, 1)
-	}
+	for _, bm := range []struct {
+		name  string
+		depth int
+	}{
+		{"depth=64", 64},
+		{"depth=1000", 1000},
+	} {
+		b.Run(bm.name, func(b *testing.B) {
+			// Channel with N "can run a goroutine" tokens
+			const N = 10
+			c := make(chan []byte, N)
+			for i := 0; i < N; i++ {
+				c <- make([]byte, 1)
+			}
 
-	for i := 0; i < b.N; i++ {
-		<-c // get token
-		go func() {
-			useStackPtrs(1000, false) // uses ~1MB max
-			m := make([]byte, 8192)   // make GC trigger occasionally
-			c <- m                    // return token
-		}()
+			for i := 0; i < b.N; i++ {
+				<-c // get token
+				go func() {
+					useStackPtrs(bm.depth, false) // uses ~depth KiB max
+					m := make([]byte, 8192)       // make GC trigger occasionally
+					c <- m                        // return token
+				}()
+			}
+		})
 	}
 }
 
@@ -628,6 +638,23 @@ func useStackPtrs(n int, b bool) {
 		return
 	}
 	useStackPtrs(n-1, b)
+}
+
+// BenchmarkStackGrowthChurn measures short-lived goroutines that grow a stack and
+// die, one at a time.
+func BenchmarkStackGrowthChurn(b *testing.B) {
+	for _, depth := range []int{8, 32, 64, 128} {
+		b.Run(fmt.Sprintf("depth=%d", depth), func(b *testing.B) {
+			c := make(chan bool)
+			for i := 0; i < b.N; i++ {
+				go func() {
+					useStackPtrs(depth, false)
+					c <- true
+				}()
+				<-c
+			}
+		})
+	}
 }
 
 type structWithMethod struct{}


### PR DESCRIPTION
A dead goroutine's stack is freed in gfput unless it is exactly
startingStackSize, and gfget re-frees a stack whose size no longer
matches. So a goroutine that grew its stack returns that memory as soon
as it dies, and the next goroutine to reuse the g must grow it again
from scratch.

In production we observe stack growth (copystack) costing ~3.9% of CPU
across the fleet, comparable to GC. The cost is dominated by short-lived
RPC goroutines that grow to 16-32 KiB and die before the next GC, so
their size is never reflected in startingStackSize and each one pays to
grow again.

Instead, retain a dead goroutine's grown stack on the per-P free-g list
for reuse, freeing only stacks larger than a 128 KiB cap. Ephemeral
goroutines reuse an already-grown stack, while long-lived goroutines are
still shrunk by GC. The per-P free-g list is already capped at 64
entries, so the additional retained memory is bounded.

Both benchmarks below spawn short-lived goroutines that grow a stack and
then die. Measured on linux/amd64 (AMD EPYC 7B13), GOMAXPROCS=48, 10
runs each with benchstat.

BenchmarkIssue18138 (existing) also allocates on each goroutine, so it
includes realistic allocation and GC costs. At depth=64 the stack stays
under the 128 KiB cap and is reused; at depth=1000 (~1 MiB) it exceeds
the cap and is largely unaffected:

                         │   vanilla    │             stackcache              │
                         │    sec/op    │   sec/op     vs base                │
Issue18138/depth=64-48     11.087µ ± 2%   4.386µ ± 4%  -60.44% (p=0.000 n=10)
Issue18138/depth=1000-48    64.59µ ± 5%   60.97µ ± 3%   -5.60% (p=0.000 n=10)
geomean                     26.76µ        16.35µ       -38.89%

BenchmarkStackGrowthChurn isolates the stack-
growth cost: it does no per-goroutine allocation, so no GC runs and the
goroutines are never scanned, so startingStackSize cannot presize them.
depth=8/32/64 grow 16/64/128 KiB stacks (<= the cap, reused); depth=128
grows a 256 KiB stack (over the cap, freed) and is an unchanged control:

                              │    vanilla    │             stackcache              │
                              │    sec/op     │   sec/op     vs base                │
StackGrowthChurn/depth=8-48      2900.5n ± 3%   429.3n ± 3%  -85.20% (p=0.000 n=10)
StackGrowthChurn/depth=32-48     9677.0n ± 4%   523.9n ± 6%  -94.59% (p=0.000 n=10)
StackGrowthChurn/depth=64-48    17408.0n ± 6%   649.5n ± 2%  -96.27% (p=0.000 n=10)
StackGrowthChurn/depth=128-48     31.69µ ± 4%   30.09µ ± 4%   -5.04% (p=0.015 n=10)
geomean                           11.15µ        1.448µ       -87.02%

Updates #77893