### PR TITLE
cmd/compile: enable CondSelect math for pow2 Or/Xor on amd64

### DIFF
--- a/src/cmd/compile/internal/ssa/rewrite.go
+++ b/src/cmd/compile/internal/ssa/rewrite.go
@@ -2825,17 +2825,12 @@ func bool2int(x bool) int {
 func rewriteCondSelectIntoMath(config *Config, op Op, constant int64) bool {
 	switch config.arch {
 	case "amd64":
-		if constant == 1 {
-			return true
-		}
-		switch op {
-		case OpAdd64, OpAdd32, OpAdd16, OpAdd8:
-			switch constant {
-			case 2, 4, 8:
-				// Implemented with LEA a + b * displacement form
-				return true
-			}
-		}
+		// constant=1 is a zext, Add with 2/4/8 uses LEA,
+		// the rest strength-reduce Mul(powerOf2, bool) to SHL.
+		// SHL is 1:3 latency vs CMOV's 2:2, but better for
+		// accumulation chains (e.g. flag packing) where the
+		// independent shift chains execute in parallel.
+		return isPowerOfTwo(uint64(constant))
 	case "arm64":
 		switch op {
 		case OpAdd64, OpAdd32, OpAdd16, OpAdd8:

--- a/src/cmd/compile/internal/ssa/rewrite.go
+++ b/src/cmd/compile/internal/ssa/rewrite.go
@@ -2826,7 +2826,7 @@ func rewriteCondSelectIntoMath(config *Config, op Op, constant int64) bool {
 	switch config.arch {
 	case "amd64":
 		// constant=1 becomes zext, add 2/4/8 becomes lea, rest becomes shl.
-		// shl has worse single latency (1:3 vs 2:2) but parallelizes in chains.
+		// shl has asymmetric latency (1:3 vs 2:2) but performs better in accumulation chains.
 		return isPowerOfTwo(uint64(constant))
 	case "arm64":
 		switch op {

--- a/src/cmd/compile/internal/ssa/rewrite.go
+++ b/src/cmd/compile/internal/ssa/rewrite.go
@@ -2825,11 +2825,8 @@ func bool2int(x bool) int {
 func rewriteCondSelectIntoMath(config *Config, op Op, constant int64) bool {
 	switch config.arch {
 	case "amd64":
-		// constant=1 is a zext, Add with 2/4/8 uses LEA,
-		// the rest strength-reduce Mul(powerOf2, bool) to SHL.
-		// SHL is 1:3 latency vs CMOV's 2:2, but better for
-		// accumulation chains (e.g. flag packing) where the
-		// independent shift chains execute in parallel.
+		// constant=1 becomes zext, add 2/4/8 becomes lea, rest becomes shl.
+		// shl has worse single latency (1:3 vs 2:2) but parallelizes in chains.
 		return isPowerOfTwo(uint64(constant))
 	case "arm64":
 		switch op {

--- a/test/codegen/condmove.go
+++ b/test/codegen/condmove.go
@@ -535,10 +535,30 @@ func cmovmathadd8else(a uint, b bool) uint {
 	return a
 }
 
+func cmovmathadd16(a uint, b bool) uint {
+	if b {
+		a += 16
+	}
+	// amd64:"ADDQ" -"CMOV"
+	// arm64:"ADD R[0-9]+<<4" -"CSEL" -"MUL"
+	// ppc64x: "ISEL" -"MUL"
+	return a
+}
+func cmovmathadd16else(a uint, b bool) uint {
+	if !b {
+		a += 16
+	}
+	// amd64:"ADDQ" -"CMOV"
+	// arm64:"ADD R[0-9]+<<4" -"CSEL" -"MUL"
+	// ppc64x: "ISEL" -"MUL"
+	return a
+}
+
 func cmovmathadd9223372036854775808(a uint, b bool) uint {
 	if b {
 		a += 1 << 63
 	}
+	// amd64:"ADDQ" -"CMOV"
 	// arm64:"ADD R[0-9]+<<63" -"CSEL" -"MUL"
 	// ppc64x: "ISEL" -"MUL"
 	return a
@@ -547,6 +567,7 @@ func cmovmathadd9223372036854775808else(a uint, b bool) uint {
 	if !b {
 		a += 1 << 63
 	}
+	// amd64:"ADDQ" -"CMOV"
 	// arm64:"ADD R[0-9]+<<63" -"CSEL" -"MUL"
 	// ppc64x: "ISEL" -"MUL"
 	return a
@@ -577,6 +598,7 @@ func cmovmathsub2(a uint, b bool) uint {
 	if b {
 		a -= 2
 	}
+	// amd64:"SUBQ" -"CMOV"
 	// arm64 :"SUB R[0-9]+<<1" -"CSEL" -"MUL"
 	// ppc64x: "ISEL" -"MUL"
 	return a
@@ -585,6 +607,7 @@ func cmovmathsub2else(a uint, b bool) uint {
 	if !b {
 		a -= 2
 	}
+	// amd64:"SUBQ" -"CMOV"
 	// arm64 :"SUB R[0-9]+<<1" -"CSEL" -"MUL"
 	// ppc64x: "ISEL" -"MUL"
 	return a
@@ -596,6 +619,7 @@ func cmovmathsub9223372036854775808(a uint, b bool) uint {
 	if b {
 		a -= 1 << 63
 	}
+	// amd64:"(SUBQ|ADDQ)" -"CMOV"
 	// arm64:"(SUB|ADD) R[0-9]+<<63" -"CSEL" -"MUL"
 	// ppc64x: "ISEL" -"MUL"
 	return a
@@ -604,6 +628,7 @@ func cmovmathsub9223372036854775808else(a uint, b bool) uint {
 	if !b {
 		a -= 1 << 63
 	}
+	// amd64:"(SUBQ|ADDQ)" -"CMOV"
 	// arm64:"(SUB|ADD) R[0-9]+<<63" -"CSEL" -"MUL"
 	// ppc64x: "ISEL" -"MUL"
 	return a
@@ -699,6 +724,7 @@ func cmovmathor2(a uint, b bool) uint {
 	if b {
 		a |= 2
 	}
+	// amd64:"ORQ" -"CMOV"
 	// arm64:"ORR R[0-9]+<<1" -"CSEL" -"MUL"
 	// ppc64x:"ISEL" -"MUL"
 	return a
@@ -707,6 +733,7 @@ func cmovmathor2else(a uint, b bool) uint {
 	if !b {
 		a |= 2
 	}
+	// amd64:"ORQ" -"CMOV"
 	// arm64:"ORR R[0-9]+<<1" -"CSEL" -"MUL"
 	// ppc64x:"ISEL" -"MUL"
 	return a
@@ -716,6 +743,7 @@ func cmovmathor9223372036854775808(a uint, b bool) uint {
 	if b {
 		a |= 1 << 63
 	}
+	// amd64:"ORQ" -"CMOV"
 	// arm64:"ORR R[0-9]+<<63" -"CSEL" -"MUL"
 	// ppc64x:"ISEL" -"MUL"
 	return a
@@ -724,6 +752,7 @@ func cmovmathor9223372036854775808else(a uint, b bool) uint {
 	if !b {
 		a |= 1 << 63
 	}
+	// amd64:"ORQ" -"CMOV"
 	// arm64:"ORR R[0-9]+<<63" -"CSEL" -"MUL"
 	// ppc64x:"ISEL" -"MUL"
 	return a
@@ -773,6 +802,7 @@ func cmovmathxor9223372036854775808(a uint, b bool) uint {
 	if b {
 		a ^= 1 << 63
 	}
+	// amd64:"XORQ" -"CMOV"
 	// arm64:"EOR R[0-9]+<<63" -"CSEL" -"MUL"
 	// ppc64x: "ISEL" -"MUL"
 	return a
@@ -781,40 +811,9 @@ func cmovmathxor9223372036854775808else(a uint, b bool) uint {
 	if !b {
 		a ^= 1 << 63
 	}
+	// amd64:"XORQ" -"CMOV"
 	// arm64:"EOR R[0-9]+<<63" -"CSEL" -"MUL"
 	// ppc64x: "ISEL" -"MUL"
-	return a
-}
-
-func cmovmathor4(a uint, b bool) uint {
-	if b {
-		a |= 4
-	}
-	// amd64:"ORQ" -"CMOV"
-	return a
-}
-
-func cmovmathor4else(a uint, b bool) uint {
-	if !b {
-		a |= 4
-	}
-	// amd64:"ORQ" -"CMOV"
-	return a
-}
-
-func cmovmathadd16(a uint, b bool) uint {
-	if b {
-		a += 16
-	}
-	// amd64:"ADDQ" -"CMOV"
-	return a
-}
-
-func cmovmathsub16(a uint, b bool) uint {
-	if b {
-		a -= 16
-	}
-	// amd64:"SUBQ" -"CMOV"
 	return a
 }
 

--- a/test/codegen/condmove.go
+++ b/test/codegen/condmove.go
@@ -754,6 +754,7 @@ func cmovmathxor2(a uint, b bool) uint {
 	if b {
 		a ^= 2
 	}
+	// amd64:"XORQ" -"CMOV"
 	// arm64:"EOR R[0-9]+<<1" -"CSEL" -"MUL"
 	// ppc64x: "ISEL" -"MUL"
 	return a
@@ -762,6 +763,7 @@ func cmovmathxor2else(a uint, b bool) uint {
 	if !b {
 		a ^= 2
 	}
+	// amd64:"XORQ" -"CMOV"
 	// arm64:"EOR R[0-9]+<<1" -"CSEL" -"MUL"
 	// ppc64x: "ISEL" -"MUL"
 	return a
@@ -781,6 +783,38 @@ func cmovmathxor9223372036854775808else(a uint, b bool) uint {
 	}
 	// arm64:"EOR R[0-9]+<<63" -"CSEL" -"MUL"
 	// ppc64x: "ISEL" -"MUL"
+	return a
+}
+
+func cmovmathor4(a uint, b bool) uint {
+	if b {
+		a |= 4
+	}
+	// amd64:"ORQ" -"CMOV"
+	return a
+}
+
+func cmovmathor4else(a uint, b bool) uint {
+	if !b {
+		a |= 4
+	}
+	// amd64:"ORQ" -"CMOV"
+	return a
+}
+
+func cmovmathadd16(a uint, b bool) uint {
+	if b {
+		a += 16
+	}
+	// amd64:"ADDQ" -"CMOV"
+	return a
+}
+
+func cmovmathsub16(a uint, b bool) uint {
+	if b {
+		a -= 16
+	}
+	// amd64:"SUBQ" -"CMOV"
 	return a
 }
 


### PR DESCRIPTION
changes rewriteCondSelectIntoMath to also use inline register shifts
for amd64 for power of 2 cases, as opposed to the cmov based approach.
this is faster for the case of accumulating independent conditions 
into a bitset, and slower for dependent conditions.

analysis of existing go code shows a 10:1+ ratio of independent to 
dependent conditions. the independent condition is also found more 
in hot paths where the optimization would help, for instance packing 
headers, as opposed to the dependent pattern which is used far more 
for reading flags for a first-time setup step.  

Fixes #80202