### PR TITLE
encoding/base64, encoding/base32: panic when encoded length overflows int

### DIFF
--- a/doc/next/6-stdlib/99-minor/encoding/base32/20235.md
+++ b/doc/next/6-stdlib/99-minor/encoding/base32/20235.md
@@ -1,0 +1,2 @@
+[Encoding.EncodedLen] now panics if the encoded length overflows int,
+rather than returning a negative number.

--- a/doc/next/6-stdlib/99-minor/encoding/base64/20235.md
+++ b/doc/next/6-stdlib/99-minor/encoding/base64/20235.md
@@ -1,0 +1,2 @@
+[Encoding.EncodedLen] now panics if the encoded length overflows int,
+rather than returning a negative number.

--- a/src/encoding/base32/base32.go
+++ b/src/encoding/base32/base32.go
@@ -7,6 +7,7 @@ package base32
 
 import (
 	"io"
+	"math"
 	"slices"
 	"strconv"
 )
@@ -279,9 +280,17 @@ func NewEncoder(enc *Encoding, w io.Writer) io.WriteCloser {
 
 // EncodedLen returns the length in bytes of the base32 encoding
 // of an input buffer of length n.
+// It panics if the encoded length overflows int,
+// which can happen only if n > [math.MaxInt]/8*5.
 func (enc *Encoding) EncodedLen(n int) int {
 	if enc.padChar == NoPadding {
+		if n > math.MaxInt/8*5+4 {
+			panic("encoded length overflows int")
+		}
 		return n/5*8 + (n%5*8+4)/5
+	}
+	if n > math.MaxInt/8*5 {
+		panic("encoded length overflows int")
 	}
 	return (n + 4) / 5 * 8
 }

--- a/src/encoding/base32/base32_test.go
+++ b/src/encoding/base32/base32_test.go
@@ -765,10 +765,30 @@ func TestEncodedLen(t *testing.T) {
 		tests = append(tests, test{rawStdEncoding, (math.MaxInt-4)/8 + 1, 1844674407370955162})
 		tests = append(tests, test{rawStdEncoding, math.MaxInt/8*5 + 4, math.MaxInt})
 	}
+	tests = append(tests, test{StdEncoding, math.MaxInt / 8 * 5, math.MaxInt - 7})
 	for _, tt := range tests {
 		if got := tt.enc.EncodedLen(tt.n); int64(got) != tt.want {
 			t.Errorf("EncodedLen(%d): got %d, want %d", tt.n, got, tt.want)
 		}
+	}
+}
+
+func TestEncodedLenOverflow(t *testing.T) {
+	for _, tt := range []struct {
+		enc *Encoding
+		n   int
+	}{
+		{StdEncoding, math.MaxInt/8*5 + 1},
+		{StdEncoding.WithPadding(NoPadding), math.MaxInt/8*5 + 5},
+	} {
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("EncodedLen(%d) did not panic", tt.n)
+				}
+			}()
+			tt.enc.EncodedLen(tt.n)
+		}()
 	}
 }
 

--- a/src/encoding/base64/base64.go
+++ b/src/encoding/base64/base64.go
@@ -8,6 +8,7 @@ package base64
 import (
 	"internal/byteorder"
 	"io"
+	"math"
 	"slices"
 	"strconv"
 )
@@ -282,9 +283,17 @@ func NewEncoder(enc *Encoding, w io.Writer) io.WriteCloser {
 
 // EncodedLen returns the length in bytes of the base64 encoding
 // of an input buffer of length n.
+// It panics if the encoded length overflows int,
+// which can happen only if n > [math.MaxInt]/4*3.
 func (enc *Encoding) EncodedLen(n int) int {
 	if enc.padChar == NoPadding {
+		if n > math.MaxInt/4*3+2 {
+			panic("encoded length overflows int")
+		}
 		return n/3*4 + (n%3*8+5)/6 // minimum # chars at 6 bits per char
+	}
+	if n > math.MaxInt/4*3 {
+		panic("encoded length overflows int")
 	}
 	return (n + 2) / 3 * 4 // minimum # 4-char quanta, 3 bytes each
 }

--- a/src/encoding/base64/base64_test.go
+++ b/src/encoding/base64/base64_test.go
@@ -305,10 +305,30 @@ func TestEncodedLen(t *testing.T) {
 		tests = append(tests, test{RawStdEncoding, (math.MaxInt-5)/8 + 1, 1537228672809129302})
 		tests = append(tests, test{RawStdEncoding, math.MaxInt/4*3 + 2, math.MaxInt})
 	}
+	tests = append(tests, test{StdEncoding, math.MaxInt / 4 * 3, math.MaxInt - 3})
 	for _, tt := range tests {
 		if got := tt.enc.EncodedLen(tt.n); int64(got) != tt.want {
 			t.Errorf("EncodedLen(%d): got %d, want %d", tt.n, got, tt.want)
 		}
+	}
+}
+
+func TestEncodedLenOverflow(t *testing.T) {
+	for _, tt := range []struct {
+		enc *Encoding
+		n   int
+	}{
+		{StdEncoding, math.MaxInt/4*3 + 1},
+		{RawStdEncoding, math.MaxInt/4*3 + 3},
+	} {
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("EncodedLen(%d) did not panic", tt.n)
+				}
+			}()
+			tt.enc.EncodedLen(tt.n)
+		}()
 	}
 }
 


### PR DESCRIPTION
EncodedLen computes the encoded length with int arithmetic that can
wrap for very large n, returning a negative or wrapped value. Callers
that size an allocation from the result (EncodeToString, AppendEncode)
then panic with no indication of the cause, or allocate an undersized
buffer. CL 510635 and CL 512200 raised the overflow threshold of the
unpadded branches but did not eliminate it, and the padded branches
were unchanged: on 32-bit platforms
base64.StdEncoding.EncodedLen(1610612736) still returns -2147483648.

Make EncodedLen panic when the encoded length does not fit in an int,
document the panic, and document the largest n that is guaranteed not
to panic. DecodedLen needs no change: its result is at most n and
cannot overflow.

Fixes #20235
