### PR TITLE
cmd/compile: fold single-bit TST; CSET NE into UBFX on arm64

### DIFF
--- a/src/cmd/compile/internal/ssa/_gen/ARM64.rules
+++ b/src/cmd/compile/internal/ssa/_gen/ARM64.rules
@@ -570,6 +570,12 @@
 ((Equal|NotEqual|LessThan|LessEqual|GreaterThan|GreaterEqual) (CMPconst [0]  x:(ANDconst [c] y))) && x.Uses == 1 =>
 	((Equal|NotEqual|LessThan|LessEqual|GreaterThan|GreaterEqual) (TSTconst [c] y))
 
+// A single-bit test materialized as a boolean is a bitfield extract:
+// TST $(1<<k); CSET NE is UBFX #k, #1. The flags stay for any other
+// reader; the branch form is handled by the TBZ/TBNZ rules below.
+(NotEqual (TSTconst  [c] x)) && oneBit(c) => (UBFX [armBFAuxInt(int64(ntz64(c)), 1)] x)
+(NotEqual (TSTWconst [c] x)) && oneBit(c) => (UBFX [armBFAuxInt(int64(ntz32(c)), 1)] x)
+
 ((EQ|NE|LT|LE|GT|GE) (CMPconst  [0] x:(ADDconst [c] y)) yes no) && x.Uses == 1 => ((EQ|NE|LTnoov|LEnoov|GTnoov|GEnoov) (CMNconst         [c] y) yes no)
 ((EQ|NE|LT|LE|GT|GE) (CMPWconst [0] x:(ADDconst [c] y)) yes no) && x.Uses == 1 => ((EQ|NE|LTnoov|LEnoov|GTnoov|GEnoov) (CMNWconst [int32(c)] y) yes no)
 ((EQ|NE|LT|LE|GT|GE) (CMPconst  [0] z:(ADD        x y)) yes no) && z.Uses == 1 => ((EQ|NE|LTnoov|LEnoov|GTnoov|GEnoov) (CMN                x y) yes no)

--- a/src/cmd/compile/internal/ssa/rewriteARM64.go
+++ b/src/cmd/compile/internal/ssa/rewriteARM64.go
@@ -14682,6 +14682,40 @@ func rewriteValueARM64_OpARM64NotEqual(v *Value) bool {
 		v.AddArg(v0)
 		return true
 	}
+	// match: (NotEqual (TSTconst [c] x))
+	// cond: oneBit(c)
+	// result: (UBFX [armBFAuxInt(int64(ntz64(c)), 1)] x)
+	for {
+		if v_0.Op != OpARM64TSTconst {
+			break
+		}
+		c := auxIntToInt64(v_0.AuxInt)
+		x := v_0.Args[0]
+		if !(oneBit(c)) {
+			break
+		}
+		v.reset(OpARM64UBFX)
+		v.AuxInt = arm64BitFieldToAuxInt(armBFAuxInt(int64(ntz64(c)), 1))
+		v.AddArg(x)
+		return true
+	}
+	// match: (NotEqual (TSTWconst [c] x))
+	// cond: oneBit(c)
+	// result: (UBFX [armBFAuxInt(int64(ntz32(c)), 1)] x)
+	for {
+		if v_0.Op != OpARM64TSTWconst {
+			break
+		}
+		c := auxIntToInt32(v_0.AuxInt)
+		x := v_0.Args[0]
+		if !(oneBit(c)) {
+			break
+		}
+		v.reset(OpARM64UBFX)
+		v.AuxInt = arm64BitFieldToAuxInt(armBFAuxInt(int64(ntz32(c)), 1))
+		v.AddArg(x)
+		return true
+	}
 	// match: (NotEqual (CMP x z:(NEG y)))
 	// cond: z.Uses == 1
 	// result: (NotEqual (CMN x y))

--- a/test/codegen/bitfield.go
+++ b/test/codegen/bitfield.go
@@ -327,6 +327,22 @@ func ubfx16(x uint64) uint64 {
 	return ((x >> 3) & 0xfff) >> 1 & 0x3f
 }
 
+// materialize a single-bit test as ubfx instead of TST + CSET.
+func ubfx17(x uint64) bool {
+	// arm64:"UBFX [$]3, R[0-9]+, [$]1" -"TST" -"CSET"
+	return x&8 != 0
+}
+
+func ubfx18(x uint64) bool {
+	// arm64:"UBFX [$]63, R[0-9]+, [$]1" -"TST" -"CSET"
+	return x&(1<<63) != 0
+}
+
+func ubfx19(x uint32) bool {
+	// arm64:"UBFX [$]31, R[0-9]+, [$]1" -"TST" -"CSET"
+	return x&(1<<31) != 0
+}
+
 // Check that we don't emit comparisons for constant shifts.
 //
 //go:nosplit

--- a/test/codegen/bits.go
+++ b/test/codegen/bits.go
@@ -455,7 +455,7 @@ func bitsOpOnMem(a []uint32, b, c, d uint32) {
 
 func bitsCheckMostNegative(b uint8) bool {
 	// amd64:"TESTB"
-	// arm64:"TSTW" "CSET"
+	// arm64:"UBFX [$]7, R[0-9]+, [$]1" -"TSTW" -"CSET"
 	// loong64:"AND [$]128," "SGTU"
 	// riscv64:"ANDI [$]128," "SNEZ" -"ADDI"
 	return b&0x80 == 0x80


### PR DESCRIPTION
A boolean materialized from a single-bit test compiles to
TST $(1<<k); CSET NE. The bit is a bitfield extract: rewrite the
NotEqual of a one-bit TSTconst/TSTWconst to UBFX #k, #1, the value
form of the existing single-bit TBZ/TBNZ branch rules. The flags
producer remains for any other reader, and a shared bool's branch
then tests the extracted bit directly, so the TST disappears there
too.

Measured with armlint on darwin/arm64:

cmd/go: 166 TST; CSET pairs eliminated, __text -672 bytes.
gofmt: 35 pairs eliminated, __text -192 bytes.