### PR TITLE
regexp: fix latent stale flag bug after NFA prefix fast-forward

### DIFF
--- a/src/regexp/exec.go
+++ b/src/regexp/exec.go
@@ -213,6 +213,7 @@ func (m *machine) match(i input, pos int) bool {
 				pos += advance
 				r, width = i.step(pos)
 				r1, width1 = i.step(pos + width)
+				flag = i.context(pos)
 			}
 		}
 		if !m.matched {

--- a/src/regexp/exec_test.go
+++ b/src/regexp/exec_test.go
@@ -734,3 +734,25 @@ func TestProgramTooLongForBacktrack(t *testing.T) {
 		t.Errorf("longRegex.MatchString(\"xxx\") was true, want false")
 	}
 }
+
+func TestNFAFastForwardStaleFlag(t *testing.T) {
+	// Compile a regex that requires a word boundary.
+	// Normally, the Go compiler leaves re.prefix empty because of the \b.
+	re := MustCompile(`\bfoo`)
+
+	// Artificially inject a prefix to simulate a smarter compiler (e.g., one that
+	// extracts literal prefixes after empty-width assertions) and force the
+	// NFA fast-forward loop to activate.
+	re.prefix = "foo"
+	re.prefixBytes = []byte("foo")
+	re.prefixRune = 'f'
+
+	// Create a string large enough to bypass the Backtracker (routes to NFA).
+	longString := strings.Repeat("a", 500000) + "foo"
+
+	// The context at index 500000 ('a' to 'f') is NO_WORD_BOUNDARY.
+	// Therefore, \b (Word Boundary) should FAIL.
+	if re.MatchString(longString) {
+		t.Errorf("BUG: \\bfoo falsely matched inside an unbroken word due to stale flag.")
+	}
+}


### PR DESCRIPTION
In `exec.go`, when the NFA machine utilizes `m.re.prefix` to fast-forward the `pos` cursor, it updates the runes (`r`, `r1`) but fails to recalculate the `flag` context for the new position. This oversight causes the subsequent `m.add()` call to evaluate `InstEmptyWidth` using the stale boundary context from the pre-jump position.

Interestingly, this was implemented correctly in the `OnePass` engine (`doOnePass` explicitly calls `flag = i.context(pos)` after fast-forwarding), but was missed in the NFA `match()` loop.

Currently, this NFA bug is dormant because `syntax.(*Prog).Prefix()` halts at `InstEmptyWidth`, meaning any regex starting with a boundary assertion will have an empty prefix and bypass the fast-forward loop entirely. However, if the prefix extractor is ever optimized to identify literal prefixes after empty-width assertions, this stale flag will immediately cause false positives and negatives.

This commit adds the missing `flag = i.context(pos)` assignment to the NFA match loop. A test is also included which artificially injects a prefix into a boundary-prefixed `Regexp` to simulate a smarter compiler and prove the stale flag evaluation.

Found it while was busy with re2js replacing thread pool with a sparse array (because js env have no threads) - https://github.com/le0pard/re2js/pull/48