### PR TITLE
simd: use fused multiply-add in emulated MulAdd

### DIFF
--- a/src/simd/simd_emulated.go
+++ b/src/simd/simd_emulated.go
@@ -2657,11 +2657,9 @@ func (x Float32s) Mul(y Float32s) Float32s {
 // MulAdd returns x * y + z element-wise.
 func (x Float32s) MulAdd(y, z Float32s) Float32s {
 	var res Float32s
-
-	res.set(0, x.get(0)*y.get(0)+z.get(0))
-	res.set(1, x.get(1)*y.get(1)+z.get(1))
-	res.set(2, x.get(2)*y.get(2)+z.get(2))
-	res.set(3, x.get(3)*y.get(3)+z.get(3))
+	for i := 0; i < 4; i++ {
+		res.set(i, float32(math.FMA(float64(x.get(i)), float64(y.get(i)), float64(z.get(i)))))
+	}
 	return res
 }
 
@@ -2925,8 +2923,9 @@ func (x Float64s) Mul(y Float64s) Float64s {
 // MulAdd returns x * y + z element-wise.
 func (x Float64s) MulAdd(y, z Float64s) Float64s {
 	var res Float64s
-	res.set(0, x.get(0)*y.get(0)+z.get(0))
-	res.set(1, x.get(1)*y.get(1)+z.get(1))
+	for i := 0; i < 2; i++ {
+		res.set(i, math.FMA(x.get(i), y.get(i), z.get(i)))
+	}
 	return res
 }
 


### PR DESCRIPTION
The emulated MulAdd (used on architectures other than amd64, arm64,
and wasm) computed x*y+z with a plain expression. Whether the gc
compiler contracts x*y+z into a hardware FMA is architecture
dependent, so on targets without FMA contraction (for example 386)
the result is double-rounded and disagrees with the arch
implementations.

MulAdd is documented as a fused multiply-add (amd64 VFMADD213PS/PD,
arm64 VFMLA), and the arch conformance tests use math.FMA as the
reference oracle. Use math.FMA in the emulated path so it produces
the fused, single-rounding result on all architectures.

Verified with GOARCH=386 GOEXPERIMENT=simd: the simd test package
passes, and over 800k random float32 triples the updated MulAdd
matches math.FMA on every element, while plain x*y+z diverged on
about 27% of them.