### PR TITLE
cmd/compile: fix for deadlock on delayed function inside named unpack

### DIFF
--- a/src/cmd/compile/internal/types2/named.go
+++ b/src/cmd/compile/internal/types2/named.go
@@ -265,7 +265,6 @@ func (n *Named) unpack() *Named {
 		assert(n.inst == nil)    // cannot import an instantiation
 
 		tparams, underlying, methods, delayed := n.loader(n)
-		n.loader = nil
 
 		n.tparams = bindTParams(tparams)
 		n.fromRHS = underlying // for cycle detection
@@ -275,6 +274,7 @@ func (n *Named) unpack() *Named {
 		for _, f := range delayed {
 			f()
 		}
+		n.loader = nil // nil here to avoid deadlock calling delayed functions. issue #80258
 	}
 
 	n.setState(lazyLoaded | unpacked | hasMethods)
@@ -669,6 +669,10 @@ func (n *Named) resolveUnderlying() {
 
 	for _, t := range path {
 		func() {
+			// t.loader is non-nil when *Named.unpack() call *Named.resolveUnderlying() on delayed functions f().
+			if t.loader != nil {
+				return
+			}
 			t.mu.Lock()
 			defer t.mu.Unlock()
 			// Careful, t.underlying has lock-free readers. Since we might be racing

--- a/src/cmd/compile/testdata/script/issue80258.txt
+++ b/src/cmd/compile/testdata/script/issue80258.txt
@@ -1,0 +1,24 @@
+go run main.go
+! stdout .
+
+-- main.go --
+package main
+
+import "example/p"
+
+var T p.I
+
+func main() {
+}
+
+-- go.mod --
+module example
+
+go 1.27
+-- p/p.go --
+
+package p
+
+type I int
+
+func (i *I) M[V I]() {}


### PR DESCRIPTION
This fixes the deadlock caused by *Named.mu.Lock() on
*Named.resolveUnderlying(). The mutex.Lock() first is called
by *Named.unpack(), and *Named.resolveUnderlying() is
call on delayed functions f().

The change uses the *Named.loader as a "flag" to understand that
resolveUnderlying was called by unpack, because unpack sets *Named.loader
to nil after call the loader(n) function, so changed the nil set for
*Named.loader to be after the delayed functions call.

Fixes #80258