### PR TITLE
text/template, html/template: document calling Funcs after parsing

### DIFF
--- a/src/html/template/template.go
+++ b/src/html/template/template.go
@@ -331,10 +331,12 @@ func (t *Template) Name() string {
 type FuncMap = template.FuncMap
 
 // Funcs adds the elements of the argument map to the template's function map.
-// It must be called before the template is parsed.
+// Any function used in the template must be added before the template is
+// parsed. Funcs may be called more than once, including after parsing (for
+// example, after [Template.Clone]), to replace a function of the same name;
+// the replacement is used when the template is executed.
 // It panics if a value in the map is not a function with appropriate return
-// type. However, it is legal to overwrite elements of the map. The return
-// value is the template, so calls can be chained.
+// type. The return value is the template, so calls can be chained.
 func (t *Template) Funcs(funcMap FuncMap) *Template {
 	t.text.Funcs(template.FuncMap(funcMap))
 	return t

--- a/src/text/template/template.go
+++ b/src/text/template/template.go
@@ -167,11 +167,13 @@ func (t *Template) Delims(left, right string) *Template {
 }
 
 // Funcs adds the elements of the argument map to the template's function map.
-// It must be called before the template is parsed.
+// Any function used in the template must be added before the template is
+// parsed. Funcs may be called more than once, including after parsing (for
+// example, after [Template.Clone]), to replace a function of the same name;
+// the replacement is used when the template is executed.
 // It panics if a value in the map is not a function with appropriate return
 // type or if the name cannot be used syntactically as a function in a template.
-// It is legal to overwrite elements of the map. The return value is the template,
-// so calls can be chained.
+// The return value is the template, so calls can be chained.
 func (t *Template) Funcs(funcMap FuncMap) *Template {
 	t.init()
 	t.muFuncs.Lock()


### PR DESCRIPTION
Funcs was documented only as "It must be called before the template is
parsed", which suggests it cannot be called afterward. In fact a
function used in the template must be registered before parsing, but
Funcs may be called again later (including after Clone) to replace a
function of the same name, and the replacement takes effect when the
template is executed.

Fixes #34680
