### PR TITLE
cmd/go: add -static flag to go build

### DIFF
--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -124,6 +124,15 @@
 //		Supported only on darwin/amd64, darwin/arm64, freebsd/amd64, linux/amd64,
 //		linux/arm64 (only for 48-bit VMA), linux/ppc64le, linux/riscv64 and
 //		windows/amd64.
+//	-static
+//		produce a statically linked binary. On Linux, this passes
+//		-extldflags=-static to the linker and enables the osusergo and netgo
+//		build tags to avoid dynamic linking of libc for name resolution and
+//		user lookup. On macOS, iOS, FreeBSD, OpenBSD, and NetBSD, only the
+//		pure-Go net and os/user implementations are selected (full static
+//		linking is not supported by the system linker).
+//		Cannot be used with -buildmode=c-shared, -buildmode=shared,
+//		-buildmode=plugin, or -linkshared.
 //	-msan
 //		enable interoperation with memory sanitizer.
 //		Supported only on linux/amd64, linux/arm64, linux/loong64, freebsd/amd64

--- a/src/cmd/go/internal/cfg/cfg.go
+++ b/src/cmd/go/internal/cfg/cfg.go
@@ -92,6 +92,7 @@ var (
 	BuildToolchainName     string
 	BuildToolchainCompiler func() string
 	BuildToolchainLinker   func() string
+	BuildStatic            bool // -static flag
 	BuildTrimpath          bool // -trimpath flag
 	BuildV                 bool // -v flag
 	BuildWork              bool // -work flag

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -80,6 +80,15 @@ and test commands:
 		Supported only on darwin/amd64, darwin/arm64, freebsd/amd64, linux/amd64,
 		linux/arm64 (only for 48-bit VMA), linux/ppc64le, linux/riscv64 and
 		windows/amd64.
+	-static
+		produce a statically linked binary. On Linux, this passes
+		-extldflags=-static to the linker and enables the osusergo and netgo
+		build tags to avoid dynamic linking of libc for name resolution and
+		user lookup. On macOS, iOS, FreeBSD, OpenBSD, and NetBSD, only the
+		pure-Go net and os/user implementations are selected (full static
+		linking is not supported by the system linker).
+		Cannot be used with -buildmode=c-shared, -buildmode=shared,
+		-buildmode=plugin, or -linkshared.
 	-msan
 		enable interoperation with memory sanitizer.
 		Supported only on linux/amd64, linux/arm64, linux/loong64, freebsd/amd64
@@ -350,6 +359,7 @@ func AddBuildFlags(cmd *base.Command, mask BuildFlagMask) {
 	cmd.Flag.StringVar(&cfg.BuildPGO, "pgo", "auto", "")
 	cmd.Flag.StringVar(&cfg.BuildPkgdir, "pkgdir", "", "")
 	cmd.Flag.BoolVar(&cfg.BuildRace, "race", false, "")
+	cmd.Flag.BoolVar(&cfg.BuildStatic, "static", false, "")
 	cmd.Flag.Var((*tagsFlag)(&cfg.BuildContext.BuildTags), "tags", "")
 	cmd.Flag.Var((*base.StringsFlag)(&cfg.BuildToolexec), "toolexec", "")
 	cmd.Flag.BoolVar(&cfg.BuildTrimpath, "trimpath", false, "")

--- a/src/cmd/go/internal/work/init.go
+++ b/src/cmd/go/internal/work/init.go
@@ -59,6 +59,7 @@ func BuildInit(ld *modload.Loader) {
 
 	modload.Init(ld)
 	instrumentInit()
+	staticInit()
 	buildModeInit()
 	initCompilerConcurrencyPool()
 	cfgChangedEnv = makeCfgChangedEnv()
@@ -210,6 +211,54 @@ func instrumentInit() {
 	}
 	cfg.BuildContext.InstallSuffix += mode
 	cfg.BuildContext.ToolTags = append(cfg.BuildContext.ToolTags, mode)
+}
+
+// staticInit configures the build for producing a statically linked binary
+// when the -static flag is set. On Linux and other ELF platforms that support
+// fully static linking, it passes -extldflags=-static to the linker and enables
+// the osusergo and netgo build tags. On macOS, iOS, FreeBSD, OpenBSD, and
+// NetBSD, only the pure-Go resolver tags are enabled because the system linker
+// does not support fully static binaries.
+func staticInit() {
+	if !cfg.BuildStatic {
+		return
+	}
+
+	// Reject incompatible build modes.
+	switch cfg.BuildBuildmode {
+	case "c-shared":
+		base.Fatalf("go: cannot use -static with -buildmode=c-shared")
+	case "shared":
+		base.Fatalf("go: cannot use -static with -buildmode=shared")
+	case "plugin":
+		base.Fatalf("go: cannot use -static with -buildmode=plugin")
+	}
+	if cfg.BuildLinkshared {
+		base.Fatalf("go: cannot use -static with -linkshared")
+	}
+
+	// Enable pure-Go implementations of net and os/user on all platforms.
+	cfg.BuildContext.BuildTags = append(cfg.BuildContext.BuildTags, "osusergo", "netgo")
+
+	// Add the "static" build tag so libraries can detect static builds.
+	cfg.BuildContext.ToolTags = append(cfg.BuildContext.ToolTags, "static")
+
+	switch cfg.Goos {
+	case "linux", "solaris", "illumos", "dragonfly":
+		// Fully static linking is supported; pass -extldflags=-static to the linker.
+		forcedLdflags = append(forcedLdflags, "-extldflags=-static")
+	case "darwin", "ios", "freebsd", "openbsd", "netbsd":
+		// Full static linking is not supported by the system linker on these
+		// platforms. The osusergo and netgo tags above ensure we use pure-Go
+		// implementations, which avoids dynamic linking of libc for DNS and
+		// user lookups. No additional linker flags are needed.
+	case "windows":
+		// Windows binaries are statically linked against the Go runtime by
+		// default. The osusergo and netgo tags are sufficient.
+	default:
+		// For unrecognized platforms, apply the same safe default as BSD:
+		// pure-Go tags only, no extra linker flags.
+	}
 }
 
 func buildModeInit() {

--- a/src/cmd/go/testdata/script/build_static_buildmode.txt
+++ b/src/cmd/go/testdata/script/build_static_buildmode.txt
@@ -1,0 +1,21 @@
+# Test that -static rejects incompatible build modes.
+
+! go build -static -buildmode=c-shared .
+stderr 'cannot use -static with -buildmode=c-shared'
+
+! go build -static -buildmode=shared .
+stderr 'cannot use -static with -buildmode=shared'
+
+! go build -static -buildmode=plugin .
+stderr 'cannot use -static with -buildmode=plugin'
+
+! go build -static -linkshared .
+stderr 'cannot use -static with -linkshared'
+
+-- go.mod --
+module example.com/static
+go 1.24
+
+-- main.go --
+package main
+func main() {}

--- a/src/cmd/go/testdata/script/build_static_linux.txt
+++ b/src/cmd/go/testdata/script/build_static_linux.txt
@@ -1,0 +1,54 @@
+# Test that -static produces a statically-linked binary on Linux.
+[!GOOS:linux] skip
+[!cgo] skip
+[short] skip
+
+go build -static -o static_bin .
+go run check_static.go static_bin
+stdout 'statically linked'
+
+-- go.mod --
+module example.com/static
+go 1.24
+
+-- main.go --
+package main
+
+import (
+	"fmt"
+	"net"
+)
+
+func main() {
+	fmt.Println("hello")
+	// Force use of net package to verify netgo tag is applied.
+	_ = net.IPv4(127, 0, 0, 1)
+}
+
+-- check_static.go --
+//go:build ignore
+
+package main
+
+import (
+	"debug/elf"
+	"fmt"
+	"os"
+)
+
+func main() {
+	f, err := elf.Open(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	for _, p := range f.Progs {
+		if p.Type == elf.PT_INTERP {
+			fmt.Println("dynamically linked")
+			return
+		}
+	}
+	fmt.Println("statically linked")
+}

--- a/src/cmd/go/testdata/script/build_static_tags.txt
+++ b/src/cmd/go/testdata/script/build_static_tags.txt
@@ -1,0 +1,37 @@
+# Test that -static enables osusergo and netgo build tags.
+# Verify by building a package that has netgo-constrained source.
+
+go build -static -o $WORK/static_tags_bin .
+
+-- go.mod --
+module example.com/static
+go 1.24
+
+-- main.go --
+package main
+
+func main() {
+	printMode()
+}
+
+-- mode_static.go --
+//go:build netgo && osusergo
+
+package main
+
+import "fmt"
+
+func printMode() {
+	fmt.Println("static mode: pure-Go net and os/user")
+}
+
+-- mode_default.go --
+//go:build !netgo || !osusergo
+
+package main
+
+import "fmt"
+
+func printMode() {
+	fmt.Println("default mode: system resolver")
+}


### PR DESCRIPTION
Add a -static flag to go build that produces statically-linked
binaries without requiring users to manually assemble CGO_ENABLED,
-ldflags, -extldflags, -tags, and buildmode flags.

On Linux and other ELF platforms (Solaris, illumos, DragonFly),
-static passes -extldflags=-static to the linker and enables the
osusergo and netgo build tags. On macOS, iOS, FreeBSD, OpenBSD,
and NetBSD, where the system linker does not support fully static
binaries, only the pure-Go net and os/user implementations are
selected. On Windows, Go binaries are already statically linked
by default; -static enables the pure-Go tags for consistency.

The flag is rejected when used with incompatible build modes:
c-shared, shared, plugin, and -linkshared.

A "static" build tag is also set so that library authors can
detect static builds at compile time.

Implementation:
- cfg.go: added BuildStatic bool field
- build.go: flag registration and documentation
- init.go: platform-specific staticInit function handles
  Linux full static + osusergo/netgo, macOS/BSD pure-Go
  resolvers only (per ianlancetaylor guidance), and Windows
  pure-Go tags for consistency

Tests:
- build_static_linux.txt: verifies static binary on Linux
- build_static_buildmode.txt: verifies incompatible buildmode
  rejection with clear error messages
- build_static_tags.txt: verifies osusergo and netgo tag
  activation under -static

Design follows ianlancetaylor's 2026-03-31 guidance on
platform-specific behavior.

Fixes #26492