### PR TITLE
text/template, html/template: correct the documentation for IsTrue

### DIFF
--- a/src/html/template/template.go
+++ b/src/html/template/template.go
@@ -477,9 +477,17 @@ func parseGlob(t *Template, pattern string) (*Template, error) {
 	return parseFiles(t, readFileOS, filenames...)
 }
 
-// IsTrue reports whether the value is 'true', in the sense of not the zero of its type,
-// and whether the value has a meaningful truth value. This is the definition of
-// truth used by if and other such actions.
+// IsTrue reports whether the value is true, in the sense of being nonzero,
+// nonempty, or non-nil, and whether the value has a meaningful truth value.
+// This is the definition of truth used in "if" actions and elsewhere in
+// templates:
+//
+//   - A boolean value is true if it is true.
+//   - A numeric value is true if it is nonzero.
+//   - An array, map, slice, or string value is true if its length is
+//     greater than zero.
+//   - Any other value is true if it is non-nil; struct values are
+//     never nil, and therefore always true.
 func IsTrue(val any) (truth, ok bool) {
 	return template.IsTrue(val)
 }

--- a/src/text/template/exec.go
+++ b/src/text/template/exec.go
@@ -314,9 +314,17 @@ func (s *state) walkIfOrWith(typ parse.NodeType, dot reflect.Value, pipe *parse.
 	}
 }
 
-// IsTrue reports whether the value is 'true', in the sense of not the zero of its type,
-// and whether the value has a meaningful truth value. This is the definition of
-// truth used by if and other such actions.
+// IsTrue reports whether the value is true, in the sense of being nonzero,
+// nonempty, or non-nil, and whether the value has a meaningful truth value.
+// This is the definition of truth used in "if" actions and elsewhere in
+// templates:
+//
+//   - A boolean value is true if it is true.
+//   - A numeric value is true if it is nonzero.
+//   - An array, map, slice, or string value is true if its length is
+//     greater than zero.
+//   - Any other value is true if it is non-nil; struct values are
+//     never nil, and therefore always true.
 func IsTrue(val any) (truth, ok bool) {
 	return isTrue(reflect.ValueOf(val))
 }


### PR DESCRIPTION
The IsTrue comment says a value is 'true' when it is not the zero
value of its type. That contradicts the implementation for structs,
which are always true, and is wrong for a negative floating-point
zero, which is untruthy without being 'the' zero of its type.
Describe the rules the implementation actually applies instead.

The comment is duplicated in html/template; update both copies.

Fixes #28394
