### PR TITLE
os: document Process.Pid

### DIFF
--- a/src/os/exec.go
+++ b/src/os/exec.go
@@ -41,6 +41,7 @@ const (
 
 // Process stores the information about a process created by [StartProcess].
 type Process struct {
+	// Pid is the operating system process ID.
 	Pid int
 
 	// state contains the atomic process state.


### PR DESCRIPTION
Pid is an exported field but had no doc comment.

Fixes #36726
