### PR TITLE
go/build/constraint: match "go1." only as a tag prefix in GoVersion

### DIFF
--- a/src/go/build/constraint/vers.go
+++ b/src/go/build/constraint/vers.go
@@ -66,7 +66,7 @@ func minVersion(z Expr, sign int) int {
 		if z.Tag == "go1" {
 			return 0
 		}
-		_, v, ok := strings.Cut(z.Tag, "go1.")
+		v, ok := strings.CutPrefix(z.Tag, "go1.")
 		if !ok {
 			return -1
 		}

--- a/src/go/build/constraint/vers_test.go
+++ b/src/go/build/constraint/vers_test.go
@@ -23,6 +23,8 @@ var tests = []struct {
 	{"//go:build !go1.60", -1},
 	{"//go:build linux && go1.50 || darwin && go1.60", 50},
 	{"//go:build linux && go1.50 || !(!darwin || !go1.60)", 50},
+	{"//go:build notgo1.21", -1},
+	{"//go:build ago1.20", -1},
 }
 
 func TestGoVersion(t *testing.T) {

--- a/src/go/version/version_test.go
+++ b/src/go/version/version_test.go
@@ -15,6 +15,7 @@ var compareTests = []testCase2[string, string, int]{
 	{"", "", 0},
 	{"x", "x", 0},
 	{"", "x", 0},
+	{"notgo1.21", "go1.21", -1},
 	{"1", "1.1", 0},
 	{"go1", "go1.1", -1},
 	{"go1.5", "go1.6", -1},
@@ -47,6 +48,7 @@ func TestLang(t *testing.T) { test1(t, langTests, "Lang", Lang) }
 
 var langTests = []testCase1[string, string]{
 	{"bad", ""},
+	{"notgo1.21", ""},
 	{"go1.2rc3", "go1.2"},
 	{"go1.2.3", "go1.2"},
 	{"go1.2", "go1.2"},
@@ -60,6 +62,7 @@ func TestIsValid(t *testing.T) { test1(t, isValidTests, "IsValid", IsValid) }
 var isValidTests = []testCase1[string, bool]{
 	{"", false},
 	{"1.2.3", false},
+	{"notgo1.21", false},
 	{"go1.2rc3", true},
 	{"go1.2.3", true},
 	{"go1.999testmod", true},


### PR DESCRIPTION
GoVersion split each tag with strings.Cut(tag, "go1."), which finds the
separator anywhere in the string. A tag that merely contained "go1.", 
such as "notgo1.21", was parsed as a go1.N constraint, so GoVersion
reported a Go version for a tag that names no version.

Use strings.CutPrefix so that only a leading "go1." is treated as a
version tag prefix.

Fixes #80406