### PR TITLE
internal/poll: document why zero-byte reads do not wait for readability

### DIFF
--- a/src/internal/poll/fd_unix.go
+++ b/src/internal/poll/fd_unix.go
@@ -148,7 +148,12 @@ func (fd *FD) Read(p []byte) (int, error) {
 		// without trying (but after acquiring the readLock).
 		// Otherwise syscall.Read returns 0, nil which looks like
 		// io.EOF.
-		// TODO(bradfitz): make it wait for readability? (Issue 15735)
+		//
+		// Waiting for readability instead was proposed in
+		// go.dev/cl/22031 and abandoned. Blocking would change
+		// the behavior of existing callers, and the netpoller's
+		// edge-triggered notifications alone cannot detect data
+		// that is already buffered. See go.dev/issue/15735.
 		return 0, nil
 	}
 	if err := fd.pd.prepareRead(fd.isFile); err != nil {


### PR DESCRIPTION
The TODO asked whether a zero-byte Read should wait for readability.
CL 22031 proposed that behavior and was abandoned. Blocking would
change the behavior of existing callers, and the netpoller's
edge-triggered notifications alone cannot detect data that is
already buffered. Replace the stale TODO with the outcome.

Updates #15735