### PR TITLE
testing: be more specific in Parallel error

### DIFF
--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -1017,7 +1017,7 @@ var (
 // may be called simultaneously from multiple goroutines.
 type T struct {
 	common
-	denyParallel bool
+	denyParallel string
 	tstate       *testState // For running tests and subtests.
 }
 
@@ -1916,8 +1916,8 @@ func (t *T) Parallel() {
 	if t.isSynctest {
 		panic("testing: t.Parallel called inside synctest bubble")
 	}
-	if t.denyParallel {
-		panic(parallelConflict)
+	if t.denyParallel != "" {
+		panic(fmt.Sprintf("testing: test using %s can not use t.Parallel", t.denyParallel))
 	}
 	if t.parent.barrier == nil {
 		// T.Parallel has no effect when fuzzing.
@@ -1978,10 +1978,10 @@ func (t *T) Parallel() {
 //
 //go:linkname checkParallel testing.checkParallel
 func checkParallel(t *T) {
-	t.checkParallel()
+	t.checkParallel("cryptotest.SetGlobalRandom")
 }
 
-func (t *T) checkParallel() {
+func (t *T) checkParallel(call string) {
 	// Non-parallel subtests that have parallel ancestors may still
 	// run in parallel with other tests: they are only non-parallel
 	// with respect to the other subtests of the same parent.
@@ -1989,11 +1989,13 @@ func (t *T) checkParallel() {
 	// to deny those if the current test or any parent is parallel.
 	for c := &t.common; c != nil; c = c.parent {
 		if c.isParallel {
-			panic(parallelConflict)
+			panic(fmt.Sprintf("testing: test using t.Parallel can not use %s", call))
 		}
 	}
 
-	t.denyParallel = true
+	if t.denyParallel == "" {
+		t.denyParallel = call
+	}
 }
 
 // Setenv calls os.Setenv(key, value) and uses Cleanup to
@@ -2003,7 +2005,7 @@ func (t *T) checkParallel() {
 // Because Setenv affects the whole process, it cannot be used
 // in parallel tests or tests with parallel ancestors.
 func (t *T) Setenv(key, value string) {
-	t.checkParallel()
+	t.checkParallel("t.Setenv")
 	t.common.Setenv(key, value)
 }
 
@@ -2014,7 +2016,7 @@ func (t *T) Setenv(key, value string) {
 // Because Chdir affects the whole process, it cannot be used
 // in parallel tests or tests with parallel ancestors.
 func (t *T) Chdir(dir string) {
-	t.checkParallel()
+	t.checkParallel("t.Chdir")
 	t.common.Chdir(dir)
 }
 

--- a/src/testing/testing_test.go
+++ b/src/testing/testing_test.go
@@ -237,43 +237,42 @@ func TestSetenv(t *testing.T) {
 	}
 }
 
-func expectParallelConflict(t *testing.T) {
-	want := testing.ParallelConflict
+func expectPanic(t *testing.T, want string) {
 	if got := recover(); got != want {
 		t.Fatalf("expected panic; got %#v want %q", got, want)
 	}
 }
 
-func testWithParallelAfter(t *testing.T, fn func(*testing.T)) {
-	defer expectParallelConflict(t)
+func testWithParallelAfter(t *testing.T, fnName string, fn func(*testing.T)) {
+	defer expectPanic(t, fmt.Sprintf("testing: test using %s can not use t.Parallel", fnName))
 
 	fn(t)
 	t.Parallel()
 }
 
-func testWithParallelBefore(t *testing.T, fn func(*testing.T)) {
-	defer expectParallelConflict(t)
+func testWithParallelBefore(t *testing.T, fnName string, fn func(*testing.T)) {
+	defer expectPanic(t, fmt.Sprintf("testing: test using t.Parallel can not use %s", fnName))
 
 	t.Parallel()
 	fn(t)
 }
 
-func testWithParallelParentBefore(t *testing.T, fn func(*testing.T)) {
+func testWithParallelParentBefore(t *testing.T, fnName string, fn func(*testing.T)) {
 	t.Parallel()
 
 	t.Run("child", func(t *testing.T) {
-		defer expectParallelConflict(t)
+		defer expectPanic(t, fmt.Sprintf("testing: test using t.Parallel can not use %s", fnName))
 
 		fn(t)
 	})
 }
 
-func testWithParallelGrandParentBefore(t *testing.T, fn func(*testing.T)) {
+func testWithParallelGrandParentBefore(t *testing.T, fnName string, fn func(*testing.T)) {
 	t.Parallel()
 
 	t.Run("child", func(t *testing.T) {
 		t.Run("grand-child", func(t *testing.T) {
-			defer expectParallelConflict(t)
+			defer expectPanic(t, fmt.Sprintf("testing: test using t.Parallel can not use %s", fnName))
 
 			fn(t)
 		})
@@ -285,19 +284,19 @@ func tSetenv(t *testing.T) {
 }
 
 func TestSetenvWithParallelAfter(t *testing.T) {
-	testWithParallelAfter(t, tSetenv)
+	testWithParallelAfter(t, "t.Setenv", tSetenv)
 }
 
 func TestSetenvWithParallelBefore(t *testing.T) {
-	testWithParallelBefore(t, tSetenv)
+	testWithParallelBefore(t, "t.Setenv", tSetenv)
 }
 
 func TestSetenvWithParallelParentBefore(t *testing.T) {
-	testWithParallelParentBefore(t, tSetenv)
+	testWithParallelParentBefore(t, "t.Setenv", tSetenv)
 }
 
 func TestSetenvWithParallelGrandParentBefore(t *testing.T) {
-	testWithParallelGrandParentBefore(t, tSetenv)
+	testWithParallelGrandParentBefore(t, "t.Setenv", tSetenv)
 }
 
 func tChdir(t *testing.T) {
@@ -305,19 +304,19 @@ func tChdir(t *testing.T) {
 }
 
 func TestChdirWithParallelAfter(t *testing.T) {
-	testWithParallelAfter(t, tChdir)
+	testWithParallelAfter(t, "t.Chdir", tChdir)
 }
 
 func TestChdirWithParallelBefore(t *testing.T) {
-	testWithParallelBefore(t, tChdir)
+	testWithParallelBefore(t, "t.Chdir", tChdir)
 }
 
 func TestChdirWithParallelParentBefore(t *testing.T) {
-	testWithParallelParentBefore(t, tChdir)
+	testWithParallelParentBefore(t, "t.Chdir", tChdir)
 }
 
 func TestChdirWithParallelGrandParentBefore(t *testing.T) {
-	testWithParallelGrandParentBefore(t, tChdir)
+	testWithParallelGrandParentBefore(t, "t.Chdir", tChdir)
 }
 
 func TestChdir(t *testing.T) {


### PR DESCRIPTION
When a test uses both t.Parallel and a process-wide state mutation
helper like t.Setenv, t.Chdir, or cryptotest.SetGlobalRandom, the
test framework panics. Previously, the panic message always listed
all three helpers regardless of which one was actually called.

This change updates testing.T to track the specific caller name
that denied parallel execution and formats the error message to
name the specific helper involved. If t.Parallel is called after
the helper, the message is "testing: test using <call> can not
use t.Parallel". If a helper is called after t.Parallel, the
message is "testing: test using t.Parallel can not use <call>".

Fixes #80267