### PR TITLE
crypto/cipher: document that GCM AEADs are safe for concurrent use

### DIFF
--- a/src/crypto/cipher/gcm.go
+++ b/src/crypto/cipher/gcm.go
@@ -23,6 +23,8 @@ const (
 
 // NewGCM returns the given 128-bit, block cipher wrapped in Galois Counter Mode
 // with the standard nonce length.
+//
+// The returned AEAD is safe for concurrent use if the underlying [Block] is.
 func NewGCM(cipher Block) (AEAD, error) {
 	if fips140only.Enforced() {
 		return nil, errors.New("crypto/cipher: use of GCM with arbitrary IVs is not allowed in FIPS 140-only mode, use NewGCMWithRandomNonce")

--- a/src/crypto/cipher/gcm_test.go
+++ b/src/crypto/cipher/gcm_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"sync"
 	"testing"
 )
 
@@ -734,6 +735,45 @@ func testGCMAEAD(t *testing.T, newCipher func(key []byte) cipher.Block) {
 			})
 		})
 	}
+}
+
+// Test that a single AEAD is safe for concurrent use; meaningful under -race.
+func TestGCMConcurrency(t *testing.T) {
+	testAllImplementations(t, testGCMConcurrency)
+}
+
+func testGCMConcurrency(t *testing.T, newCipher func(key []byte) cipher.Block) {
+	const goroutines, iterations = 16, 256
+
+	aead, err := cipher.NewGCM(newCipher(make([]byte, 16)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			nonce := make([]byte, aead.NonceSize())
+			nonce[0] = byte(g)
+			for i := 0; i < iterations; i++ {
+				nonce[len(nonce)-1] = byte(i)
+				plaintext := []byte(fmt.Sprintf("message %d-%d", g, i))
+				ct := aead.Seal(nil, nonce, plaintext, nil)
+				got, err := aead.Open(nil, nonce, ct, nil)
+				if err != nil {
+					t.Errorf("goroutine %d, iteration %d: Open failed: %v", g, i, err)
+					return
+				}
+				if !bytes.Equal(got, plaintext) {
+					t.Errorf("goroutine %d, iteration %d: got %x, want %x", g, i, got, plaintext)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 func TestGCMExtraMethods(t *testing.T) {


### PR DESCRIPTION
The AEAD returned by NewGCM keeps no mutable state after construction:
Seal and Open read only the key material and tables set up at
construction time and write only to the destination and stack-local
buffers. It is therefore safe for concurrent use whenever the
underlying cipher.Block is, as is the case for the Block returned by
aes.NewCipher.

Note that through the legacy gcmAble hook a Block can supply its own
AEAD implementation, whose concurrency behavior this package cannot
guarantee; the hook is unexported and slated for removal, so the
wording treats concurrency safety as a requirement on such
implementations.

Document this on NewGCM, and add a test that shares one AEAD across
goroutines running Seal and Open round-trips with distinct nonces, so
the race detector can check the property. The test covers the AES and
fallback implementations via testAllImplementations.

Fixes #41689
