### PR TITLE
encoding/xml: reject invalid comment tokens

### DIFF
--- a/src/encoding/xml/marshal.go
+++ b/src/encoding/xml/marshal.go
@@ -224,11 +224,15 @@ func (enc *Encoder) EncodeToken(t Token) error {
 	case CharData:
 		escapeText(p, t, false)
 	case Comment:
-		if bytes.Contains(t, endComment) {
-			return fmt.Errorf("xml: EncodeToken of Comment containing --> marker")
+		if bytes.Contains(t, ddBytes) {
+			return fmt.Errorf("xml: EncodeToken of Comment containing -- marker")
 		}
 		p.WriteString("<!--")
 		p.Write(t)
+		if len(t) > 0 && t[len(t)-1] == '-' {
+			// "--->" is invalid grammar. Make it "- -->"
+			p.WriteByte(' ')
+		}
 		p.WriteString("-->")
 		return p.cachedWriteError()
 	case ProcInst:

--- a/src/encoding/xml/marshal_test.go
+++ b/src/encoding/xml/marshal_test.go
@@ -2006,7 +2006,19 @@ var encodeTokenTests = []struct {
 	toks: []Token{
 		Comment("foo-->"),
 	},
-	err: "xml: EncodeToken of Comment containing --> marker",
+	err: "xml: EncodeToken of Comment containing -- marker",
+}, {
+	desc: "comment with double hyphen",
+	toks: []Token{
+		Comment("foo--bar"),
+	},
+	err: "xml: EncodeToken of Comment containing -- marker",
+}, {
+	desc: "comment ending in hyphen",
+	toks: []Token{
+		Comment("foo-"),
+	},
+	want: `<!--foo- -->`,
 }, {
 	desc: "proc instruction",
 	toks: []Token{


### PR DESCRIPTION
EncodeToken currently rejects comment contents only when they contain "-->",
which allows other occurrences of "--" and emits invalid XML. It also emits
"--->" when comment content ends in a hyphen.

Reject any "--" in Comment tokens, as required by XML 1.0, and insert a space
before the closing delimiter when comment content ends in a hyphen. This
matches encoding of struct fields tagged ",comment".

Fixes #80155
