### PR TITLE
testing: run parent B.Cleanup functions when a benchmark panics

### DIFF
--- a/src/testing/benchmark.go
+++ b/src/testing/benchmark.go
@@ -226,6 +226,24 @@ func (b *B) runN(n int) {
 	}
 }
 
+// signalDone signals that the benchmark has finished, whether it returned
+// normally or by FailNow's runtime.Goexit. If the benchmark function
+// panicked, signalDone instead runs the Cleanup functions registered on the
+// parent benchmarks, which the panic would otherwise skip, and re-panics
+// without signaling, so that the process cannot exit before the panic is
+// reported. See https://go.dev/issue/60129.
+func (b *B) signalDone() {
+	if err := recover(); err != nil {
+		for root := &b.common; root.parent != nil; root = root.parent {
+			if r := root.parent.runCleanup(recoverAndReturnPanic); r != nil {
+				fmt.Fprintf(root.parent.w, "cleanup panicked with %v", r)
+			}
+		}
+		panic(err)
+	}
+	b.signal <- true
+}
+
 // run1 runs the first iteration of benchFunc. It reports whether more
 // iterations of this benchmarks should be run.
 func (b *B) run1() bool {
@@ -236,12 +254,7 @@ func (b *B) run1() bool {
 		}
 	}
 	go func() {
-		// Signal that we're done whether we return normally
-		// or by FailNow's runtime.Goexit.
-		defer func() {
-			b.signal <- true
-		}()
-
+		defer b.signalDone()
 		b.runN(1)
 	}()
 	<-b.signal
@@ -329,11 +342,7 @@ func predictN(goalns int64, prevIters int64, prevns int64, last int64) int {
 // launch is run by the doBench function as a separate goroutine.
 // run1 must have been called on b.
 func (b *B) launch() {
-	// Signal that we're done whether we return normally
-	// or by FailNow's runtime.Goexit.
-	defer func() {
-		b.signal <- true
-	}()
+	defer b.signalDone()
 
 	// b.Loop does its own ramp-up logic so we just need to run it once.
 	// If b.loop.n is non zero, it means b.Loop has already run.

--- a/src/testing/panic_test.go
+++ b/src/testing/panic_test.go
@@ -283,3 +283,35 @@ func TestGoexitInCleanupAfterPanicHelper(t *testing.T) {
 	t.Parallel()
 	panic("die")
 }
+
+func TestBenchmarkPanic(t *testing.T) {
+	testenv.MustHaveExec(t)
+
+	cmd := exec.Command(testenv.Executable(t), "-test.run=^$", "-test.bench=^BenchmarkPanicHelper$", "-test.benchtime=1x")
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+	b, err := cmd.CombinedOutput()
+	got := string(b)
+	if err == nil {
+		t.Error("subprocess succeeded; want it to crash from the panic")
+	}
+	for _, want := range []string{"ran inner cleanup", "ran middle cleanup", "ran outer cleanup", "panic: die"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output does not contain %q:\n%s", want, got)
+		}
+	}
+}
+
+func BenchmarkPanicHelper(b *testing.B) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	b.Cleanup(func() { fmt.Println("ran outer cleanup") })
+	b.Run("middle", func(b *testing.B) {
+		b.Cleanup(func() { fmt.Println("ran middle cleanup") })
+		b.Run("inner", func(b *testing.B) {
+			b.Cleanup(func() { fmt.Println("ran inner cleanup") })
+			panic("die")
+		})
+	})
+}


### PR DESCRIPTION
A panic in a benchmark function unwinds only the goroutine started by
run1 or launch, so the deferred runCleanup calls of the parent
benchmarks never execute and their Cleanup functions are silently
skipped. Tests already handle this: tRunner walks the parent chain
running each parent's cleanups before re-panicking.

Do the same for benchmarks: on panic, run the Cleanup functions
registered on the parent benchmarks and re-panic without signaling, so
that the process cannot exit before the panic is reported. The recover
lives in the goroutine closures, not in runN, so panics still crash
the process and other runN callers are unaffected.

Fixes #60129
