### PR TITLE
net/url: clarify ParseQuery semicolon handling in docs

### DIFF
--- a/src/net/url/url.go
+++ b/src/net/url/url.go
@@ -945,6 +945,9 @@ func (vs Values) Clone() Values {
 // encountered, if any.
 //
 // Query is expected to be a list of key=value settings separated by ampersands.
+// Semicolons in query keys or values are not treated as separators and are
+// therefore rejected unless percent-encoded, so callers must provide them as
+// `%3B` when the value needs to contain a semicolon.
 // A setting without an equals sign is interpreted as a key set to an empty
 // value.
 // Settings containing a non-URL-encoded semicolon are considered invalid.


### PR DESCRIPTION
## Summary
Document `ParseQuery` semicolon behavior more explicitly in `net/url`.

## Changes
- Update `src/net/url/url.go` doc comment for `ParseQuery`.
- Clarify that semicolons are not query separators for keys/values and must be percent-encoded (`%3B`) when used as literal semicolons.

## Motivation
This is a docs cleanup for [golang/go#78594](https://github.com/golang/go/issues/78594), to remove ambiguity around parse behavior and expected encoding.

## Validation
- Documentation-only change; no tests required.