### PR TITLE
strconv: document that an overflowing prefix reports ErrRange

### DIFF
--- a/src/strconv/number.go
+++ b/src/strconv/number.go
@@ -133,6 +133,11 @@ func ParseUint(s string, base int, bitSize int) (uint64, error) {
 // returned value is the maximum magnitude integer of the
 // appropriate bitSize and sign.
 //
+// ParseInt does not always read all of s: when it detects that the
+// value is out of range, it returns err.Err = [ErrRange] without
+// reading the rest, so trailing invalid digits yield [ErrRange]
+// rather than [ErrSyntax].
+//
 // [integer literals]: https://go.dev/ref/spec#Integer_literals
 func ParseInt(s string, base int, bitSize int) (i int64, err error) {
 	x, err := strconv.ParseInt(s, base, bitSize)


### PR DESCRIPTION
ParseInt and ParseUint stop reading s as soon as they detect the value
is out of range and return ErrRange at that point, so trailing invalid
digits are never examined. The doc says a string containing invalid
digits reports ErrSyntax, which does not hold when the numeric prefix
overflows first.

Document the current behavior rather than change it, as suggested on
the issue.

Fixes #78546
