### PR TITLE
cmd/internal/obj/x86: narrow TEST with 7-bit immediates to TESTB

### DIFF
--- a/src/cmd/asm/internal/asm/testdata/386enc.s
+++ b/src/cmd/asm/internal/asm/testdata/386enc.s
@@ -36,5 +36,16 @@ TEXT asmtest(SB),DUPOK|NOSPLIT,$0
 
 	RDPID AX                                // f30fc7f8
 
+	// TEST with an immediate in [0, 127] against AX, CX, DX or BX
+	// narrows to the flag-identical byte form; SI, DI, BP and SP
+	// have no byte registers on 386. See progedit in
+	// cmd/internal/obj/x86/obj6.go.
+	TESTL $7, AX                            // a807
+	TESTL $7, BX                            // f6c307
+	TESTW $63, DX                           // f6c23f
+	TESTL $7, SI                            // f7c607000000
+	TESTL $128, AX                          // a980000000
+	TESTW $63, (BX)                         // 66f7033f00
+
 	// End of tests.
 	RET

--- a/src/cmd/asm/internal/asm/testdata/amd64enc.s
+++ b/src/cmd/asm/internal/asm/testdata/amd64enc.s
@@ -5753,6 +5753,22 @@ TEXT asmtest(SB),DUPOK|NOSPLIT,$0
 	TESTW $61731, AX                        // 66a923f1
 	TESTL $4045620583, AX                   // a9674523f1
 	TESTQ $-249346713, AX                   // 48a9674523f1
+	// TEST with an immediate in [0, 127] against a register narrows
+	// to the flag-identical byte form. See progedit in
+	// cmd/internal/obj/x86/obj6.go.
+	TESTW $63, AX                           // a83f
+	TESTW $63, DX                           // f6c23f
+	TESTW $63, R11                          // 41f6c33f
+	TESTL $7, AX                            // a807
+	TESTL $7, DX                            // f6c207
+	TESTL $7, SI                            // 40f6c607
+	TESTQ $7, AX                            // a807
+	TESTQ $7, DX                            // f6c207
+	TESTQ $127, R11                         // 41f6c37f
+	TESTL $128, DX                          // f7c280000000
+	TESTQ $128, AX                          // 48a980000000
+	TESTL $7, (BX)                          // f70307000000
+	TESTW $63, (BX)                         // 66f7033f00
 	TESTW $61731, (BX)                      // 66f70323f1
 	TESTW $61731, (R11)                     // 6641f70323f1
 	TESTW $61731, DX                        // 66f7c223f1

--- a/src/cmd/internal/obj/x86/obj6.go
+++ b/src/cmd/internal/obj/x86/obj6.go
@@ -233,6 +233,28 @@ func progedit(ctxt *obj.Link, p *obj.Prog, newprog obj.ProgAlloc) {
 		}
 	}
 
+	// Rewrite TEST $c, reg to TESTB $c, bytereg when c is in [0, 127].
+	// TEST has no sign-extended imm8 form, so the wider forms carry a
+	// full 16- or 32-bit immediate. Such a mask confines the AND result
+	// to the low seven bits at every operand width: ZF and PF depend
+	// only on the low byte, CF and OF are always cleared, and SF is
+	// zero either way because bit 7 of the immediate is clear. The byte
+	// form therefore sets identical flags and is 2-4 bytes shorter.
+	// The register is renamed to its byte form here so that the ytab
+	// match sees it on the first pass and picks the short accumulator
+	// encoding for AL. Memory operands are excluded because narrowing
+	// would change the access width. On 386 only AX, CX, DX and BX
+	// have byte forms.
+	switch p.As {
+	case ATESTQ, ATESTL, ATESTW:
+		if p.From.Type == obj.TYPE_CONST && uint64(p.From.Offset) < 128 &&
+			p.To.Type == obj.TYPE_REG && REG_AX <= p.To.Reg &&
+			(p.To.Reg <= REG_BX || ctxt.Arch.Family == sys.AMD64 && p.To.Reg <= REG_R15) {
+			p.As = ATESTB
+			p.To.Reg += REG_AL - REG_AX
+		}
+	}
+
 	// Rewrite float constants to values stored in memory.
 	switch p.As {
 	// Convert AMOVSS $(0), Xx to AXORPS Xx, Xx

--- a/test/codegen/arithmetic.go
+++ b/test/codegen/arithmetic.go
@@ -436,15 +436,15 @@ func Pow2Mods(n1 uint, n2 int) (uint, int) {
 
 // Check that signed divisibility checks get converted to AND on low bits
 func Pow2DivisibleSigned(n1, n2 int) (bool, bool) {
-	// 386:"TESTL [$]63" -"DIVL" -"SHRL"
-	// amd64:"TESTQ [$]63" -"DIVQ" -"SHRQ"
+	// 386:"TESTB [$]63" -"DIVL" -"SHRL"
+	// amd64:"TESTB [$]63" -"TESTQ" -"DIVQ" -"SHRQ"
 	// arm:"AND [$]63" -".*udiv" -"SRA"
 	// arm64:"TST [$]63" -"UDIV" -"ASR" -"AND"
 	// ppc64x:"ANDCC" -"RLDICL" -"SRAD" -"CMP"
 	a := n1%64 == 0 // signed divisible
 
-	// 386:"TESTL [$]63" -"DIVL" -"SHRL"
-	// amd64:"TESTQ [$]63" -"DIVQ" -"SHRQ"
+	// 386:"TESTB [$]63" -"DIVL" -"SHRL"
+	// amd64:"TESTB [$]63" -"TESTQ" -"DIVQ" -"SHRQ"
 	// arm:"AND [$]63" -".*udiv" -"SRA"
 	// arm64:"TST [$]63" -"UDIV" -"ASR" -"AND"
 	// ppc64x:"ANDCC" -"RLDICL" -"SRAD" -"CMP"

--- a/test/codegen/bits.go
+++ b/test/codegen/bits.go
@@ -539,6 +539,28 @@ func bitsSetTest(x int) bool {
 	return x&9 == 9
 }
 
+func bitsAndConst64Test(x int64) bool {
+	// amd64:"TESTB [$]7" -"TESTQ"
+	return x&7 != 0
+}
+
+func bitsAndConst32Test(x int32) bool {
+	// amd64:"TESTB [$]5" -"TESTL"
+	return x&5 == 0
+}
+
+func bitsAndConst16Test(x int16) bool {
+	// amd64:"TESTB [$]6" -"TESTW"
+	return x&6 != 0
+}
+
+func bitsAndConst64WideTest(x int64) bool {
+	// Bit 7 of the immediate is set, so narrowing to TESTB would
+	// change SF; the wide TEST must be kept.
+	// amd64:"TESTQ [$]129" -"TESTB"
+	return x&129 != 0
+}
+
 func bitsMaskContiguousOnes64U(x uint64) uint64 {
 	// s390x:"RISBGZ [$]16, [$]47, [$]0,"
 	return x & 0x0000ffffffff0000

--- a/test/codegen/divmod.go
+++ b/test/codegen/divmod.go
@@ -418,37 +418,37 @@ func ndivis32_uint8(i uint8) bool {
 }
 
 func divis32_uint16(i uint16) bool {
-	// 386: "TESTW [$]31,"
+	// 386: "TESTB [$]31,"
 	// arm64: "TSTW [$]31,"
 	return i%32 == 0
 }
 
 func ndivis32_uint16(i uint16) bool {
-	// 386: "TESTW [$]31,"
+	// 386: "TESTB [$]31,"
 	// arm64: "TSTW [$]31,"
 	return i%32 != 0
 }
 
 func divis32_uint32(i uint32) bool {
-	// 386: "TESTL [$]31,"
+	// 386: "TESTB [$]31,"
 	// arm64: "TSTW [$]31,"
 	return i%32 == 0
 }
 
 func ndivis32_uint32(i uint32) bool {
-	// 386: "TESTL [$]31,"
+	// 386: "TESTB [$]31,"
 	// arm64: "TSTW [$]31,"
 	return i%32 != 0
 }
 
 func divis32_uint64(i uint64) bool {
-	// 386: "TESTL [$]31,"
+	// 386: "TESTB [$]31,"
 	// arm64: "TST [$]31,"
 	return i%32 == 0
 }
 
 func ndivis32_uint64(i uint64) bool {
-	// 386: "TESTL [$]31,"
+	// 386: "TESTB [$]31,"
 	// arm64: "TST [$]31,"
 	return i%32 != 0
 }
@@ -466,37 +466,37 @@ func ndivis32_int8(i int8) bool {
 }
 
 func divis32_int16(i int16) bool {
-	// 386: "TESTW [$]31,"
+	// 386: "TESTB [$]31,"
 	// arm64: "TSTW [$]31,"
 	return i%32 == 0
 }
 
 func ndivis32_int16(i int16) bool {
-	// 386: "TESTW [$]31,"
+	// 386: "TESTB [$]31,"
 	// arm64: "TSTW [$]31,"
 	return i%32 != 0
 }
 
 func divis32_int32(i int32) bool {
-	// 386: "TESTL [$]31,"
+	// 386: "TESTB [$]31,"
 	// arm64: "TSTW [$]31,"
 	return i%32 == 0
 }
 
 func ndivis32_int32(i int32) bool {
-	// 386: "TESTL [$]31,"
+	// 386: "TESTB [$]31,"
 	// arm64: "TSTW [$]31,"
 	return i%32 != 0
 }
 
 func divis32_int64(i int64) bool {
-	// 386: "TESTL [$]31,"
+	// 386: "TESTB [$]31,"
 	// arm64: "TST [$]31,"
 	return i%32 == 0
 }
 
 func ndivis32_int64(i int64) bool {
-	// 386: "TESTL [$]31,"
+	// 386: "TESTB [$]31,"
 	// arm64: "TST [$]31,"
 	return i%32 != 0
 }
@@ -525,7 +525,7 @@ func div_ndivis32_uint8(i uint8) (uint8, bool) {
 
 func div_divis32_uint16(i uint16) (uint16, bool) {
 	// 386: "SHRW [$]5,"
-	// 386: "TESTW [$]31,"
+	// 386: "TESTB [$]31,"
 	// 386: "SETEQ"
 	// arm64: "UBFX [$]5, R[0-9]+, [$]11"
 	// arm64: "TSTW [$]31,"
@@ -535,7 +535,7 @@ func div_divis32_uint16(i uint16) (uint16, bool) {
 
 func div_ndivis32_uint16(i uint16) (uint16, bool) {
 	// 386: "SHRW [$]5,"
-	// 386: "TESTW [$]31,"
+	// 386: "TESTB [$]31,"
 	// 386: "SETNE"
 	// arm64: "UBFX [$]5, R[0-9]+, [$]11,"
 	// arm64: "TSTW [$]31,"
@@ -545,7 +545,7 @@ func div_ndivis32_uint16(i uint16) (uint16, bool) {
 
 func div_divis32_uint32(i uint32) (uint32, bool) {
 	// 386: "SHRL [$]5,"
-	// 386: "TESTL [$]31,"
+	// 386: "TESTB [$]31,"
 	// 386: "SETEQ"
 	// arm64: "UBFX [$]5, R[0-9]+, [$]27,"
 	// arm64: "TSTW [$]31,"
@@ -555,7 +555,7 @@ func div_divis32_uint32(i uint32) (uint32, bool) {
 
 func div_ndivis32_uint32(i uint32) (uint32, bool) {
 	// 386: "SHRL [$]5,"
-	// 386: "TESTL [$]31,"
+	// 386: "TESTB [$]31,"
 	// 386: "SETNE"
 	// arm64: "UBFX [$]5, R[0-9]+, [$]27,"
 	// arm64: "TSTW [$]31,"
@@ -566,7 +566,7 @@ func div_ndivis32_uint32(i uint32) (uint32, bool) {
 func div_divis32_uint64(i uint64) (uint64, bool) {
 	// 386: "SHRL [$]5,"
 	// 386: "SHLL [$]27,"
-	// 386: "TESTL [$]31,"
+	// 386: "TESTB [$]31,"
 	// 386: "SETEQ"
 	// arm64: "LSR [$]5,"
 	// arm64: "TST [$]31,"
@@ -577,7 +577,7 @@ func div_divis32_uint64(i uint64) (uint64, bool) {
 func div_ndivis32_uint64(i uint64) (uint64, bool) {
 	// 386: "SHRL [$]5,"
 	// 386: "SHLL [$]27,"
-	// 386: "TESTL [$]31,"
+	// 386: "TESTB [$]31,"
 	// 386: "SETNE"
 	// arm64: "LSR [$]5,"
 	// arm64: "TST [$]31,"
@@ -617,7 +617,7 @@ func div_divis32_int16(i int16) (int16, bool) {
 	// 386: "SARW [$]15,"
 	// 386: "SHRW [$]11,"
 	// 386: "SARW [$]5,"
-	// 386: "TESTW [$]31,"
+	// 386: "TESTB [$]31,"
 	// 386: "SETEQ"
 	// arm64: "SBFX [$]15, R[0-9]+, [$]1,"
 	// arm64: "ADD R[0-9]+>>11,"
@@ -631,7 +631,7 @@ func div_ndivis32_int16(i int16) (int16, bool) {
 	// 386: "SARW [$]15,"
 	// 386: "SHRW [$]11,"
 	// 386: "SARW [$]5,"
-	// 386: "TESTW [$]31,"
+	// 386: "TESTB [$]31,"
 	// 386: "SETNE"
 	// arm64: "SBFX [$]15, R[0-9]+, [$]1,"
 	// arm64: "ADD R[0-9]+>>11,"
@@ -645,7 +645,7 @@ func div_divis32_int32(i int32) (int32, bool) {
 	// 386: "SARL [$]31,"
 	// 386: "SHRL [$]27,"
 	// 386: "SARL [$]5,"
-	// 386: "TESTL [$]31,"
+	// 386: "TESTB [$]31,"
 	// 386: "SETEQ"
 	// arm64: "SBFX [$]31, R[0-9]+, [$]1,"
 	// arm64: "ADD R[0-9]+>>27,"
@@ -659,7 +659,7 @@ func div_ndivis32_int32(i int32) (int32, bool) {
 	// 386: "SARL [$]31,"
 	// 386: "SHRL [$]27,"
 	// 386: "SARL [$]5,"
-	// 386: "TESTL [$]31,"
+	// 386: "TESTB [$]31,"
 	// 386: "SETNE"
 	// arm64: "SBFX [$]31, R[0-9]+, [$]1,"
 	// arm64: "ADD R[0-9]+>>27,"
@@ -674,7 +674,7 @@ func div_divis32_int64(i int64) (int64, bool) {
 	// 386: "SHRL [$]27,"
 	// 386: "SARL [$]5,"
 	// 386: "SHLL [$]27,"
-	// 386: "TESTL [$]31,"
+	// 386: "TESTB [$]31,"
 	// 386: "SETEQ"
 	// arm64: "ASR [$]63,"
 	// arm64: "ADD R[0-9]+>>59,"
@@ -689,7 +689,7 @@ func div_ndivis32_int64(i int64) (int64, bool) {
 	// 386: "SHRL [$]27,"
 	// 386: "SARL [$]5,"
 	// 386: "SHLL [$]27,"
-	// 386: "TESTL [$]31,"
+	// 386: "TESTB [$]31,"
 	// 386: "SETNE"
 	// arm64: "ASR [$]63,"
 	// arm64: "ADD R[0-9]+>>59,"


### PR DESCRIPTION
TEST has no sign-extended imm8 form, so TESTQ/TESTL/TESTW $c, reg
encodes a full 16- or 32-bit immediate: 5-7 bytes versus 2-4 for
TESTB. For c in [0, 127] the AND result is confined to the low seven
bits at every operand width, so the byte form sets every flag
identically: ZF and PF depend only on the low byte, CF and OF are
cleared by all TEST forms, and SF is zero either way because bit 7 of
the immediate is clear. Narrowing TESTW also drops its
length-changing 66 prefix.

Rewrite these forms in progedit, renaming the register to its byte
form so that the ytab match sees it on the first pass and picks the
short accumulator encoding for AL. Register operands only: narrowing
a memory TEST would change the access width. On 386 restrict to AX,
CX, DX and BX, which have byte forms. Working in the assembler
rather than the compiler covers hand-written assembly (runtime
memmove and the map hash, crypto/internal/fips140/subtle) as well as
all compiler-generated code.

Verified with x86lint: "oversized TEST immediate" findings drop from
339 to 0 on cmd/go and from 83 to 0 on gofmt. Text section shrinks
by 1312 bytes (0.017%) on cmd/go and 416 bytes (0.031%) on gofmt.