### PR TITLE
reflect: acknowledge ValueError applies to non-receiver arguments

### DIFF
--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -3761,7 +3761,7 @@ func TestTagGet(t *testing.T) {
 }
 
 func TestBytes(t *testing.T) {
-	shouldPanic("on int Value", func() { ValueOf(0).Bytes() })
+	shouldPanic("with int Value", func() { ValueOf(0).Bytes() })
 	shouldPanic("of non-byte slice", func() { ValueOf([]string{}).Bytes() })
 
 	type S []byte
@@ -3777,7 +3777,7 @@ func TestBytes(t *testing.T) {
 	type A [4]byte
 	a := A{1, 2, 3, 4}
 	shouldPanic("unaddressable", func() { ValueOf(a).Bytes() })
-	shouldPanic("on ptr Value", func() { ValueOf(&a).Bytes() })
+	shouldPanic("with ptr Value", func() { ValueOf(&a).Bytes() })
 	b := ValueOf(&a).Elem().Bytes()
 	if !bytes.Equal(a[:], y) {
 		t.Fatalf("ValueOf(%v).Bytes() = %v", a, b)
@@ -4044,49 +4044,57 @@ func TestCallPanic(t *testing.T) {
 	badCall(func() { call(v.Field(7).Field(1).Elem().Method(0)) }) // .namedT2.t0.W
 }
 
+func TestValueErrorNonReceiverArgument(t *testing.T) {
+	// Issue 41953: ValueError is also used for non-receiver arguments, so
+	// its message must not imply that the receiver is the offending Value.
+	var i int
+	v := ValueOf(&i).Elem()
+	shouldPanic("call of reflect.Value.Set with zero Value", func() { v.Set(Value{}) })
+}
+
 func TestValuePanic(t *testing.T) {
 	vo := ValueOf
 	shouldPanic("reflect.Value.Addr of unaddressable value", func() { vo(0).Addr() })
-	shouldPanic("call of reflect.Value.Bool on float64 Value", func() { vo(0.0).Bool() })
-	shouldPanic("call of reflect.Value.Bytes on string Value", func() { vo("").Bytes() })
-	shouldPanic("call of reflect.Value.Call on bool Value", func() { vo(true).Call(nil) })
-	shouldPanic("call of reflect.Value.CallSlice on int Value", func() { vo(0).CallSlice(nil) })
-	shouldPanic("call of reflect.Value.Close on string Value", func() { vo("").Close() })
-	shouldPanic("call of reflect.Value.Complex on float64 Value", func() { vo(0.0).Complex() })
-	shouldPanic("call of reflect.Value.Elem on bool Value", func() { vo(false).Elem() })
-	shouldPanic("call of reflect.Value.Field on int Value", func() { vo(0).Field(0) })
-	shouldPanic("call of reflect.Value.Float on string Value", func() { vo("").Float() })
-	shouldPanic("call of reflect.Value.Index on float64 Value", func() { vo(0.0).Index(0) })
-	shouldPanic("call of reflect.Value.Int on bool Value", func() { vo(false).Int() })
-	shouldPanic("call of reflect.Value.IsNil on int Value", func() { vo(0).IsNil() })
-	shouldPanic("call of reflect.Value.Len on bool Value", func() { vo(false).Len() })
-	shouldPanic("call of reflect.Value.MapIndex on float64 Value", func() { vo(0.0).MapIndex(vo(0.0)) })
-	shouldPanic("call of reflect.Value.MapKeys on string Value", func() { vo("").MapKeys() })
-	shouldPanic("call of reflect.Value.MapRange on int Value", func() { vo(0).MapRange() })
-	shouldPanic("call of reflect.Value.Method on zero Value", func() { vo(nil).Method(0) })
-	shouldPanic("call of reflect.Value.NumField on string Value", func() { vo("").NumField() })
-	shouldPanic("call of reflect.Value.NumMethod on zero Value", func() { vo(nil).NumMethod() })
-	shouldPanic("call of reflect.Value.OverflowComplex on float64 Value", func() { vo(float64(0)).OverflowComplex(0) })
-	shouldPanic("call of reflect.Value.OverflowFloat on int64 Value", func() { vo(int64(0)).OverflowFloat(0) })
-	shouldPanic("call of reflect.Value.OverflowInt on uint64 Value", func() { vo(uint64(0)).OverflowInt(0) })
-	shouldPanic("call of reflect.Value.OverflowUint on complex64 Value", func() { vo(complex64(0)).OverflowUint(0) })
-	shouldPanic("call of reflect.Value.Recv on string Value", func() { vo("").Recv() })
-	shouldPanic("call of reflect.Value.Send on bool Value", func() { vo(true).Send(vo(true)) })
+	shouldPanic("call of reflect.Value.Bool with float64 Value", func() { vo(0.0).Bool() })
+	shouldPanic("call of reflect.Value.Bytes with string Value", func() { vo("").Bytes() })
+	shouldPanic("call of reflect.Value.Call with bool Value", func() { vo(true).Call(nil) })
+	shouldPanic("call of reflect.Value.CallSlice with int Value", func() { vo(0).CallSlice(nil) })
+	shouldPanic("call of reflect.Value.Close with string Value", func() { vo("").Close() })
+	shouldPanic("call of reflect.Value.Complex with float64 Value", func() { vo(0.0).Complex() })
+	shouldPanic("call of reflect.Value.Elem with bool Value", func() { vo(false).Elem() })
+	shouldPanic("call of reflect.Value.Field with int Value", func() { vo(0).Field(0) })
+	shouldPanic("call of reflect.Value.Float with string Value", func() { vo("").Float() })
+	shouldPanic("call of reflect.Value.Index with float64 Value", func() { vo(0.0).Index(0) })
+	shouldPanic("call of reflect.Value.Int with bool Value", func() { vo(false).Int() })
+	shouldPanic("call of reflect.Value.IsNil with int Value", func() { vo(0).IsNil() })
+	shouldPanic("call of reflect.Value.Len with bool Value", func() { vo(false).Len() })
+	shouldPanic("call of reflect.Value.MapIndex with float64 Value", func() { vo(0.0).MapIndex(vo(0.0)) })
+	shouldPanic("call of reflect.Value.MapKeys with string Value", func() { vo("").MapKeys() })
+	shouldPanic("call of reflect.Value.MapRange with int Value", func() { vo(0).MapRange() })
+	shouldPanic("call of reflect.Value.Method with zero Value", func() { vo(nil).Method(0) })
+	shouldPanic("call of reflect.Value.NumField with string Value", func() { vo("").NumField() })
+	shouldPanic("call of reflect.Value.NumMethod with zero Value", func() { vo(nil).NumMethod() })
+	shouldPanic("call of reflect.Value.OverflowComplex with float64 Value", func() { vo(float64(0)).OverflowComplex(0) })
+	shouldPanic("call of reflect.Value.OverflowFloat with int64 Value", func() { vo(int64(0)).OverflowFloat(0) })
+	shouldPanic("call of reflect.Value.OverflowInt with uint64 Value", func() { vo(uint64(0)).OverflowInt(0) })
+	shouldPanic("call of reflect.Value.OverflowUint with complex64 Value", func() { vo(complex64(0)).OverflowUint(0) })
+	shouldPanic("call of reflect.Value.Recv with string Value", func() { vo("").Recv() })
+	shouldPanic("call of reflect.Value.Send with bool Value", func() { vo(true).Send(vo(true)) })
 	shouldPanic("value of type string is not assignable to type bool", func() { vo(new(bool)).Elem().Set(vo("")) })
-	shouldPanic("call of reflect.Value.SetBool on string Value", func() { vo(new(string)).Elem().SetBool(false) })
+	shouldPanic("call of reflect.Value.SetBool with string Value", func() { vo(new(string)).Elem().SetBool(false) })
 	shouldPanic("reflect.Value.SetBytes using unaddressable value", func() { vo("").SetBytes(nil) })
-	shouldPanic("call of reflect.Value.SetCap on string Value", func() { vo(new(string)).Elem().SetCap(0) })
-	shouldPanic("call of reflect.Value.SetComplex on string Value", func() { vo(new(string)).Elem().SetComplex(0) })
-	shouldPanic("call of reflect.Value.SetFloat on string Value", func() { vo(new(string)).Elem().SetFloat(0) })
-	shouldPanic("call of reflect.Value.SetInt on string Value", func() { vo(new(string)).Elem().SetInt(0) })
-	shouldPanic("call of reflect.Value.SetLen on string Value", func() { vo(new(string)).Elem().SetLen(0) })
-	shouldPanic("call of reflect.Value.SetString on int Value", func() { vo(new(int)).Elem().SetString("") })
+	shouldPanic("call of reflect.Value.SetCap with string Value", func() { vo(new(string)).Elem().SetCap(0) })
+	shouldPanic("call of reflect.Value.SetComplex with string Value", func() { vo(new(string)).Elem().SetComplex(0) })
+	shouldPanic("call of reflect.Value.SetFloat with string Value", func() { vo(new(string)).Elem().SetFloat(0) })
+	shouldPanic("call of reflect.Value.SetInt with string Value", func() { vo(new(string)).Elem().SetInt(0) })
+	shouldPanic("call of reflect.Value.SetLen with string Value", func() { vo(new(string)).Elem().SetLen(0) })
+	shouldPanic("call of reflect.Value.SetString with int Value", func() { vo(new(int)).Elem().SetString("") })
 	shouldPanic("reflect.Value.SetUint using unaddressable value", func() { vo(0.0).SetUint(0) })
-	shouldPanic("call of reflect.Value.Slice on bool Value", func() { vo(true).Slice(1, 2) })
-	shouldPanic("call of reflect.Value.Slice3 on int Value", func() { vo(0).Slice3(1, 2, 3) })
-	shouldPanic("call of reflect.Value.TryRecv on bool Value", func() { vo(true).TryRecv() })
-	shouldPanic("call of reflect.Value.TrySend on string Value", func() { vo("").TrySend(vo("")) })
-	shouldPanic("call of reflect.Value.Uint on float64 Value", func() { vo(0.0).Uint() })
+	shouldPanic("call of reflect.Value.Slice with bool Value", func() { vo(true).Slice(1, 2) })
+	shouldPanic("call of reflect.Value.Slice3 with int Value", func() { vo(0).Slice3(1, 2, 3) })
+	shouldPanic("call of reflect.Value.TryRecv with bool Value", func() { vo(true).TryRecv() })
+	shouldPanic("call of reflect.Value.TrySend with string Value", func() { vo("").TrySend(vo("")) })
+	shouldPanic("call of reflect.Value.Uint with float64 Value", func() { vo(0.0).Uint() })
 }
 
 func shouldPanic(expect string, f func()) {

--- a/src/reflect/nih_test.go
+++ b/src/reflect/nih_test.go
@@ -24,7 +24,7 @@ func TestNotInHeapDeref(t *testing.T) {
 	// See issue 48399.
 	v := ValueOf((*nih)(nil))
 	v.Elem()
-	shouldPanic("reflect: call of reflect.Value.Field on zero Value", func() { v.Elem().Field(0) })
+	shouldPanic("reflect: call of reflect.Value.Field with zero Value", func() { v.Elem().Field(0) })
 
 	v = ValueOf(&global_nih)
 	if got := v.Elem().Field(1).Int(); got != 7 {

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -168,7 +168,7 @@ func unpackEface(i any) Value {
 	return Value{t, e.Data, f}
 }
 
-// A ValueError occurs when a Value method is invoked on
+// A ValueError occurs when a Value method is invoked using
 // a [Value] that does not support it. Such cases are documented
 // in the description of each method.
 type ValueError struct {
@@ -178,9 +178,9 @@ type ValueError struct {
 
 func (e *ValueError) Error() string {
 	if e.Kind == 0 {
-		return "reflect: call of " + e.Method + " on zero Value"
+		return "reflect: call of " + e.Method + " with zero Value"
 	}
-	return "reflect: call of " + e.Method + " on " + e.Kind.String() + " Value"
+	return "reflect: call of " + e.Method + " with " + e.Kind.String() + " Value"
 }
 
 // valueMethodName returns the name of the exported calling method on Value.


### PR DESCRIPTION
ValueError is used to report both receiver and non-receiver arguments,
but its message assumed the receiver, producing misleading panics such
as

    reflect: call of reflect.Value.Set on zero Value

for v.Set(reflect.Value{}), where the zero Value is the argument, not
the receiver. Say "with" instead of "on" so the message doesn't point
at the receiver, and update the ValueError doc comment to match.

Revives CL 262157 by Toni Cárdenas, with the test expectations updated
and a regression test added.

Fixes #41953