### PR TITLE
encoding/base64: make decoder errors independent of read chunking

### DIFF
--- a/src/encoding/base64/base64.go
+++ b/src/encoding/base64/base64.go
@@ -432,10 +432,21 @@ type decoder struct {
 	readErr error // error from r.Read
 	enc     *Encoding
 	r       io.Reader
+	end     bool       // saw a padded group: no more input may follow
+	total   int64      // input consumed so far, excluding filtered newlines
 	buf     [1024]byte // leftover input
 	nbuf    int
 	out     []byte // leftover decoded output
 	outbuf  [1024 / 4 * 3]byte
+}
+
+// rebaseError updates the offset of a CorruptInputError returned by decoding
+// d.buf so that it refers to a position in the whole input stream.
+func (d *decoder) rebaseError(err error) error {
+	if e, ok := err.(CorruptInputError); ok {
+		return CorruptInputError(int64(e) + d.total)
+	}
+	return err
 }
 
 func (d *decoder) Read(p []byte) (n int, err error) {
@@ -465,11 +476,19 @@ func (d *decoder) Read(p []byte) (n int, err error) {
 		d.nbuf += nn
 	}
 
+	// A padded group must end the stream: decoding the same input as a whole
+	// reports any input after it as garbage.
+	if d.end && d.nbuf > 0 {
+		d.err = CorruptInputError(d.total)
+		return 0, d.err
+	}
+
 	if d.nbuf < 4 {
 		if d.enc.padChar == NoPadding && d.nbuf > 0 {
 			// Decode final fragment, without padding.
 			var nw int
 			nw, d.err = d.enc.Decode(d.outbuf[:], d.buf[:d.nbuf])
+			d.err = d.rebaseError(d.err)
 			d.nbuf = 0
 			d.out = d.outbuf[:nw]
 			n = copy(p, d.out)
@@ -499,6 +518,13 @@ func (d *decoder) Read(p []byte) (n int, err error) {
 	} else {
 		n, d.err = d.enc.Decode(p, d.buf[:nr])
 	}
+	if d.err != nil {
+		d.err = d.rebaseError(d.err)
+	} else if d.enc.padChar != NoPadding && d.buf[nr-1] == byte(d.enc.padChar) {
+		// The decoded chunk ended with a padded group.
+		d.end = true
+	}
+	d.total += int64(nr)
 	d.nbuf -= nr
 	copy(d.buf[:d.nbuf], d.buf[nr:])
 	return n, d.err

--- a/src/encoding/base64/base64_test.go
+++ b/src/encoding/base64/base64_test.go
@@ -197,6 +197,36 @@ func TestDecoder(t *testing.T) {
 	}
 }
 
+func TestDecoderChunking(t *testing.T) {
+	// The decoder must behave identically to decoding the whole input at
+	// once, regardless of how the underlying reader chunks the input.
+	// See golang.org/issue/31626.
+	tests := []struct {
+		enc *Encoding
+		in  string
+	}{
+		{StdEncoding, "Rw==bw=="},     // padding inside the stream
+		{StdEncoding, "AAAA####"},     // error offset must not reset per chunk
+		{StdEncoding, "Rw==x"},        // trailing garbage after a padded group
+		{StdEncoding, "Rw===="},       // extra padding after a padded group
+		{StdEncoding, "AAAABBBBCCCC"}, // valid input
+		{StdEncoding, "AAAABB=="},     // valid input with padding
+		{RawStdEncoding, "AAAABB"},    // valid input, no padding
+		{RawStdEncoding, "AAAA#B"},    // invalid byte in final fragment
+	}
+	for _, tt := range tests {
+		want, wantErr := tt.enc.DecodeString(tt.in)
+		for i := 0; i <= len(tt.in); i++ {
+			r := io.MultiReader(strings.NewReader(tt.in[:i]), strings.NewReader(tt.in[i:]))
+			got, gotErr := io.ReadAll(NewDecoder(tt.enc, r))
+			if !bytes.Equal(got, want) || gotErr != wantErr {
+				t.Errorf("Decode(%q) with split at %d = %q, %v; want %q, %v",
+					tt.in, i, got, gotErr, want, wantErr)
+			}
+		}
+	}
+}
+
 func TestDecoderBuffering(t *testing.T) {
 	for bs := 1; bs <= 12; bs++ {
 		decoder := NewDecoder(StdEncoding, strings.NewReader(bigtest.encoded))


### PR DESCRIPTION
The stream decoder decoded each buffered chunk with a stateless call
to Decode, so validity and error offsets depended on how the
underlying reader happened to chunk the input. A padded group followed
by more input was accepted whenever a chunk boundary fell right after
the padding, even though decoding the same input as a whole rejects
it, and CorruptInputError offsets were relative to the current chunk
rather than the whole stream.

Track how much input has been consumed and whether a padded group has
been seen: reject any input that follows a padded group, and rebase
error offsets so they refer to positions in the whole input stream.

Fixes #31626