### PR TITLE
testing: name the conflicting operation in t.Parallel panics

### DIFF
--- a/src/testing/export_test.go
+++ b/src/testing/export_test.go
@@ -10,4 +10,4 @@ type HighPrecisionTime = highPrecisionTime
 
 var HighPrecisionTimeNow = highPrecisionTimeNow
 
-const ParallelConflict = parallelConflict
+var ParallelConflict = parallelConflict

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -1017,7 +1017,9 @@ var (
 // may be called simultaneously from multiple goroutines.
 type T struct {
 	common
-	denyParallel bool
+	// denyParallel, if non-empty, is the operation (such as "t.Setenv") that
+	// forbids a later call to t.Parallel.
+	denyParallel string
 	tstate       *testState // For running tests and subtests.
 }
 
@@ -1902,7 +1904,12 @@ func pcToName(pc uintptr) string {
 	return frame.Function
 }
 
-const parallelConflict = `testing: test using t.Setenv, t.Chdir, or cryptotest.SetGlobalRandom can not use t.Parallel`
+// parallelConflict returns the panic message for a conflict between t.Parallel
+// and op, the operation that cannot be combined with a parallel test: one of
+// "t.Setenv", "t.Chdir", or "cryptotest.SetGlobalRandom".
+func parallelConflict(op string) string {
+	return "testing: test using " + op + " can not use t.Parallel"
+}
 
 // Parallel signals that this test is to be run in parallel with (and only with)
 // other parallel tests, and pauses until all non-parallel tests have finished.
@@ -1916,8 +1923,8 @@ func (t *T) Parallel() {
 	if t.isSynctest {
 		panic("testing: t.Parallel called inside synctest bubble")
 	}
-	if t.denyParallel {
-		panic(parallelConflict)
+	if t.denyParallel != "" {
+		panic(parallelConflict(t.denyParallel))
 	}
 	if t.parent.barrier == nil {
 		// T.Parallel has no effect when fuzzing.
@@ -1978,10 +1985,10 @@ func (t *T) Parallel() {
 //
 //go:linkname checkParallel testing.checkParallel
 func checkParallel(t *T) {
-	t.checkParallel()
+	t.checkParallel("cryptotest.SetGlobalRandom")
 }
 
-func (t *T) checkParallel() {
+func (t *T) checkParallel(op string) {
 	// Non-parallel subtests that have parallel ancestors may still
 	// run in parallel with other tests: they are only non-parallel
 	// with respect to the other subtests of the same parent.
@@ -1989,11 +1996,11 @@ func (t *T) checkParallel() {
 	// to deny those if the current test or any parent is parallel.
 	for c := &t.common; c != nil; c = c.parent {
 		if c.isParallel {
-			panic(parallelConflict)
+			panic(parallelConflict(op))
 		}
 	}
 
-	t.denyParallel = true
+	t.denyParallel = op
 }
 
 // Setenv calls os.Setenv(key, value) and uses Cleanup to
@@ -2003,7 +2010,7 @@ func (t *T) checkParallel() {
 // Because Setenv affects the whole process, it cannot be used
 // in parallel tests or tests with parallel ancestors.
 func (t *T) Setenv(key, value string) {
-	t.checkParallel()
+	t.checkParallel("t.Setenv")
 	t.common.Setenv(key, value)
 }
 
@@ -2014,7 +2021,7 @@ func (t *T) Setenv(key, value string) {
 // Because Chdir affects the whole process, it cannot be used
 // in parallel tests or tests with parallel ancestors.
 func (t *T) Chdir(dir string) {
-	t.checkParallel()
+	t.checkParallel("t.Chdir")
 	t.common.Chdir(dir)
 }
 

--- a/src/testing/testing_test.go
+++ b/src/testing/testing_test.go
@@ -237,43 +237,43 @@ func TestSetenv(t *testing.T) {
 	}
 }
 
-func expectParallelConflict(t *testing.T) {
-	want := testing.ParallelConflict
+func expectParallelConflict(t *testing.T, op string) {
+	want := testing.ParallelConflict(op)
 	if got := recover(); got != want {
 		t.Fatalf("expected panic; got %#v want %q", got, want)
 	}
 }
 
-func testWithParallelAfter(t *testing.T, fn func(*testing.T)) {
-	defer expectParallelConflict(t)
+func testWithParallelAfter(t *testing.T, op string, fn func(*testing.T)) {
+	defer expectParallelConflict(t, op)
 
 	fn(t)
 	t.Parallel()
 }
 
-func testWithParallelBefore(t *testing.T, fn func(*testing.T)) {
-	defer expectParallelConflict(t)
+func testWithParallelBefore(t *testing.T, op string, fn func(*testing.T)) {
+	defer expectParallelConflict(t, op)
 
 	t.Parallel()
 	fn(t)
 }
 
-func testWithParallelParentBefore(t *testing.T, fn func(*testing.T)) {
+func testWithParallelParentBefore(t *testing.T, op string, fn func(*testing.T)) {
 	t.Parallel()
 
 	t.Run("child", func(t *testing.T) {
-		defer expectParallelConflict(t)
+		defer expectParallelConflict(t, op)
 
 		fn(t)
 	})
 }
 
-func testWithParallelGrandParentBefore(t *testing.T, fn func(*testing.T)) {
+func testWithParallelGrandParentBefore(t *testing.T, op string, fn func(*testing.T)) {
 	t.Parallel()
 
 	t.Run("child", func(t *testing.T) {
 		t.Run("grand-child", func(t *testing.T) {
-			defer expectParallelConflict(t)
+			defer expectParallelConflict(t, op)
 
 			fn(t)
 		})
@@ -285,19 +285,19 @@ func tSetenv(t *testing.T) {
 }
 
 func TestSetenvWithParallelAfter(t *testing.T) {
-	testWithParallelAfter(t, tSetenv)
+	testWithParallelAfter(t, "t.Setenv", tSetenv)
 }
 
 func TestSetenvWithParallelBefore(t *testing.T) {
-	testWithParallelBefore(t, tSetenv)
+	testWithParallelBefore(t, "t.Setenv", tSetenv)
 }
 
 func TestSetenvWithParallelParentBefore(t *testing.T) {
-	testWithParallelParentBefore(t, tSetenv)
+	testWithParallelParentBefore(t, "t.Setenv", tSetenv)
 }
 
 func TestSetenvWithParallelGrandParentBefore(t *testing.T) {
-	testWithParallelGrandParentBefore(t, tSetenv)
+	testWithParallelGrandParentBefore(t, "t.Setenv", tSetenv)
 }
 
 func tChdir(t *testing.T) {
@@ -305,19 +305,19 @@ func tChdir(t *testing.T) {
 }
 
 func TestChdirWithParallelAfter(t *testing.T) {
-	testWithParallelAfter(t, tChdir)
+	testWithParallelAfter(t, "t.Chdir", tChdir)
 }
 
 func TestChdirWithParallelBefore(t *testing.T) {
-	testWithParallelBefore(t, tChdir)
+	testWithParallelBefore(t, "t.Chdir", tChdir)
 }
 
 func TestChdirWithParallelParentBefore(t *testing.T) {
-	testWithParallelParentBefore(t, tChdir)
+	testWithParallelParentBefore(t, "t.Chdir", tChdir)
 }
 
 func TestChdirWithParallelGrandParentBefore(t *testing.T) {
-	testWithParallelGrandParentBefore(t, tChdir)
+	testWithParallelGrandParentBefore(t, "t.Chdir", tChdir)
 }
 
 func TestChdir(t *testing.T) {


### PR DESCRIPTION
t.Parallel and the operations that forbid it (t.Setenv, t.Chdir, and
cryptotest.SetGlobalRandom) shared a single panic message that listed all
three operations, so the panic never named the one that actually caused the
conflict. A test that only calls t.Setenv could panic with a message
mentioning cryptotest.SetGlobalRandom, which is confusing.

Record the specific operation that denies parallelism and report it in both
directions: when t.Parallel is called after one of those operations, and
when one of them is called on a test that is already parallel.

Fixes #80267
