### PR TITLE
net/http/internal/http2: fix doc links for TrailerPrefix

### DIFF
--- a/src/net/http/internal/http2/server.go
+++ b/src/net/http/internal/http2/server.go
@@ -2679,8 +2679,8 @@ func (rws *responseWriterState) writeChunk(p []byte) (n int, err error) {
 // or known before the header is written, the normal Go trailers mechanism
 // is preferred:
 //
-//	https://golang.org/pkg/net/http/#ResponseWriter
-//	https://golang.org/pkg/net/http/#example_ResponseWriter_trailers
+//	https://pkg.go.dev/net/http#ResponseWriter
+//	https://pkg.go.dev/net/http#example-ResponseWriter-Trailers
 const TrailerPrefix = "Trailer:"
 
 // promoteUndeclaredTrailers permits http.Handlers to set trailers


### PR DESCRIPTION
The TrailerPrefix documentation linked to golang.org/pkg and used an
example anchor of the form #example_ResponseWriter_trailers, which
pkg.go.dev does not recognize, so the example link did not resolve.
Update both links to their pkg.go.dev equivalents.

Fixes #51069