### PR TITLE
regexp/syntax: clarify repeat-count checks have additional internal limits

### DIFF
--- a/src/regexp/syntax/doc.go
+++ b/src/regexp/syntax/doc.go
@@ -52,6 +52,9 @@ Implementation restriction: The counting forms x{n,m}, x{n,}, and x{n}
 reject forms that create a minimum or maximum repetition count above 1000.
 Unlimited repetitions are not subject to this restriction.
 
+In addition, some concrete expressions are rejected below this limit by
+other internal checks to avoid excessive compilation complexity.
+
 Grouping:
 
 	(re)           numbered capturing group (submatch)


### PR DESCRIPTION
## Summary
Clarify implementation limits for repetition in `regexp/syntax` docs.

## Changes
- Update `src/regexp/syntax/doc.go` implementation-restriction note.
- Keep the documented 1000-count rule and add clarification that other internal checks may still reject patterns within that bound.

## Motivation
This addresses [golang/go#78222](https://github.com/golang/go/issues/78222), documenting observable behavior to reduce confusion.

## Validation
- Documentation-only change; no runtime tests run.