### PR TITLE
os: ReadFile docstring doesn't mention returned errors

### DIFF
--- a/src/os/file.go
+++ b/src/os/file.go
@@ -865,6 +865,7 @@ func (dir dirFS) join(name string) (string, error) {
 
 // ReadFile reads the named file and returns the contents.
 // A successful call returns err == nil, not err == EOF.
+// If there is an error, it will be of type [*PathError].
 // Because ReadFile reads the whole file, it does not treat an EOF from Read
 // as an error to be reported.
 func ReadFile(name string) ([]byte, error) {


### PR DESCRIPTION
Add a clarification that ReadFile returns *PathError on failure, aligning docs with actual behavior. Fixes #80111.