### PR TITLE
net/http: use consistent IDNA processing for dial target and Host header

### DIFF
--- a/src/net/http/internal/http2/transport.go
+++ b/src/net/http/internal/http2/transport.go
@@ -394,7 +394,12 @@ func authorityAddr(scheme string, authority string) (addr string) {
 			port = "80"
 		}
 	}
-	if a, err := idna.ToASCII(host); err == nil {
+	// Use the same UTS #46 processing (with mapping) that net/http uses to
+	// choose the address to dial (see idnaASCII/canonicalAddr in the
+	// net/http Transport) and to write the Host / :authority header, so the
+	// connection pool key, the dialed address, and the header all agree.
+	// See https://go.dev/issue/80417.
+	if a, err := idna.Lookup.ToASCII(host); err == nil {
 		host = a
 	}
 	// IPv6 address literal, without a port:

--- a/src/net/http/internal/httpcommon/httpcommon.go
+++ b/src/net/http/internal/httpcommon/httpcommon.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http/httptrace"
 	"net/textproto"
 	"net/url"
@@ -17,6 +18,7 @@ import (
 
 	"golang.org/x/net/http/httpguts"
 	"golang.org/x/net/http2/hpack"
+	"golang.org/x/net/idna"
 )
 
 // The HTTP protocols are defined in terms of ASCII, not Unicode. This file
@@ -228,7 +230,13 @@ func EncodeHeaders(ctx context.Context, param EncodeHeadersParam, headerf func(n
 	if host == "" {
 		host = req.URL.Host
 	}
-	host, err := httpguts.PunycodeHostPort(host)
+	// Convert the host to its IDNA ASCII form using the same UTS #46
+	// processing (with mapping) used to pick the address the request is
+	// dialed to. Using a different IDNA profile here would let the
+	// :authority header disagree with the address actually dialed, which
+	// can be used to bypass SSRF filters that inspect URL.Hostname.
+	// See https://go.dev/issue/80417.
+	host, err := idnaASCIIHostPort(host)
 	if err != nil {
 		return res, err
 	}
@@ -623,4 +631,39 @@ func NewServerRequest(rp ServerRequestParam) ServerRequestResult {
 		RequestURI:    requestURI,
 		Trailer:       trailer,
 	}
+}
+
+// idnaASCIIHostPort applies UTS #46 IDNA processing (with mapping) to the host
+// portion of a "host" or "host:port" string, leaving the port unchanged. It is
+// used to compute the Host / :authority header so that it is consistent with
+// the address the request is dialed to. See https://go.dev/issue/80417.
+func idnaASCIIHostPort(v string) (string, error) {
+	if isASCII(v) {
+		return v, nil
+	}
+	host, port, err := net.SplitHostPort(v)
+	if err != nil {
+		// Assume v is a host without a port. Any error will be reported
+		// by idna.Lookup.ToASCII or by later Host header validation.
+		host = v
+		port = ""
+	}
+	host, err = idna.Lookup.ToASCII(host)
+	if err != nil {
+		return "", err
+	}
+	if port == "" {
+		return host, nil
+	}
+	return net.JoinHostPort(host, port), nil
+}
+
+// isASCII reports whether s is composed entirely of ASCII bytes.
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
 }

--- a/src/net/http/request.go
+++ b/src/net/http/request.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"mime"
 	"mime/multipart"
+	"net"
 	"net/http/httptrace"
 	"net/http/internal/ascii"
 	"net/textproto"
@@ -619,7 +620,13 @@ func (r *Request) write(w io.Writer, usingProxy bool, extraHeaders Header, waitF
 		}
 		host = r.URL.Host
 	}
-	host, err = httpguts.PunycodeHostPort(host)
+	// Convert the host to its IDNA ASCII form using the same UTS #46
+	// processing used to pick the address we dial (see idnaASCIIFromURL and
+	// canonicalAddr in transport.go). Using a different IDNA profile here
+	// would let the Host header disagree with the address actually dialed,
+	// which can be used to bypass SSRF filters that inspect URL.Hostname.
+	// See https://go.dev/issue/80417.
+	host, err = idnaASCIIHostPort(host)
 	if err != nil {
 		return err
 	}
@@ -802,6 +809,32 @@ func idnaASCII(v string) (string, error) {
 		return v, nil
 	}
 	return idna.Lookup.ToASCII(v)
+}
+
+// idnaASCIIHostPort applies idnaASCII (UTS #46 processing, with mapping) to
+// the host portion of a "host" or "host:port" string, leaving the port
+// unchanged. It is used to compute the Host header so that it is consistent
+// with the address the request is dialed to; see idnaASCIIFromURL and
+// canonicalAddr in transport.go, and https://go.dev/issue/80417.
+func idnaASCIIHostPort(v string) (string, error) {
+	if ascii.Is(v) {
+		return v, nil
+	}
+	host, port, err := net.SplitHostPort(v)
+	if err != nil {
+		// Assume v is a host without a port. Any error will be reported
+		// by idnaASCII or by later Host header validation.
+		host = v
+		port = ""
+	}
+	host, err = idnaASCII(host)
+	if err != nil {
+		return "", err
+	}
+	if port == "" {
+		return host, nil
+	}
+	return net.JoinHostPort(host, port), nil
 }
 
 // removeZone removes IPv6 zone identifier from host.

--- a/src/net/http/transport_test.go
+++ b/src/net/http/transport_test.go
@@ -48,6 +48,7 @@ import (
 	"time"
 
 	"golang.org/x/net/http/httpguts"
+	"golang.org/x/net/idna"
 )
 
 // TODO: test 5 pipelined requests with responses: 1) OK, 2) OK, Connection: Close
@@ -5946,6 +5947,71 @@ func testTransportIDNA(t *testing.T, mode testMode) {
 		}
 		t.Errorf("Response body wasn't from Handler. Got:\n%s\n", out)
 	}
+}
+
+// Issue 80417: the address the request is dialed to and the Host header
+// (HTTP/1) / :authority pseudo-header (HTTP/2) must be computed with the same
+// IDNA processing. The dial target uses UTS #46 processing (with mapping), so
+// the host header must too. Otherwise a request can be dialed to one host
+// while announcing a different one, which can be used to bypass SSRF filters
+// that inspect URL.Hostname.
+func TestTransportIDNAMapping(t *testing.T) { run(t, testTransportIDNAMapping, http3SkippedMode) }
+func testTransportIDNAMapping(t *testing.T, mode testMode) {
+	// uniDomain maps to mappedDomain under UTS #46 processing (the profile
+	// used to pick the dial address). idna.ToASCII (Punycode only, without
+	// mapping, which used to be used for the Host header) instead produces a
+	// different, "xn--"-prefixed name; verify the two disagree so this test
+	// actually exercises the mapping.
+	const uniDomain = "ⓖⓞⓟⓗⓔⓡ.example"
+	mappedDomain, err := idna.Lookup.ToASCII(uniDomain)
+	if err != nil {
+		t.Fatalf("idna.Lookup.ToASCII(%q) = %v", uniDomain, err)
+	}
+	if puny, err := idna.ToASCII(uniDomain); err == nil && puny == mappedDomain {
+		t.Fatalf("test host %q does not distinguish IDNA profiles", uniDomain)
+	}
+
+	var port string
+	cst := newClientServerTest(t, mode, HandlerFunc(func(w ResponseWriter, r *Request) {
+		if want := mappedDomain + ":" + port; r.Host != want {
+			t.Errorf("Host header = %q; want %q", r.Host, want)
+		}
+	}), func(tr *Transport) {
+		if tr.TLSClientConfig != nil {
+			tr.TLSClientConfig.InsecureSkipVerify = true
+		}
+	})
+
+	ip, port, err := net.SplitHostPort(cst.ts.Listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Install a fake DNS server. The dial must be for the mapped domain, not
+	// the raw Unicode host or its Punycode-only encoding.
+	ctx := context.WithValue(context.Background(), nettrace.LookupIPAltResolverKey{}, func(ctx context.Context, network, host string) ([]net.IPAddr, error) {
+		if host != mappedDomain {
+			t.Errorf("got DNS host lookup for %q/%q; want %q", network, host, mappedDomain)
+			return nil, nil
+		}
+		return []net.IPAddr{{IP: net.ParseIP(ip)}}, nil
+	})
+
+	req, _ := NewRequest("GET", cst.scheme()+"://"+uniDomain+":"+port, nil)
+	trace := &httptrace.ClientTrace{
+		GetConn: func(hostPort string) {
+			if want := net.JoinHostPort(mappedDomain, port); hostPort != want {
+				t.Errorf("getting conn for %q; want %q", hostPort, want)
+			}
+		},
+	}
+	req = req.WithContext(httptrace.WithClientTrace(ctx, trace))
+
+	res, err := cst.tr.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res.Body.Close()
 }
 
 // Issue 13290: send User-Agent in proxy CONNECT

--- a/src/vendor/golang.org/x/net/internal/httpcommon/request.go
+++ b/src/vendor/golang.org/x/net/internal/httpcommon/request.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http/httptrace"
 	"net/textproto"
 	"net/url"
@@ -17,6 +18,7 @@ import (
 
 	"golang.org/x/net/http/httpguts"
 	"golang.org/x/net/http2/hpack"
+	"golang.org/x/net/idna"
 )
 
 var (
@@ -77,7 +79,13 @@ func EncodeHeaders(ctx context.Context, param EncodeHeadersParam, headerf func(n
 	if host == "" {
 		host = req.URL.Host
 	}
-	host, err := httpguts.PunycodeHostPort(host)
+	// Convert the host to its IDNA ASCII form using the same UTS #46
+	// processing (with mapping) used to pick the address the request is
+	// dialed to. Using a different IDNA profile here would let the
+	// :authority header disagree with the address actually dialed, which
+	// can be used to bypass SSRF filters that inspect URL.Hostname.
+	// See https://go.dev/issue/80417.
+	host, err := idnaASCIIHostPort(host)
 	if err != nil {
 		return res, err
 	}
@@ -472,4 +480,39 @@ func NewServerRequest(rp ServerRequestParam) ServerRequestResult {
 		RequestURI:    requestURI,
 		Trailer:       trailer,
 	}
+}
+
+// idnaASCIIHostPort applies UTS #46 IDNA processing (with mapping) to the host
+// portion of a "host" or "host:port" string, leaving the port unchanged. It is
+// used to compute the Host / :authority header so that it is consistent with
+// the address the request is dialed to. See https://go.dev/issue/80417.
+func idnaASCIIHostPort(v string) (string, error) {
+	if isASCII(v) {
+		return v, nil
+	}
+	host, port, err := net.SplitHostPort(v)
+	if err != nil {
+		// Assume v is a host without a port. Any error will be reported
+		// by idna.Lookup.ToASCII or by later Host header validation.
+		host = v
+		port = ""
+	}
+	host, err = idna.Lookup.ToASCII(host)
+	if err != nil {
+		return "", err
+	}
+	if port == "" {
+		return host, nil
+	}
+	return net.JoinHostPort(host, port), nil
+}
+
+// isASCII reports whether s is composed entirely of ASCII bytes.
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Changes:
  - src/net/http/request.go: add idnaASCIIHostPort and use it for the HTTP/1
    Host header instead of httpguts.PunycodeHostPort.
  - src/net/http/internal/httpcommon/httpcommon.go: use idnaASCIIHostPort
    for the HTTP/2 :authority in EncodeHeaders (bundled copy).
  - src/vendor/golang.org/x/net/internal/httpcommon/request.go: same change
    in the vendored source of the bundle (see golang/net#253).
  - src/net/http/internal/http2/transport.go: map authorityAddr with
    idna.Lookup.ToASCII so the h2 connection-pool key matches the dial and
    header.
  - src/net/http/transport_test.go: add TestTransportIDNAMapping covering
    HTTP/1 and HTTP/2.

For golang/net#253
Fixes #80417