### PR TITLE
crypto: document that AES and DES cipher.Block are safe for concurrent use

### DIFF
--- a/src/crypto/aes/aes.go
+++ b/src/crypto/aes/aes.go
@@ -33,6 +33,8 @@ func (k KeySizeError) Error() string {
 // The key argument must be the AES key,
 // either 16, 24, or 32 bytes to select
 // AES-128, AES-192, or AES-256.
+//
+// The returned [cipher.Block] is safe for concurrent use.
 func NewCipher(key []byte) (cipher.Block, error) {
 	k := len(key)
 	switch k {

--- a/src/crypto/des/cipher.go
+++ b/src/crypto/des/cipher.go
@@ -28,6 +28,7 @@ type desCipher struct {
 }
 
 // NewCipher creates and returns a new [cipher.Block].
+// The returned [cipher.Block] is safe for concurrent use.
 func NewCipher(key []byte) (cipher.Block, error) {
 	if fips140only.Enforced() {
 		return nil, errors.New("crypto/des: use of DES is not allowed in FIPS 140-only mode")
@@ -76,6 +77,7 @@ type tripleDESCipher struct {
 }
 
 // NewTripleDESCipher creates and returns a new [cipher.Block].
+// The returned [cipher.Block] is safe for concurrent use.
 func NewTripleDESCipher(key []byte) (cipher.Block, error) {
 	if fips140only.Enforced() {
 		return nil, errors.New("crypto/des: use of TripleDES is not allowed in FIPS 140-only mode")


### PR DESCRIPTION
The cipher.Block values returned by aes.NewCipher, des.NewCipher, and
des.NewTripleDESCipher only read the key schedule computed at
construction time. Their Encrypt and Decrypt methods write only to dst
and never mutate receiver state, so the returned blocks are safe for
concurrent use.

The crypto/internal/fips140/aes Block already documents this guarantee;
state it on the exported constructors so callers can rely on it.

Fixes #25882
