### PR TITLE
cmd/compile: fold CSET; EOR $1 into inverted CSET on arm64

### DIFF
--- a/src/cmd/compile/internal/ssa/_gen/ARM64.rules
+++ b/src/cmd/compile/internal/ssa/_gen/ARM64.rules
@@ -555,6 +555,18 @@
 
 (TB(Z|NZ) [0] (XORconst [1] x) yes no) => (TB(NZ|Z) [0] x yes no)
 
+// Fold !eq(cc) into ne(cc) and all similar others.
+(XORconst [1] ((Equal|NotEqual) cc))                       => ((NotEqual|Equal) cc)
+(XORconst [1] ((LessThan|GreaterEqual) cc))                => ((GreaterEqual|LessThan) cc)
+(XORconst [1] ((LessThanU|GreaterEqualU) cc))              => ((GreaterEqualU|LessThanU) cc)
+(XORconst [1] ((LessEqual|GreaterThan) cc))                => ((GreaterThan|LessEqual) cc)
+(XORconst [1] ((LessEqualU|GreaterThanU) cc))              => ((GreaterThanU|LessEqualU) cc)
+(XORconst [1] ((LessThanF|NotLessThanF) cc))               => ((NotLessThanF|LessThanF) cc)
+(XORconst [1] ((LessEqualF|NotLessEqualF) cc))             => ((NotLessEqualF|LessEqualF) cc)
+(XORconst [1] ((GreaterThanF|NotGreaterThanF) cc))         => ((NotGreaterThanF|GreaterThanF) cc)
+(XORconst [1] ((GreaterEqualF|NotGreaterEqualF) cc))       => ((NotGreaterEqualF|GreaterEqualF) cc)
+(XORconst [1] ((LessThanNoov|GreaterEqualNoov) cc))        => ((GreaterEqualNoov|LessThanNoov) cc)
+
 ((EQ|NE|LT|LE|GT|GE) (CMPconst  [0] z:(AND        x y)) yes no) && z.Uses == 1 => ((EQ|NE|LT|LE|GT|GE) (TST                x y) yes no)
 ((EQ|NE|LT|LE|GT|GE) (CMPconst  [0] x:(ANDconst [c] y)) yes no) && x.Uses == 1 => ((EQ|NE|LT|LE|GT|GE) (TSTconst         [c] y) yes no)
 ((EQ|NE|LT|LE|GT|GE) (CMPWconst [0] z:(AND        x y)) yes no) && z.Uses == 1 => ((EQ|NE|LT|LE|GT|GE) (TSTW               x y) yes no)

--- a/src/cmd/compile/internal/ssa/rewriteARM64.go
+++ b/src/cmd/compile/internal/ssa/rewriteARM64.go
@@ -19264,6 +19264,226 @@ func rewriteValueARM64_OpARM64XOR(v *Value) bool {
 }
 func rewriteValueARM64_OpARM64XORconst(v *Value) bool {
 	v_0 := v.Args[0]
+	// match: (XORconst [1] (Equal cc))
+	// result: (NotEqual cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64Equal {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64NotEqual)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (NotEqual cc))
+	// result: (Equal cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64NotEqual {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64Equal)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (LessThan cc))
+	// result: (GreaterEqual cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64LessThan {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64GreaterEqual)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (GreaterEqual cc))
+	// result: (LessThan cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64GreaterEqual {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64LessThan)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (LessThanU cc))
+	// result: (GreaterEqualU cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64LessThanU {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64GreaterEqualU)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (GreaterEqualU cc))
+	// result: (LessThanU cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64GreaterEqualU {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64LessThanU)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (LessEqual cc))
+	// result: (GreaterThan cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64LessEqual {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64GreaterThan)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (GreaterThan cc))
+	// result: (LessEqual cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64GreaterThan {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64LessEqual)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (LessEqualU cc))
+	// result: (GreaterThanU cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64LessEqualU {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64GreaterThanU)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (GreaterThanU cc))
+	// result: (LessEqualU cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64GreaterThanU {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64LessEqualU)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (LessThanF cc))
+	// result: (NotLessThanF cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64LessThanF {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64NotLessThanF)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (NotLessThanF cc))
+	// result: (LessThanF cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64NotLessThanF {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64LessThanF)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (LessEqualF cc))
+	// result: (NotLessEqualF cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64LessEqualF {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64NotLessEqualF)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (NotLessEqualF cc))
+	// result: (LessEqualF cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64NotLessEqualF {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64LessEqualF)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (GreaterThanF cc))
+	// result: (NotGreaterThanF cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64GreaterThanF {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64NotGreaterThanF)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (NotGreaterThanF cc))
+	// result: (GreaterThanF cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64NotGreaterThanF {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64GreaterThanF)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (GreaterEqualF cc))
+	// result: (NotGreaterEqualF cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64GreaterEqualF {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64NotGreaterEqualF)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (NotGreaterEqualF cc))
+	// result: (GreaterEqualF cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64NotGreaterEqualF {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64GreaterEqualF)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (LessThanNoov cc))
+	// result: (GreaterEqualNoov cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64LessThanNoov {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64GreaterEqualNoov)
+		v.AddArg(cc)
+		return true
+	}
+	// match: (XORconst [1] (GreaterEqualNoov cc))
+	// result: (LessThanNoov cc)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpARM64GreaterEqualNoov {
+			break
+		}
+		cc := v_0.Args[0]
+		v.reset(OpARM64LessThanNoov)
+		v.AddArg(cc)
+		return true
+	}
 	// match: (XORconst [0] x)
 	// result: x
 	for {

--- a/test/codegen/comparisons.go
+++ b/test/codegen/comparisons.go
@@ -940,3 +940,26 @@ func bijectiveMul(x uint) bool {
 	// arm64: -"MUL"
 	return x*1337 == 42
 }
+
+// ------------------------- //
+//    Inverted conditions    //
+// ------------------------- //
+
+// A materialized condition negated with XOR $1 (e.g. the Not that the
+// generic "x == nil" rewrite introduces) folds the negation into the
+// condition instead of emitting CSET + EOR $1.
+
+func invertedCondEqNilPtr(p *int) bool {
+	// arm64:`CSET EQ` -`EOR`
+	return p == nil
+}
+
+func invertedCondEqNilIface(err error) bool {
+	// arm64:`CSET EQ` -`EOR`
+	return err == nil
+}
+
+func invertedCondNotLessF(a, b float64) bool {
+	// arm64:`CSET PL` -`EOR`
+	return !(a < b)
+}


### PR DESCRIPTION
A boolean negated with XOR $1 (the lowering of Not) survives to code
generation as CSET; EOR $1 when the Not is introduced where the
generic inversion rules cannot see it, most commonly by the generic
"x == nil => Not(IsNonNil x)" rewrite and by phiopt. Fold the
XORconst [1] into the flag-materializing op itself, mirroring amd64's
XORLconst [1] (SETcc) rules. Each pair reads the same flags with
complementary conditions, so the fold is exact: the floating-point
Not* variants are true on unordered, and the Noov ops are complements
of each other by definition.

Measured with armlint on darwin/arm64:

cmd/go: 131 CSET; EOR $1 pairs eliminated, __text -832 bytes.
gofmt: 15 pairs eliminated, __text -96 bytes.