### PR TITLE
math: document Nextafter and Nextafter32 special cases for signed zero

### DIFF
--- a/src/math/nextafter.go
+++ b/src/math/nextafter.go
@@ -8,7 +8,8 @@ package math
 //
 // Special cases are:
 //
-//	Nextafter32(x, x)   = x
+//	Nextafter32(x, y)   = x when x == y
+//	Nextafter32(0, y)   = ±SmallestNonzeroFloat32 towards y, for y ≠ 0
 //	Nextafter32(NaN, y) = NaN
 //	Nextafter32(x, NaN) = NaN
 func Nextafter32(x, y float32) (r float32) {
@@ -31,7 +32,8 @@ func Nextafter32(x, y float32) (r float32) {
 //
 // Special cases are:
 //
-//	Nextafter(x, x)   = x
+//	Nextafter(x, y)   = x when x == y
+//	Nextafter(0, y)   = ±SmallestNonzeroFloat64 towards y, for y ≠ 0
 //	Nextafter(NaN, y) = NaN
 //	Nextafter(x, NaN) = NaN
 func Nextafter(x, y float64) (r float64) {


### PR DESCRIPTION
Nextafter and Nextafter32 have distinct behavior when the starting
value is a signed zero, which the special-case lists did not mention:
towards the oppositely-signed zero the result keeps the starting sign,
and towards any nonzero y the result is the smallest subnormal with the
sign of y. Document these cases; the behavior is unchanged.

Fixes #42613
