### PR TITLE
os: document ReadFile returned error type

### DIFF
--- a/src/os/file.go
+++ b/src/os/file.go
@@ -865,6 +865,7 @@ func (dir dirFS) join(name string) (string, error) {
 
 // ReadFile reads the named file and returns the contents.
 // A successful call returns err == nil, not err == EOF.
+// If there is an error, it will be of type [*PathError].
 // Because ReadFile reads the whole file, it does not treat an EOF from Read
 // as an error to be reported.
 func ReadFile(name string) ([]byte, error) {


### PR DESCRIPTION
Add a clarification to the os.ReadFile documentation: when ReadFile fails, the returned error is of type *PathError. This makes error-handling expectations explicit for callers that rely on error type checks.
