### PR TITLE
os/exec: Cmd.Start example uses too long timeout

### DIFF
--- a/src/os/exec/example_test.go
+++ b/src/os/exec/example_test.go
@@ -63,7 +63,7 @@ func ExampleCmd_Run() {
 }
 
 func ExampleCmd_Start() {
-	cmd := exec.Command("sleep", "5")
+	cmd := exec.Command("sleep", "1")
 	err := cmd.Start()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Shorten the example sleep duration in ExampleCmd_Start from 5s to 1s to avoid unnecessary wait time in documentation output and keep the example quick.