### PR TITLE
doc: clarify fips140 module version with GODEBUG=on

### DIFF
--- a/doc/godebug.md
+++ b/doc/godebug.md
@@ -277,6 +277,8 @@ The possible values are:
 - "on": the Go Cryptographic Module operates in FIPS 140-3 mode.
 - "only": like "on", but cryptographic algorithms not approved by
   FIPS 140-3 return an error or panic.
+For `on` and `only`, the module version is controlled by the
+`GOFIPS140` environment variable. By default it is `GOFIPS140=latest`.
 For more information, see [FIPS 140-3 Compliance](/doc/security/fips140).
 This setting is fixed at program startup time, and can't be modified
 by changing the `GODEBUG` environment variable after the program starts.

--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -2609,6 +2609,8 @@
 //		The default is GOFIPS140=off, which makes no FIPS-140 changes at all.
 //		Other values enable FIPS-140 compliance measures and select alternate
 //		versions of the cryptography source code.
+//		Valid values are off, latest, inprocess, certified, and versions
+//		of the form v1.N.N.
 //		See https://go.dev/doc/security/fips140 for details.
 //	GO_EXTLINK_ENABLED
 //		Whether the linker should use external linking mode

--- a/src/cmd/go/internal/help/helpdoc.go
+++ b/src/cmd/go/internal/help/helpdoc.go
@@ -744,6 +744,8 @@ Special-purpose environment variables:
 		The default is GOFIPS140=off, which makes no FIPS-140 changes at all.
 		Other values enable FIPS-140 compliance measures and select alternate
 		versions of the cryptography source code.
+		Valid values are off, latest, inprocess, certified, and versions
+		of the form v1.N.N.
 		See https://go.dev/doc/security/fips140 for details.
 	GO_EXTLINK_ENABLED
 		Whether the linker should use external linking mode


### PR DESCRIPTION
Go docs should explicitly state that when GODEBUG=fips140 is on/only, the cryptographic module version is selected via GOFIPS140 (default latest). This update improves discoverability for users configuring FIPS-140 mode.