### PR TITLE
all: add algebraic enum types

### DIFF
--- a/api/next/19412.txt
+++ b/api/next/19412.txt
@@ -1,0 +1,22 @@
+pkg go/ast, method (*EnumDecl) End() token.Pos #19412
+pkg go/ast, method (*EnumDecl) Pos() token.Pos #19412
+pkg go/ast, method (*EnumVariant) End() token.Pos #19412
+pkg go/ast, method (*EnumVariant) Pos() token.Pos #19412
+pkg go/ast, type EnumDecl struct #19412
+pkg go/ast, type EnumDecl struct, Doc *CommentGroup #19412
+pkg go/ast, type EnumDecl struct, Enum token.Pos #19412
+pkg go/ast, type EnumDecl struct, Lbrace token.Pos #19412
+pkg go/ast, type EnumDecl struct, Name *Ident #19412
+pkg go/ast, type EnumDecl struct, Rbrace token.Pos #19412
+pkg go/ast, type EnumDecl struct, Type token.Pos #19412
+pkg go/ast, type EnumDecl struct, TypeParams *FieldList #19412
+pkg go/ast, type EnumDecl struct, Variants []*EnumVariant #19412
+pkg go/ast, type EnumVariant struct #19412
+pkg go/ast, type EnumVariant struct, Comment *CommentGroup #19412
+pkg go/ast, type EnumVariant struct, Doc *CommentGroup #19412
+pkg go/ast, type EnumVariant struct, Fields *FieldList #19412
+pkg go/ast, type EnumVariant struct, Name *Ident #19412
+pkg go/token, const ENUM = 89 #19412
+pkg go/token, const ENUM Token #19412
+pkg go/types, method (*Named) EnumType() *Named #19412
+pkg go/types, method (*Named) EnumVariants() []*Named #19412

--- a/doc/go_spec.html
+++ b/doc/go_spec.html
@@ -2454,11 +2454,12 @@ of the last non-empty expression list.
 
 <p>
 A type declaration binds an identifier, the <i>type name</i>, to a <a href="#Types">type</a>.
-Type declarations come in two forms: alias declarations and type definitions.
+Type declarations come in three forms: alias declarations, type definitions,
+and enum declarations.
 </p>
 
 <pre class="ebnf">
-TypeDecl = "type" ( TypeSpec | "(" { TypeSpec ";" } ")" ) .
+TypeDecl = "type" ( TypeSpec | EnumSpec | "(" { TypeSpec ";" } ")" ) .
 TypeSpec = AliasDecl | TypeDef .
 </pre>
 
@@ -2630,6 +2631,68 @@ present in the generic type definition.
 // The method Len returns the number of elements in the linked list l.
 func (l *List[T]) Len() int  { … }
 </pre>
+
+<h4 id="Enum_declarations">Enum declarations</h4>
+
+<p>
+An enum declaration creates a new, distinct <i>enum type</i> and a fixed set
+of <i>variants</i> [<a href="#Go_1.28">Go 1.28</a>].
+Each variant contains zero or more fields. The identifier <code>enum</code> is
+contextual: it introduces an enum only in an EnumSpec and remains an ordinary
+identifier elsewhere. Enum declarations may not appear in grouped type
+declarations.
+</p>
+
+<pre class="ebnf">
+EnumSpec    = identifier [ TypeParameters ] "enum" "{" { EnumVariant ";" } "}" .
+EnumVariant = identifier [ "{" { FieldDecl ";" } "}" ] .
+</pre>
+
+<pre>
+type Result[T any] enum {
+	Ok { value T }
+	Err { err error }
+	None
+}
+</pre>
+
+<p>
+The values of an enum type are <code>nil</code> and the values constructed by
+its declared variants. Each variant denotes a distinct, non-interface defined
+type whose underlying type is the struct described by the variant's fields.
+Only the variant itself, not a pointer to it or a type that embeds it, is
+assignable to the enum type. The set of variants is fixed by the declaration;
+no other type implements the enum type.
+</p>
+
+<p>
+A variant name is a constructor, not a type name. Outside an enum switch it
+must be selected from its enum type and may be used only as the direct type of
+a composite literal. Thus <code>Result[int].Ok{value: 1}</code> constructs an
+<code>Ok</code> value, but a variable, parameter, alias, conversion, or type
+case may not use <code>Result[int].Ok</code> as a type. Taking the address of a
+variant literal is permitted, but the resulting pointer is not an enum value.
+An unexported variant may be constructed only within its declaring package.
+</p>
+
+<p>
+When an enum type is the expected type of a composite literal, its variant may
+be written without qualification. This shorthand also applies to variant names
+in enum switch cases.
+</p>
+
+<pre>
+var r Result[int] = Ok{value: 1} // same value as Result[int].Ok{value: 1}
+</pre>
+
+<p>
+Every enum type and variant has an implicitly declared method
+<code>Variant() string</code>. For a variant value, the method returns the
+variant's declared identifier. A program may not declare another method named
+<code>Variant</code> on the enum type. Methods otherwise declared on the enum
+type receive an enum value and are not methods of the individual variant types.
+The zero value of an enum type is <code>nil</code>.
+</p>
 
 <h3 id="Type_parameter_declarations">Type parameter declarations</h3>
 
@@ -3172,7 +3235,7 @@ math.Sin // denotes the Sin function in package math
 <h3 id="Composite_literals">Composite literals</h3>
 
 <p>
-Composite literals construct new values for structs, arrays, slices, and maps
+Composite literals construct new values for structs, arrays, slices, maps, and enum variants
 each time they are evaluated.
 They consist of the type of the literal followed by a (possibly empty)
 brace-bound list of elements.
@@ -3212,6 +3275,12 @@ It is an error to specify multiple elements with the same field selector
 or constant key value.
 A literal may omit the element list; such a literal evaluates
 to the zero value for its type.
+</p>
+
+<p>
+As a special case, the literal type may be an
+<a href="#Enum_declarations">enum variant constructor</a>. Its literal value
+is interpreted as a struct literal for the fields of that variant.
 </p>
 
 <p>
@@ -6427,6 +6496,29 @@ for equality.
 </p>
 
 <p>
+If the switch expression has enum type, the switch is an <i>enum switch</i>
+[<a href="#Go_1.28">Go 1.28</a>]. Each non-<code>nil</code> case expression
+must be an unqualified variant name of that enum and matches every value of
+that variant, independently of its fields. The variants need not be comparable.
+If the switch expression is an identifier and a case lists exactly one variant,
+that identifier denotes the corresponding variant value within the case's
+implicit block, so its fields may be selected. Otherwise it retains the enum
+type. Unless a default case is present, the cases must collectively list every
+variant and <code>nil</code>. Variant cases may not be repeated, and
+<code>fallthrough</code> is not permitted.
+</p>
+
+<pre>
+switch r {
+case Ok:
+	use(r.value) // r is the Ok variant in this clause
+case Err:
+	log.Print(r.err)
+case None, nil:
+}
+</pre>
+
+<p>
 In a case or default clause, the last non-empty statement
 may be a (possibly <a href="#Labeled_statements">labeled</a>)
 <a href="#Fallthrough_statements">"fallthrough" statement</a> to
@@ -6491,6 +6583,13 @@ expression <code>x</code>. As with type assertions, <code>x</code> must be of
 <code>T</code> listed in a case must implement the type of <code>x</code>.
 The types listed in the cases of a type switch must all be
 <a href="#Type_identity">different</a>.
+</p>
+
+<p>
+If <code>x</code> has enum type, an unqualified variant name may appear in
+place of its otherwise unnameable variant type
+[<a href="#Go_1.28">Go 1.28</a>]. Unless a default case is present, the
+cases must collectively list every variant and <code>nil</code>.
 </p>
 
 <pre class="ebnf">
@@ -8853,6 +8952,14 @@ A <a href="#Method_declarations">method declaration</a> may declare
 A key in a struct <a href="#Composite_literals">composite literal</a> may
 be any valid field <a href="#Selectors">selector</a> for the struct type,
 not just a (top-level) field name of the struct.
+</li>
+</ul>
+
+<h4 id="Go_1.28">Go 1.28</h4>
+<ul>
+<li>
+<a href="#Enum_declarations">Enum declarations</a> define closed sets of
+variants with optional payload fields, and enum switches are exhaustive.
 </li>
 </ul>
 

--- a/doc/next/2-language.md
+++ b/doc/next/2-language.md
@@ -1,3 +1,6 @@
 ## Changes to the language {#language}
 
+Go 1.28 adds [enum declarations](/ref/spec#Enum_declarations). Enums define a
+closed set of variants with optional payload fields, and switches over enum
+values are checked for exhaustiveness. See [#19412](/issue/19412).
 

--- a/doc/next/6-stdlib/99-minor/go/ast/19412.md
+++ b/doc/next/6-stdlib/99-minor/go/ast/19412.md
@@ -1,0 +1,2 @@
+The new [EnumDecl] and [EnumVariant] nodes represent enum declarations and
+their variants. See [#19412](/issue/19412).

--- a/doc/next/6-stdlib/99-minor/go/token/19412.md
+++ b/doc/next/6-stdlib/99-minor/go/token/19412.md
@@ -1,0 +1,2 @@
+The new [ENUM] token represents the contextual `enum` keyword. See
+[#19412](/issue/19412).

--- a/doc/next/6-stdlib/99-minor/go/types/19412.md
+++ b/doc/next/6-stdlib/99-minor/go/types/19412.md
@@ -1,0 +1,2 @@
+The new [Named.EnumType] and [Named.EnumVariants] methods expose enum metadata
+to type-aware tools. See [#19412](/issue/19412).

--- a/src/cmd/cgo/ast.go
+++ b/src/cmd/cgo/ast.go
@@ -352,6 +352,9 @@ const (
 // walk walks the AST x, calling visit(f, x, context) for each node.
 func (f *File) walk(x any, context astContext, visit func(*File, any, astContext)) {
 	visit(f, x, context)
+	if f.walkEnum(x, visit) {
+		return
+	}
 	switch n := x.(type) {
 	case *ast.Expr:
 		f.walk(*n, context, visit)
@@ -539,7 +542,6 @@ func (f *File) walk(x any, context astContext, visit func(*File, any, astContext
 		if n.Body != nil {
 			f.walk(n.Body, ctxStmt, visit)
 		}
-
 	case *ast.File:
 		f.walk(n.Decls, ctxDecl, visit)
 

--- a/src/cmd/cgo/ast_enum.go
+++ b/src/cmd/cgo/ast_enum.go
@@ -1,0 +1,29 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !compiler_bootstrap
+
+package main
+
+import "go/ast"
+
+// walkEnum handles AST nodes unavailable in the bootstrap toolchain.
+func (f *File) walkEnum(x any, visit func(*File, any, astContext)) bool {
+	switch node := x.(type) {
+	case *ast.EnumVariant:
+		if node.Fields != nil {
+			f.walk(node.Fields, ctxField, visit)
+		}
+		return true
+	case *ast.EnumDecl:
+		if node.TypeParams != nil {
+			f.walk(node.TypeParams, ctxParam, visit)
+		}
+		for _, variant := range node.Variants {
+			f.walk(variant, ctxDecl, visit)
+		}
+		return true
+	}
+	return false
+}

--- a/src/cmd/cgo/ast_enum_bootstrap.go
+++ b/src/cmd/cgo/ast_enum_bootstrap.go
@@ -1,0 +1,11 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build compiler_bootstrap
+
+package main
+
+// walkEnum is empty while cmd/cgo is built against bootstrap go/ast, which
+// predates enum nodes. Bootstrap inputs cannot contain enum syntax.
+func (*File) walkEnum(any, func(*File, any, astContext)) bool { return false }

--- a/src/cmd/cgo/ast_test.go
+++ b/src/cmd/cgo/ast_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func TestWalkEnum(t *testing.T) {
+	const src = `package p
+
+type Result[T any] enum {
+	Ok { value T }
+	None
+}
+`
+	file, err := parser.ParseFile(token.NewFileSet(), "enum.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var variants int
+	new(File).walk(file, ctxProg, func(_ *File, x any, _ astContext) {
+		if _, ok := x.(*ast.EnumVariant); ok {
+			variants++
+		}
+	})
+	if variants != 2 {
+		t.Fatalf("walk visited %d variants, want 2", variants)
+	}
+}

--- a/src/cmd/compile/internal/noder/linker.go
+++ b/src/cmd/compile/internal/noder/linker.go
@@ -200,8 +200,11 @@ func (l *linker) relocObj(pr *pkgReader, idx index) index {
 		}
 
 		if obj.Op() == ir.OTYPE && !obj.Alias() {
-			if typ := obj.Type(); !typ.IsInterface() {
+			if typ := obj.Type(); typ != nil {
 				for _, method := range typ.Methods() {
+					if method.Nname == nil {
+						continue // interface method, not a declared enum method
+					}
 					l.exportBody(method.Nname.(*ir.Name), local)
 				}
 			}
@@ -320,8 +323,8 @@ func (l *linker) relocTypeExt(w *pkgbits.Encoder, name *ir.Name) {
 	l.lsymIdx(w, "", reflectdata.TypeLinksym(typ))
 	l.lsymIdx(w, "", reflectdata.TypeLinksym(typ.PtrTo()))
 
-	if typ.Kind() != types.TINTER {
-		for _, method := range typ.Methods() {
+	for _, method := range typ.Methods() {
+		if method.Nname != nil {
 			l.relocFuncExt(w, method.Nname.(*ir.Name))
 		}
 	}

--- a/src/cmd/compile/internal/noder/reader.go
+++ b/src/cmd/compile/internal/noder/reader.go
@@ -864,6 +864,11 @@ func (pr *pkgReader) objIdxMayFail(idx index, implicits, explicits []*types.Type
 			methods[i] = r.method(rext)
 		}
 		if len(methods) != 0 {
+			if typ.IsInterface() {
+				// Preserve an enum's marker-only interface method set before
+				// attaching its statically dispatched convenience methods.
+				types.CalcSize(typ)
+			}
 			typ.SetMethods(methods)
 		}
 

--- a/src/cmd/compile/internal/noder/unified.go
+++ b/src/cmd/compile/internal/noder/unified.go
@@ -134,12 +134,8 @@ func lookupMethod(pkg *types.Pkg, symName string) (*ir.Func, error) {
 	if name.Alias() {
 		return nil, fmt.Errorf("type sym %v refers to alias", typ)
 	}
-	if name.Type().IsInterface() {
-		return nil, fmt.Errorf("type sym %v refers to interface type", typ)
-	}
-
 	for _, m := range name.Type().Methods() {
-		if m.Sym == meth {
+		if m.Sym == meth && m.Nname != nil {
 			fn := m.Nname.(*ir.Name).Func
 			return fn, nil
 		}

--- a/src/cmd/compile/internal/noder/writer.go
+++ b/src/cmd/compile/internal/noder/writer.go
@@ -13,6 +13,7 @@ import (
 	"internal/pkgbits"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 
 	"cmd/compile/internal/base"
@@ -82,8 +83,9 @@ type pkgWriter struct {
 
 	// Maps from types2.Objects back to their syntax.Decl.
 
-	funDecls map[*types2.Func]*syntax.FuncDecl
-	typDecls map[*types2.TypeName]typeDeclGen
+	funDecls    map[*types2.Func]*syntax.FuncDecl
+	typDecls    map[*types2.TypeName]typeDeclGen
+	enumMethods []enumMethod
 
 	// linknames maps package-scope objects to their linker symbol name,
 	// if specified by a //go:linkname or //go:linknamestd directive.
@@ -1527,7 +1529,7 @@ func (w *writer) declStmt(decl syntax.Decl) {
 	default:
 		w.p.unexpected("declaration", decl)
 
-	case *syntax.ConstDecl, *syntax.TypeDecl:
+	case *syntax.ConstDecl, *syntax.TypeDecl, *syntax.EnumDecl:
 
 	case *syntax.VarDecl:
 		w.assignStmt(decl, namesAsExpr(decl.NameList), decl.Values)
@@ -1705,19 +1707,38 @@ func (w *writer) switchStmt(stmt *syntax.SwitchStmt) {
 
 	var iface, tagType types2.Type
 	var tagTypeIsChan bool
-	if guard, ok := stmt.Tag.(*syntax.TypeSwitchGuard); w.Bool(ok) {
-		iface = w.p.typeOf(guard.X)
+	guard, typeSwitch := stmt.Tag.(*syntax.TypeSwitchGuard)
+	var enumTag *syntax.Name
+	if !typeSwitch && stmt.Tag != nil {
+		enumTag, _ = syntax.Unparen(stmt.Tag).(*syntax.Name)
+		named, _ := types2.Unalias(w.p.typeOf(stmt.Tag)).(*types2.Named)
+		typeSwitch = named != nil && named.EnumType() != nil && named.EnumType().Origin() == named.Origin()
+	}
+	if w.Bool(typeSwitch) {
+		if guard != nil {
+			iface = w.p.typeOf(guard.X)
 
-		w.pos(guard)
-		if tag := guard.Lhs; w.Bool(tag != nil) {
-			w.pos(tag)
+			w.pos(guard)
+			if tag := guard.Lhs; w.Bool(tag != nil) {
+				w.pos(tag)
 
-			// Like w.localIdent, but we don't have a types2.Object.
-			w.Sync(pkgbits.SyncLocalIdent)
-			w.pkg(w.p.curpkg)
-			w.String(tag.Value)
+				// Like w.localIdent, but we don't have a types2.Object.
+				w.Sync(pkgbits.SyncLocalIdent)
+				w.pkg(w.p.curpkg)
+				w.String(tag.Value)
+			}
+			w.expr(guard.X)
+		} else {
+			iface = w.p.typeOf(stmt.Tag)
+			w.pos(stmt.Tag)
+			if w.Bool(enumTag != nil) {
+				w.pos(enumTag)
+				w.Sync(pkgbits.SyncLocalIdent)
+				w.pkg(w.p.curpkg)
+				w.String(enumTag.Value)
+			}
+			w.expr(stmt.Tag)
 		}
-		w.expr(guard.X)
 	} else {
 		tag := stmt.Tag
 
@@ -2774,11 +2795,16 @@ func (w *writer) op(op ir.Op) {
 // particularly sensitive to it.
 
 type typeDeclGen struct {
-	*syntax.TypeDecl
-	gen int
+	Pragma syntax.Pragma
+	gen    int
 
 	// Implicit type parameters in scope at this type declaration.
 	implicits []*types2.TypeParam
+}
+
+type enumMethod struct {
+	recv   *types2.Named
+	method *types2.Func
 }
 
 type fileImports struct {
@@ -2843,7 +2869,7 @@ func (c *declCollector) Visit(n syntax.Node) syntax.Visitor {
 
 	case *syntax.TypeDecl:
 		obj := pw.info.Defs[n.Name].(*types2.TypeName)
-		d := typeDeclGen{TypeDecl: n, implicits: c.implicits}
+		d := typeDeclGen{Pragma: n.Pragma, implicits: c.implicits}
 
 		if n.Alias {
 			pw.checkPragmas(n.Pragma, 0, false)
@@ -2864,6 +2890,58 @@ func (c *declCollector) Visit(n syntax.Node) syntax.Visitor {
 		// type declarations, but types2 the function literals will be
 		// constant folded away.
 		return c.withTParams(obj)
+
+	case *syntax.EnumDecl:
+		pw.checkPragmas(n.Pragma, 0, false)
+
+		registerType := func(name *syntax.Name) *types2.TypeName {
+			obj := pw.info.Defs[name].(*types2.TypeName)
+			d := typeDeclGen{Pragma: n.Pragma, implicits: c.implicits}
+			if c.withinFunc {
+				*c.typegen++
+				d.gen = *c.typegen
+			}
+			pw.typDecls[obj] = d
+			return obj
+		}
+
+		registerType(n.Name)
+		markerName := ".enum." + n.Name.Value
+		for _, variant := range n.VariantList {
+			obj := registerType(variant.Name)
+			named := obj.Type().(*types2.Named)
+			for i := range named.NumMethods() {
+				method := named.Method(i)
+				isMarker := method.Name() == markerName || strings.HasPrefix(method.Name(), markerName+".")
+				if !isMarker && method.Name() != "Variant" {
+					continue
+				}
+				body := new(syntax.BlockStmt)
+				body.SetPos(variant.Pos())
+				body.Rbrace = variant.Pos()
+				if method.Name() == "Variant" {
+					literal := new(syntax.BasicLit)
+					literal.SetPos(variant.Pos())
+					literal.Value = strconv.Quote(variant.Name.Value)
+					literal.Kind = syntax.StringLit
+					tv := syntax.TypeAndValue{Type: types2.Typ[types2.String], Value: constant.MakeString(variant.Name.Value)}
+					tv.SetIsValue()
+					literal.SetTypeInfo(tv)
+					ret := &syntax.ReturnStmt{Results: literal}
+					ret.SetPos(variant.Pos())
+					body.List = []syntax.Stmt{ret}
+				}
+				decl := &syntax.FuncDecl{
+					Name: syntax.NewName(variant.Pos(), method.Name()),
+					Body: body,
+				}
+				decl.SetPos(variant.Pos())
+				pw.funDecls[method] = decl
+				pw.enumMethods = append(pw.enumMethods, enumMethod{named, method})
+			}
+		}
+
+		return c.withTParams(pw.info.Defs[n.Name])
 
 	case *syntax.VarDecl:
 		pw.checkPragmas(n.Pragma, 0, true)
@@ -2965,6 +3043,14 @@ func (w *writer) pkgInit(noders []*noder) {
 			w.pkgDecl(decl)
 		}
 	}
+	for _, synthetic := range w.p.enumMethods {
+		if synthetic.method.Type().(*types2.Signature).RecvTypeParams().Len() != 0 {
+			continue // generic methods are instantiated on demand
+		}
+		w.Code(declMethod)
+		w.typ(synthetic.recv)
+		w.selector(synthetic.method)
+	}
 	w.Code(declEnd)
 
 	w.Sync(pkgbits.SyncEOF)
@@ -3033,6 +3119,19 @@ func (w *writer) pkgDecl(decl syntax.Decl) {
 
 		w.Code(declOther)
 		w.pkgObjs(decl.Name)
+
+	case *syntax.EnumDecl:
+		if len(decl.TParamList) != 0 {
+			break // skip generic type decls
+		}
+
+		names := make([]*syntax.Name, 1, 1+len(decl.VariantList))
+		names[0] = decl.Name
+		for _, variant := range decl.VariantList {
+			names = append(names, variant.Name)
+		}
+		w.Code(declOther)
+		w.pkgObjs(names...)
 
 	case *syntax.VarDecl:
 		w.Code(declVar)

--- a/src/cmd/compile/internal/reflectdata/reflect.go
+++ b/src/cmd/compile/internal/reflectdata/reflect.go
@@ -420,6 +420,18 @@ func ABIKindOfType(t *types.Type) abi.Kind {
 	return kinds[t.Kind()]
 }
 
+func isEnumVariant(t *types.Type) bool {
+	if t.Kind() == types.TINTER {
+		return false
+	}
+	for _, method := range t.Methods() {
+		if method.Sym != nil && strings.HasPrefix(method.Sym.Name, ".enum.") {
+			return true
+		}
+	}
+	return false
+}
+
 var (
 	memhashvarlen  *obj.LSym
 	memequalvarlen *obj.LSym
@@ -476,6 +488,9 @@ func dcommontype(c rttype.Cursor, t *types.Type) {
 	}
 	if onDemand {
 		tflag |= abi.TFlagGCMaskOnDemand
+	}
+	if isEnumVariant(t) {
+		tflag |= abi.TFlagEnumVariant
 	}
 
 	exported := false
@@ -959,6 +974,9 @@ func writeType(t *types.Type) *obj.LSym {
 		case types.TPTR, types.TARRAY, types.TCHAN, types.TFUNC, types.TMAP, types.TSLICE, types.TSTRUCT:
 			keep = true
 		}
+	}
+	if isEnumVariant(t) {
+		keep = true
 	}
 	// Do not put Noalg types in typelinks.  See issue #22605.
 	if types.TypeHasNoAlg(t) {

--- a/src/cmd/compile/internal/syntax/enum_test.go
+++ b/src/cmd/compile/internal/syntax/enum_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package syntax
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestEnumSyntax(t *testing.T) {
+	const src = `package p
+
+type Result[T any] enum {
+	Ok {
+		value T
+	}
+	Err {
+		err error
+	}
+	None
+	Empty {}
+}
+`
+
+	file, err := Parse(NewFileBase("enum.go"), strings.NewReader(src), nil, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(file.DeclList) != 1 {
+		t.Fatalf("got %d declarations, want 1", len(file.DeclList))
+	}
+	decl, ok := file.DeclList[0].(*EnumDecl)
+	if !ok {
+		t.Fatalf("declaration has type %T, want *EnumDecl", file.DeclList[0])
+	}
+	if decl.Name.Value != "Result" || len(decl.TParamList) != 1 {
+		t.Fatalf("enum header = %s with %d type parameters", decl.Name.Value, len(decl.TParamList))
+	}
+	if len(decl.VariantList) != 4 {
+		t.Fatalf("got %d variants, want 4", len(decl.VariantList))
+	}
+	if decl.VariantList[2].HasPayload {
+		t.Error("None unexpectedly has a payload")
+	}
+	if empty := decl.VariantList[3]; !empty.HasPayload || len(empty.FieldList) != 0 {
+		t.Errorf("Empty payload = (%t, %d fields), want explicit empty payload", empty.HasPayload, len(empty.FieldList))
+	}
+
+	var variants int
+	Inspect(file, func(n Node) bool {
+		if _, ok := n.(*EnumVariant); ok {
+			variants++
+		}
+		return true
+	})
+	if variants != 4 {
+		t.Errorf("Inspect visited %d variants, want 4", variants)
+	}
+
+	var printed bytes.Buffer
+	if _, err := Fprint(&printed, file, 0); err != nil {
+		t.Fatal(err)
+	}
+	want := strings.TrimSuffix(src, "\n")
+	if got := printed.String(); got != want {
+		t.Errorf("printed enum:\n%q\nwant:\n%q", got, want)
+	}
+	if _, err := Parse(NewFileBase("printed.go"), strings.NewReader(printed.String()), nil, nil, 0); err != nil {
+		t.Fatalf("printed enum does not parse: %v", err)
+	}
+}
+
+func TestEnumIsContextualKeyword(t *testing.T) {
+	const src = `package p
+var enum = 1
+func f(enum string) string {
+	enum += "x"
+	{
+		enum := 2
+		enum++
+		_ = enum
+	}
+	type Local enum { A }
+	var _ Local = A{}
+	return enum
+}
+`
+	if _, err := Parse(NewFileBase("enum.go"), strings.NewReader(src), nil, nil, 0); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnumUnderlyingTypeName(t *testing.T) {
+	const src = `package p
+type enum int
+type E enum
+type G[T any] enum
+type I enum[int]
+`
+	if _, err := Parse(NewFileBase("enum.go"), strings.NewReader(src), nil, nil, 0); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGroupedEnumRejected(t *testing.T) {
+	const src = "package p; type ( E enum { A } )"
+	if _, err := Parse(NewFileBase("enum.go"), strings.NewReader(src), nil, nil, 0); err == nil {
+		t.Fatal("grouped enum declaration parsed without error")
+	}
+}

--- a/src/cmd/compile/internal/syntax/nodes.go
+++ b/src/cmd/compile/internal/syntax/nodes.go
@@ -117,7 +117,27 @@ type (
 		Body       *BlockStmt // nil means no body (forward declaration)
 		decl
 	}
+
+	// type Name[T, ...] enum { VariantList[0]; VariantList[1]; ... }
+	EnumDecl struct {
+		Pragma      Pragma
+		Group       *Group
+		Name        *Name
+		TParamList  []*Field // nil means no type parameters
+		VariantList []*EnumVariant
+		decl
+	}
 )
+
+// EnumVariant is one variant in an algebraic enum. HasPayload distinguishes a
+// variant without a payload from one with an explicitly empty payload.
+type EnumVariant struct {
+	Name       *Name
+	FieldList  []*Field
+	TagList    []*BasicLit
+	HasPayload bool
+	node
+}
 
 func (d *FuncDecl) String() string {
 	return fmt.Sprintf("FuncDecl{Name:%v}", d.Name)

--- a/src/cmd/compile/internal/syntax/parser.go
+++ b/src/cmd/compile/internal/syntax/parser.go
@@ -660,7 +660,15 @@ func (p *parser) typeDecl(group *Group) Decl {
 				// d.Name "[" pname ptype "," ...
 				d.TParamList = p.paramList(pname, ptype, _Rbrack, true, false) // ptype may be nil
 				d.Alias = p.gotAssign()
-				d.Type = p.typeOrNil()
+				if !d.Alias && p.tok == _Name && p.lit == "enum" {
+					name := p.name()
+					if p.tok == _Lbrace {
+						return p.enumDecl(d)
+					}
+					d.Type = p.qualifiedName(name)
+				} else {
+					d.Type = p.typeOrNil()
+				}
 			} else {
 				// d.Name "[" pname "]" ...
 				// d.Name "[" x ...
@@ -676,7 +684,15 @@ func (p *parser) typeDecl(group *Group) Decl {
 		}
 	} else {
 		d.Alias = p.gotAssign()
-		d.Type = p.typeOrNil()
+		if !d.Alias && p.tok == _Name && p.lit == "enum" {
+			name := p.name()
+			if p.tok == _Lbrace {
+				return p.enumDecl(d)
+			}
+			d.Type = p.qualifiedName(name)
+		} else {
+			d.Type = p.typeOrNil()
+		}
 	}
 
 	if d.Type == nil {
@@ -685,6 +701,50 @@ func (p *parser) typeDecl(group *Group) Decl {
 		p.advance(_Semi, _Rparen)
 	}
 
+	return d
+}
+
+// EnumDecl = "type" identifier [ TypeParams ] "enum" "{" { EnumVariant ";" } "}" .
+func (p *parser) enumDecl(header *TypeDecl) Decl {
+	if trace {
+		defer p.trace("enumDecl")()
+	}
+	if header.Group != nil {
+		p.syntaxError("enum declarations cannot be grouped")
+	}
+
+	d := &EnumDecl{
+		Pragma:     header.Pragma,
+		Group:      header.Group,
+		Name:       header.Name,
+		TParamList: header.TParamList,
+	}
+	d.pos = header.pos
+	p.want(_Lbrace)
+	p.list("enum declaration", _Semi, _Rbrace, func() bool {
+		if p.tok != _Name {
+			p.syntaxError("expected variant name")
+			p.advance(_Semi, _Rbrace)
+			return false
+		}
+
+		v := new(EnumVariant)
+		v.pos = p.pos()
+		v.Name = p.name()
+		if p.got(_Lbrace) {
+			v.HasPayload = true
+			payload := new(StructType)
+			payload.pos = v.pos
+			p.list("enum variant payload", _Semi, _Rbrace, func() bool {
+				p.fieldDecl(payload)
+				return false
+			})
+			v.FieldList = payload.FieldList
+			v.TagList = payload.TagList
+		}
+		d.VariantList = append(d.VariantList, v)
+		return false
+	})
 	return d
 }
 
@@ -2621,6 +2681,7 @@ func (p *parser) stmtOrNil() Stmt {
 
 	case _Type:
 		return p.declStmt(p.typeDecl)
+
 	}
 
 	p.clearPragma()
@@ -2819,7 +2880,10 @@ func (p *parser) exprList() Expr {
 		defer p.trace("exprList")()
 	}
 
-	x := p.expr()
+	return p.exprListFrom(p.expr())
+}
+
+func (p *parser) exprListFrom(x Expr) Expr {
 	if p.got(_Comma) {
 		list := []Expr{x, p.expr()}
 		for p.got(_Comma) {

--- a/src/cmd/compile/internal/syntax/printer.go
+++ b/src/cmd/compile/internal/syntax/printer.go
@@ -700,6 +700,41 @@ func (p *printer) printRawNode(n Node) {
 			p.print(blank, n.Body)
 		}
 
+	case *EnumDecl:
+		if n.Group == nil {
+			p.print(_Type, blank)
+		}
+		p.print(n.Name)
+		if n.TParamList != nil {
+			p.printParameterList(n.TParamList, _Type)
+		}
+		p.print(blank, _Enum, blank, _Lbrace)
+		if len(n.VariantList) > 0 {
+			p.print(newline, indent)
+			for _, variant := range n.VariantList {
+				p.printNode(variant)
+				p.print(_Semi, newline)
+			}
+			p.print(outdent)
+		}
+		p.print(_Rbrace)
+
+	case *EnumVariant:
+		p.print(n.Name)
+		if n.HasPayload {
+			p.print(blank, _Lbrace)
+			if len(n.FieldList) > 0 {
+				if p.linebreaks {
+					p.print(newline, indent)
+					p.printFieldList(n.FieldList, n.TagList, _Semi)
+					p.print(outdent, newline)
+				} else {
+					p.printFieldList(n.FieldList, n.TagList, _Semi)
+				}
+			}
+			p.print(_Rbrace)
+		}
+
 	case *printGroup:
 		p.print(n.Tok, blank, _Lparen)
 		if len(n.Decls) > 0 {
@@ -815,6 +850,8 @@ func groupFor(d Decl) (token, *Group) {
 		return _Var, d.Group
 	case *FuncDecl:
 		return _Func, nil
+	case *EnumDecl:
+		return _Type, d.Group
 	default:
 		panic("unreachable")
 	}

--- a/src/cmd/compile/internal/syntax/scanner.go
+++ b/src/cmd/compile/internal/syntax/scanner.go
@@ -426,6 +426,9 @@ var keywordMap [1 << 6]token // size must be power of two
 func init() {
 	// populate keywordMap
 	for tok := _Break; tok <= _Var; tok++ {
+		if tok == _Enum {
+			continue // enum is a contextual keyword
+		}
 		h := hash([]byte(tok.String()))
 		if keywordMap[h] != 0 {
 			panic("imperfect hash")

--- a/src/cmd/compile/internal/syntax/scanner_test.go
+++ b/src/cmd/compile/internal/syntax/scanner_test.go
@@ -302,6 +302,7 @@ var sampleTokens = [...]struct {
 	{_Default, "default", 0, 0},
 	{_Defer, "defer", 0, 0},
 	{_Else, "else", 0, 0},
+	{_Name, "enum", 0, 0},
 	{_Fallthrough, "fallthrough", 0, 0},
 	{_For, "for", 0, 0},
 	{_Func, "func", 0, 0},

--- a/src/cmd/compile/internal/syntax/token_string.go
+++ b/src/cmd/compile/internal/syntax/token_string.go
@@ -37,29 +37,30 @@ func _() {
 	_ = x[_Default-27]
 	_ = x[_Defer-28]
 	_ = x[_Else-29]
-	_ = x[_Fallthrough-30]
-	_ = x[_For-31]
-	_ = x[_Func-32]
-	_ = x[_Go-33]
-	_ = x[_Goto-34]
-	_ = x[_If-35]
-	_ = x[_Import-36]
-	_ = x[_Interface-37]
-	_ = x[_Map-38]
-	_ = x[_Package-39]
-	_ = x[_Range-40]
-	_ = x[_Return-41]
-	_ = x[_Select-42]
-	_ = x[_Struct-43]
-	_ = x[_Switch-44]
-	_ = x[_Type-45]
-	_ = x[_Var-46]
-	_ = x[tokenCount-47]
+	_ = x[_Enum-30]
+	_ = x[_Fallthrough-31]
+	_ = x[_For-32]
+	_ = x[_Func-33]
+	_ = x[_Go-34]
+	_ = x[_Goto-35]
+	_ = x[_If-36]
+	_ = x[_Import-37]
+	_ = x[_Interface-38]
+	_ = x[_Map-39]
+	_ = x[_Package-40]
+	_ = x[_Range-41]
+	_ = x[_Return-42]
+	_ = x[_Select-43]
+	_ = x[_Struct-44]
+	_ = x[_Switch-45]
+	_ = x[_Type-46]
+	_ = x[_Var-47]
+	_ = x[tokenCount-48]
 }
 
-const _token_name = "EOFnameliteralopop=opop=:=<-*([{)]},;:....breakcasechanconstcontinuedefaultdeferelsefallthroughforfuncgogotoifimportinterfacemappackagerangereturnselectstructswitchtypevar"
+const _token_name = "EOFnameliteralopop=opop=:=<-*([{)]},;:....breakcasechanconstcontinuedefaultdeferelseenumfallthroughforfuncgogotoifimportinterfacemappackagerangereturnselectstructswitchtypevar"
 
-var _token_index = [...]uint8{0, 3, 7, 14, 16, 19, 23, 24, 26, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 42, 47, 51, 55, 60, 68, 75, 80, 84, 95, 98, 102, 104, 108, 110, 116, 125, 128, 135, 140, 146, 152, 158, 164, 168, 171, 171}
+var _token_index = [...]uint8{0, 3, 7, 14, 16, 19, 23, 24, 26, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 42, 47, 51, 55, 60, 68, 75, 80, 84, 88, 99, 102, 106, 108, 112, 114, 120, 129, 132, 139, 144, 150, 156, 162, 168, 172, 175, 175}
 
 func (i token) String() string {
 	idx := int(i) - 1

--- a/src/cmd/compile/internal/syntax/tokens.go
+++ b/src/cmd/compile/internal/syntax/tokens.go
@@ -50,6 +50,7 @@ const (
 	_Default     // default
 	_Defer       // defer
 	_Else        // else
+	_Enum        // enum
 	_Fallthrough // fallthrough
 	_For         // for
 	_Func        // func

--- a/src/cmd/compile/internal/syntax/walk.go
+++ b/src/cmd/compile/internal/syntax/walk.go
@@ -109,6 +109,22 @@ func (w walker) node(n Node) {
 			w.node(n.Body)
 		}
 
+	case *EnumDecl:
+		w.node(n.Name)
+		w.fieldList(n.TParamList)
+		for _, variant := range n.VariantList {
+			w.node(variant)
+		}
+
+	case *EnumVariant:
+		w.node(n.Name)
+		w.fieldList(n.FieldList)
+		for _, tag := range n.TagList {
+			if tag != nil {
+				w.node(tag)
+			}
+		}
+
 	// expressions
 	case *BadExpr: // nothing to do
 	case *Name: // nothing to do

--- a/src/cmd/compile/internal/typecheck/typecheck.go
+++ b/src/cmd/compile/internal/typecheck/typecheck.go
@@ -791,6 +791,12 @@ func NewMethodExpr(pos src.XPos, recv *types.Type, sym *types.Sym) *ir.SelectorE
 	}
 
 	m := Lookdot1(nil, sym, recv, ms, 0)
+	if m == nil && recv.IsInterface() && recv.Sym() != nil {
+		// Enum methods are ordinary, statically dispatched methods on the
+		// named enum type. They are intentionally not part of the underlying
+		// interface method set, which contains only the enum marker.
+		m = Lookdot1(nil, sym, recv, recv.Methods(), 0)
+	}
 	if m == nil {
 		base.FatalfAt(pos, "type %v has no method %v", recv, sym)
 	}
@@ -831,9 +837,14 @@ func Lookdot(n *ir.SelectorExpr, t *types.Type, dostrcmp int) *types.Field {
 	}
 
 	var f2 *types.Field
+	if f1 == nil && t.IsInterface() && t.Sym() != nil {
+		// A named enum's declared methods are separate from the interface
+		// methods used to recognize its variants at run time.
+		f2 = Lookdot1(n, s, t, t.Methods(), dostrcmp)
+	}
 	if n.X.Type() == t || n.X.Type().Sym() == nil {
 		mt := types.ReceiverBaseType(t)
-		if mt != nil {
+		if f2 == nil && mt != nil {
 			f2 = Lookdot1(n, s, mt, mt.Methods(), dostrcmp)
 		}
 	}

--- a/src/cmd/compile/internal/types2/builtins.go
+++ b/src/cmd/compile/internal/types2/builtins.go
@@ -654,6 +654,10 @@ func (check *Checker) builtin(x *operand, call *syntax.CallExpr, id builtinId) (
 			return
 		case typexpr:
 			// new(T)
+			if check.rejectEnumVariantType(arg, x.typ()) {
+				x.invalidate()
+				return
+			}
 			check.validVarType(arg, x.typ())
 		default:
 			// new(expr)

--- a/src/cmd/compile/internal/types2/call.go
+++ b/src/cmd/compile/internal/types2/call.go
@@ -193,6 +193,10 @@ func (check *Checker) callExpr(x *operand, call *syntax.CallExpr) exprKind {
 
 	case typexpr:
 		// conversion
+		if check.rejectEnumVariantType(call.Fun, x.typ()) {
+			x.invalidate()
+			return conversion
+		}
 		check.nonGeneric(nil, x)
 		if !x.isValid() {
 			return conversion
@@ -696,6 +700,19 @@ func (check *Checker) selector(x *operand, e *syntax.SelectorExpr, wantType bool
 	// selector expressions.
 	if ident, ok := e.X.(*syntax.Name); ok {
 		obj := check.lookup(ident.Value)
+		if tname, _ := obj.(*TypeName); tname != nil && tname.typ != nil {
+			if variant := enumVariant(tname.typ, sel); variant != nil {
+				if variant.Obj().Pkg() != check.pkg && !variant.Obj().Exported() {
+					check.errorf(e.Sel, UnexportedName, "cannot refer to unexported enum variant %s", variant)
+				}
+				check.recordUse(ident, tname)
+				check.recordUse(e.Sel, variant.Obj())
+				x.mode_ = typexpr
+				x.typ_ = variant
+				x.expr = e
+				return
+			}
+		}
 		if pname, _ := obj.(*PkgName); pname != nil {
 			assert(pname.pkg == check.pkg)
 			check.recordUse(ident, pname)
@@ -787,7 +804,7 @@ func (check *Checker) selector(x *operand, e *syntax.SelectorExpr, wantType bool
 		}
 	}
 
-	check.exprOrType(x, e.X, false)
+	check.exprOrType(x, e.X, true)
 	switch x.mode() {
 	case builtin:
 		check.errorf(e.Pos(), UncalledBuiltin, "invalid use of %s in selector expression", x)
@@ -799,6 +816,23 @@ func (check *Checker) selector(x *operand, e *syntax.SelectorExpr, wantType bool
 	// We cannot select on an incomplete type; make sure it's complete.
 	if !check.isComplete(x.typ()) {
 		goto Error
+	}
+
+	if x.mode() == typexpr {
+		if variant := enumVariant(x.typ(), sel); variant != nil {
+			if variant.Obj().Pkg() != check.pkg && !variant.Obj().Exported() {
+				check.errorf(e.Sel, UnexportedName, "cannot refer to unexported enum variant %s", variant)
+			}
+			check.recordUse(e.Sel, variant.Obj())
+			x.mode_ = typexpr
+			x.typ_ = variant
+			x.expr = e
+			return
+		}
+		if isGeneric(x.typ()) {
+			check.nonGeneric(nil, x)
+			goto Error
+		}
 	}
 
 	// Avoid crashing when checking an invalid selector in a method declaration.

--- a/src/cmd/compile/internal/types2/check.go
+++ b/src/cmd/compile/internal/types2/check.go
@@ -34,16 +34,17 @@ type exprInfo struct {
 // An environment represents the environment within which an object is
 // type-checked.
 type environment struct {
-	decl          *declInfo                 // package-level declaration whose init expression/function body is checked
-	scope         *Scope                    // top-most scope for lookups
-	version       goVersion                 // current accepted language version; changes across files
-	iota          constant.Value            // value of iota in a constant declaration; nil otherwise
-	errpos        syntax.Pos                // if valid, identifier position of a constant with inherited initializer
-	inTParamList  bool                      // set if inside a type parameter list
-	sig           *Signature                // function signature if inside a function; nil otherwise
-	isPanic       map[*syntax.CallExpr]bool // set of panic call expressions (used for termination check)
-	hasLabel      bool                      // set if a function makes use of labels (only ~1% of functions); unused outside functions
-	hasCallOrRecv bool                      // set if an expression contains a function call or channel receive operation
+	decl          *declInfo                   // package-level declaration whose init expression/function body is checked
+	scope         *Scope                      // top-most scope for lookups
+	version       goVersion                   // current accepted language version; changes across files
+	iota          constant.Value              // value of iota in a constant declaration; nil otherwise
+	errpos        syntax.Pos                  // if valid, identifier position of a constant with inherited initializer
+	inTParamList  bool                        // set if inside a type parameter list
+	sig           *Signature                  // function signature if inside a function; nil otherwise
+	isPanic       map[*syntax.CallExpr]bool   // set of panic call expressions (used for termination check)
+	enumSwitches  map[*syntax.SwitchStmt]bool // set of exhaustive enum switches (used for termination check)
+	hasLabel      bool                        // set if a function makes use of labels (only ~1% of functions); unused outside functions
+	hasCallOrRecv bool                        // set if an expression contains a function call or channel receive operation
 }
 
 // lookupScope looks up name in the current environment and if an object

--- a/src/cmd/compile/internal/types2/cycles.go
+++ b/src/cmd/compile/internal/types2/cycles.go
@@ -71,7 +71,11 @@ func (check *Checker) directCycle(tname *TypeName, pathIdx map[*TypeName]int) {
 
 		// For direct cycle detection, we don't care about whether we have an alias or not.
 		// If the associated type is not a name, we're at the end of the path and we're done.
-		rhs, ok := check.objMap[tname].tdecl.Type.(*syntax.Name)
+		info := check.objMap[tname]
+		if info == nil || info.edecl != nil {
+			break
+		}
+		rhs, ok := info.tdecl.Type.(*syntax.Name)
 		if !ok {
 			break
 		}

--- a/src/cmd/compile/internal/types2/decl.go
+++ b/src/cmd/compile/internal/types2/decl.go
@@ -10,6 +10,7 @@ import (
 	"go/constant"
 	. "internal/types/errors"
 	"slices"
+	"strings"
 )
 
 func (check *Checker) declare(scope *Scope, id *syntax.Name, obj Object, pos syntax.Pos) {
@@ -155,8 +156,12 @@ func (check *Checker) objDecl(obj Object) {
 		check.varDecl(obj, d.lhs, d.vtyp, d.init)
 	case *TypeName:
 		// invalid recursive types are detected via path
-		check.typeDecl(obj, d.tdecl)
-		check.collectMethods(obj) // methods can only be added to top-level types
+		if d.edecl != nil {
+			check.enumDecl(d.edecl)
+		} else {
+			check.typeDecl(obj, d.tdecl)
+			check.collectMethods(obj) // methods can only be added to top-level types
+		}
 	case *Func:
 		// functions may be recursive - no need to track dependencies
 		check.funcDecl(obj, d)
@@ -505,6 +510,193 @@ func (check *Checker) typeDecl(obj *TypeName, tdecl *syntax.TypeDecl) {
 	}
 }
 
+func (check *Checker) enumDecl(info *enumDeclInfo) {
+	// Another object from this enum may have initialized the whole declaration.
+	if info.objects[0].typ != nil {
+		return
+	}
+
+	decl := info.decl
+	check.verifyVersionf(decl, go1_28, "enum declaration")
+	named := make([]*Named, len(info.objects))
+	for i, obj := range info.objects {
+		named[i] = check.newNamed(obj, nil, nil)
+	}
+
+	if decl.TParamList != nil {
+		check.openScope(decl, "enum type parameters")
+		defer check.closeScope()
+		check.collectEnumTypeParams(named, decl.TParamList)
+	}
+
+	markerName := ".enum." + decl.Name.Value
+	if named[0].Obj().Parent() != check.pkg.Scope() {
+		markerName += "." + decl.Name.Pos().String()
+	}
+	markerSig := NewSignatureType(nil, nil, nil, enumMarkerParams(decl.Name.Pos(), check.pkg, named[0].TypeParams().list()), nil, false)
+	marker := NewFunc(decl.Name.Pos(), check.pkg, markerName, markerSig)
+	variantResult := NewTuple(newVar(ResultVar, decl.Name.Pos(), check.pkg, "", Typ[String]))
+	variantSig := NewSignatureType(nil, nil, nil, nil, variantResult, false)
+	variantMethod := NewFunc(decl.Name.Pos(), check.pkg, "Variant", variantSig)
+	named[0].fromRHS = NewInterfaceType([]*Func{marker, variantMethod}, nil)
+	einfo := &enumInfo{parent: named[0], variants: named[1:]}
+	for _, typ := range named {
+		typ.enumInfo = einfo
+	}
+
+	for i, variant := range decl.VariantList {
+		styp := new(Struct)
+		check.structType(styp, &syntax.StructType{FieldList: variant.FieldList, TagList: variant.TagList})
+		for i := 0; i < styp.NumFields(); i++ {
+			field := styp.Field(i)
+			if field.Embedded() && promotesEnumMarker(field.Type(), nil) {
+				check.errorf(field, InvalidPtrEmbed, "enum variant %s cannot anonymously embed a type that promotes an enum marker: %s", variant.Name.Value, field.Type())
+			}
+		}
+		baseTParams := named[0].TypeParams().list()
+		variantTParams := named[i+1].TypeParams().list()
+		if len(baseTParams) == 0 {
+			named[i+1].fromRHS = styp
+		} else {
+			smap := makeRenameMap(baseTParams, variantTParams)
+			named[i+1].fromRHS = check.subst(variant.Name.Pos(), styp, smap, nil, check.context())
+		}
+
+		newReceiver := func() (*Var, []*TypeParam) {
+			recvType := Type(named[i+1])
+			rparams := make([]*TypeParam, len(variantTParams))
+			for i, baseTParam := range variantTParams {
+				obj := NewTypeName(variant.Name.Pos(), check.pkg, baseTParam.Obj().Name(), nil)
+				rparams[i] = check.newTypeParam(obj, nil)
+			}
+			if len(rparams) != 0 {
+				smap := makeRenameMap(variantTParams, rparams)
+				targs := make([]Type, len(rparams))
+				for i, tparam := range rparams {
+					tparam.bound = check.subst(variant.Name.Pos(), variantTParams[i].bound, smap, nil, check.context())
+					targs[i] = tparam
+				}
+				recvType = check.instance(variant.Name.Pos(), named[i+1], targs, nil, check.context())
+			}
+			return newVar(RecvVar, variant.Name.Pos(), check.pkg, "", recvType), rparams
+		}
+		markerRecv, markerRParams := newReceiver()
+		sig := NewSignatureType(markerRecv, markerRParams, nil, enumMarkerParams(variant.Name.Pos(), check.pkg, markerRParams), nil, false)
+		variantRecv, variantRParams := newReceiver()
+		variantResult := NewTuple(newVar(ResultVar, variant.Name.Pos(), check.pkg, "", Typ[String]))
+		variantSig := NewSignatureType(variantRecv, variantRParams, nil, nil, variantResult, false)
+		named[i+1].methods = []*Func{
+			NewFunc(variant.Name.Pos(), check.pkg, markerName, sig),
+			NewFunc(variant.Name.Pos(), check.pkg, "Variant", variantSig),
+		}
+	}
+	for _, variant := range named[1:] {
+		variant := variant
+		check.later(func() {
+			check.validType(variant)
+		}).describef(variant.obj, "validType(%s)", variant.obj.Name())
+	}
+
+	for _, obj := range info.objects {
+		check.collectMethods(obj)
+	}
+}
+
+func promotesEnumMarker(typ Type, seen map[Type]bool) bool {
+	typ = Unalias(typ)
+	if ptr, _ := Unalias(typ).(*Pointer); ptr != nil {
+		typ = Unalias(ptr.Elem())
+	}
+	if seen == nil {
+		seen = make(map[Type]bool)
+	}
+	if seen[typ] {
+		return false
+	}
+	seen[typ] = true
+	if named, _ := typ.(*Named); named != nil {
+		if named.EnumType() != nil {
+			return true
+		}
+		typ = named.Underlying()
+	}
+	switch typ := typ.(type) {
+	case *Interface:
+		for i := 0; i < typ.NumMethods(); i++ {
+			if strings.HasPrefix(typ.Method(i).name, ".enum.") {
+				return true
+			}
+		}
+	case *Struct:
+		for i := 0; i < typ.NumFields(); i++ {
+			field := typ.Field(i)
+			if field.Embedded() && promotesEnumMarker(field.Type(), seen) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func enumMarkerParams(pos syntax.Pos, pkg *Package, tparams []*TypeParam) *Tuple {
+	if len(tparams) == 0 {
+		return nil
+	}
+	params := make([]*Var, len(tparams))
+	for i, tparam := range tparams {
+		params[i] = NewParam(pos, pkg, "", tparam)
+	}
+	return NewTuple(params...)
+}
+
+// collectEnumTypeParams declares the enum's type parameters and creates a
+// distinct, equivalent type parameter list for every variant. Distinct lists
+// are required because each variant is a separate defined type.
+func (check *Checker) collectEnumTypeParams(named []*Named, list []*syntax.Field) {
+	base := make([]*TypeParam, len(list))
+	if len(list) > 0 {
+		scopePos := list[0].Pos()
+		for i, field := range list {
+			base[i] = check.declareTypeParam(field.Name, scopePos)
+		}
+	}
+	named[0].tparams = bindTParams(base)
+
+	variantParams := make([][]*TypeParam, len(named)-1)
+	for i, variant := range named[1:] {
+		params := make([]*TypeParam, len(base))
+		for j, tparam := range base {
+			obj := NewTypeName(tparam.Obj().Pos(), check.pkg, tparam.Obj().Name(), nil)
+			params[j] = check.newTypeParam(obj, Typ[Invalid])
+		}
+		variant.tparams = bindTParams(params)
+		variantParams[i] = params
+	}
+
+	assert(!check.inTParamList)
+	check.inTParamList = true
+	defer func() { check.inTParamList = false }()
+
+	var bound Type
+	for i, field := range list {
+		if i == 0 || field.Type != list[i-1].Type {
+			bound = check.bound(field.Type)
+			if isTypeParam(bound) {
+				check.error(field.Type, MisplacedTypeParam, "cannot use type parameter as constraint")
+				bound = Typ[Invalid]
+			}
+		}
+		base[i].bound = bound
+	}
+
+	for _, params := range variantParams {
+		smap := makeRenameMap(base, params)
+		for i, tparam := range params {
+			tparam.bound = check.subst(tparam.Obj().Pos(), base[i].bound, smap, nil, check.context())
+		}
+	}
+}
+
 func (check *Checker) collectTypeParams(dst **TypeParamList, list []*syntax.Field) {
 	tparams := make([]*TypeParam, len(list))
 
@@ -595,7 +787,9 @@ func (check *Checker) collectMethods(obj *TypeName) {
 		return
 	}
 	delete(check.methods, obj)
-	assert(!check.objMap[obj].tdecl.Alias) // don't use TypeName.IsAlias (requires fully set up object)
+	if tdecl := check.objMap[obj].tdecl; tdecl != nil {
+		assert(!tdecl.Alias) // don't use TypeName.IsAlias (requires fully set up object)
+	}
 
 	// use an objset to check for name conflicts
 	var mset objset
@@ -627,6 +821,14 @@ func (check *Checker) collectMethods(obj *TypeName) {
 		// spec: "For a base type, the non-blank names of methods bound
 		// to it must be unique."
 		assert(m.name != "_")
+		if base != nil && enumHasVariantName(base, m.name) {
+			check.errorf(m.pos, DuplicateMethod, "method %s.%s conflicts with enum variant %s", obj.Name(), m.name, m.name)
+			continue
+		}
+		if base != nil && m.name == "Variant" && isEnumType(base) {
+			check.errorf(m.pos, DuplicateMethod, "method %s.Variant conflicts with generated enum method Variant", obj.Name())
+			continue
+		}
 		if alt := mset.insert(m); alt != nil {
 			if alt.Pos().IsKnown() {
 				check.errorf(m.pos, DuplicateMethod, "method %s.%s already declared at %v", obj.Name(), m.name, alt.Pos())
@@ -838,6 +1040,17 @@ func (check *Checker) declStmt(list []syntax.Decl) {
 			check.push(obj) // mark as grey
 			check.typeDecl(obj, s)
 			check.pop()
+
+		case *syntax.EnumDecl:
+			info := &enumDeclInfo{decl: s, objects: make([]*TypeName, 1+len(s.VariantList))}
+			info.objects[0] = NewTypeName(s.Name.Pos(), pkg, s.Name.Value, nil)
+			check.declare(check.scope, s.Name, info.objects[0], s.Name.Pos())
+			for i, variant := range s.VariantList {
+				obj := NewTypeName(variant.Name.Pos(), pkg, s.Name.Value+"."+variant.Name.Value, nil)
+				info.objects[i+1] = obj
+				check.declare(check.scope, variant.Name, obj, s.Name.Pos())
+			}
+			check.enumDecl(info)
 
 		default:
 			check.errorf(s, InvalidSyntaxTree, "unknown syntax.Decl node %T", s)

--- a/src/cmd/compile/internal/types2/enum_test.go
+++ b/src/cmd/compile/internal/types2/enum_test.go
@@ -1,0 +1,482 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package types2_test
+
+import (
+	. "cmd/compile/internal/types2"
+	"strings"
+	"testing"
+)
+
+func TestEnumTypes(t *testing.T) {
+	const src = `package p
+
+type Result enum {
+	Ok { value int }
+	Err { err error }
+	None
+}
+
+func (r Result) Value() int {
+	switch r {
+	case Ok: return r.value
+	case Err: return -1
+	case None, nil: return 0
+	}
+	return 0
+}
+func makeResult() Result { return Result.Ok{value: 42} }
+`
+	pkg, err := typecheck(src, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := pkg.Scope().Lookup("Result").Type().(*Named)
+	variants := result.EnumVariants()
+	if len(variants) != 3 || variants[0].Obj().Name() != "Result.Ok" || variants[1].Obj().Name() != "Result.Err" || variants[2].Obj().Name() != "Result.None" {
+		t.Fatalf("Result variants = %v, want [Result.Ok Result.Err Result.None]", variants)
+	}
+	ok, errVariant, none := variants[0], variants[1], variants[2]
+
+	if _, ok := result.Underlying().(*Interface); !ok {
+		t.Fatalf("Result underlying type is %T, want *Interface", result.Underlying())
+	}
+	if !Implements(result, result.Underlying().(*Interface)) {
+		t.Error("Result does not implement its own enum interface")
+	}
+	for _, variant := range []*Named{ok, errVariant, none} {
+		if _, ok := variant.Underlying().(*Struct); !ok {
+			t.Errorf("%s underlying type is %T, want *Struct", variant.Obj().Name(), variant.Underlying())
+		}
+		if !AssignableTo(variant, result) {
+			t.Errorf("%s is not assignable to Result", variant.Obj().Name())
+		}
+	}
+	if fields := ok.Underlying().(*Struct); fields.NumFields() != 1 || fields.Field(0).Name() != "value" {
+		t.Fatalf("Ok fields = %s, want value int", fields)
+	}
+	if method, _, _ := LookupFieldOrMethod(result, true, pkg, "Value"); method == nil {
+		t.Error("method declared on enum Result was not collected")
+	}
+	if method, _, _ := LookupFieldOrMethod(ok, true, pkg, "Value"); method != nil {
+		t.Error("enum method Value unexpectedly belongs to variant Ok")
+	}
+	if ok.EnumType() != result {
+		t.Fatalf("Ok enum type = %v, want Result", ok.EnumType())
+	}
+	if AssignableTo(NewPointer(ok), result) {
+		t.Error("*Ok is assignable to Result")
+	}
+	if Implements(NewPointer(ok), result.Underlying().(*Interface)) {
+		t.Error("*Ok implements Result")
+	}
+	forged := NewNamed(NewTypeName(nopos, pkg, "Forged", nil), NewStruct([]*Var{
+		NewField(nopos, pkg, "Ok", ok, true),
+	}, nil), nil)
+	if AssignableTo(forged, result) || Implements(forged, result.Underlying().(*Interface)) {
+		t.Error("type embedding Ok implements Result")
+	}
+	orSig := NewSignatureType(nil, nil, nil,
+		NewTuple(NewVar(nopos, nil, "", Typ[Int])),
+		NewTuple(NewVar(nopos, nil, "", Typ[Int])), false)
+	orIface := NewInterfaceType([]*Func{NewFunc(nopos, nil, "Value", orSig)}, nil)
+	if Implements(result, orIface) {
+		t.Error("enum convenience methods must not make Result implement another interface")
+	}
+}
+
+func TestEnumVariantMethods(t *testing.T) {
+	pkg, err := typecheck(`package p
+type Decision enum { Allow; Deny { Reason string } }
+var _ string = Decision.Allow{}.Variant()
+func decisionVariant(decision Decision) string { return decision.Variant() }
+`, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision := pkg.Scope().Lookup("Decision").Type().(*Named)
+	for _, typ := range append([]*Named{decision}, decision.EnumVariants()...) {
+		method, _, _ := LookupFieldOrMethod(typ, true, pkg, "Variant")
+		fn, ok := method.(*Func)
+		if !ok {
+			t.Fatalf("%s Variant method = %T, want *Func", typ, method)
+		}
+		sig := fn.Type().(*Signature)
+		if sig.Params().Len() != 0 || sig.Results().Len() != 1 || sig.Results().At(0).Type() != Typ[String] {
+			t.Fatalf("%s Variant signature = %s, want func() string", typ, sig)
+		}
+	}
+}
+
+func TestEnumVariantMethodCannotBeOverridden(t *testing.T) {
+	_, err := typecheck(`package p
+type Decision enum { Allow }
+func (Decision) Variant() string { return "custom" }
+`, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "conflicts with generated enum method Variant") {
+		t.Fatalf("Variant override error = %v", err)
+	}
+}
+
+func TestVariantMethodOnRecursiveNonEnum(t *testing.T) {
+	_, err := typecheck(`package p
+type A struct { B *B }
+type B A
+func (B) Variant() string { return "B" }
+`, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnumVersion(t *testing.T) {
+	conf := Config{GoVersion: "go1.27"}
+	_, err := typecheck("package p; type E enum { A }", &conf, nil)
+	if err == nil || !strings.Contains(err.Error(), "requires go1.28 or later") {
+		t.Fatalf("enum version error = %v", err)
+	}
+}
+
+func TestEnumVariantTypeRejected(t *testing.T) {
+	const src = `package p
+type Result enum { Ok { value int }; Err }
+func (o Result.Ok) Value() int { return o.value }
+`
+	_, err := typecheck(src, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "is a constructor, not a type") {
+		t.Fatalf("variant type error = %v", err)
+	}
+}
+
+func TestEnumMethodVariantCollisionRejected(t *testing.T) {
+	const src = `package p
+type Result enum { Ok }
+func (Result) Ok() {}
+`
+	_, err := typecheck(src, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "conflicts with enum variant Ok") {
+		t.Fatalf("method/variant collision error = %v", err)
+	}
+}
+
+func TestEnumTypeSwitch(t *testing.T) {
+	const exhaustive = `package p
+type Result enum { Ok { value int }; Err { err error }; None }
+func inspect(r Result) int {
+	switch v := r.(type) {
+	case Ok: return v.value
+	case Err: return len(v.err.Error())
+	case None: return 0
+	case nil: return -1
+	}
+	return -1
+}
+`
+	if _, err := typecheck(exhaustive, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	const missing = `package p
+type Result enum { Ok; Err; None }
+func inspect(r Result) { switch r.(type) { case Ok: } }
+`
+	_, err := typecheck(missing, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "non-exhaustive enum switch on Result; missing Err, None, nil") {
+		t.Fatalf("non-exhaustive switch error = %v", err)
+	}
+
+	const withDefault = `package p
+type Result enum { Ok; Err }
+func inspect(r Result) { switch r.(type) { case Ok:; default: } }
+`
+	if _, err := typecheck(withDefault, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnumValueSwitchNarrowing(t *testing.T) {
+	const exhaustive = `package p
+type Result enum { Ok { value int }; Err { err error }; None }
+func inspect(result Result) int {
+	switch result {
+	case Ok: return result.value
+	case Err: return len(result.err.Error())
+	case None: return 0
+	case nil: return -1
+	}
+	return -2
+}
+`
+	if _, err := typecheck(exhaustive, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	const expressions = `package p
+type Result enum { Ok; Err }
+func makeResult() Result { return Result.Ok{} }
+type Holder struct { Result Result }
+func inspect(h Holder) {
+	switch makeResult() { case Ok:; case Err:; case nil: }
+	switch h.Result { case Ok:; case Err:; case nil: }
+}
+`
+	if _, err := typecheck(expressions, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	const duplicate = `package p
+type Result enum { Ok; Err }
+func inspect(result Result) { switch result { case Ok:; case Ok:; case Err:; case nil: } }
+`
+	_, err := typecheck(duplicate, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "duplicate case Result.Ok in enum switch") {
+		t.Fatalf("duplicate enum case error = %v", err)
+	}
+}
+
+func TestExhaustiveEnumSwitchTerminates(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "value switch",
+			body: `switch result {
+	case Ok: return result.value
+	case Err, None, nil: return 0
+}`,
+		},
+		{
+			name: "type switch",
+			body: `switch result := result.(type) {
+	case Ok: return result.value
+	case Err, None, nil: return 0
+}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			src := `package p
+type Result enum { Ok { value int }; Err; None }
+func value(result Result) int {
+` + test.body + `
+}
+`
+			if _, err := typecheck(src, nil, nil); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestEnumRejectsPointerVariant(t *testing.T) {
+	const src = `package p
+type Result enum { Ok }
+type R = Result
+var _ R = &Result.Ok{}
+`
+	_, err := typecheck(src, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "pointer to enum variant is not an enum value") {
+		t.Fatalf("pointer variant error = %v", err)
+	}
+}
+
+func TestEnumRejectsPromotedMarker(t *testing.T) {
+	tests := []string{`package p
+type Inner enum { Public }
+type Outer enum { Wrap { Inner } }
+		`, `package p
+type Inner enum { Public }
+type Carrier struct { Inner }
+type Outer enum { Wrap { Carrier } }
+		`}
+	for _, src := range tests {
+		_, err := typecheck(src, nil, nil)
+		if err == nil || !strings.Contains(err.Error(), "promotes an enum marker") {
+			t.Fatalf("promoted enum marker error = %v", err)
+		}
+	}
+}
+
+func TestEnumVariantOnlyAllowedAsConstructor(t *testing.T) {
+	valid := `package p
+type Result enum { Ok { Value int } }
+var _ = Result.Ok{Value: 1}
+var _ any = &Result.Ok{Value: 2}
+type Option[T any] enum { Some { Value T } }
+var _ = Option.Some[int]{Value: 3}
+`
+	if _, err := typecheck(valid, nil, nil); err != nil {
+		t.Fatalf("variant constructors: %v", err)
+	}
+	for _, use := range []string{
+		"type Alias = Result.Ok",
+		"var _ Result.Ok",
+		"type Embedded struct { Result.Ok }",
+		"type Outer enum { Wrap { Result.Ok } }",
+		"func f(Result.Ok) {}",
+		"var _ = new(Result.Ok)",
+		"var _ = Result.Ok(0)",
+		"func f(x Result) { switch x.(type) { case Result.Ok: } }",
+	} {
+		src := "package p\ntype Result enum { Ok }\n" + use
+		_, err := typecheck(src, nil, nil)
+		if err == nil || !strings.Contains(err.Error(), "is a constructor, not a type") {
+			t.Fatalf("%s: variant type error = %v", use, err)
+		}
+	}
+}
+
+func TestGenericEnumTypes(t *testing.T) {
+	const src = `package p
+
+type Option[T any] enum {
+	Some { value T }
+	None
+}
+
+func (o Option[T]) Or(zero T) T {
+	switch o {
+	case Some: return o.value
+	case None, nil: return zero
+	}
+	return zero
+}
+
+var _ Option[int] = Option.Some[int]{value: 1}
+`
+	pkg, err := typecheck(src, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	option := pkg.Scope().Lookup("Option").Type().(*Named)
+	variants := option.EnumVariants()
+	some, none := variants[0], variants[1]
+	optionParam := option.TypeParams().At(0)
+	someParam := some.TypeParams().At(0)
+	noneParam := none.TypeParams().At(0)
+	if optionParam == someParam || optionParam == noneParam || someParam == noneParam {
+		t.Fatal("generic enum and variants share type parameter objects")
+	}
+	if fieldType := some.Underlying().(*Struct).Field(0).Type(); fieldType != someParam {
+		t.Fatalf("Some.value type = %v, want Some type parameter %v", fieldType, someParam)
+	}
+	if method, _, _ := LookupFieldOrMethod(option, true, pkg, "Or"); method == nil {
+		t.Fatal("generic enum method Or was not collected")
+	}
+	marker := some.Method(0).Type().(*Signature)
+	recv := marker.Recv().Type().(*Named)
+	if recv.TypeArgs().Len() != 1 || marker.RecvTypeParams().Len() != 1 {
+		t.Fatalf("marker receiver = %v (type args %d, receiver type params %d)", recv, recv.TypeArgs().Len(), marker.RecvTypeParams().Len())
+	}
+}
+
+func TestEnumVariantsRequireQualification(t *testing.T) {
+	const src = `package p
+type Result enum { Ok }
+var inferred Result = Ok{}
+func f() Result { return Ok{} }
+var _ = Result.Ok{}
+`
+	if _, err := typecheck(src, nil, nil); err != nil {
+		t.Fatalf("contextual variants: %v", err)
+	}
+
+	const invalid = `package p
+type Result enum { Ok }
+var _ = Ok{}
+`
+	_, err := typecheck(invalid, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "undefined: Ok") {
+		t.Fatalf("bare variant error = %v", err)
+	}
+}
+
+func TestDuplicateEnumVariant(t *testing.T) {
+	const src = `package p
+type E enum { A; A }
+`
+	_, err := typecheck(src, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "A redeclared") {
+		t.Fatalf("duplicate variant error = %v, want redeclaration error", err)
+	}
+}
+
+func TestEnumVariantVisibility(t *testing.T) {
+	const src = `package p
+type E enum { Public; private }
+`
+	pkg, err := typecheck(src, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	variants := pkg.Scope().Lookup("E").Type().(*Named).EnumVariants()
+	if !variants[0].Obj().Exported() || variants[1].Obj().Exported() {
+		t.Fatalf("variant visibility: Public=%v private=%v", variants[0].Obj().Exported(), variants[1].Obj().Exported())
+	}
+	if got := variants[1].Obj().Id(); got != "p.E.private" {
+		t.Fatalf("private variant ID = %q, want p.E.private", got)
+	}
+}
+
+func TestGenericEnumInstantiationSeal(t *testing.T) {
+	const src = `package p
+type Option[T any] enum { Some { Value T }; None }
+var _ Option[int] = Option.Some[string]{Value: "wrong"}
+`
+	if _, err := typecheck(src, nil, nil); err == nil || !strings.Contains(err.Error(), "cannot use") {
+		t.Fatalf("cross-instantiation assignment error = %v", err)
+	}
+}
+
+func TestLocalEnumSeal(t *testing.T) {
+	const src = `package p
+func f() {
+	type E enum { A }
+	var outer E = A{}
+	{
+		type E enum { A }
+		var inner E = A{}
+		outer = inner
+	}
+}
+`
+	if _, err := typecheck(src, nil, nil); err == nil || !strings.Contains(err.Error(), "cannot use") {
+		t.Fatalf("same-named local enum assignment error = %v", err)
+	}
+}
+
+func TestImportedEnumSwitchVariantVisibility(t *testing.T) {
+	pkg, err := typecheck(`package p; type E enum { Public; private }`, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, switchStmt := range []string{
+		`switch x { case private: default: }`,
+		`switch x.(type) { case private: default: }`,
+	} {
+		conf := Config{Importer: testImporter{"p": pkg}}
+		_, err := typecheck("package q; import \"p\"; func f(x p.E) { "+switchStmt+" }", &conf, nil)
+		if err == nil || !strings.Contains(err.Error(), "unexported enum variant") {
+			t.Errorf("%s: visibility error = %v", switchStmt, err)
+		}
+	}
+}
+
+func TestImportedPrivateVariantSelectorVisibility(t *testing.T) {
+	pkg, err := typecheck(`package p; type E enum { Public; private }`, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, src := range []string{
+		`package q; import "p"; type Alias = p.E; var _ = Alias.private{}`,
+		`package q; import . "p"; var _ = E.private{}`,
+	} {
+		conf := Config{Importer: testImporter{"p": pkg}}
+		if _, err := typecheck(src, &conf, nil); err == nil || !strings.Contains(err.Error(), "unexported enum variant") {
+			t.Errorf("%s: visibility error = %v", src, err)
+		}
+	}
+}

--- a/src/cmd/compile/internal/types2/instantiate.go
+++ b/src/cmd/compile/internal/types2/instantiate.go
@@ -265,6 +265,16 @@ func (check *Checker) implements(V, T Type, constraint bool, cause *string) bool
 		}
 		return false
 	}
+	if marker := enumInterfaceMarker(Ti); marker != "" {
+		variant, _ := Unalias(V).(*Named)
+		_, interfaceType := Vu.(*Interface)
+		if !interfaceType && (variant == nil || variant.enumVariantMarker() != marker) {
+			if cause != nil {
+				*cause = check.sprintf("%s is not a declared variant of %s", V, T)
+			}
+			return false
+		}
+	}
 
 	// Every type satisfies the empty interface.
 	if Ti.Empty() {
@@ -288,8 +298,19 @@ func (check *Checker) implements(V, T Type, constraint bool, cause *string) bool
 		return false
 	}
 
+	// Methods declared on an enum are statically dispatched conveniences on
+	// enum-typed values. They are not runtime interface methods implemented by
+	// every variant, so they don't make the enum implement another interface.
+	methodSource := V
+	if named, _ := Unalias(V).(*Named); named != nil && named.enumMarker() != "" {
+		target, _ := Unalias(T).(*Named)
+		if target == nil || target.Origin() != named.Origin() {
+			methodSource = Vu
+		}
+	}
+
 	// V must implement T's methods, if any.
-	if !check.hasAllMethods(V, T, true, Identical, cause) /* !Implements(V, T) */ {
+	if !check.hasAllMethods(methodSource, T, true, Identical, cause) /* !Implements(V, T) */ {
 		if cause != nil {
 			*cause = check.sprintf("%s does not %s %s %s", V, verb, T, *cause)
 		}
@@ -378,6 +399,16 @@ func (check *Checker) implements(V, T Type, constraint bool, cause *string) bool
 	}
 
 	return checkComparability()
+}
+
+func enumInterfaceMarker(iface *Interface) string {
+	for i := 0; i < iface.NumMethods(); i++ {
+		name := iface.Method(i).name
+		if len(name) > len(".enum.") && name[:len(".enum.")] == ".enum." {
+			return name
+		}
+	}
+	return ""
 }
 
 // mentions reports whether type T "mentions" typ in an (embedded) element or term

--- a/src/cmd/compile/internal/types2/literals.go
+++ b/src/cmd/compile/internal/types2/literals.go
@@ -111,6 +111,22 @@ func (check *Checker) compositeLit(U Type, x *operand, e *syntax.CompositeLit, h
 	switch {
 	case e.Type != nil:
 		// composite literal type present - use it
+		if id, _ := e.Type.(*syntax.Name); id != nil {
+			context := U
+			if context == nil {
+				context = hint
+			}
+			if variant := enumVariant(context, id.Value); variant != nil {
+				if variant.Obj().Pkg() != check.pkg && !variant.Obj().Exported() {
+					check.errorf(id, UnexportedName, "cannot refer to unexported enum variant %s", variant)
+				}
+				typ = variant
+				base = typ
+				check.recordUse(id, variant.Obj())
+				check.recordTypeAndValue(id, typexpr, variant, nil)
+				break
+			}
+		}
 		// [...]T array types may only appear with composite literals.
 		// Check for them here so we don't have to handle ... in general.
 		if atyp, _ := e.Type.(*syntax.ArrayType); atyp != nil && isdddArray(atyp) {
@@ -121,7 +137,7 @@ func (check *Checker) compositeLit(U Type, x *operand, e *syntax.CompositeLit, h
 			base = typ
 			break
 		}
-		typ = check.typ(e.Type)
+		typ = check.enumLitType(e.Type)
 		base = typ
 
 	// The hint mechanism is kept around to avoid reporting a false "need Go 1.28" error

--- a/src/cmd/compile/internal/types2/named.go
+++ b/src/cmd/compile/internal/types2/named.go
@@ -6,6 +6,7 @@ package types2
 
 import (
 	"cmd/compile/internal/syntax"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -124,6 +125,9 @@ type Named struct {
 	// accessed.
 	methods []*Func
 
+	// enumInfo refers to metadata shared by an enum and all of its variants.
+	enumInfo *enumInfo
+
 	// loader may be provided to lazily load type parameters, underlying type, methods, and delayed functions
 	loader func(*Named) ([]*TypeParam, Type, []*Func, []func())
 }
@@ -135,6 +139,11 @@ type instance struct {
 	targs           *TypeList // type arguments
 	expandedMethods int       // number of expanded methods; expandedMethods <= len(orig.methods)
 	ctxt            *Context  // local Context; set to nil after full expansion
+}
+
+type enumInfo struct {
+	parent   *Named
+	variants []*Named
 }
 
 // stateMask represents each state in the lifecycle of a named type.
@@ -410,6 +419,178 @@ func (t *Named) TypeArgs() *TypeList {
 // NumMethods returns the number of explicit methods defined for t.
 func (t *Named) NumMethods() int {
 	return len(t.Origin().unpack().methods)
+}
+
+// EnumType returns the enum type that t belongs to. It returns t itself when
+// t is an enum type, and nil when t is neither an enum nor an enum variant.
+func (t *Named) EnumType() *Named {
+	orig := t.Origin()
+	var parent *Named
+	if orig.enumInfo != nil {
+		parent = orig.enumInfo.parent
+	} else if orig.enumMarker() != "" {
+		parent = orig
+	} else if marker := orig.enumVariantMarker(); marker != "" && orig.obj.pkg != nil {
+		obj, _ := orig.obj.pkg.Scope().Lookup(marker[len(".enum."):]).(*TypeName)
+		if obj != nil {
+			parent, _ = Unalias(obj.Type()).(*Named)
+		}
+	}
+	if parent == nil {
+		return nil
+	}
+	return instantiateEnumNamed(parent, t.TypeArgs())
+}
+
+// EnumVariants returns the variants of enum type t in declaration order.
+// It returns nil when t is not an enum type.
+func (t *Named) EnumVariants() []*Named {
+	orig := t.Origin()
+	if orig.enumInfo == nil && orig.enumMarker() == "" {
+		return nil
+	}
+	var variants []*Named
+	if orig.enumInfo != nil && orig.enumInfo.parent == orig {
+		variants = orig.enumInfo.variants
+	}
+	if variants == nil && orig.obj.pkg != nil {
+		marker := ".enum." + orig.obj.name
+		seen := make(map[*Named]bool)
+		for _, name := range orig.obj.pkg.Scope().Names() {
+			obj, _ := orig.obj.pkg.Scope().Lookup(name).(*TypeName)
+			if obj == nil || obj.IsAlias() {
+				continue
+			}
+			variant, _ := Unalias(obj.Type()).(*Named)
+			if variant == nil {
+				continue
+			}
+			variant = variant.Origin()
+			if variant == orig || seen[variant] {
+				continue
+			}
+			for i := range variant.NumMethods() {
+				method := variant.Method(i)
+				if method.name == marker && method.pkg == orig.obj.pkg {
+					variants = append(variants, variant)
+					seen[variant] = true
+					break
+				}
+			}
+		}
+		slices.SortFunc(variants, func(a, b *Named) int {
+			if c := cmpPos(a.Obj().Pos(), b.Obj().Pos()); c != 0 {
+				return c
+			}
+			return strings.Compare(a.Obj().Name(), b.Obj().Name())
+		})
+	}
+	result := make([]*Named, len(variants))
+	for i, variant := range variants {
+		result[i] = instantiateEnumNamed(variant, t.TypeArgs())
+	}
+	return result
+}
+
+func enumVariant(typ Type, name string) *Named {
+	named, _ := Unalias(typ).(*Named)
+	if named == nil {
+		return nil
+	}
+	orig := named.Origin().unpack()
+	if orig.enumInfo == nil {
+		if !orig.stateHas(hasUnder) || orig.enumMarker() == "" {
+			return nil
+		}
+	}
+	parent := named.EnumType()
+	if parent == nil || parent.Origin() != named.Origin() {
+		return nil
+	}
+	for _, variant := range named.EnumVariants() {
+		if enumVariantName(variant) == name {
+			return variant
+		}
+	}
+	return nil
+}
+
+func enumHasVariantName(named *Named, name string) bool {
+	orig := named.Origin()
+	if orig.enumInfo == nil || orig.enumInfo.parent != orig {
+		return false
+	}
+	for _, variant := range orig.enumInfo.variants {
+		if enumVariantName(variant) == name {
+			return true
+		}
+	}
+	return false
+}
+
+func isEnumType(named *Named) bool {
+	orig := named.Origin()
+	return orig.enumInfo != nil && orig.enumInfo.parent == orig
+}
+
+func enumVariantName(variant *Named) string {
+	name := variant.Obj().Name()
+	if i := strings.LastIndexByte(name, '.'); i >= 0 {
+		return name[i+1:]
+	}
+	return name
+}
+
+func isEnumVariantNamed(named *Named) bool {
+	orig := named.Origin()
+	if orig.enumInfo != nil {
+		return orig.enumInfo.parent != orig
+	}
+	// Imported variants are reconstructed from their qualified object name.
+	// A source-level Go type name cannot itself contain a dot.
+	return strings.Contains(orig.obj.name, ".")
+}
+
+func (t *Named) enumVariantMarker() string {
+	orig := t.Origin()
+	for i := range orig.NumMethods() {
+		method := orig.Method(i)
+		if len(method.name) > len(".enum.") && method.name[:len(".enum.")] == ".enum." && method.pkg == orig.obj.pkg {
+			return method.name
+		}
+	}
+	return ""
+}
+
+func (t *Named) enumMarker() string {
+	orig := t.Origin()
+	iface, _ := orig.Underlying().(*Interface)
+	if iface == nil {
+		return ""
+	}
+	marker := ".enum." + orig.obj.name
+	for i := range iface.NumExplicitMethods() {
+		method := iface.ExplicitMethod(i)
+		if method.name == marker && method.pkg == orig.obj.pkg {
+			return marker
+		}
+	}
+	return ""
+}
+
+func instantiateEnumNamed(orig *Named, targs *TypeList) *Named {
+	if targs.Len() == 0 {
+		return orig
+	}
+	args := make([]Type, targs.Len())
+	for i := range args {
+		args[i] = targs.At(i)
+	}
+	typ, err := Instantiate(nil, orig, args, false)
+	if err != nil {
+		return orig
+	}
+	return typ.(*Named)
 }
 
 // Method returns the i'th method of named type t for 0 <= i < t.NumMethods().

--- a/src/cmd/compile/internal/types2/object.go
+++ b/src/cmd/compile/internal/types2/object.go
@@ -240,6 +240,30 @@ type TypeName struct {
 	object
 }
 
+// Exported reports whether the declared type name is exported. Enum variant
+// objects use a qualified package-local name such as Result.Ok, so visibility
+// is determined by the final component.
+func (obj *TypeName) Exported() bool {
+	name := obj.name
+	if i := strings.LastIndexByte(name, '.'); i >= 0 {
+		name = name[i+1:]
+	}
+	return isExported(name)
+}
+
+// Id returns the qualified package-local name, additionally prefixed by the
+// package path when the final name component is not exported.
+func (obj *TypeName) Id() string {
+	if obj.Exported() {
+		return obj.name
+	}
+	path := "_"
+	if obj.pkg != nil && obj.pkg.path != "" {
+		path = obj.pkg.path
+	}
+	return path + "." + obj.name
+}
+
 // NewTypeName returns a new type name denoting the given typ.
 // The remaining arguments set the attributes found with all Objects.
 //

--- a/src/cmd/compile/internal/types2/operand.go
+++ b/src/cmd/compile/internal/types2/operand.go
@@ -369,6 +369,17 @@ func (x *operand) assignableTo(check *Checker, T Type, cause *string) (bool, Cod
 		return true, 0
 	}
 
+	// Enum values are represented by a sealed interface internally. A pointer
+	// to a variant inherits its marker method, but is not itself an enum variant.
+	if named, _ := T.(*Named); named != nil && named.enumMarker() != "" {
+		if _, ok := V.(*Pointer); ok {
+			if cause != nil {
+				*cause = "pointer to enum variant is not an enum value"
+			}
+			return false, IncompatibleAssign
+		}
+	}
+
 	// T is an interface type, but not a type parameter, and V implements T.
 	// Also handle the case where T is a pointer to an interface so that we get
 	// the Checker.implements error cause.

--- a/src/cmd/compile/internal/types2/resolver.go
+++ b/src/cmd/compile/internal/types2/resolver.go
@@ -25,10 +25,16 @@ type declInfo struct {
 	init      syntax.Expr      // init/orig expression, or nil (for const and var declarations only)
 	inherited bool             // if set, the init expression is inherited from a previous constant declaration
 	tdecl     *syntax.TypeDecl // type declaration, or nil
+	edecl     *enumDeclInfo    // enum declaration shared by enum and variant objects, or nil
 	fdecl     *syntax.FuncDecl // func declaration, or nil
 
 	// The deps field tracks initialization expression dependencies.
 	deps map[Object]bool // lazily initialized
+}
+
+type enumDeclInfo struct {
+	decl    *syntax.EnumDecl
+	objects []*TypeName // enum type followed by variant types in source order
 }
 
 // hasInitializer reports whether the declared object has an initialization
@@ -413,6 +419,18 @@ func (check *Checker) collectObjects() {
 				obj := NewTypeName(s.Name.Pos(), pkg, s.Name.Value, nil)
 				check.declarePkgObj(s.Name, obj, &declInfo{file: fileScope, version: check.version, tdecl: s})
 
+			case *syntax.EnumDecl:
+				info := &enumDeclInfo{decl: s, objects: make([]*TypeName, 1+len(s.VariantList))}
+				info.objects[0] = NewTypeName(s.Name.Pos(), pkg, s.Name.Value, nil)
+				check.declarePkgObj(s.Name, info.objects[0], &declInfo{file: fileScope, version: check.version, edecl: info})
+				for i, variant := range s.VariantList {
+					obj := NewTypeName(variant.Name.Pos(), pkg, s.Name.Value+"."+variant.Name.Value, nil)
+					info.objects[i+1] = obj
+					check.declare(check.pkg.scope, variant.Name, obj, nopos)
+					check.objMap[obj] = &declInfo{file: fileScope, version: check.version, edecl: info}
+					obj.setOrder(uint32(len(check.objMap)))
+				}
+
 			case *syntax.FuncDecl:
 				name := s.Name.Value
 				obj := NewFunc(s.Name.Pos(), pkg, name, nil) // signature set later
@@ -601,7 +619,11 @@ func (check *Checker) resolveBaseTypeName(ptr bool, name *syntax.Name) (ptr_ boo
 		}
 
 		// we're done if tdecl describes a defined type (not an alias)
-		tdecl := check.objMap[tname].tdecl // must exist for objects in package scope
+		info := check.objMap[tname] // must exist for objects in package scope
+		if info.edecl != nil {
+			return ptr, tname
+		}
+		tdecl := info.tdecl
 		if !tdecl.Alias {
 			return ptr, tname
 		}
@@ -681,7 +703,8 @@ func (check *Checker) packageObjects() {
 		// phase 1: non-alias type declarations
 		for _, obj := range check.objList {
 			if tname, _ := obj.(*TypeName); tname != nil {
-				if check.objMap[tname].tdecl.Alias {
+				info := check.objMap[tname]
+				if info.edecl == nil && info.tdecl.Alias {
 					aliasList = append(aliasList, tname)
 				} else {
 					check.objDecl(obj)

--- a/src/cmd/compile/internal/types2/return.go
+++ b/src/cmd/compile/internal/types2/return.go
@@ -50,7 +50,7 @@ func (check *Checker) isTerminating(s syntax.Stmt, label string) bool {
 		}
 
 	case *syntax.SwitchStmt:
-		return check.isTerminatingSwitch(s.Body, label)
+		return check.isTerminatingSwitch(s.Body, label, check.enumSwitches[s])
 
 	case *syntax.SelectStmt:
 		for _, cc := range s.Body {
@@ -85,8 +85,8 @@ func (check *Checker) isTerminatingList(list []syntax.Stmt, label string) bool {
 	return false // all statements are empty
 }
 
-func (check *Checker) isTerminatingSwitch(body []*syntax.CaseClause, label string) bool {
-	hasDefault := false
+func (check *Checker) isTerminatingSwitch(body []*syntax.CaseClause, label string, exhaustive bool) bool {
+	hasDefault := exhaustive
 	for _, cc := range body {
 		if cc.Cases == nil {
 			hasDefault = true

--- a/src/cmd/compile/internal/types2/signature.go
+++ b/src/cmd/compile/internal/types2/signature.go
@@ -469,6 +469,12 @@ func (check *Checker) validRecv(pos poser, recv *Var) {
 			check.errorf(pos, InvalidRecv, "cannot define new methods on non-local type %s", rtyp)
 			break
 		}
+		if enumType := T.EnumType(); enumType != nil {
+			if T.Origin() != enumType.Origin() {
+				check.errorf(pos, InvalidRecv, "cannot define method on enum variant %s; use enum type %s as receiver", enumVariantName(T), enumType.obj.name)
+			}
+			break
+		}
 		var cause string
 		switch u := T.Underlying().(type) {
 		case *Basic:

--- a/src/cmd/compile/internal/types2/sizeof_test.go
+++ b/src/cmd/compile/internal/types2/sizeof_test.go
@@ -31,7 +31,7 @@ func TestSizeof(t *testing.T) {
 		{Interface{}, 40, 80},
 		{Map{}, 16, 32},
 		{Chan{}, 12, 24},
-		{Named{}, 68, 128},
+		{Named{}, 72, 136},
 		{TypeParam{}, 28, 48},
 		{term{}, 12, 24},
 

--- a/src/cmd/compile/internal/types2/stmt.go
+++ b/src/cmd/compile/internal/types2/stmt.go
@@ -11,6 +11,7 @@ import (
 	"go/constant"
 	. "internal/types/errors"
 	"slices"
+	"strings"
 )
 
 // decl may be nil
@@ -308,12 +309,29 @@ func (check *Checker) caseTypes(x *operand, types []syntax.Expr, seen map[Type]s
 	var dummy operand
 L:
 	for _, e := range types {
+		T = nil
 		// The spec allows the value nil instead of a type.
 		if check.isNil(e) {
 			T = nil
 			check.expr(nil, nil, &dummy, e) // run e through expr so we get the usual Info recordings
 		} else {
-			T = check.varType(e)
+			if x != nil && check.isEnumType(x.typ()) {
+				if id, _ := e.(*syntax.Name); id != nil {
+					if variant := enumVariant(x.typ(), id.Value); variant != nil {
+						if obj := variant.Obj(); obj.Pkg() != check.pkg && !obj.Exported() {
+							check.errorf(id, UnexportedName, "cannot refer to unexported enum variant %s", variant)
+							T = Typ[Invalid]
+						} else {
+							T = variant
+							check.recordUse(id, obj)
+							check.recordTypeAndValue(id, typexpr, variant, nil)
+						}
+					}
+				}
+			}
+			if T == nil {
+				T = check.varType(e)
+			}
 			if !isValid(T) {
 				continue L
 			}
@@ -726,6 +744,11 @@ func (check *Checker) switchStmt(inner stmtContext, s *syntax.SwitchStmt) {
 		// By checking assignment of x to an invisible temporary
 		// (as a compiler would), we get all the relevant checks.
 		check.assignment(&x, nil, "switch expression")
+		if check.isEnumType(x.typ()) {
+			name, _ := syntax.Unparen(s.Tag).(*syntax.Name)
+			check.enumValueSwitchStmt(inner|inTypeSwitch, s, name, &x)
+			return
+		}
 		if x.isValid() && !Comparable(x.typ()) && !hasNil(x.typ()) {
 			check.errorf(&x, InvalidExprSwitch, "cannot switch on %s (%s is not comparable)", &x, x.typ())
 			x.invalidate()
@@ -763,6 +786,115 @@ func (check *Checker) switchStmt(inner stmtContext, s *syntax.SwitchStmt) {
 		check.stmtList(inner, clause.Body)
 		check.closeScope()
 	}
+}
+
+func (check *Checker) isEnumType(typ Type) bool {
+	named, _ := Unalias(typ).(*Named)
+	return named != nil && named.EnumType() != nil && named.EnumType().Origin() == named.Origin()
+}
+
+func (check *Checker) enumValueSwitchStmt(inner stmtContext, s *syntax.SwitchStmt, tag *syntax.Name, x *operand) {
+	check.multipleSwitchDefaults(s.Body)
+
+	seen := make(map[Type]syntax.Expr)
+	for _, clause := range s.Body {
+		if clause == nil {
+			check.error(s, InvalidSyntaxTree, "incorrect enum switch case")
+			continue
+		}
+		cases := syntax.UnpackListExpr(clause.Cases)
+		T := check.enumCaseTypes(x, cases, seen)
+		check.openScope(clause, "enum case")
+
+		var obj *Var
+		if tag != nil {
+			obj = newVar(LocalVar, tag.Pos(), check.pkg, tag.Value, T)
+			check.declare(check.scope, nil, obj, clause.Colon)
+			check.recordImplicit(clause, obj)
+		}
+		check.stmtList(inner, clause.Body)
+		if obj != nil {
+			check.usedVars[obj] = true // the narrowed shadow is implicit
+		}
+		check.closeScope()
+	}
+
+	var hasDefault bool
+	for _, clause := range s.Body {
+		if clause != nil && clause.Cases == nil {
+			hasDefault = true
+			break
+		}
+	}
+	if !hasDefault {
+		check.enumSwitchExhaustive(s, x.typ(), seen)
+	}
+}
+
+func (check *Checker) enumCaseTypes(x *operand, exprs []syntax.Expr, seen map[Type]syntax.Expr) Type {
+	result := x.typ()
+	var single Type
+	variants := Unalias(x.typ()).(*Named).EnumVariants()
+
+Next:
+	for _, e := range exprs {
+		var T Type
+		if check.isNil(e) {
+			var dummy operand
+			check.expr(nil, nil, &dummy, e)
+		} else {
+			if id, _ := e.(*syntax.Name); id != nil {
+				if variant := enumVariant(x.typ(), id.Value); variant != nil {
+					if obj := variant.Obj(); obj.Pkg() != check.pkg && !obj.Exported() {
+						check.errorf(id, UnexportedName, "cannot refer to unexported enum variant %s", variant)
+						T = Typ[Invalid]
+					} else {
+						T = variant
+						check.recordUse(id, obj)
+						check.recordTypeAndValue(id, typexpr, variant, nil)
+					}
+				}
+			}
+			if T == nil {
+				T = check.varType(e)
+			}
+			if !isValid(T) {
+				continue
+			}
+			valid := false
+			for _, variant := range variants {
+				if Identical(T, variant) {
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				check.errorf(e, InvalidTypeSwitch, "%s is not a variant of %s", T, x.typ())
+				continue
+			}
+		}
+
+		for other, prev := range seen {
+			if T == nil && other == nil || T != nil && other != nil && Identical(T, other) {
+				name := "nil"
+				if T != nil {
+					name = TypeString(T, check.qualifier)
+				}
+				err := check.newError(DuplicateCase)
+				err.addf(e, "duplicate case %s in enum switch", name)
+				err.addf(prev, "previous case")
+				err.report()
+				continue Next
+			}
+		}
+		seen[T] = e
+		single = T
+	}
+
+	if len(exprs) == 1 && single != nil {
+		result = single
+	}
+	return result
 }
 
 func (check *Checker) typeSwitchStmt(inner stmtContext, s *syntax.SwitchStmt, guard *syntax.TypeSwitchGuard) {
@@ -828,6 +960,19 @@ func (check *Checker) typeSwitchStmt(inner stmtContext, s *syntax.SwitchStmt, gu
 		check.closeScope()
 	}
 
+	if sx != nil {
+		var hasDefault bool
+		for _, clause := range s.Body {
+			if clause != nil && clause.Cases == nil {
+				hasDefault = true
+				break
+			}
+		}
+		if !hasDefault {
+			check.enumSwitchExhaustive(s, sx.typ(), seen)
+		}
+	}
+
 	// If lhs exists, we must have at least one lhs variable that was used.
 	// (We can't use check.usage because that only looks at one scope; and
 	// we don't want to use the same variable for all scopes and change the
@@ -844,4 +989,35 @@ func (check *Checker) typeSwitchStmt(inner stmtContext, s *syntax.SwitchStmt, gu
 			check.softErrorf(lhs, UnusedVar, "%s declared and not used", lhs.Value)
 		}
 	}
+}
+
+func (check *Checker) enumSwitchExhaustive(s *syntax.SwitchStmt, typ Type, seen map[Type]syntax.Expr) {
+	named, _ := Unalias(typ).(*Named)
+	if named == nil || named.EnumType() == nil || named.EnumType().Origin() != named.Origin() {
+		return
+	}
+	var missing []string
+	for _, variant := range named.EnumVariants() {
+		covered := false
+		for caseType := range seen {
+			if caseType != nil && AssignableTo(variant, caseType) {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			missing = append(missing, enumVariantName(variant))
+		}
+	}
+	if _, covered := seen[nil]; !covered {
+		missing = append(missing, "nil")
+	}
+	if len(missing) != 0 {
+		check.errorf(s, InvalidTypeSwitch, "non-exhaustive enum switch on %s; missing %s", named, strings.Join(missing, ", "))
+		return
+	}
+	if check.enumSwitches == nil {
+		check.enumSwitches = make(map[*syntax.SwitchStmt]bool)
+	}
+	check.enumSwitches[s] = true
 }

--- a/src/cmd/compile/internal/types2/typexpr.go
+++ b/src/cmd/compile/internal/types2/typexpr.go
@@ -181,14 +181,36 @@ func (check *Checker) validVarType(e syntax.Expr, typ Type) {
 // named def, and def.typ.fromRHS will be set to the [Type] of e immediately
 // after its creation.
 func (check *Checker) declaredType(e syntax.Expr, def *TypeName) Type {
+	return check.declaredType0(e, def, false)
+}
+
+// enumLitType accepts an enum variant as the direct type of a composite
+// literal. Variants are constructors in source, not standalone types.
+func (check *Checker) enumLitType(e syntax.Expr) Type {
+	return check.declaredType0(e, nil, true)
+}
+
+func (check *Checker) declaredType0(e syntax.Expr, def *TypeName, allowEnumVariant bool) Type {
 	typ := check.typInternal(e, def)
 	assert(isTyped(typ))
+	if !allowEnumVariant && check.rejectEnumVariantType(e, typ) {
+		typ = Typ[Invalid]
+	}
 	if isGeneric(typ) {
 		check.errorf(e, WrongTypeArgCount, "cannot use generic type %s without instantiation", typ)
 		typ = Typ[Invalid]
 	}
 	check.recordTypeAndValue(e, typexpr, typ, nil)
 	return typ
+}
+
+func (check *Checker) rejectEnumVariantType(e syntax.Expr, typ Type) bool {
+	named, _ := Unalias(typ).(*Named)
+	if named == nil || !isEnumVariantNamed(named) {
+		return false
+	}
+	check.errorf(e, NotAType, "enum variant %s is a constructor, not a type", typ)
+	return true
 }
 
 // genericType is like typ but the type must be an (uninstantiated) generic

--- a/src/cmd/go/testdata/script/enum_import_method.txt
+++ b/src/cmd/go/testdata/script/enum_import_method.txt
@@ -1,0 +1,49 @@
+go test ./...
+
+-- go.mod --
+module example.com/enumimport
+
+go 1.28
+
+-- timer/model.go --
+package timer
+
+import "time"
+
+type Key enum {
+	Chat
+}
+
+func ChatKey() Key {
+	return Key.Chat{}
+}
+
+func (key Key) Duration() time.Duration {
+	switch key {
+	case Chat:
+		return 3 * time.Second
+	default:
+		panic("should never happen")
+	}
+}
+
+-- timer/service.go --
+package timer
+
+type Service struct {
+	values map[Key]int
+}
+
+func (service *Service) Remaining(key Key) int {
+	return service.values[key]
+}
+
+-- chat/chat.go --
+package chat
+
+import "example.com/enumimport/timer"
+
+func Duration() int64 {
+	service := &timer.Service{}
+	return int64(timer.ChatKey().Duration()) + int64(service.Remaining(timer.ChatKey()))
+}

--- a/src/cmd/internal/moddeps/moddeps_test.go
+++ b/src/cmd/internal/moddeps/moddeps_test.go
@@ -207,10 +207,16 @@ func TestAllDependencies(t *testing.T) {
 			r.run(t, goBinCopy, "mod", "vendor") // See issue 36852.
 			pkgs := packagePattern(m.Path)
 			r.run(t, goBinCopy, "generate", `-run=^//go:generate bundle `, pkgs) // See issue 41409.
+			if m.Path == "cmd" {
+				r.run(t, goBinCopy, "generate", "-run=toolsvendor", "cmd/vet")
+			}
 			advice := "$ cd " + m.Dir + "\n" +
 				"$ go mod tidy                               # to remove extraneous dependencies\n" +
 				"$ go mod vendor                             # to vendor dependencies\n" +
 				"$ go generate -run=bundle " + pkgs + "               # to regenerate bundled packages\n"
+			if m.Path == "cmd" {
+				advice += "$ go generate -run=toolsvendor cmd/vet      # to restore enum-aware x/tools packages\n"
+			}
 			if m.Path == "std" {
 				r.run(t, goBinCopy, "generate", "syscall", "internal/syscall/...") // See issue 43440.
 				advice += "$ go generate syscall internal/syscall/...  # to regenerate syscall packages\n"

--- a/src/cmd/internal/toolsvendor/main.go
+++ b/src/cmd/internal/toolsvendor/main.go
@@ -1,0 +1,223 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Command toolsvendor reapplies enum AST compatibility changes to the x/tools
+// packages in cmd/vendor after "go mod vendor" replaces them.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type edit struct {
+	path string
+	old  string
+	new  string
+}
+
+var edits = []edit{
+	{
+		"golang.org/x/tools/go/ast/edge/edge.go",
+		`\tValueSpec_Names
+\tValueSpec_Type
+\tValueSpec_Values
+
+\tmaxKind`,
+		`\tValueSpec_Names
+\tValueSpec_Type
+\tValueSpec_Values
+\tEnumDecl_Doc
+\tEnumDecl_Name
+\tEnumDecl_TypeParams
+\tEnumDecl_Variants
+\tEnumVariant_Comment
+\tEnumVariant_Doc
+\tEnumVariant_Fields
+\tEnumVariant_Name
+
+\tmaxKind`,
+	},
+	{
+		"golang.org/x/tools/go/ast/edge/edge.go",
+		`\tValueSpec_Names:       info[*ast.ValueSpec]("Names"),
+\tValueSpec_Type:        info[*ast.ValueSpec]("Type"),
+\tValueSpec_Values:      info[*ast.ValueSpec]("Values"),
+}`,
+		`\tValueSpec_Names:       info[*ast.ValueSpec]("Names"),
+\tValueSpec_Type:        info[*ast.ValueSpec]("Type"),
+\tValueSpec_Values:      info[*ast.ValueSpec]("Values"),
+\tEnumDecl_Doc:          info[*ast.EnumDecl]("Doc"),
+\tEnumDecl_Name:         info[*ast.EnumDecl]("Name"),
+\tEnumDecl_TypeParams:   info[*ast.EnumDecl]("TypeParams"),
+\tEnumDecl_Variants:     info[*ast.EnumDecl]("Variants"),
+\tEnumVariant_Comment:   info[*ast.EnumVariant]("Comment"),
+\tEnumVariant_Doc:       info[*ast.EnumVariant]("Doc"),
+\tEnumVariant_Fields:    info[*ast.EnumVariant]("Fields"),
+\tEnumVariant_Name:      info[*ast.EnumVariant]("Name"),
+}`,
+	},
+	{
+		"golang.org/x/tools/go/ast/inspector/typeof.go",
+		`\tnTypeSwitchStmt
+\tnUnaryExpr
+\tnValueSpec
+)`,
+		`\tnTypeSwitchStmt
+\tnUnaryExpr
+\tnValueSpec
+\tnEnumDecl
+\tnEnumVariant
+)`,
+	},
+	{
+		"golang.org/x/tools/go/ast/inspector/typeof.go",
+		`\tcase *ast.ValueSpec:
+\t\treturn 1 << nValueSpec
+\t}
+\treturn 0`,
+		`\tcase *ast.ValueSpec:
+\t\treturn 1 << nValueSpec
+\tcase *ast.EnumDecl:
+\t\treturn 1 << nEnumDecl
+\tcase *ast.EnumVariant:
+\t\treturn 1 << nEnumVariant
+\t}
+\treturn 0`,
+	},
+	{
+		"golang.org/x/tools/go/ast/inspector/walk.go",
+		`\t\twalkList(v, edge.GenDecl_Specs, n.Specs)
+
+\tcase *ast.FuncDecl:`,
+		`\t\twalkList(v, edge.GenDecl_Specs, n.Specs)
+
+\tcase *ast.EnumDecl:
+\t\tif n.Doc != nil {
+\t\t\twalk(v, edge.EnumDecl_Doc, -1, n.Doc)
+\t\t}
+\t\twalk(v, edge.EnumDecl_Name, -1, n.Name)
+\t\tif n.TypeParams != nil {
+\t\t\twalk(v, edge.EnumDecl_TypeParams, -1, n.TypeParams)
+\t\t}
+\t\twalkList(v, edge.EnumDecl_Variants, n.Variants)
+
+\tcase *ast.EnumVariant:
+\t\tif n.Doc != nil {
+\t\t\twalk(v, edge.EnumVariant_Doc, -1, n.Doc)
+\t\t}
+\t\twalk(v, edge.EnumVariant_Name, -1, n.Name)
+\t\tif n.Fields != nil {
+\t\t\twalk(v, edge.EnumVariant_Fields, -1, n.Fields)
+\t\t}
+\t\tif n.Comment != nil {
+\t\t\twalk(v, edge.EnumVariant_Comment, -1, n.Comment)
+\t\t}
+
+\tcase *ast.FuncDecl:`,
+	},
+	{
+		"golang.org/x/tools/go/cfg/builder.go",
+		`\tcase *ast.DeclStmt:
+\t\t// Treat each var ValueSpec as a separate statement.
+\t\td := s.Decl.(*ast.GenDecl)
+\t\tif d.Tok == token.VAR {`,
+		`\tcase *ast.DeclStmt:
+\t\t// Treat each var ValueSpec as a separate statement.
+\t\td, ok := s.Decl.(*ast.GenDecl)
+\t\tif !ok {
+\t\t\tbreak // local enum or another declaration with no control-flow effect
+\t\t}
+\t\tif d.Tok == token.VAR {`,
+	},
+	{
+		"golang.org/x/tools/internal/refactor/inline/calleefx.go",
+		`\t\tcase *ast.DeclStmt:
+\t\t\tdecl := n.Decl.(*ast.GenDecl)
+\t\t\tfor _, spec := range decl.Specs {`,
+		`\t\tcase *ast.DeclStmt:
+\t\t\tdecl, ok := n.Decl.(*ast.GenDecl)
+\t\t\tif !ok {
+\t\t\t\treturn true // local enum declaration has no runtime effect
+\t\t\t}
+\t\t\tfor _, spec := range decl.Specs {`,
+	},
+	{
+		"golang.org/x/tools/internal/refactor/inline/inline.go",
+		`\t\tcase *ast.DeclStmt:
+\t\t\tfor _, spec := range stmt.Decl.(*ast.GenDecl).Specs {
+\t\t\t\tswitch spec := spec.(type) {
+\t\t\t\tcase *ast.ValueSpec:
+\t\t\t\t\tfor _, id := range spec.Names {
+\t\t\t\t\t\tnames[id.Name] = true
+\t\t\t\t\t}
+\t\t\t\tcase *ast.TypeSpec:
+\t\t\t\t\tnames[spec.Name.Name] = true
+\t\t\t\t}
+\t\t\t}`,
+		`\t\tcase *ast.DeclStmt:
+\t\t\tswitch decl := stmt.Decl.(type) {
+\t\t\tcase *ast.GenDecl:
+\t\t\t\tfor _, spec := range decl.Specs {
+\t\t\t\t\tswitch spec := spec.(type) {
+\t\t\t\t\tcase *ast.ValueSpec:
+\t\t\t\t\t\tfor _, id := range spec.Names {
+\t\t\t\t\t\t\tnames[id.Name] = true
+\t\t\t\t\t\t}
+\t\t\t\t\tcase *ast.TypeSpec:
+\t\t\t\t\t\tnames[spec.Name.Name] = true
+\t\t\t\t\t}
+\t\t\t\t}
+\t\t\tcase *ast.EnumDecl:
+\t\t\t\tnames[decl.Name.Name] = true
+\t\t\t\tfor _, variant := range decl.Variants {
+\t\t\t\t\tnames[variant.Name.Name] = true
+\t\t\t\t}
+\t\t\t}`,
+	},
+	{
+		"golang.org/x/tools/refactor/satisfy/find.go",
+		`\tcase *ast.DeclStmt:
+\t\td := s.Decl.(*ast.GenDecl)
+\t\tif d.Tok == token.VAR { // ignore consts`,
+		`\tcase *ast.DeclStmt:
+\t\td, ok := s.Decl.(*ast.GenDecl)
+\t\tif !ok {
+\t\t\tbreak // local enum declaration has no assignment constraints
+\t\t}
+\t\tif d.Tok == token.VAR { // ignore consts`,
+	},
+}
+
+func main() {
+	vendor := flag.String("vendor", "vendor", "path to the vendor directory")
+	flag.Parse()
+	for _, edit := range edits {
+		if err := apply(filepath.Join(*vendor, filepath.FromSlash(edit.path)), edit); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+}
+
+func apply(path string, edit edit) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	s := string(data)
+	old := strings.ReplaceAll(edit.old, `\t`, "\t")
+	new := strings.ReplaceAll(edit.new, `\t`, "\t")
+	if strings.Contains(s, new) {
+		return nil
+	}
+	if strings.Count(s, old) != 1 {
+		return fmt.Errorf("%s: x/tools vendor edit no longer applies", path)
+	}
+	s = strings.Replace(s, old, new, 1)
+	return os.WriteFile(path, []byte(s), 0o666)
+}

--- a/src/cmd/vendor/golang.org/x/tools/go/ast/edge/edge.go
+++ b/src/cmd/vendor/golang.org/x/tools/go/ast/edge/edge.go
@@ -165,6 +165,14 @@ const (
 	ValueSpec_Names
 	ValueSpec_Type
 	ValueSpec_Values
+	EnumDecl_Doc
+	EnumDecl_Name
+	EnumDecl_TypeParams
+	EnumDecl_Variants
+	EnumVariant_Comment
+	EnumVariant_Doc
+	EnumVariant_Fields
+	EnumVariant_Name
 
 	maxKind
 )
@@ -296,4 +304,12 @@ var fieldInfos = [...]fieldInfo{
 	ValueSpec_Names:       info[*ast.ValueSpec]("Names"),
 	ValueSpec_Type:        info[*ast.ValueSpec]("Type"),
 	ValueSpec_Values:      info[*ast.ValueSpec]("Values"),
+	EnumDecl_Doc:          info[*ast.EnumDecl]("Doc"),
+	EnumDecl_Name:         info[*ast.EnumDecl]("Name"),
+	EnumDecl_TypeParams:   info[*ast.EnumDecl]("TypeParams"),
+	EnumDecl_Variants:     info[*ast.EnumDecl]("Variants"),
+	EnumVariant_Comment:   info[*ast.EnumVariant]("Comment"),
+	EnumVariant_Doc:       info[*ast.EnumVariant]("Doc"),
+	EnumVariant_Fields:    info[*ast.EnumVariant]("Fields"),
+	EnumVariant_Name:      info[*ast.EnumVariant]("Name"),
 }

--- a/src/cmd/vendor/golang.org/x/tools/go/ast/inspector/typeof.go
+++ b/src/cmd/vendor/golang.org/x/tools/go/ast/inspector/typeof.go
@@ -71,6 +71,8 @@ const (
 	nTypeSwitchStmt
 	nUnaryExpr
 	nValueSpec
+	nEnumDecl
+	nEnumVariant
 )
 
 // typeOf returns a distinct single-bit value that represents the type of n.
@@ -211,6 +213,10 @@ func typeOf(n ast.Node) uint64 {
 		return 1 << nUnaryExpr
 	case *ast.ValueSpec:
 		return 1 << nValueSpec
+	case *ast.EnumDecl:
+		return 1 << nEnumDecl
+	case *ast.EnumVariant:
+		return 1 << nEnumVariant
 	}
 	return 0
 }

--- a/src/cmd/vendor/golang.org/x/tools/go/ast/inspector/walk.go
+++ b/src/cmd/vendor/golang.org/x/tools/go/ast/inspector/walk.go
@@ -309,6 +309,28 @@ func walk(v *visitor, ek edge.Kind, index int, node ast.Node) {
 		}
 		walkList(v, edge.GenDecl_Specs, n.Specs)
 
+	case *ast.EnumDecl:
+		if n.Doc != nil {
+			walk(v, edge.EnumDecl_Doc, -1, n.Doc)
+		}
+		walk(v, edge.EnumDecl_Name, -1, n.Name)
+		if n.TypeParams != nil {
+			walk(v, edge.EnumDecl_TypeParams, -1, n.TypeParams)
+		}
+		walkList(v, edge.EnumDecl_Variants, n.Variants)
+
+	case *ast.EnumVariant:
+		if n.Doc != nil {
+			walk(v, edge.EnumVariant_Doc, -1, n.Doc)
+		}
+		walk(v, edge.EnumVariant_Name, -1, n.Name)
+		if n.Fields != nil {
+			walk(v, edge.EnumVariant_Fields, -1, n.Fields)
+		}
+		if n.Comment != nil {
+			walk(v, edge.EnumVariant_Comment, -1, n.Comment)
+		}
+
 	case *ast.FuncDecl:
 		if n.Doc != nil {
 			walk(v, edge.FuncDecl_Doc, -1, n.Doc)

--- a/src/cmd/vendor/golang.org/x/tools/go/cfg/builder.go
+++ b/src/cmd/vendor/golang.org/x/tools/go/cfg/builder.go
@@ -53,7 +53,10 @@ start:
 
 	case *ast.DeclStmt:
 		// Treat each var ValueSpec as a separate statement.
-		d := s.Decl.(*ast.GenDecl)
+		d, ok := s.Decl.(*ast.GenDecl)
+		if !ok {
+			break // local enum or another declaration with no control-flow effect
+		}
 		if d.Tok == token.VAR {
 			for _, spec := range d.Specs {
 				if spec, ok := spec.(*ast.ValueSpec); ok {

--- a/src/cmd/vendor/golang.org/x/tools/internal/refactor/inline/calleefx.go
+++ b/src/cmd/vendor/golang.org/x/tools/internal/refactor/inline/calleefx.go
@@ -228,7 +228,10 @@ func calleefx(info *types.Info, body *ast.BlockStmt, paramInfos map[*types.Var]*
 	visitStmt = func(n ast.Stmt) bool {
 		switch n := n.(type) {
 		case *ast.DeclStmt:
-			decl := n.Decl.(*ast.GenDecl)
+			decl, ok := n.Decl.(*ast.GenDecl)
+			if !ok {
+				return true // local enum declaration has no runtime effect
+			}
 			for _, spec := range decl.Specs {
 				switch spec := spec.(type) {
 				case *ast.ValueSpec:

--- a/src/cmd/vendor/golang.org/x/tools/internal/refactor/inline/inline.go
+++ b/src/cmd/vendor/golang.org/x/tools/internal/refactor/inline/inline.go
@@ -3151,14 +3151,22 @@ func declares(stmts []ast.Stmt) map[string]bool {
 	for _, stmt := range stmts {
 		switch stmt := stmt.(type) {
 		case *ast.DeclStmt:
-			for _, spec := range stmt.Decl.(*ast.GenDecl).Specs {
-				switch spec := spec.(type) {
-				case *ast.ValueSpec:
-					for _, id := range spec.Names {
-						names[id.Name] = true
+			switch decl := stmt.Decl.(type) {
+			case *ast.GenDecl:
+				for _, spec := range decl.Specs {
+					switch spec := spec.(type) {
+					case *ast.ValueSpec:
+						for _, id := range spec.Names {
+							names[id.Name] = true
+						}
+					case *ast.TypeSpec:
+						names[spec.Name.Name] = true
 					}
-				case *ast.TypeSpec:
-					names[spec.Name.Name] = true
+				}
+			case *ast.EnumDecl:
+				names[decl.Name.Name] = true
+				for _, variant := range decl.Variants {
+					names[variant.Name.Name] = true
 				}
 			}
 

--- a/src/cmd/vendor/golang.org/x/tools/refactor/satisfy/find.go
+++ b/src/cmd/vendor/golang.org/x/tools/refactor/satisfy/find.go
@@ -521,7 +521,10 @@ func (f *Finder) stmt(s ast.Stmt) {
 		// no-op
 
 	case *ast.DeclStmt:
-		d := s.Decl.(*ast.GenDecl)
+		d, ok := s.Decl.(*ast.GenDecl)
+		if !ok {
+			break // local enum declaration has no assignment constraints
+		}
 		if d.Tok == token.VAR { // ignore consts
 			for _, spec := range d.Specs {
 				f.valueSpec(spec.(*ast.ValueSpec))

--- a/src/cmd/vet/doc.go
+++ b/src/cmd/vet/doc.go
@@ -81,3 +81,6 @@ Core flags:
 	  	emit analysis diagnostics (and errors) in JSON format
 */
 package main
+
+// Keep the x/tools packages vendored by cmd aware of first-class enums.
+//go:generate go run cmd/internal/toolsvendor -vendor ../vendor

--- a/src/cmd/vet/testdata/enum/enum.go
+++ b/src/cmd/vet/testdata/enum/enum.go
@@ -1,0 +1,28 @@
+package enumtest
+
+import "cmd/vet/testdata/enum/model"
+
+func load() (model.Decision, error) { return model.Decision.Allow{}, nil }
+
+func save() error { return nil }
+
+func inspect(decision model.Decision) (string, error) {
+	loaded, err := load()
+	if err != nil {
+		return "", err
+	}
+	if err := save(); err != nil {
+		return "", err
+	}
+	qualified := model.Decision.Deny{Reason: "no"}
+	_ = qualified
+	switch loaded {
+	case Allow:
+		return "yes", nil
+	case Deny:
+		return loaded.Reason, nil
+	case nil:
+		return "", nil
+	}
+	panic("unreachable")
+}

--- a/src/cmd/vet/testdata/enum/model/model.go
+++ b/src/cmd/vet/testdata/enum/model/model.go
@@ -1,0 +1,6 @@
+package model
+
+type Decision enum {
+	Allow
+	Deny { Reason string }
+}

--- a/src/cmd/vet/vet_test.go
+++ b/src/cmd/vet/vet_test.go
@@ -175,6 +175,15 @@ func TestVet(t *testing.T) {
 	})
 }
 
+func TestEnumSyntax(t *testing.T) {
+	t.Parallel()
+	cmd := testenv.Command(t, testenv.GoToolPath(t), "vet", "-vettool="+vetPath(t), path.Join("cmd/vet/testdata", "enum"))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go vet failed: %v\n%s", err, output)
+	}
+}
+
 func cgoEnabled(t *testing.T) bool {
 	// Don't trust build.Default.CgoEnabled as it is false for
 	// cross-builds unless CGO_ENABLED is explicitly specified.

--- a/src/go/ast/ast.go
+++ b/src/go/ast/ast.go
@@ -1009,6 +1009,28 @@ type (
 		Type *FuncType     // function signature: type and value parameters, results, and position of "func" keyword
 		Body *BlockStmt    // function body; or nil for external (non-Go) function
 	}
+
+	// An EnumDecl node represents an algebraic enum declaration.
+	EnumDecl struct {
+		Doc        *CommentGroup // associated documentation; or nil
+		Type       token.Pos     // position of "type" keyword
+		Enum       token.Pos     // position of "enum" keyword
+		Name       *Ident        // enum name
+		TypeParams *FieldList    // type parameters; or nil
+		Lbrace     token.Pos     // position of "{"
+		Variants   []*EnumVariant
+		Rbrace     token.Pos // position of "}"
+	}
+
+	// An EnumVariant node represents one variant in an algebraic enum.
+	// Fields is nil for a variant without a payload. A non-nil empty
+	// FieldList represents an explicitly empty payload.
+	EnumVariant struct {
+		Doc     *CommentGroup // associated documentation; or nil
+		Name    *Ident        // variant name
+		Fields  *FieldList    // payload fields; or nil
+		Comment *CommentGroup // line comments; or nil
+	}
 )
 
 // Pos and End implementations for declaration nodes.
@@ -1016,6 +1038,9 @@ type (
 func (d *BadDecl) Pos() token.Pos  { return d.From }
 func (d *GenDecl) Pos() token.Pos  { return d.TokPos }
 func (d *FuncDecl) Pos() token.Pos { return d.Type.Pos() }
+func (d *EnumDecl) Pos() token.Pos { return d.Type }
+
+func (v *EnumVariant) Pos() token.Pos { return v.Name.Pos() }
 
 func (d *BadDecl) End() token.Pos { return d.To }
 func (d *GenDecl) End() token.Pos {
@@ -1030,12 +1055,21 @@ func (d *FuncDecl) End() token.Pos {
 	}
 	return d.Type.End()
 }
+func (d *EnumDecl) End() token.Pos { return d.Rbrace + 1 }
+
+func (v *EnumVariant) End() token.Pos {
+	if v.Fields != nil {
+		return v.Fields.End()
+	}
+	return v.Name.End()
+}
 
 // declNode() ensures that only declaration nodes can be
 // assigned to a Decl.
 func (*BadDecl) declNode()  {}
 func (*GenDecl) declNode()  {}
 func (*FuncDecl) declNode() {}
+func (*EnumDecl) declNode() {}
 
 // ----------------------------------------------------------------------------
 // Files and packages

--- a/src/go/ast/filter.go
+++ b/src/go/ast/filter.go
@@ -240,8 +240,35 @@ func filterDecl(decl Decl, f Filter, export bool) bool {
 		return len(d.Specs) > 0
 	case *FuncDecl:
 		return f(d.Name.Name)
+	case *EnumDecl:
+		if f(d.Name.Name) {
+			d.Variants = filterEnumVariants(d.Variants, f, export)
+			return true
+		}
+		if !export {
+			d.Variants = filterEnumVariants(d.Variants, f, export)
+			return len(d.Variants) > 0
+		}
 	}
 	return false
+}
+
+func filterEnumVariants(list []*EnumVariant, f Filter, export bool) []*EnumVariant {
+	j := 0
+	for _, variant := range list {
+		keep := f(variant.Name.Name)
+		if keep {
+			filterFieldList(variant.Fields, f, export)
+		} else if !export && variant.Fields != nil {
+			filterFieldList(variant.Fields, f, export)
+			keep = len(variant.Fields.List) > 0
+		}
+		if keep {
+			list[j] = variant
+			j++
+		}
+	}
+	return list[:j]
 }
 
 // FilterFile trims the AST for a Go file in place by removing all

--- a/src/go/ast/filter_test.go
+++ b/src/go/ast/filter_test.go
@@ -83,3 +83,68 @@ func TestFilterDuplicates(t *testing.T) {
 		t.Errorf("incorrect output:\n%s", output)
 	}
 }
+
+func TestFilterEnum(t *testing.T) {
+	const src = `package p
+
+type Result enum {
+	Ok {
+		Value int
+		hidden int
+	}
+	hidden
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "enum.go", src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ast.FileExports(file) {
+		t.Fatal("FileExports removed exported enum")
+	}
+	decl := file.Decls[0].(*ast.EnumDecl)
+	if len(decl.Variants) != 1 || decl.Variants[0].Name.Name != "Ok" {
+		t.Fatalf("variants after export filtering = %#v", decl.Variants)
+	}
+	fields := decl.Variants[0].Fields.List
+	if len(fields) != 1 || fields[0].Names[0].Name != "Value" {
+		t.Fatalf("payload fields after export filtering = %#v", fields)
+	}
+
+	file, err = parser.ParseFile(fset, "enum2.go", src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ast.FilterFile(file, func(name string) bool { return name == "Value" }) {
+		t.Fatal("FilterFile removed enum containing matching payload field")
+	}
+	decl = file.Decls[0].(*ast.EnumDecl)
+	if len(decl.Variants) != 1 || len(decl.Variants[0].Fields.List) != 1 {
+		t.Fatalf("filtered enum = %#v", decl)
+	}
+
+	file, err = parser.ParseFile(fset, "enum3.go", src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ast.FilterFile(file, func(name string) bool { return name == "Result" }) {
+		t.Fatal("FilterFile removed matching enum")
+	}
+	decl = file.Decls[0].(*ast.EnumDecl)
+	if len(decl.Variants) != 0 {
+		t.Fatalf("variants matching only enum name = %#v, want none", decl.Variants)
+	}
+
+	file, err = parser.ParseFile(fset, "enum4.go", src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ast.FilterFile(file, func(name string) bool { return name == "Ok" }) {
+		t.Fatal("FilterFile removed matching enum variant")
+	}
+	decl = file.Decls[0].(*ast.EnumDecl)
+	if len(decl.Variants) != 1 || len(decl.Variants[0].Fields.List) != 0 {
+		t.Fatalf("fields matching only variant name = %#v, want none", decl.Variants)
+	}
+}

--- a/src/go/ast/walk.go
+++ b/src/go/ast/walk.go
@@ -332,6 +332,28 @@ func Walk(v Visitor, node Node) {
 			Walk(v, n.Body)
 		}
 
+	case *EnumVariant:
+		if n.Doc != nil {
+			Walk(v, n.Doc)
+		}
+		Walk(v, n.Name)
+		if n.Fields != nil {
+			Walk(v, n.Fields)
+		}
+		if n.Comment != nil {
+			Walk(v, n.Comment)
+		}
+
+	case *EnumDecl:
+		if n.Doc != nil {
+			Walk(v, n.Doc)
+		}
+		Walk(v, n.Name)
+		if n.TypeParams != nil {
+			Walk(v, n.TypeParams)
+		}
+		walkList(v, n.Variants)
+
 	// Files and packages
 	case *File:
 		if n.Doc != nil {

--- a/src/go/format/format_test.go
+++ b/src/go/format/format_test.go
@@ -109,6 +109,27 @@ func TestSource(t *testing.T) {
 	diff(t, res, src)
 }
 
+func TestSourceEnum(t *testing.T) {
+	const src = "package p\ntype Result[T any] enum{Ok{value T};Err{err error};None;Empty{}}\n"
+	const want = `package p
+
+type Result[T any] enum {
+	Ok { value T }
+	Err { err error }
+	None
+	Empty {}
+}
+`
+
+	got, err := Source([]byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Errorf("formatted enum:\n%s\nwant:\n%s", got, want)
+	}
+}
+
 // Test cases that are expected to fail are marked by the prefix "ERROR".
 // The formatted result must look the same as the input for successful tests.
 var tests = []string{

--- a/src/go/internal/gcimporter/gcimporter_test.go
+++ b/src/go/internal/gcimporter/gcimporter_test.go
@@ -123,6 +123,30 @@ func TestImportTestdata(t *testing.T) {
 	}
 }
 
+func TestImportEnum(t *testing.T) {
+	tmpdir := mktmpdir(t)
+	defer os.RemoveAll(tmpdir)
+
+	compile(t, "testdata", "enum.go", filepath.Join(tmpdir, "testdata"), nil)
+	pkg := testPath(t, "./testdata/enum", tmpdir)
+	if pkg == nil {
+		t.Fatal("import enum package")
+	}
+	result := pkg.Scope().Lookup("Result").Type().(*types.Named)
+	if result.EnumType() == nil {
+		t.Fatal("imported Result lost enum metadata")
+	}
+	variants := result.EnumVariants()
+	if len(variants) != 2 {
+		t.Fatalf("imported Result has %d variants, want 2; scope=%v methods=%d", len(variants), pkg.Scope().Names(), result.NumMethods())
+	}
+	for _, typ := range append([]*types.Named{result}, variants...) {
+		if method, _, _ := types.LookupFieldOrMethod(typ, true, pkg, "Variant"); method == nil {
+			t.Fatalf("imported %s lost generated Variant method; underlying=%s methods=%d", typ, typ.Underlying(), typ.NumMethods())
+		}
+	}
+}
+
 func TestImportTypeparamTests(t *testing.T) {
 	if testing.Short() {
 		t.Skipf("in short mode, skipping test that requires export data for all of std")

--- a/src/go/internal/gcimporter/testdata/enum.go
+++ b/src/go/internal/gcimporter/testdata/enum.go
@@ -1,0 +1,6 @@
+package enum
+
+type Result enum {
+	Allow
+	Deny { Reason string }
+}

--- a/src/go/internal/gcimporter/ureader.go
+++ b/src/go/internal/gcimporter/ureader.go
@@ -481,8 +481,9 @@ func (pr *pkgReader) objIdx(idx pkgbits.Index) (*types.Package, string) {
 	}
 
 	// TODO(mark): This, like the above splitVargenSuffix, is not ideal.
-	// Ignore generic methods promoted to global scope.
-	if strings.Contains(objName, ".") {
+	// Ignore generic methods promoted to global scope. Enum variants are named
+	// Parent.Variant and must remain available for contextual resolution.
+	if strings.Contains(objName, ".") && tag != pkgbits.ObjType {
 		return objPkg, objName
 	}
 

--- a/src/go/parser/parser.go
+++ b/src/go/parser/parser.go
@@ -1917,6 +1917,10 @@ func (p *parser) parseSimpleStmt(mode int) (ast.Stmt, bool) {
 	}
 
 	x := p.parseList(false)
+	return p.finishSimpleStmt(x, mode)
+}
+
+func (p *parser) finishSimpleStmt(x []ast.Expr, mode int) (ast.Stmt, bool) {
 
 	switch p.tok {
 	case
@@ -2818,9 +2822,125 @@ func (p *parser) parseFuncDecl() *ast.FuncDecl {
 	return decl
 }
 
+func (p *parser) parseEnumVariant() *ast.EnumVariant {
+	if p.trace {
+		defer un(trace(p, "EnumVariant"))
+	}
+
+	doc := p.leadComment
+	name := p.parseIdent()
+	variant := &ast.EnumVariant{Doc: doc, Name: name}
+	if p.tok == token.LBRACE {
+		lbrace := p.expect(token.LBRACE)
+		var fields []*ast.Field
+		for p.tok == token.IDENT || p.tok == token.MUL || p.tok == token.LPAREN {
+			fields = append(fields, p.parseFieldDecl())
+		}
+		rbrace := p.expect(token.RBRACE)
+		variant.Fields = &ast.FieldList{Opening: lbrace, List: fields, Closing: rbrace}
+	}
+	variant.Comment = p.expectSemi()
+	return variant
+}
+
+func (p *parser) typeDeclIsEnum() bool {
+	errorCount := len(p.errors)
+	defer func() {
+		p.errors = p.errors[:errorCount]
+	}()
+
+	s := p.scanner
+	next := func() (token.Token, string) {
+		for {
+			_, tok, lit := s.Scan()
+			if tok != token.COMMENT {
+				return tok, lit
+			}
+		}
+	}
+
+	tok, _ := next()
+	if tok != token.IDENT {
+		return false
+	}
+	tok, lit := next()
+	if tok == token.LBRACK {
+		depth := 1
+		for depth > 0 {
+			tok, _ = next()
+			switch tok {
+			case token.LBRACK:
+				depth++
+			case token.RBRACK:
+				depth--
+			case token.EOF:
+				return false
+			}
+		}
+		tok, lit = next()
+	}
+	if tok != token.IDENT || lit != "enum" {
+		return false
+	}
+	tok, _ = next()
+	return tok == token.LBRACE
+}
+
+func (p *parser) parseEnumDecl(doc *ast.CommentGroup) *ast.EnumDecl {
+	if p.trace {
+		defer un(trace(p, "EnumDecl"))
+	}
+
+	typePos := p.expect(token.TYPE)
+	name := p.parseIdent()
+	var tparams *ast.FieldList
+	if p.tok == token.LBRACK {
+		tparams = p.parseTypeParameters()
+	}
+	enumPos := p.pos
+	if p.tok != token.IDENT || p.lit != "enum" {
+		p.errorExpected(p.pos, "enum")
+	} else {
+		p.next()
+	}
+	lbrace := p.expect(token.LBRACE)
+	var variants []*ast.EnumVariant
+	for p.tok != token.RBRACE && p.tok != token.EOF {
+		if p.tok == token.SEMICOLON {
+			p.next()
+			continue
+		}
+		if p.tok != token.IDENT {
+			p.errorExpected(p.pos, "variant name")
+			p.advance(exprEnd)
+			if p.tok == token.SEMICOLON {
+				p.next()
+			}
+			continue
+		}
+		variants = append(variants, p.parseEnumVariant())
+	}
+	rbrace := p.expect(token.RBRACE)
+	p.expectSemi()
+	return &ast.EnumDecl{
+		Doc:        doc,
+		Type:       typePos,
+		Enum:       enumPos,
+		Name:       name,
+		TypeParams: tparams,
+		Lbrace:     lbrace,
+		Variants:   variants,
+		Rbrace:     rbrace,
+	}
+}
+
 func (p *parser) parseDecl(sync map[token.Token]bool) ast.Decl {
 	if p.trace {
 		defer un(trace(p, "Declaration"))
+	}
+
+	if p.tok == token.TYPE && p.typeDeclIsEnum() {
+		return p.parseEnumDecl(p.leadComment)
 	}
 
 	var f parseSpecFunction

--- a/src/go/parser/parser_test.go
+++ b/src/go/parser/parser_test.go
@@ -7,6 +7,7 @@ package parser
 import (
 	"fmt"
 	"go/ast"
+	"go/scanner"
 	"go/token"
 	"io/fs"
 	"reflect"
@@ -994,5 +995,163 @@ const _ = ` + stringlit + ` ;
 	})
 	if count != 3 {
 		t.Errorf("found %d BasicLit, want 3", count)
+	}
+}
+
+func TestParseEnumDecl(t *testing.T) {
+	const src = `package p
+
+// Result reports success or failure.
+type Result[T any] enum {
+	// Ok carries a value.
+	Ok {
+		value T
+	}
+	Err {
+		err error
+	}
+	None // no payload
+	Empty {}
+}
+`
+
+	fset := token.NewFileSet()
+	f, err := ParseFile(fset, "enum.go", src, ParseComments|DeclarationErrors)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Decls) != 1 {
+		t.Fatalf("got %d declarations, want 1", len(f.Decls))
+	}
+	decl, ok := f.Decls[0].(*ast.EnumDecl)
+	if !ok {
+		t.Fatalf("declaration has type %T, want *ast.EnumDecl", f.Decls[0])
+	}
+	if decl.Name.Name != "Result" || decl.Name.Obj == nil || decl.Name.Obj.Kind != ast.Typ {
+		t.Fatalf("enum name not declared as type: %#v", decl.Name)
+	}
+	if decl.TypeParams == nil || len(decl.TypeParams.List) != 1 {
+		t.Fatalf("type parameters = %#v, want one parameter", decl.TypeParams)
+	}
+	if len(decl.Variants) != 4 {
+		t.Fatalf("got %d variants, want 4", len(decl.Variants))
+	}
+	if decl.Doc == nil || decl.Doc.Text() != "Result reports success or failure.\n" {
+		t.Fatalf("enum documentation = %#v", decl.Doc)
+	}
+	if doc := decl.Variants[0].Doc; doc == nil || doc.Text() != "Ok carries a value.\n" {
+		t.Fatalf("variant documentation = %#v", doc)
+	}
+	for _, variant := range decl.Variants {
+		if variant.Name.Obj == nil || variant.Name.Obj.Kind != ast.Typ {
+			t.Errorf("variant %s not declared as type", variant.Name)
+		}
+	}
+	if decl.Variants[2].Fields != nil {
+		t.Errorf("payload-free variant has fields %#v", decl.Variants[2].Fields)
+	}
+	if decl.Variants[2].Comment == nil {
+		t.Fatal("payload-free variant is missing trailing comment")
+	}
+	file := fset.File(decl.Pos())
+	start := file.Offset(decl.Variants[2].Pos())
+	end := file.Offset(decl.Variants[2].End())
+	if got := src[start:end]; got != "None" {
+		t.Errorf("variant source range = %q, want %q", got, "None")
+	}
+	if fields := decl.Variants[3].Fields; fields == nil || len(fields.List) != 0 {
+		t.Errorf("explicit empty payload = %#v, want non-nil empty field list", fields)
+	}
+	tparam := decl.TypeParams.List[0].Names[0]
+	valueType := decl.Variants[0].Fields.List[0].Type.(*ast.Ident)
+	if valueType.Obj != tparam.Obj {
+		t.Errorf("payload type parameter resolved to %p, want %p", valueType.Obj, tparam.Obj)
+	}
+
+	var variants int
+	ast.Inspect(f, func(n ast.Node) bool {
+		if _, ok := n.(*ast.EnumVariant); ok {
+			variants++
+		}
+		return true
+	})
+	if variants != 4 {
+		t.Errorf("ast.Inspect visited %d variants, want 4", variants)
+	}
+}
+
+func TestParseEnumDuplicateVariant(t *testing.T) {
+	const src = "package p; type E enum { A; A }"
+	_, err := ParseFile(token.NewFileSet(), "enum.go", src, DeclarationErrors)
+	if err == nil || !strings.Contains(err.Error(), "A redeclared") {
+		t.Fatalf("duplicate variant error = %v, want redeclaration error", err)
+	}
+}
+
+func TestGroupedEnumRejected(t *testing.T) {
+	const src = "package p; type ( E enum { A } )"
+	if _, err := ParseFile(token.NewFileSet(), "enum.go", src, 0); err == nil {
+		t.Fatal("grouped enum declaration parsed without error")
+	}
+}
+
+func TestEnumIsContextualKeyword(t *testing.T) {
+	const src = `package p
+var enum = 1
+func f(enum string) string {
+	enum += "x"
+	{
+		enum := 2
+		enum++
+		_ = enum
+	}
+	type Local enum { A }
+	var _ Local = A{}
+	return enum
+}
+`
+	if _, err := ParseFile(token.NewFileSet(), "enum.go", src, DeclarationErrors); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnumUnderlyingTypeName(t *testing.T) {
+	const src = `package p
+type enum int
+type E enum
+type G[T any] enum
+type I enum[int]
+`
+	if _, err := ParseFile(token.NewFileSet(), "enum.go", src, DeclarationErrors); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnumLookaheadDoesNotDuplicateErrors(t *testing.T) {
+	const src = "package p; type E[T @] enum { A }"
+	_, err := ParseFile(token.NewFileSet(), "enum.go", src, 0)
+	errs, ok := err.(scanner.ErrorList)
+	if !ok {
+		t.Fatalf("error has type %T, want scanner.ErrorList", err)
+	}
+	var illegal int
+	for _, err := range errs {
+		if strings.Contains(err.Msg, "illegal character") {
+			illegal++
+		}
+	}
+	if illegal != 1 {
+		t.Fatalf("got %d illegal-character errors, want 1: %v", illegal, errs)
+	}
+}
+
+func TestEnumVariantsStayNamespacedInResolver(t *testing.T) {
+	const src = `package p
+type E enum { A }
+type F enum { A }
+type A int
+`
+	if _, err := ParseFile(token.NewFileSet(), "enum.go", src, DeclarationErrors); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/src/go/parser/resolver.go
+++ b/src/go/parser/resolver.go
@@ -505,6 +505,28 @@ func (r *resolver) Visit(node ast.Node) ast.Visitor {
 			r.declare(n, nil, r.pkgScope, ast.Fun, n.Name)
 		}
 
+	case *ast.EnumDecl:
+		// The enum name is in the enclosing scope. Variants use an enum-local
+		// scope only for duplicate detection; their constructors are namespaced.
+		r.declare(n, nil, r.topScope, ast.Typ, n.Name)
+		variantScope := ast.NewScope(nil)
+		for _, variant := range n.Variants {
+			r.declare(variant, nil, variantScope, ast.Typ, variant.Name)
+		}
+		if n.TypeParams != nil {
+			r.openScope(n.Pos())
+			defer r.closeScope()
+			r.walkTParams(n.TypeParams)
+		}
+		for _, variant := range n.Variants {
+			if variant.Fields == nil {
+				continue
+			}
+			r.openScope(variant.Pos())
+			r.walkFieldList(variant.Fields, ast.Var)
+			r.closeScope()
+		}
+
 	default:
 		return r
 	}

--- a/src/go/printer/nodes.go
+++ b/src/go/printer/nodes.go
@@ -1951,6 +1951,41 @@ func (p *printer) funcDecl(d *ast.FuncDecl) {
 	p.funcBody(p.distanceFrom(d.Pos(), startCol), vtab, d.Body)
 }
 
+func (p *printer) enumDecl(d *ast.EnumDecl) {
+	p.setComment(d.Doc)
+	p.setPos(d.Type)
+	p.print(token.TYPE, blank)
+	p.expr(d.Name)
+	if d.TypeParams != nil {
+		p.parameters(d.TypeParams, typeTParam)
+	}
+	p.print(blank)
+	p.setPos(d.Enum)
+	p.print(token.ENUM)
+	p.print(blank)
+	p.setPos(d.Lbrace)
+	p.print(token.LBRACE, indent, formfeed)
+
+	var line int
+	for i, variant := range d.Variants {
+		if i > 0 {
+			p.linebreak(p.lineFor(variant.Pos()), 1, ignore, p.linesFrom(line) > 0)
+		}
+		p.setComment(variant.Doc)
+		p.recordLine(&line)
+		p.expr(variant.Name)
+		if variant.Fields != nil {
+			p.print(blank)
+			p.fieldList(variant.Fields, true, false)
+		}
+		p.setComment(variant.Comment)
+	}
+
+	p.print(unindent, formfeed)
+	p.setPos(d.Rbrace)
+	p.print(token.RBRACE)
+}
+
 func (p *printer) decl(decl ast.Decl) {
 	switch d := decl.(type) {
 	case *ast.BadDecl:
@@ -1960,6 +1995,8 @@ func (p *printer) decl(decl ast.Decl) {
 		p.genDecl(d)
 	case *ast.FuncDecl:
 		p.funcDecl(d)
+	case *ast.EnumDecl:
+		p.enumDecl(d)
 	default:
 		panic("unreachable")
 	}
@@ -1975,6 +2012,8 @@ func declToken(decl ast.Decl) (tok token.Token) {
 		tok = d.Tok
 	case *ast.FuncDecl:
 		tok = token.FUNC
+	case *ast.EnumDecl:
+		tok = token.TYPE
 	}
 	return
 }

--- a/src/go/printer/printer.go
+++ b/src/go/printer/printer.go
@@ -1062,6 +1062,10 @@ func getDoc(n ast.Node) *ast.CommentGroup {
 		return n.Doc
 	case *ast.FuncDecl:
 		return n.Doc
+	case *ast.EnumDecl:
+		return n.Doc
+	case *ast.EnumVariant:
+		return n.Doc
 	case *ast.File:
 		return n.Doc
 	}
@@ -1081,6 +1085,12 @@ func getLastComment(n ast.Node) *ast.CommentGroup {
 	case *ast.GenDecl:
 		if len(n.Specs) > 0 {
 			return getLastComment(n.Specs[len(n.Specs)-1])
+		}
+	case *ast.EnumVariant:
+		return n.Comment
+	case *ast.EnumDecl:
+		if len(n.Variants) > 0 {
+			return getLastComment(n.Variants[len(n.Variants)-1])
 		}
 	case *ast.File:
 		if len(n.Comments) > 0 {

--- a/src/go/scanner/scanner_test.go
+++ b/src/go/scanner/scanner_test.go
@@ -163,6 +163,7 @@ var tokens = []elt{
 	{token.DEFAULT, "default", keyword},
 	{token.DEFER, "defer", keyword},
 	{token.ELSE, "else", keyword},
+	{token.IDENT, "enum", literal},
 	{token.FALLTHROUGH, "fallthrough", keyword},
 	{token.FOR, "for", keyword},
 

--- a/src/go/token/token.go
+++ b/src/go/token/token.go
@@ -128,6 +128,7 @@ const (
 	additional_beg
 	// additional tokens, handled in an ad-hoc manner
 	TILDE
+	ENUM // contextual keyword
 	additional_end
 )
 
@@ -231,6 +232,7 @@ var tokens = [...]string{
 	VAR:    "var",
 
 	TILDE: "~",
+	ENUM:  "enum",
 }
 
 // String returns the string corresponding to the token tok.

--- a/src/go/token/token_test.go
+++ b/src/go/token/token_test.go
@@ -31,3 +31,21 @@ func TestIsIdentifier(t *testing.T) {
 		})
 	}
 }
+
+func TestEnumIsContextualKeyword(t *testing.T) {
+	if ENUM.IsKeyword() {
+		t.Error("ENUM.IsKeyword() = true, want false")
+	}
+	if got := Lookup("enum"); got != IDENT {
+		t.Errorf("Lookup(\"enum\") = %v, want IDENT", got)
+	}
+	if IsKeyword("enum") {
+		t.Error("IsKeyword(\"enum\") = true, want false")
+	}
+	if !IsIdentifier("enum") {
+		t.Error("IsIdentifier(\"enum\") = false, want true")
+	}
+	if got := ENUM.String(); got != "enum" {
+		t.Errorf("ENUM.String() = %q, want %q", got, "enum")
+	}
+}

--- a/src/go/types/builtins.go
+++ b/src/go/types/builtins.go
@@ -657,6 +657,10 @@ func (check *Checker) builtin(x *operand, call *ast.CallExpr, id builtinId) (_ b
 			return
 		case typexpr:
 			// new(T)
+			if check.rejectEnumVariantType(arg, x.typ()) {
+				x.invalidate()
+				return
+			}
 			check.validVarType(arg, x.typ())
 		default:
 			// new(expr)

--- a/src/go/types/call.go
+++ b/src/go/types/call.go
@@ -195,6 +195,10 @@ func (check *Checker) callExpr(x *operand, call *ast.CallExpr) exprKind {
 
 	case typexpr:
 		// conversion
+		if check.rejectEnumVariantType(call.Fun, x.typ()) {
+			x.invalidate()
+			return conversion
+		}
 		check.nonGeneric(nil, x)
 		if !x.isValid() {
 			return conversion
@@ -698,6 +702,19 @@ func (check *Checker) selector(x *operand, e *ast.SelectorExpr, wantType bool) {
 	// selector expressions.
 	if ident, ok := e.X.(*ast.Ident); ok {
 		obj := check.lookup(ident.Name)
+		if tname, _ := obj.(*TypeName); tname != nil && tname.typ != nil {
+			if variant := enumVariant(tname.typ, sel); variant != nil {
+				if variant.Obj().Pkg() != check.pkg && !variant.Obj().Exported() {
+					check.errorf(e.Sel, UnexportedName, "cannot refer to unexported enum variant %s", variant)
+				}
+				check.recordUse(ident, tname)
+				check.recordUse(e.Sel, variant.Obj())
+				x.mode_ = typexpr
+				x.typ_ = variant
+				x.expr = e
+				return
+			}
+		}
 		if pname, _ := obj.(*PkgName); pname != nil {
 			assert(pname.pkg == check.pkg)
 			check.recordUse(ident, pname)
@@ -789,7 +806,7 @@ func (check *Checker) selector(x *operand, e *ast.SelectorExpr, wantType bool) {
 		}
 	}
 
-	check.exprOrType(x, e.X, false)
+	check.exprOrType(x, e.X, true)
 	switch x.mode() {
 	case builtin:
 		// types2 uses the position of '.' for the error
@@ -802,6 +819,23 @@ func (check *Checker) selector(x *operand, e *ast.SelectorExpr, wantType bool) {
 	// We cannot select on an incomplete type; make sure it's complete.
 	if !check.isComplete(x.typ()) {
 		goto Error
+	}
+
+	if x.mode() == typexpr {
+		if variant := enumVariant(x.typ(), sel); variant != nil {
+			if variant.Obj().Pkg() != check.pkg && !variant.Obj().Exported() {
+				check.errorf(e.Sel, UnexportedName, "cannot refer to unexported enum variant %s", variant)
+			}
+			check.recordUse(e.Sel, variant.Obj())
+			x.mode_ = typexpr
+			x.typ_ = variant
+			x.expr = e
+			return
+		}
+		if isGeneric(x.typ()) {
+			check.nonGeneric(nil, x)
+			goto Error
+		}
 	}
 
 	// Avoid crashing when checking an invalid selector in a method declaration.

--- a/src/go/types/check.go
+++ b/src/go/types/check.go
@@ -44,6 +44,7 @@ type environment struct {
 	inTParamList  bool                   // set if inside a type parameter list
 	sig           *Signature             // function signature if inside a function; nil otherwise
 	isPanic       map[*ast.CallExpr]bool // set of panic call expressions (used for termination check)
+	enumSwitches  map[ast.Stmt]bool      // set of exhaustive enum switches (used for termination check)
 	hasLabel      bool                   // set if a function makes use of labels (only ~1% of functions); unused outside functions
 	hasCallOrRecv bool                   // set if an expression contains a function call or channel receive operation
 

--- a/src/go/types/cycles.go
+++ b/src/go/types/cycles.go
@@ -74,7 +74,11 @@ func (check *Checker) directCycle(tname *TypeName, pathIdx map[*TypeName]int) {
 
 		// For direct cycle detection, we don't care about whether we have an alias or not.
 		// If the associated type is not a name, we're at the end of the path and we're done.
-		rhs, ok := check.objMap[tname].tdecl.Type.(*ast.Ident)
+		info := check.objMap[tname]
+		if info == nil || info.edecl != nil {
+			break
+		}
+		rhs, ok := info.tdecl.Type.(*ast.Ident)
 		if !ok {
 			break
 		}

--- a/src/go/types/decl.go
+++ b/src/go/types/decl.go
@@ -11,6 +11,7 @@ import (
 	"go/token"
 	. "internal/types/errors"
 	"slices"
+	"strings"
 )
 
 func (check *Checker) declare(scope *Scope, id *ast.Ident, obj Object, pos token.Pos) {
@@ -156,8 +157,12 @@ func (check *Checker) objDecl(obj Object) {
 		check.varDecl(obj, d.lhs, d.vtyp, d.init)
 	case *TypeName:
 		// invalid recursive types are detected via path
-		check.typeDecl(obj, d.tdecl)
-		check.collectMethods(obj) // methods can only be added to top-level types
+		if d.edecl != nil {
+			check.enumDecl(d.edecl)
+		} else {
+			check.typeDecl(obj, d.tdecl)
+			check.collectMethods(obj) // methods can only be added to top-level types
+		}
 	case *Func:
 		// functions may be recursive - no need to track dependencies
 		check.funcDecl(obj, d)
@@ -325,6 +330,7 @@ type (
 	}
 	varDecl  struct{ spec *ast.ValueSpec }
 	typeDecl struct{ spec *ast.TypeSpec }
+	enumDecl struct{ decl *ast.EnumDecl }
 	funcDecl struct{ decl *ast.FuncDecl }
 )
 
@@ -332,6 +338,7 @@ func (d importDecl) node() ast.Node { return d.spec }
 func (d constDecl) node() ast.Node  { return d.spec }
 func (d varDecl) node() ast.Node    { return d.spec }
 func (d typeDecl) node() ast.Node   { return d.spec }
+func (d enumDecl) node() ast.Node   { return d.decl }
 func (d funcDecl) node() ast.Node   { return d.decl }
 
 func (check *Checker) walkDecls(decls []ast.Decl, f func(decl)) {
@@ -379,6 +386,8 @@ func (check *Checker) walkDecl(d ast.Decl, f func(decl)) {
 		}
 	case *ast.FuncDecl:
 		f(funcDecl{d})
+	case *ast.EnumDecl:
+		f(enumDecl{d})
 	default:
 		check.errorf(d, InvalidSyntaxTree, "unknown ast.Decl node %T", d)
 	}
@@ -581,6 +590,197 @@ func (check *Checker) typeDecl(obj *TypeName, tdecl *ast.TypeSpec) {
 	}
 }
 
+func (check *Checker) enumDecl(info *enumDeclInfo) {
+	// Another object from this enum may have initialized the whole declaration.
+	if info.objects[0].typ != nil {
+		return
+	}
+
+	decl := info.decl
+	check.verifyVersionf(decl, go1_28, "enum declaration")
+	named := make([]*Named, len(info.objects))
+	for i, obj := range info.objects {
+		named[i] = check.newNamed(obj, nil, nil)
+	}
+
+	if decl.TypeParams != nil {
+		check.openScope(decl, "enum type parameters")
+		defer check.closeScope()
+		check.collectEnumTypeParams(named, decl.TypeParams)
+	}
+
+	markerName := ".enum." + decl.Name.Name
+	if named[0].Obj().Parent() != check.pkg.Scope() {
+		markerName += fmt.Sprintf(".%d", decl.Name.Pos())
+	}
+	markerSig := NewSignatureType(nil, nil, nil, enumMarkerParams(decl.Name.Pos(), check.pkg, named[0].TypeParams().list()), nil, false)
+	marker := NewFunc(decl.Name.Pos(), check.pkg, markerName, markerSig)
+	variantResult := NewTuple(newVar(ResultVar, decl.Name.Pos(), check.pkg, "", Typ[String]))
+	variantSig := NewSignatureType(nil, nil, nil, nil, variantResult, false)
+	variantMethod := NewFunc(decl.Name.Pos(), check.pkg, "Variant", variantSig)
+	named[0].fromRHS = NewInterfaceType([]*Func{marker, variantMethod}, nil)
+	einfo := &enumInfo{parent: named[0], variants: named[1:]}
+	for _, typ := range named {
+		typ.enumInfo = einfo
+	}
+
+	for i, variant := range decl.Variants {
+		styp := new(Struct)
+		check.structType(styp, &ast.StructType{Fields: variant.Fields})
+		for i := 0; i < styp.NumFields(); i++ {
+			field := styp.Field(i)
+			if field.Embedded() && promotesEnumMarker(field.Type(), nil) {
+				check.errorf(field, InvalidPtrEmbed, "enum variant %s cannot anonymously embed a type that promotes an enum marker: %s", variant.Name, field.Type())
+			}
+		}
+		baseTParams := named[0].TypeParams().list()
+		variantTParams := named[i+1].TypeParams().list()
+		if len(baseTParams) == 0 {
+			named[i+1].fromRHS = styp
+		} else {
+			smap := makeRenameMap(baseTParams, variantTParams)
+			named[i+1].fromRHS = check.subst(variant.Name.Pos(), styp, smap, nil, check.context())
+		}
+
+		newReceiver := func() (*Var, []*TypeParam) {
+			recvType := Type(named[i+1])
+			rparams := make([]*TypeParam, len(variantTParams))
+			for i, baseTParam := range variantTParams {
+				obj := NewTypeName(variant.Name.Pos(), check.pkg, baseTParam.Obj().Name(), nil)
+				rparams[i] = check.newTypeParam(obj, nil)
+			}
+			if len(rparams) != 0 {
+				smap := makeRenameMap(variantTParams, rparams)
+				targs := make([]Type, len(rparams))
+				for i, tparam := range rparams {
+					tparam.bound = check.subst(variant.Name.Pos(), variantTParams[i].bound, smap, nil, check.context())
+					targs[i] = tparam
+				}
+				recvType = check.instance(variant.Name.Pos(), named[i+1], targs, nil, check.context())
+			}
+			return newVar(RecvVar, variant.Name.Pos(), check.pkg, "", recvType), rparams
+		}
+		markerRecv, markerRParams := newReceiver()
+		sig := NewSignatureType(markerRecv, markerRParams, nil, enumMarkerParams(variant.Name.Pos(), check.pkg, markerRParams), nil, false)
+		variantRecv, variantRParams := newReceiver()
+		variantResult := NewTuple(newVar(ResultVar, variant.Name.Pos(), check.pkg, "", Typ[String]))
+		variantSig := NewSignatureType(variantRecv, variantRParams, nil, nil, variantResult, false)
+		named[i+1].methods = []*Func{
+			NewFunc(variant.Name.Pos(), check.pkg, markerName, sig),
+			NewFunc(variant.Name.Pos(), check.pkg, "Variant", variantSig),
+		}
+	}
+	for _, variant := range named[1:] {
+		variant := variant
+		check.later(func() {
+			check.validType(variant)
+		}).describef(variant.obj, "validType(%s)", variant.obj.Name())
+	}
+
+	for _, obj := range info.objects {
+		check.collectMethods(obj)
+	}
+}
+
+func promotesEnumMarker(typ Type, seen map[Type]bool) bool {
+	typ = Unalias(typ)
+	if ptr, _ := Unalias(typ).(*Pointer); ptr != nil {
+		typ = Unalias(ptr.Elem())
+	}
+	if seen == nil {
+		seen = make(map[Type]bool)
+	}
+	if seen[typ] {
+		return false
+	}
+	seen[typ] = true
+	if named, _ := typ.(*Named); named != nil {
+		if named.EnumType() != nil {
+			return true
+		}
+		typ = named.Underlying()
+	}
+	switch typ := typ.(type) {
+	case *Interface:
+		for i := 0; i < typ.NumMethods(); i++ {
+			if strings.HasPrefix(typ.Method(i).name, ".enum.") {
+				return true
+			}
+		}
+	case *Struct:
+		for i := 0; i < typ.NumFields(); i++ {
+			field := typ.Field(i)
+			if field.Embedded() && promotesEnumMarker(field.Type(), seen) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func enumMarkerParams(pos token.Pos, pkg *Package, tparams []*TypeParam) *Tuple {
+	if len(tparams) == 0 {
+		return nil
+	}
+	params := make([]*Var, len(tparams))
+	for i, tparam := range tparams {
+		params[i] = NewParam(pos, pkg, "", tparam)
+	}
+	return NewTuple(params...)
+}
+
+// collectEnumTypeParams declares the enum's type parameters and creates a
+// distinct, equivalent type parameter list for every variant. Distinct lists
+// are required because each variant is a separate defined type.
+func (check *Checker) collectEnumTypeParams(named []*Named, list *ast.FieldList) {
+	var base []*TypeParam
+	scopePos := list.Pos()
+	for _, field := range list.List {
+		for _, name := range field.Names {
+			base = append(base, check.declareTypeParam(name, scopePos))
+		}
+	}
+	named[0].tparams = bindTParams(base)
+
+	variantParams := make([][]*TypeParam, len(named)-1)
+	for i, variant := range named[1:] {
+		params := make([]*TypeParam, len(base))
+		for j, tparam := range base {
+			obj := NewTypeName(tparam.Obj().Pos(), check.pkg, tparam.Obj().Name(), nil)
+			params[j] = check.newTypeParam(obj, Typ[Invalid])
+		}
+		variant.tparams = bindTParams(params)
+		variantParams[i] = params
+	}
+
+	assert(!check.inTParamList)
+	check.inTParamList = true
+	defer func() { check.inTParamList = false }()
+
+	index := 0
+	for _, field := range list.List {
+		var bound Type = Typ[Invalid]
+		if field.Type != nil {
+			bound = check.bound(field.Type)
+			if isTypeParam(bound) {
+				check.error(field.Type, MisplacedTypeParam, "cannot use type parameter as constraint")
+				bound = Typ[Invalid]
+			}
+		}
+		for range field.Names {
+			base[index].bound = bound
+			index++
+		}
+	}
+
+	for _, params := range variantParams {
+		smap := makeRenameMap(base, params)
+		for i, tparam := range params {
+			tparam.bound = check.subst(tparam.Obj().Pos(), base[i].bound, smap, nil, check.context())
+		}
+	}
+}
+
 func (check *Checker) collectTypeParams(dst **TypeParamList, list *ast.FieldList) {
 	var tparams []*TypeParam
 	// Declare type parameters up-front, with empty interface as type bound.
@@ -682,7 +882,9 @@ func (check *Checker) collectMethods(obj *TypeName) {
 		return
 	}
 	delete(check.methods, obj)
-	assert(!check.objMap[obj].tdecl.Assign.IsValid()) // don't use TypeName.IsAlias (requires fully set up object)
+	if tdecl := check.objMap[obj].tdecl; tdecl != nil {
+		assert(!tdecl.Assign.IsValid()) // don't use TypeName.IsAlias (requires fully set up object)
+	}
 
 	// use an objset to check for name conflicts
 	var mset objset
@@ -714,6 +916,14 @@ func (check *Checker) collectMethods(obj *TypeName) {
 		// spec: "For a base type, the non-blank names of methods bound
 		// to it must be unique."
 		assert(m.name != "_")
+		if base != nil && enumHasVariantName(base, m.name) {
+			check.errorf(m, DuplicateMethod, "method %s.%s conflicts with enum variant %s", obj.Name(), m.name, m.name)
+			continue
+		}
+		if base != nil && m.name == "Variant" && isEnumType(base) {
+			check.errorf(m, DuplicateMethod, "method %s.Variant conflicts with generated enum method Variant", obj.Name())
+			continue
+		}
 		if alt := mset.insert(m); alt != nil {
 			if alt.Pos().IsValid() {
 				check.errorf(m, DuplicateMethod, "method %s.%s already declared at %v", obj.Name(), m.name, alt.Pos())
@@ -888,6 +1098,16 @@ func (check *Checker) declStmt(d ast.Decl) {
 			check.push(obj) // mark as grey
 			check.typeDecl(obj, d.spec)
 			check.pop()
+		case enumDecl:
+			info := &enumDeclInfo{decl: d.decl, objects: make([]*TypeName, 1+len(d.decl.Variants))}
+			info.objects[0] = NewTypeName(d.decl.Name.Pos(), pkg, d.decl.Name.Name, nil)
+			check.declare(check.scope, d.decl.Name, info.objects[0], d.decl.Name.Pos())
+			for i, variant := range d.decl.Variants {
+				obj := NewTypeName(variant.Name.Pos(), pkg, d.decl.Name.Name+"."+variant.Name.Name, nil)
+				info.objects[i+1] = obj
+				check.declare(check.scope, variant.Name, obj, d.decl.Name.Pos())
+			}
+			check.enumDecl(info)
 		default:
 			check.errorf(d.node(), InvalidSyntaxTree, "unknown ast.Decl node %T", d.node())
 		}

--- a/src/go/types/enum_test.go
+++ b/src/go/types/enum_test.go
@@ -1,0 +1,508 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package types_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+)
+
+func checkEnumPackage(t *testing.T, src string) (*types.Package, error) {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "enum.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return new(types.Config).Check("p", fset, []*ast.File{file}, nil)
+}
+
+func TestEnumTypes(t *testing.T) {
+	const src = `package p
+
+type Result enum {
+	Ok { value int }
+	Err { err error }
+	None
+}
+
+func (r Result) Value() int {
+	switch r {
+	case Ok: return r.value
+	case Err: return -1
+	case None, nil: return 0
+	}
+	return 0
+}
+func makeResult() Result { return Result.Ok{value: 42} }
+`
+	pkg, err := checkEnumPackage(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := pkg.Scope().Lookup("Result").Type().(*types.Named)
+	variants := result.EnumVariants()
+	if len(variants) != 3 || variants[0].Obj().Name() != "Result.Ok" || variants[1].Obj().Name() != "Result.Err" || variants[2].Obj().Name() != "Result.None" {
+		t.Fatalf("Result variants = %v, want [Result.Ok Result.Err Result.None]", variants)
+	}
+	ok, errVariant, none := variants[0], variants[1], variants[2]
+
+	if _, ok := result.Underlying().(*types.Interface); !ok {
+		t.Fatalf("Result underlying type is %T, want *types.Interface", result.Underlying())
+	}
+	if !types.Implements(result, result.Underlying().(*types.Interface)) {
+		t.Error("Result does not implement its own enum interface")
+	}
+	for _, variant := range []*types.Named{ok, errVariant, none} {
+		if _, ok := variant.Underlying().(*types.Struct); !ok {
+			t.Errorf("%s underlying type is %T, want *types.Struct", variant.Obj().Name(), variant.Underlying())
+		}
+		if !types.AssignableTo(variant, result) {
+			t.Errorf("%s is not assignable to Result", variant.Obj().Name())
+		}
+	}
+	if fields := ok.Underlying().(*types.Struct); fields.NumFields() != 1 || fields.Field(0).Name() != "value" {
+		t.Fatalf("Ok fields = %s, want value int", fields)
+	}
+	if method, _, _ := types.LookupFieldOrMethod(result, true, pkg, "Value"); method == nil {
+		t.Error("method declared on enum Result was not collected")
+	}
+	if method, _, _ := types.LookupFieldOrMethod(ok, true, pkg, "Value"); method != nil {
+		t.Error("enum method Value unexpectedly belongs to variant Ok")
+	}
+	if ok.EnumType() != result {
+		t.Fatalf("Ok enum type = %v, want Result", ok.EnumType())
+	}
+	if types.AssignableTo(types.NewPointer(ok), result) {
+		t.Error("*Ok is assignable to Result")
+	}
+	if types.Implements(types.NewPointer(ok), result.Underlying().(*types.Interface)) {
+		t.Error("*Ok implements Result")
+	}
+	forged := types.NewNamed(types.NewTypeName(token.NoPos, pkg, "Forged", nil), types.NewStruct([]*types.Var{
+		types.NewField(token.NoPos, pkg, "Ok", ok, true),
+	}, nil), nil)
+	if types.AssignableTo(forged, result) || types.Implements(forged, result.Underlying().(*types.Interface)) {
+		t.Error("type embedding Ok implements Result")
+	}
+	orSig := types.NewSignatureType(nil, nil, nil,
+		types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.Int])),
+		types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.Int])), false)
+	orIface := types.NewInterfaceType([]*types.Func{types.NewFunc(token.NoPos, nil, "Value", orSig)}, nil).Complete()
+	if types.Implements(result, orIface) {
+		t.Error("enum convenience methods must not make Result implement another interface")
+	}
+}
+
+func TestEnumVariantMethods(t *testing.T) {
+	pkg, err := checkEnumPackage(t, `package p
+type Decision enum { Allow; Deny { Reason string } }
+var _ string = Decision.Allow{}.Variant()
+func decisionVariant(decision Decision) string { return decision.Variant() }
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision := pkg.Scope().Lookup("Decision").Type().(*types.Named)
+	for _, typ := range append([]*types.Named{decision}, decision.EnumVariants()...) {
+		method, _, _ := types.LookupFieldOrMethod(typ, true, pkg, "Variant")
+		fn, ok := method.(*types.Func)
+		if !ok {
+			t.Fatalf("%s Variant method = %T, want *types.Func", typ, method)
+		}
+		sig := fn.Type().(*types.Signature)
+		if sig.Params().Len() != 0 || sig.Results().Len() != 1 || sig.Results().At(0).Type() != types.Typ[types.String] {
+			t.Fatalf("%s Variant signature = %s, want func() string", typ, sig)
+		}
+	}
+}
+
+func TestEnumVariantMethodCannotBeOverridden(t *testing.T) {
+	_, err := checkEnumPackage(t, `package p
+type Decision enum { Allow }
+func (Decision) Variant() string { return "custom" }
+`)
+	if err == nil || !strings.Contains(err.Error(), "conflicts with generated enum method Variant") {
+		t.Fatalf("Variant override error = %v", err)
+	}
+}
+
+func TestVariantMethodOnRecursiveNonEnum(t *testing.T) {
+	_, err := checkEnumPackage(t, `package p
+type A struct { B *B }
+type B A
+func (B) Variant() string { return "B" }
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnumVersion(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "enum.go", "package p; type E enum { A }", parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = (&types.Config{GoVersion: "go1.27"}).Check("p", fset, []*ast.File{file}, nil)
+	if err == nil || !strings.Contains(err.Error(), "requires go1.28 or later") {
+		t.Fatalf("enum version error = %v", err)
+	}
+}
+
+func TestEnumVariantTypeRejected(t *testing.T) {
+	const src = `package p
+type Result enum { Ok { value int }; Err }
+func (o Result.Ok) Value() int { return o.value }
+`
+	_, err := checkEnumPackage(t, src)
+	if err == nil || !strings.Contains(err.Error(), "is a constructor, not a type") {
+		t.Fatalf("variant type error = %v", err)
+	}
+}
+
+func TestEnumMethodVariantCollisionRejected(t *testing.T) {
+	const src = `package p
+type Result enum { Ok }
+func (Result) Ok() {}
+`
+	_, err := checkEnumPackage(t, src)
+	if err == nil || !strings.Contains(err.Error(), "conflicts with enum variant Ok") {
+		t.Fatalf("method/variant collision error = %v", err)
+	}
+}
+
+func TestEnumTypeSwitch(t *testing.T) {
+	const exhaustive = `package p
+type Result enum { Ok { value int }; Err { err error }; None }
+func inspect(r Result) int {
+	switch v := r.(type) {
+	case Ok: return v.value
+	case Err: return len(v.err.Error())
+	case None: return 0
+	case nil: return -1
+	}
+	return -1
+}
+`
+	if _, err := checkEnumPackage(t, exhaustive); err != nil {
+		t.Fatal(err)
+	}
+
+	const missing = `package p
+type Result enum { Ok; Err; None }
+func inspect(r Result) { switch r.(type) { case Ok: } }
+`
+	_, err := checkEnumPackage(t, missing)
+	if err == nil || !strings.Contains(err.Error(), "non-exhaustive enum switch on Result; missing Err, None, nil") {
+		t.Fatalf("non-exhaustive switch error = %v", err)
+	}
+
+	const withDefault = `package p
+type Result enum { Ok; Err }
+func inspect(r Result) { switch r.(type) { case Ok:; default: } }
+`
+	if _, err := checkEnumPackage(t, withDefault); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnumValueSwitchNarrowing(t *testing.T) {
+	const exhaustive = `package p
+type Result enum { Ok { value int }; Err { err error }; None }
+func inspect(result Result) int {
+	switch result {
+	case Ok: return result.value
+	case Err: return len(result.err.Error())
+	case None: return 0
+	case nil: return -1
+	}
+	return -2
+}
+`
+	if _, err := checkEnumPackage(t, exhaustive); err != nil {
+		t.Fatal(err)
+	}
+
+	const expressions = `package p
+type Result enum { Ok; Err }
+func makeResult() Result { return Result.Ok{} }
+type Holder struct { Result Result }
+func inspect(h Holder) {
+	switch makeResult() { case Ok:; case Err:; case nil: }
+	switch h.Result { case Ok:; case Err:; case nil: }
+}
+`
+	if _, err := checkEnumPackage(t, expressions); err != nil {
+		t.Fatal(err)
+	}
+
+	const duplicate = `package p
+type Result enum { Ok; Err }
+func inspect(result Result) { switch result { case Ok:; case Ok:; case Err:; case nil: } }
+`
+	_, err := checkEnumPackage(t, duplicate)
+	if err == nil || !strings.Contains(err.Error(), "duplicate case Result.Ok in enum switch") {
+		t.Fatalf("duplicate enum case error = %v", err)
+	}
+}
+
+func TestExhaustiveEnumSwitchTerminates(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "value switch",
+			body: `switch result {
+	case Ok: return result.value
+	case Err, None, nil: return 0
+}`,
+		},
+		{
+			name: "type switch",
+			body: `switch result := result.(type) {
+	case Ok: return result.value
+	case Err, None, nil: return 0
+}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			src := `package p
+type Result enum { Ok { value int }; Err; None }
+func value(result Result) int {
+` + test.body + `
+}
+`
+			if _, err := checkEnumPackage(t, src); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestEnumRejectsPointerVariant(t *testing.T) {
+	const src = `package p
+type Result enum { Ok }
+type R = Result
+var _ R = &Result.Ok{}
+`
+	_, err := checkEnumPackage(t, src)
+	if err == nil || !strings.Contains(err.Error(), "pointer to enum variant is not an enum value") {
+		t.Fatalf("pointer variant error = %v", err)
+	}
+}
+
+func TestEnumRejectsPromotedMarker(t *testing.T) {
+	tests := []string{`package p
+type Inner enum { Public }
+type Outer enum { Wrap { Inner } }
+		`, `package p
+type Inner enum { Public }
+type Carrier struct { Inner }
+type Outer enum { Wrap { Carrier } }
+		`}
+	for _, src := range tests {
+		_, err := checkEnumPackage(t, src)
+		if err == nil || !strings.Contains(err.Error(), "promotes an enum marker") {
+			t.Fatalf("promoted enum marker error = %v", err)
+		}
+	}
+}
+
+func TestEnumVariantOnlyAllowedAsConstructor(t *testing.T) {
+	valid := `package p
+type Result enum { Ok { Value int } }
+var _ = Result.Ok{Value: 1}
+var _ any = &Result.Ok{Value: 2}
+type Option[T any] enum { Some { Value T } }
+var _ = Option.Some[int]{Value: 3}
+`
+	if _, err := checkEnumPackage(t, valid); err != nil {
+		t.Fatalf("variant constructors: %v", err)
+	}
+	for _, use := range []string{
+		"type Alias = Result.Ok",
+		"var _ Result.Ok",
+		"type Embedded struct { Result.Ok }",
+		"type Outer enum { Wrap { Result.Ok } }",
+		"func f(Result.Ok) {}",
+		"var _ = new(Result.Ok)",
+		"var _ = Result.Ok(0)",
+		"func f(x Result) { switch x.(type) { case Result.Ok: } }",
+	} {
+		src := "package p\ntype Result enum { Ok }\n" + use
+		_, err := checkEnumPackage(t, src)
+		if err == nil || !strings.Contains(err.Error(), "is a constructor, not a type") {
+			t.Fatalf("%s: variant type error = %v", use, err)
+		}
+	}
+}
+
+func TestGenericEnumTypes(t *testing.T) {
+	const src = `package p
+
+type Option[T any] enum {
+	Some { value T }
+	None
+}
+
+func (o Option[T]) Or(zero T) T {
+	switch o {
+	case Some: return o.value
+	case None, nil: return zero
+	}
+	return zero
+}
+
+var _ Option[int] = Option.Some[int]{value: 1}
+`
+	pkg, err := checkEnumPackage(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	option := pkg.Scope().Lookup("Option").Type().(*types.Named)
+	variants := option.EnumVariants()
+	some, none := variants[0], variants[1]
+	optionParam := option.TypeParams().At(0)
+	someParam := some.TypeParams().At(0)
+	noneParam := none.TypeParams().At(0)
+	if optionParam == someParam || optionParam == noneParam || someParam == noneParam {
+		t.Fatal("generic enum and variants share type parameter objects")
+	}
+	if fieldType := some.Underlying().(*types.Struct).Field(0).Type(); fieldType != someParam {
+		t.Fatalf("Some.value type = %v, want Some type parameter %v", fieldType, someParam)
+	}
+	if method, _, _ := types.LookupFieldOrMethod(option, true, pkg, "Or"); method == nil {
+		t.Fatal("generic enum method Or was not collected")
+	}
+	marker := some.Method(0).Type().(*types.Signature)
+	recv := marker.Recv().Type().(*types.Named)
+	if recv.TypeArgs().Len() != 1 || marker.RecvTypeParams().Len() != 1 {
+		t.Fatalf("marker receiver = %v (type args %d, receiver type params %d)", recv, recv.TypeArgs().Len(), marker.RecvTypeParams().Len())
+	}
+}
+
+func TestEnumVariantsRequireQualification(t *testing.T) {
+	const src = `package p
+type Result enum { Ok }
+var inferred Result = Ok{}
+func f() Result { return Ok{} }
+var _ = Result.Ok{}
+`
+	if _, err := checkEnumPackage(t, src); err != nil {
+		t.Fatalf("contextual variants: %v", err)
+	}
+
+	const invalid = `package p
+type Result enum { Ok }
+var _ = Ok{}
+`
+	_, err := checkEnumPackage(t, invalid)
+	if err == nil || !strings.Contains(err.Error(), "undefined: Ok") {
+		t.Fatalf("bare variant error = %v", err)
+	}
+}
+
+func TestDuplicateEnumVariant(t *testing.T) {
+	const src = `package p
+type E enum { A; A }
+`
+	_, err := checkEnumPackage(t, src)
+	if err == nil || !strings.Contains(err.Error(), "A redeclared") {
+		t.Fatalf("duplicate variant error = %v, want redeclaration error", err)
+	}
+}
+
+func TestEnumVariantVisibility(t *testing.T) {
+	const src = `package p
+type E enum { Public; private }
+`
+	pkg, err := checkEnumPackage(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	variants := pkg.Scope().Lookup("E").Type().(*types.Named).EnumVariants()
+	if !variants[0].Obj().Exported() || variants[1].Obj().Exported() {
+		t.Fatalf("variant visibility: Public=%v private=%v", variants[0].Obj().Exported(), variants[1].Obj().Exported())
+	}
+	if got := variants[1].Obj().Id(); got != "p.E.private" {
+		t.Fatalf("private variant ID = %q, want p.E.private", got)
+	}
+}
+
+func TestGenericEnumInstantiationSeal(t *testing.T) {
+	const src = `package p
+type Option[T any] enum { Some { Value T }; None }
+var _ Option[int] = Option.Some[string]{Value: "wrong"}
+`
+	if _, err := checkEnumPackage(t, src); err == nil || !strings.Contains(err.Error(), "cannot use") {
+		t.Fatalf("cross-instantiation assignment error = %v", err)
+	}
+}
+
+func TestLocalEnumSeal(t *testing.T) {
+	const src = `package p
+func f() {
+	type E enum { A }
+	var outer E = A{}
+	{
+		type E enum { A }
+		var inner E = A{}
+		outer = inner
+	}
+}
+`
+	if _, err := checkEnumPackage(t, src); err == nil || !strings.Contains(err.Error(), "cannot use") {
+		t.Fatalf("same-named local enum assignment error = %v", err)
+	}
+}
+
+func TestImportedEnumSwitchVariantVisibility(t *testing.T) {
+	pkg, err := checkEnumPackage(t, `package p; type E enum { Public; private }`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, switchStmt := range []string{
+		`switch x { case private: default: }`,
+		`switch x.(type) { case private: default: }`,
+	} {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, "consumer.go", "package q; import \"p\"; func f(x p.E) { "+switchStmt+" }", parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatal(err)
+		}
+		conf := types.Config{Importer: testImporter{"p": pkg}}
+		if _, err := conf.Check("q", fset, []*ast.File{file}, nil); err == nil || !strings.Contains(err.Error(), "unexported enum variant") {
+			t.Errorf("%s: visibility error = %v", switchStmt, err)
+		}
+	}
+}
+
+func TestImportedPrivateVariantSelectorVisibility(t *testing.T) {
+	pkg, err := checkEnumPackage(t, `package p; type E enum { Public; private }`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, src := range []string{
+		`package q; import "p"; type Alias = p.E; var _ = Alias.private{}`,
+		`package q; import . "p"; var _ = E.private{}`,
+	} {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, "consumer.go", src, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatal(err)
+		}
+		conf := types.Config{Importer: testImporter{"p": pkg}}
+		if _, err := conf.Check("q", fset, []*ast.File{file}, nil); err == nil || !strings.Contains(err.Error(), "unexported enum variant") {
+			t.Errorf("%s: visibility error = %v", src, err)
+		}
+	}
+}

--- a/src/go/types/generate_test.go
+++ b/src/go/types/generate_test.go
@@ -135,10 +135,12 @@ var filemap = map[string]action{
 		renameSelectorExprs(f, "syntax.Name->ast.Ident", "rhs.Value->rhs.Name")
 		renameSelectors(f, "Trace->_Trace")
 	},
-	"errors_test.go":  func(f *ast.File) { renameIdents(f, "nopos->noposn") },
-	"errsupport.go":   nil,
-	"gccgosizes.go":   nil,
-	"gcsizes.go":      func(f *ast.File) { renameIdents(f, "IsSyncAtomicAlign64->_IsSyncAtomicAlign64", "IsSyncAtomicAlign128->_IsSyncAtomicAlign128") },
+	"errors_test.go": func(f *ast.File) { renameIdents(f, "nopos->noposn") },
+	"errsupport.go":  nil,
+	"gccgosizes.go":  nil,
+	"gcsizes.go": func(f *ast.File) {
+		renameIdents(f, "IsSyncAtomicAlign64->_IsSyncAtomicAlign64", "IsSyncAtomicAlign128->_IsSyncAtomicAlign128")
+	},
 	"hilbert_test.go": func(f *ast.File) { renameImportPath(f, `"cmd/compile/internal/types2"->"go/types"`) },
 	"infer.go":        func(f *ast.File) { fixTokenPos(f); fixInferSig(f) },
 	"initorder.go":    nil,
@@ -150,7 +152,7 @@ var filemap = map[string]action{
 		renameImportPath(f, `"cmd/compile/internal/syntax"->"go/ast"`)
 		renameSelectorExprs(f,
 			"syntax.IntLit->token.INT", "syntax.FloatLit->token.FLOAT", "syntax.ImagLit->token.IMAG",
-			"syntax.Name->ast.Ident", "key.Value->key.Name", "atyp.Elem->atyp.Elt") // must happen before renaming identifiers
+			"syntax.Name->ast.Ident", "id.Value->id.Name", "key.Value->key.Name", "atyp.Elem->atyp.Elt") // must happen before renaming identifiers
 		renameIdents(f, "syntax->ast")
 		renameSelectors(f, "ElemList->Elts")
 	},
@@ -191,9 +193,11 @@ var filemap = map[string]action{
 		renameIdents(f, "syntax->ast")
 		fixAtPosCall(f)
 	},
-	"scope.go":         func(f *ast.File) { fixTokenPos(f); renameIdents(f, "InsertLazy->_InsertLazy") },
-	"selection.go":     nil,
-	"sizes.go":         func(f *ast.File) { renameIdents(f, "IsSyncAtomicAlign64->_IsSyncAtomicAlign64", "IsSyncAtomicAlign128->_IsSyncAtomicAlign128") },
+	"scope.go":     func(f *ast.File) { fixTokenPos(f); renameIdents(f, "InsertLazy->_InsertLazy") },
+	"selection.go": nil,
+	"sizes.go": func(f *ast.File) {
+		renameIdents(f, "IsSyncAtomicAlign64->_IsSyncAtomicAlign64", "IsSyncAtomicAlign128->_IsSyncAtomicAlign128")
+	},
 	"slice.go":         nil,
 	"subst.go":         func(f *ast.File) { fixTokenPos(f); renameSelectors(f, "Trace->_Trace") },
 	"termlist.go":      nil,

--- a/src/go/types/instantiate.go
+++ b/src/go/types/instantiate.go
@@ -268,6 +268,16 @@ func (check *Checker) implements(V, T Type, constraint bool, cause *string) bool
 		}
 		return false
 	}
+	if marker := enumInterfaceMarker(Ti); marker != "" {
+		variant, _ := Unalias(V).(*Named)
+		_, interfaceType := Vu.(*Interface)
+		if !interfaceType && (variant == nil || variant.enumVariantMarker() != marker) {
+			if cause != nil {
+				*cause = check.sprintf("%s is not a declared variant of %s", V, T)
+			}
+			return false
+		}
+	}
 
 	// Every type satisfies the empty interface.
 	if Ti.Empty() {
@@ -291,8 +301,19 @@ func (check *Checker) implements(V, T Type, constraint bool, cause *string) bool
 		return false
 	}
 
+	// Methods declared on an enum are statically dispatched conveniences on
+	// enum-typed values. They are not runtime interface methods implemented by
+	// every variant, so they don't make the enum implement another interface.
+	methodSource := V
+	if named, _ := Unalias(V).(*Named); named != nil && named.enumMarker() != "" {
+		target, _ := Unalias(T).(*Named)
+		if target == nil || target.Origin() != named.Origin() {
+			methodSource = Vu
+		}
+	}
+
 	// V must implement T's methods, if any.
-	if !check.hasAllMethods(V, T, true, Identical, cause) /* !Implements(V, T) */ {
+	if !check.hasAllMethods(methodSource, T, true, Identical, cause) /* !Implements(V, T) */ {
 		if cause != nil {
 			*cause = check.sprintf("%s does not %s %s %s", V, verb, T, *cause)
 		}
@@ -381,6 +402,16 @@ func (check *Checker) implements(V, T Type, constraint bool, cause *string) bool
 	}
 
 	return checkComparability()
+}
+
+func enumInterfaceMarker(iface *Interface) string {
+	for i := 0; i < iface.NumMethods(); i++ {
+		name := iface.Method(i).name
+		if len(name) > len(".enum.") && name[:len(".enum.")] == ".enum." {
+			return name
+		}
+	}
+	return ""
 }
 
 // mentions reports whether type T "mentions" typ in an (embedded) element or term

--- a/src/go/types/literals.go
+++ b/src/go/types/literals.go
@@ -115,6 +115,22 @@ func (check *Checker) compositeLit(U Type, x *operand, e *ast.CompositeLit, hint
 	switch {
 	case e.Type != nil:
 		// composite literal type present - use it
+		if id, _ := e.Type.(*ast.Ident); id != nil {
+			context := U
+			if context == nil {
+				context = hint
+			}
+			if variant := enumVariant(context, id.Name); variant != nil {
+				if variant.Obj().Pkg() != check.pkg && !variant.Obj().Exported() {
+					check.errorf(id, UnexportedName, "cannot refer to unexported enum variant %s", variant)
+				}
+				typ = variant
+				base = typ
+				check.recordUse(id, variant.Obj())
+				check.recordTypeAndValue(id, typexpr, variant, nil)
+				break
+			}
+		}
 		// [...]T array types may only appear with composite literals.
 		// Check for them here so we don't have to handle ... in general.
 		if atyp, _ := e.Type.(*ast.ArrayType); atyp != nil && isdddArray(atyp) {
@@ -125,7 +141,7 @@ func (check *Checker) compositeLit(U Type, x *operand, e *ast.CompositeLit, hint
 			base = typ
 			break
 		}
-		typ = check.typ(e.Type)
+		typ = check.enumLitType(e.Type)
 		base = typ
 
 	// The hint mechanism is kept around to avoid reporting a false "need Go 1.28" error

--- a/src/go/types/named.go
+++ b/src/go/types/named.go
@@ -9,6 +9,7 @@ package types
 
 import (
 	"go/token"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -127,6 +128,9 @@ type Named struct {
 	// accessed.
 	methods []*Func
 
+	// enumInfo refers to metadata shared by an enum and all of its variants.
+	enumInfo *enumInfo
+
 	// loader may be provided to lazily load type parameters, underlying type, methods, and delayed functions
 	loader func(*Named) ([]*TypeParam, Type, []*Func, []func())
 }
@@ -138,6 +142,11 @@ type instance struct {
 	targs           *TypeList // type arguments
 	expandedMethods int       // number of expanded methods; expandedMethods <= len(orig.methods)
 	ctxt            *Context  // local Context; set to nil after full expansion
+}
+
+type enumInfo struct {
+	parent   *Named
+	variants []*Named
 }
 
 // stateMask represents each state in the lifecycle of a named type.
@@ -413,6 +422,178 @@ func (t *Named) TypeArgs() *TypeList {
 // NumMethods returns the number of explicit methods defined for t.
 func (t *Named) NumMethods() int {
 	return len(t.Origin().unpack().methods)
+}
+
+// EnumType returns the enum type that t belongs to. It returns t itself when
+// t is an enum type, and nil when t is neither an enum nor an enum variant.
+func (t *Named) EnumType() *Named {
+	orig := t.Origin()
+	var parent *Named
+	if orig.enumInfo != nil {
+		parent = orig.enumInfo.parent
+	} else if orig.enumMarker() != "" {
+		parent = orig
+	} else if marker := orig.enumVariantMarker(); marker != "" && orig.obj.pkg != nil {
+		obj, _ := orig.obj.pkg.Scope().Lookup(marker[len(".enum."):]).(*TypeName)
+		if obj != nil {
+			parent, _ = Unalias(obj.Type()).(*Named)
+		}
+	}
+	if parent == nil {
+		return nil
+	}
+	return instantiateEnumNamed(parent, t.TypeArgs())
+}
+
+// EnumVariants returns the variants of enum type t in declaration order.
+// It returns nil when t is not an enum type.
+func (t *Named) EnumVariants() []*Named {
+	orig := t.Origin()
+	if orig.enumInfo == nil && orig.enumMarker() == "" {
+		return nil
+	}
+	var variants []*Named
+	if orig.enumInfo != nil && orig.enumInfo.parent == orig {
+		variants = orig.enumInfo.variants
+	}
+	if variants == nil && orig.obj.pkg != nil {
+		marker := ".enum." + orig.obj.name
+		seen := make(map[*Named]bool)
+		for _, name := range orig.obj.pkg.Scope().Names() {
+			obj, _ := orig.obj.pkg.Scope().Lookup(name).(*TypeName)
+			if obj == nil || obj.IsAlias() {
+				continue
+			}
+			variant, _ := Unalias(obj.Type()).(*Named)
+			if variant == nil {
+				continue
+			}
+			variant = variant.Origin()
+			if variant == orig || seen[variant] {
+				continue
+			}
+			for i := range variant.NumMethods() {
+				method := variant.Method(i)
+				if method.name == marker && method.pkg == orig.obj.pkg {
+					variants = append(variants, variant)
+					seen[variant] = true
+					break
+				}
+			}
+		}
+		slices.SortFunc(variants, func(a, b *Named) int {
+			if c := cmpPos(a.Obj().Pos(), b.Obj().Pos()); c != 0 {
+				return c
+			}
+			return strings.Compare(a.Obj().Name(), b.Obj().Name())
+		})
+	}
+	result := make([]*Named, len(variants))
+	for i, variant := range variants {
+		result[i] = instantiateEnumNamed(variant, t.TypeArgs())
+	}
+	return result
+}
+
+func enumVariant(typ Type, name string) *Named {
+	named, _ := Unalias(typ).(*Named)
+	if named == nil {
+		return nil
+	}
+	orig := named.Origin().unpack()
+	if orig.enumInfo == nil {
+		if !orig.stateHas(hasUnder) || orig.enumMarker() == "" {
+			return nil
+		}
+	}
+	parent := named.EnumType()
+	if parent == nil || parent.Origin() != named.Origin() {
+		return nil
+	}
+	for _, variant := range named.EnumVariants() {
+		if enumVariantName(variant) == name {
+			return variant
+		}
+	}
+	return nil
+}
+
+func enumHasVariantName(named *Named, name string) bool {
+	orig := named.Origin()
+	if orig.enumInfo == nil || orig.enumInfo.parent != orig {
+		return false
+	}
+	for _, variant := range orig.enumInfo.variants {
+		if enumVariantName(variant) == name {
+			return true
+		}
+	}
+	return false
+}
+
+func isEnumType(named *Named) bool {
+	orig := named.Origin()
+	return orig.enumInfo != nil && orig.enumInfo.parent == orig
+}
+
+func enumVariantName(variant *Named) string {
+	name := variant.Obj().Name()
+	if i := strings.LastIndexByte(name, '.'); i >= 0 {
+		return name[i+1:]
+	}
+	return name
+}
+
+func isEnumVariantNamed(named *Named) bool {
+	orig := named.Origin()
+	if orig.enumInfo != nil {
+		return orig.enumInfo.parent != orig
+	}
+	// Imported variants are reconstructed from their qualified object name.
+	// A source-level Go type name cannot itself contain a dot.
+	return strings.Contains(orig.obj.name, ".")
+}
+
+func (t *Named) enumVariantMarker() string {
+	orig := t.Origin()
+	for i := range orig.NumMethods() {
+		method := orig.Method(i)
+		if len(method.name) > len(".enum.") && method.name[:len(".enum.")] == ".enum." && method.pkg == orig.obj.pkg {
+			return method.name
+		}
+	}
+	return ""
+}
+
+func (t *Named) enumMarker() string {
+	orig := t.Origin()
+	iface, _ := orig.Underlying().(*Interface)
+	if iface == nil {
+		return ""
+	}
+	marker := ".enum." + orig.obj.name
+	for i := range iface.NumExplicitMethods() {
+		method := iface.ExplicitMethod(i)
+		if method.name == marker && method.pkg == orig.obj.pkg {
+			return marker
+		}
+	}
+	return ""
+}
+
+func instantiateEnumNamed(orig *Named, targs *TypeList) *Named {
+	if targs.Len() == 0 {
+		return orig
+	}
+	args := make([]Type, targs.Len())
+	for i := range args {
+		args[i] = targs.At(i)
+	}
+	typ, err := Instantiate(nil, orig, args, false)
+	if err != nil {
+		return orig
+	}
+	return typ.(*Named)
 }
 
 // Method returns the i'th method of named type t for 0 <= i < t.NumMethods().

--- a/src/go/types/object.go
+++ b/src/go/types/object.go
@@ -243,6 +243,30 @@ type TypeName struct {
 	object
 }
 
+// Exported reports whether the declared type name is exported. Enum variant
+// objects use a qualified package-local name such as Result.Ok, so visibility
+// is determined by the final component.
+func (obj *TypeName) Exported() bool {
+	name := obj.name
+	if i := strings.LastIndexByte(name, '.'); i >= 0 {
+		name = name[i+1:]
+	}
+	return isExported(name)
+}
+
+// Id returns the qualified package-local name, additionally prefixed by the
+// package path when the final name component is not exported.
+func (obj *TypeName) Id() string {
+	if obj.Exported() {
+		return obj.name
+	}
+	path := "_"
+	if obj.pkg != nil && obj.pkg.path != "" {
+		path = obj.pkg.path
+	}
+	return path + "." + obj.name
+}
+
 // NewTypeName returns a new type name denoting the given typ.
 // The remaining arguments set the attributes found with all Objects.
 //

--- a/src/go/types/operand.go
+++ b/src/go/types/operand.go
@@ -373,6 +373,17 @@ func (x *operand) assignableTo(check *Checker, T Type, cause *string) (bool, Cod
 		return true, 0
 	}
 
+	// Enum values are represented by a sealed interface internally. A pointer
+	// to a variant inherits its marker method, but is not itself an enum variant.
+	if named, _ := T.(*Named); named != nil && named.enumMarker() != "" {
+		if _, ok := V.(*Pointer); ok {
+			if cause != nil {
+				*cause = "pointer to enum variant is not an enum value"
+			}
+			return false, IncompatibleAssign
+		}
+	}
+
 	// T is an interface type, but not a type parameter, and V implements T.
 	// Also handle the case where T is a pointer to an interface so that we get
 	// the Checker.implements error cause.

--- a/src/go/types/resolver.go
+++ b/src/go/types/resolver.go
@@ -26,10 +26,16 @@ type declInfo struct {
 	init      ast.Expr      // init/orig expression, or nil (for const and var declarations only)
 	inherited bool          // if set, the init expression is inherited from a previous constant declaration
 	tdecl     *ast.TypeSpec // type declaration, or nil
+	edecl     *enumDeclInfo // enum declaration shared by enum and variant objects, or nil
 	fdecl     *ast.FuncDecl // func declaration, or nil
 
 	// The deps field tracks initialization expression dependencies.
 	deps map[Object]bool // lazily initialized
+}
+
+type enumDeclInfo struct {
+	decl    *ast.EnumDecl
+	objects []*TypeName // enum type followed by variant types in source order
 }
 
 // hasInitializer reports whether the declared object has an initialization
@@ -397,6 +403,17 @@ func (check *Checker) collectObjects() {
 			case typeDecl:
 				obj := NewTypeName(d.spec.Name.Pos(), pkg, d.spec.Name.Name, nil)
 				check.declarePkgObj(d.spec.Name, obj, &declInfo{file: fileScope, version: check.version, tdecl: d.spec})
+			case enumDecl:
+				info := &enumDeclInfo{decl: d.decl, objects: make([]*TypeName, 1+len(d.decl.Variants))}
+				info.objects[0] = NewTypeName(d.decl.Name.Pos(), pkg, d.decl.Name.Name, nil)
+				check.declarePkgObj(d.decl.Name, info.objects[0], &declInfo{file: fileScope, version: check.version, edecl: info})
+				for i, variant := range d.decl.Variants {
+					obj := NewTypeName(variant.Name.Pos(), pkg, d.decl.Name.Name+"."+variant.Name.Name, nil)
+					info.objects[i+1] = obj
+					check.declare(check.pkg.scope, variant.Name, obj, nopos)
+					check.objMap[obj] = &declInfo{file: fileScope, version: check.version, edecl: info}
+					obj.setOrder(uint32(len(check.objMap)))
+				}
 			case funcDecl:
 				name := d.decl.Name.Name
 				obj := NewFunc(d.decl.Name.Pos(), pkg, name, nil) // signature set later
@@ -587,7 +604,11 @@ func (check *Checker) resolveBaseTypeName(ptr bool, name *ast.Ident) (ptr_ bool,
 		}
 
 		// we're done if tdecl describes a defined type (not an alias)
-		tdecl := check.objMap[tname].tdecl // must exist for objects in package scope
+		info := check.objMap[tname] // must exist for objects in package scope
+		if info.edecl != nil {
+			return ptr, tname
+		}
+		tdecl := info.tdecl
 		if !tdecl.Assign.IsValid() {
 			return ptr, tname
 		}
@@ -670,7 +691,8 @@ func (check *Checker) packageObjects() {
 		// phase 1: non-alias type declarations
 		for _, obj := range check.objList {
 			if tname, _ := obj.(*TypeName); tname != nil {
-				if check.objMap[tname].tdecl.Assign.IsValid() {
+				info := check.objMap[tname]
+				if info.edecl == nil && info.tdecl.Assign.IsValid() {
 					aliasList = append(aliasList, tname)
 				} else {
 					check.objDecl(obj)

--- a/src/go/types/return.go
+++ b/src/go/types/return.go
@@ -52,10 +52,10 @@ func (check *Checker) isTerminating(s ast.Stmt, label string) bool {
 		}
 
 	case *ast.SwitchStmt:
-		return check.isTerminatingSwitch(s.Body, label)
+		return check.isTerminatingSwitch(s.Body, label, check.enumSwitches[s])
 
 	case *ast.TypeSwitchStmt:
-		return check.isTerminatingSwitch(s.Body, label)
+		return check.isTerminatingSwitch(s.Body, label, check.enumSwitches[s])
 
 	case *ast.SelectStmt:
 		for _, s := range s.Body.List {
@@ -86,8 +86,8 @@ func (check *Checker) isTerminatingList(list []ast.Stmt, label string) bool {
 	return false // all statements are empty
 }
 
-func (check *Checker) isTerminatingSwitch(body *ast.BlockStmt, label string) bool {
-	hasDefault := false
+func (check *Checker) isTerminatingSwitch(body *ast.BlockStmt, label string, exhaustive bool) bool {
+	hasDefault := exhaustive
 	for _, s := range body.List {
 		cc := s.(*ast.CaseClause)
 		if cc.List == nil {

--- a/src/go/types/signature.go
+++ b/src/go/types/signature.go
@@ -486,6 +486,12 @@ func (check *Checker) validRecv(pos positioner, recv *Var) {
 			check.errorf(pos, InvalidRecv, "cannot define new methods on non-local type %s", rtyp)
 			break
 		}
+		if enumType := T.EnumType(); enumType != nil {
+			if T.Origin() != enumType.Origin() {
+				check.errorf(pos, InvalidRecv, "cannot define method on enum variant %s; use enum type %s as receiver", enumVariantName(T), enumType.obj.name)
+			}
+			break
+		}
 		var cause string
 		switch u := T.Underlying().(type) {
 		case *Basic:

--- a/src/go/types/sizeof_test.go
+++ b/src/go/types/sizeof_test.go
@@ -30,7 +30,7 @@ func TestSizeof(t *testing.T) {
 		{Interface{}, 40, 80},
 		{Map{}, 16, 32},
 		{Chan{}, 12, 24},
-		{Named{}, 68, 128},
+		{Named{}, 72, 136},
 		{TypeParam{}, 28, 48},
 		{term{}, 12, 24},
 

--- a/src/go/types/stmt.go
+++ b/src/go/types/stmt.go
@@ -12,6 +12,7 @@ import (
 	"go/token"
 	. "internal/types/errors"
 	"slices"
+	"strings"
 )
 
 // decl may be nil
@@ -309,12 +310,29 @@ func (check *Checker) caseTypes(x *operand, types []ast.Expr, seen map[Type]ast.
 	var dummy operand
 L:
 	for _, e := range types {
+		T = nil
 		// The spec allows the value nil instead of a type.
 		if check.isNil(e) {
 			T = nil
 			check.expr(nil, nil, &dummy, e) // run e through expr so we get the usual Info recordings
 		} else {
-			T = check.varType(e)
+			if x != nil && check.isEnumType(x.typ()) {
+				if id, _ := e.(*ast.Ident); id != nil {
+					if variant := enumVariant(x.typ(), id.Name); variant != nil {
+						if obj := variant.Obj(); obj.Pkg() != check.pkg && !obj.Exported() {
+							check.errorf(id, UnexportedName, "cannot refer to unexported enum variant %s", variant)
+							T = Typ[Invalid]
+						} else {
+							T = variant
+							check.recordUse(id, obj)
+							check.recordTypeAndValue(id, typexpr, variant, nil)
+						}
+					}
+				}
+			}
+			if T == nil {
+				T = check.varType(e)
+			}
 			if !isValid(T) {
 				continue L
 			}
@@ -641,6 +659,11 @@ func (check *Checker) stmt(ctxt stmtContext, s ast.Stmt) {
 			// By checking assignment of x to an invisible temporary
 			// (as a compiler would), we get all the relevant checks.
 			check.assignment(&x, nil, "switch expression")
+			if check.isEnumType(x.typ()) {
+				name, _ := ast.Unparen(s.Tag).(*ast.Ident)
+				check.enumValueSwitchStmt(inner|inTypeSwitch, s, name, &x)
+				return
+			}
 			if x.isValid() && !Comparable(x.typ()) && !hasNil(x.typ()) {
 				check.errorf(&x, InvalidExprSwitch, "cannot switch on %s (%s is not comparable)", &x, x.typ())
 				x.invalidate()
@@ -771,6 +794,20 @@ func (check *Checker) stmt(ctxt stmtContext, s ast.Stmt) {
 			check.closeScope()
 		}
 
+		if sx != nil {
+			var hasDefault bool
+			for _, stmt := range s.Body.List {
+				clause, _ := stmt.(*ast.CaseClause)
+				if clause != nil && clause.List == nil {
+					hasDefault = true
+					break
+				}
+			}
+			if !hasDefault {
+				check.enumSwitchExhaustive(s, sx.typ(), seen)
+			}
+		}
+
 		// If lhs exists, we must have at least one lhs variable that was used.
 		// (We can't use check.usage because that only looks at one scope; and
 		// we don't want to use the same variable for all scopes and change the
@@ -871,4 +908,145 @@ func (check *Checker) stmt(ctxt stmtContext, s ast.Stmt) {
 	default:
 		check.error(s, InvalidSyntaxTree, "invalid statement")
 	}
+}
+
+func (check *Checker) isEnumType(typ Type) bool {
+	named, _ := Unalias(typ).(*Named)
+	return named != nil && named.EnumType() != nil && named.EnumType().Origin() == named.Origin()
+}
+
+func (check *Checker) enumValueSwitchStmt(inner stmtContext, s *ast.SwitchStmt, tag *ast.Ident, x *operand) {
+	check.multipleDefaults(s.Body.List)
+
+	seen := make(map[Type]ast.Expr)
+	for _, stmt := range s.Body.List {
+		clause, _ := stmt.(*ast.CaseClause)
+		if clause == nil {
+			check.error(s, InvalidSyntaxTree, "incorrect enum switch case")
+			continue
+		}
+		T := check.enumCaseTypes(x, clause.List, seen)
+		check.openScope(clause, "enum case")
+
+		var obj *Var
+		if tag != nil {
+			obj = newVar(LocalVar, tag.Pos(), check.pkg, tag.Name, T)
+			check.declare(check.scope, nil, obj, clause.Colon)
+			check.recordImplicit(clause, obj)
+		}
+		check.stmtList(inner, clause.Body)
+		if obj != nil {
+			check.usedVars[obj] = true // the narrowed shadow is implicit
+		}
+		check.closeScope()
+	}
+
+	var hasDefault bool
+	for _, stmt := range s.Body.List {
+		clause, _ := stmt.(*ast.CaseClause)
+		if clause != nil && clause.List == nil {
+			hasDefault = true
+			break
+		}
+	}
+	if !hasDefault {
+		check.enumSwitchExhaustive(s, x.typ(), seen)
+	}
+}
+
+func (check *Checker) enumCaseTypes(x *operand, exprs []ast.Expr, seen map[Type]ast.Expr) Type {
+	result := x.typ()
+	var single Type
+	variants := Unalias(x.typ()).(*Named).EnumVariants()
+
+Next:
+	for _, e := range exprs {
+		var T Type
+		if check.isNil(e) {
+			var dummy operand
+			check.expr(nil, nil, &dummy, e)
+		} else {
+			if id, _ := e.(*ast.Ident); id != nil {
+				if variant := enumVariant(x.typ(), id.Name); variant != nil {
+					if obj := variant.Obj(); obj.Pkg() != check.pkg && !obj.Exported() {
+						check.errorf(id, UnexportedName, "cannot refer to unexported enum variant %s", variant)
+						T = Typ[Invalid]
+					} else {
+						T = variant
+						check.recordUse(id, obj)
+						check.recordTypeAndValue(id, typexpr, variant, nil)
+					}
+				}
+			}
+			if T == nil {
+				T = check.varType(e)
+			}
+			if !isValid(T) {
+				continue
+			}
+			valid := false
+			for _, variant := range variants {
+				if Identical(T, variant) {
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				check.errorf(e, InvalidTypeSwitch, "%s is not a variant of %s", T, x.typ())
+				continue
+			}
+		}
+
+		for other, prev := range seen {
+			if T == nil && other == nil || T != nil && other != nil && Identical(T, other) {
+				name := "nil"
+				if T != nil {
+					name = TypeString(T, check.qualifier)
+				}
+				err := check.newError(DuplicateCase)
+				err.addf(e, "duplicate case %s in enum switch", name)
+				err.addf(prev, "previous case")
+				err.report()
+				continue Next
+			}
+		}
+		seen[T] = e
+		single = T
+	}
+
+	if len(exprs) == 1 && single != nil {
+		result = single
+	}
+	return result
+}
+
+func (check *Checker) enumSwitchExhaustive(s ast.Stmt, typ Type, seen map[Type]ast.Expr) {
+	named, _ := Unalias(typ).(*Named)
+	if named == nil || named.EnumType() == nil || named.EnumType().Origin() != named.Origin() {
+		return
+	}
+	var missing []string
+	for _, variant := range named.EnumVariants() {
+		covered := false
+		for caseType := range seen {
+			if caseType != nil && AssignableTo(variant, caseType) {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			missing = append(missing, enumVariantName(variant))
+		}
+	}
+	if _, covered := seen[nil]; !covered {
+		missing = append(missing, "nil")
+	}
+	if len(missing) != 0 {
+		check.errorf(s, InvalidTypeSwitch, "non-exhaustive enum switch on %s; missing %s", named, strings.Join(missing, ", "))
+		return
+	}
+	if check.enumSwitches == nil {
+		check.enumSwitches = make(map[ast.Stmt]bool)
+	}
+	check.enumSwitches[s] = true
 }

--- a/src/go/types/typexpr.go
+++ b/src/go/types/typexpr.go
@@ -179,14 +179,36 @@ func (check *Checker) validVarType(e ast.Expr, typ Type) {
 // named def, and def.typ.fromRHS will be set to the [Type] of e immediately
 // after its creation.
 func (check *Checker) declaredType(e ast.Expr, def *TypeName) Type {
+	return check.declaredType0(e, def, false)
+}
+
+// enumLitType accepts an enum variant as the direct type of a composite
+// literal. Variants are constructors in source, not standalone types.
+func (check *Checker) enumLitType(e ast.Expr) Type {
+	return check.declaredType0(e, nil, true)
+}
+
+func (check *Checker) declaredType0(e ast.Expr, def *TypeName, allowEnumVariant bool) Type {
 	typ := check.typInternal(e, def)
 	assert(isTyped(typ))
+	if !allowEnumVariant && check.rejectEnumVariantType(e, typ) {
+		typ = Typ[Invalid]
+	}
 	if isGeneric(typ) {
 		check.errorf(e, WrongTypeArgCount, "cannot use generic type %s without instantiation", typ)
 		typ = Typ[Invalid]
 	}
 	check.recordTypeAndValue(e, typexpr, typ, nil)
 	return typ
+}
+
+func (check *Checker) rejectEnumVariantType(e ast.Expr, typ Type) bool {
+	named, _ := Unalias(typ).(*Named)
+	if named == nil || !isEnumVariantNamed(named) {
+		return false
+	}
+	check.errorf(e, NotAType, "enum variant %s is a constructor, not a type", typ)
+	return true
 }
 
 // genericType is like typ but the type must be an (uninstantiated) generic

--- a/src/internal/abi/type.go
+++ b/src/internal/abi/type.go
@@ -126,6 +126,11 @@ const (
 	// This flag is just a cached computation of Size_ == PtrBytes == goarch.PtrSize.
 	TFlagDirectIface TFlag = 1 << 5
 
+	// TFlagEnumVariant marks a concrete type declared as an enum variant.
+	// Runtime interface checks use this bit to reject types that only promote
+	// an enum's unspellable marker method through embedding.
+	TFlagEnumVariant TFlag = 1 << 6
+
 	// Leaving this breadcrumb behind for dlv. It should not be used, and no
 	// Kind should be big enough to set this bit.
 	KindDirectIface Kind = 1 << 5

--- a/src/internal/reflectlite/type.go
+++ b/src/internal/reflectlite/type.go
@@ -421,6 +421,9 @@ func implements(T, V *abi.Type) bool {
 	}
 	rT := toRType(T)
 	rV := toRType(V)
+	if isEnumInterface(t, rT) && V.Kind() != abi.Interface && V.TFlag&abi.TFlagEnumVariant == 0 {
+		return false
+	}
 
 	// The same algorithm applies in both cases, but the
 	// method tables for an interface type and a concrete type
@@ -492,6 +495,16 @@ func implements(T, V *abi.Type) bool {
 			if i++; i >= len(t.Methods) {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+func isEnumInterface(t *interfaceType, rt rtype) bool {
+	for i := range t.Methods {
+		name := rt.nameOff(t.Methods[i].Name).Name()
+		if len(name) > len(".enum.") && name[:len(".enum.")] == ".enum." {
+			return true
 		}
 	}
 	return false

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -1493,6 +1493,9 @@ func implements(T, V *abi.Type) bool {
 	if len(t.Methods) == 0 {
 		return true
 	}
+	if isEnumInterface(t) && V.Kind() != abi.Interface && V.TFlag&abi.TFlagEnumVariant == 0 {
+		return false
+	}
 
 	// The same algorithm applies in both cases, but the
 	// method tables for an interface type and a concrete type
@@ -1564,6 +1567,16 @@ func implements(T, V *abi.Type) bool {
 			if i++; i >= len(t.Methods) {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+func isEnumInterface(t *interfaceType) bool {
+	for i := range t.Methods {
+		name := t.nameOff(t.Methods[i].Name).Name()
+		if len(name) > len(".enum.") && name[:len(".enum.")] == ".enum." {
+			return true
 		}
 	}
 	return false

--- a/src/runtime/iface.go
+++ b/src/runtime/iface.go
@@ -45,6 +45,13 @@ func getitab(inter *interfacetype, typ *_type, canfail bool) *itab {
 	if len(inter.Methods) == 0 {
 		throw("internal error - misuse of itab")
 	}
+	if isEnumInterface(inter) && typ.TFlag&abi.TFlagEnumVariant == 0 {
+		if canfail {
+			return nil
+		}
+		name := toRType(&inter.Type).nameOff(inter.Methods[0].Name)
+		panic(&TypeAssertionError{concrete: typ, asserted: &inter.Type, missingMethod: name.Name()})
+	}
 
 	// easy case
 	if typ.TFlag&abi.TFlagUncommon == 0 {
@@ -100,6 +107,19 @@ finish:
 	// interface function was missing, so initialize
 	// the itab again to get the missing function name.
 	panic(&TypeAssertionError{concrete: typ, asserted: &inter.Type, missingMethod: itabInit(m, false)})
+}
+
+// isEnumInterface reports whether inter contains the sealed runtime marker
+// used to represent an enum. Only concrete types carrying TFlagEnumVariant may
+// satisfy an interface containing this otherwise-unspellable marker.
+func isEnumInterface(inter *interfacetype) bool {
+	for i := range inter.Methods {
+		name := toRType(&inter.Type).nameOff(inter.Methods[i].Name).Name()
+		if len(name) > len(".enum.") && name[:len(".enum.")] == ".enum." {
+			return true
+		}
+	}
+	return false
 }
 
 // find finds the given interface/type pair in t.

--- a/src/runtime/mgcmark_greenteagc.go
+++ b/src/runtime/mgcmark_greenteagc.go
@@ -797,11 +797,11 @@ func freeDeadSpanSPMCs() {
 func (w *gcWork) tryStealSpan() objptr {
 	pp := getg().m.p.ptr()
 
-	for enum := stealOrder.start(cheaprand()); !enum.done(); enum.next() {
-		if !work.spanqMask.read(enum.position()) {
+	for iter := stealOrder.start(cheaprand()); !iter.done(); iter.next() {
+		if !work.spanqMask.read(iter.position()) {
 			continue
 		}
-		p2 := allp[enum.position()]
+		p2 := allp[iter.position()]
 		if pp == p2 {
 			continue
 		}
@@ -815,7 +815,7 @@ func (w *gcWork) tryStealSpan() objptr {
 		// the bit on each P if there's local work we missed. This race
 		// should generally be rare, since the window between noticing
 		// an empty local queue and this bit being set is quite small.
-		work.spanqMask.clear(int32(enum.position()))
+		work.spanqMask.clear(int32(iter.position()))
 	}
 	return 0
 }

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -3849,12 +3849,12 @@ func stealWork(now int64) (gp *g, inheritTime bool, rnow, pollUntil int64, newWo
 	for i := 0; i < stealTries; i++ {
 		stealTimersOrRunNextG := i == stealTries-1
 
-		for enum := stealOrder.start(cheaprand()); !enum.done(); enum.next() {
+		for iter := stealOrder.start(cheaprand()); !iter.done(); iter.next() {
 			if sched.gcwaiting.Load() {
 				// GC work may be available.
 				return nil, false, now, pollUntil, true
 			}
-			p2 := allp[enum.position()]
+			p2 := allp[iter.position()]
 			if pp == p2 {
 				continue
 			}
@@ -3872,7 +3872,7 @@ func stealWork(now int64) (gp *g, inheritTime bool, rnow, pollUntil int64, newWo
 			//
 			// timerpMask tells us whether the P may have timers at all. If it
 			// can't, no need to check at all.
-			if stealTimersOrRunNextG && timerpMask.read(enum.position()) {
+			if stealTimersOrRunNextG && timerpMask.read(iter.position()) {
 				tnow, w, ran := p2.timers.check(now, nil)
 				now = tnow
 				if w != 0 && (pollUntil == 0 || w < pollUntil) {
@@ -3895,7 +3895,7 @@ func stealWork(now int64) (gp *g, inheritTime bool, rnow, pollUntil int64, newWo
 			}
 
 			// Don't bother to attempt to steal if p2 is idle.
-			if !idlepMask.read(enum.position()) {
+			if !idlepMask.read(iter.position()) {
 				if gp := runqsteal(pp, p2, stealTimersOrRunNextG); gp != nil {
 					return gp, false, now, pollUntil, ranTimer
 				}
@@ -8077,17 +8077,17 @@ func (ord *randomOrder) start(i uint32) randomEnum {
 	}
 }
 
-func (enum *randomEnum) done() bool {
-	return enum.i == enum.count
+func (e *randomEnum) done() bool {
+	return e.i == e.count
 }
 
-func (enum *randomEnum) next() {
-	enum.i++
-	enum.pos = (enum.pos + enum.inc) % enum.count
+func (e *randomEnum) next() {
+	e.i++
+	e.pos = (e.pos + e.inc) % e.count
 }
 
-func (enum *randomEnum) position() uint32 {
-	return enum.pos
+func (e *randomEnum) position() uint32 {
+	return e.pos
 }
 
 func gcd(a, b uint32) uint32 {

--- a/src/runtime/proc_runtime_test.go
+++ b/src/runtime/proc_runtime_test.go
@@ -14,18 +14,18 @@ func RunStealOrderTest() {
 			panic("too few coprimes")
 		}
 		for co := 0; co < len(ord.coprimes); co++ {
-			enum := ord.start(uint32(co))
+			iter := ord.start(uint32(co))
 			checked := make([]bool, procs)
 			for p := 0; p < procs; p++ {
-				x := enum.position()
+				x := iter.position()
 				if checked[x] {
-					println("procs:", procs, "inc:", enum.inc)
+					println("procs:", procs, "inc:", iter.inc)
 					panic("duplicate during enumeration")
 				}
 				checked[x] = true
-				enum.next()
+				iter.next()
 			}
-			if !enum.done() {
+			if !iter.done() {
 				panic("not done")
 			}
 		}
@@ -38,10 +38,10 @@ func RunStealOrderTest() {
 		// We want at least procs*len(ord.coprimes) different pos+inc values
 		// before we start repeating.
 		for i := 0; i < procs*len(ord.coprimes); i++ {
-			enum := ord.start(uint32(i))
-			j := enum.pos*uint32(procs) + enum.inc
+			iter := ord.start(uint32(i))
+			j := iter.pos*uint32(procs) + iter.inc
 			if checked[j] {
-				println("procs:", procs, "pos:", enum.pos, "inc:", enum.inc)
+				println("procs:", procs, "pos:", iter.pos, "inc:", iter.inc)
 				panic("duplicate pos+inc during enumeration")
 			}
 			checked[j] = true

--- a/test/enum.go
+++ b/test/enum.go
@@ -1,0 +1,127 @@
+// run
+
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import "reflect"
+
+var enum = 1
+
+type Result enum {
+	Ok { value int }
+	Err { err string }
+	None
+}
+
+type Option[T any] enum {
+	Some { value T }
+	Nothing
+}
+
+func (o Option[T]) Or(zero T) T {
+	switch o {
+	case Some:
+		return o.value
+	case Nothing, nil:
+		return zero
+	}
+	return zero
+}
+
+func (r Result) Value() int {
+	switch r {
+	case Ok:
+		return r.value
+	case Err:
+		return -1
+	case None, nil:
+		return 0
+	}
+	return 0
+}
+
+func inspect(result Result) int {
+	switch result {
+	case Ok:
+		return result.value
+	case Err:
+		return len(result.err)
+	case None:
+		return 0
+	case nil:
+		return -1
+	}
+	panic("unreachable")
+}
+
+func makeResult() Result { return Ok{value: 42} }
+
+func inspectExpression() int {
+	switch makeResult() {
+	case Ok:
+		return 42
+	case Err, None, nil:
+		return 0
+	}
+	return 0
+}
+
+func unwrap[T any](option Option[T], zero T) T {
+	switch option {
+	case Some:
+		return option.value
+	case Nothing, nil:
+		return zero
+	}
+	panic("unreachable")
+}
+
+func main() {
+	enum := enum + 1
+	enum++
+	if enum != 3 {
+		panic("contextual enum keyword")
+	}
+
+	var pointer any = &Result.Ok{value: 42}
+	if _, ok := pointer.(Result); ok {
+		panic("pointer to enum variant passed runtime assertion")
+	}
+	if !reflect.TypeFor[Result]().Implements(reflect.TypeFor[Result]()) {
+		panic("enum does not implement itself through reflection")
+	}
+
+	var result Result = Ok{value: 42}
+	if inspect(result) != 42 || inspectExpression() != 42 || result.Value() != 42 {
+		panic("non-generic enum")
+	}
+	if got := result.Variant(); got != "Ok" || (Result.Err{err: "no"}).Variant() != "Err" {
+		panic("enum variant")
+	}
+
+	var option Option[string] = Some{value: "ok"}
+	if unwrap(option, "bad") != "ok" || option.Or("bad") != "ok" || option.Variant() != "Some" {
+		panic("generic enum")
+	}
+	var qualified Option[int] = Option[int].Some{value: 7}
+	if unwrap(qualified, 0) != 7 {
+		panic("qualified generic enum variant")
+	}
+
+	type Local enum {
+		Here { value int }
+		Gone
+	}
+	var local Local = Here{value: 7}
+	switch local {
+	case Here:
+		if local.value != 7 {
+			panic("local enum")
+		}
+	case Gone, nil:
+		panic("wrong local variant")
+	}
+}

--- a/test/enumimport.dir/enumlib.go
+++ b/test/enumimport.dir/enumlib.go
@@ -1,0 +1,39 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package enumlib
+
+type Result enum {
+	Ok { Value int }
+	Err
+}
+
+func (r Result) Or(zero int) int {
+	switch r {
+	case Ok:
+		return r.Value
+	case Err, nil:
+		return zero
+	}
+	return zero
+}
+
+func NewResult() Result { return Ok{Value: 7} }
+
+type Option[T any] enum {
+	Some { Value T }
+	None
+}
+
+func (o Option[T]) Or(zero T) T {
+	switch o {
+	case Some:
+		return o.Value
+	case None, nil:
+		return zero
+	}
+	return zero
+}
+
+func NewOption() Option[int] { return Some{Value: 9} }

--- a/test/enumimport.dir/main.go
+++ b/test/enumimport.dir/main.go
@@ -1,0 +1,30 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import "./enumlib"
+
+func main() {
+	var result enumlib.Result = Ok{Value: 3}
+	if result.Or(0) != 3 {
+		panic("qualified imported result variant")
+	}
+	if result.Variant() != "Ok" {
+		panic("imported result variant")
+	}
+	var option enumlib.Option[int] = Some{Value: 4}
+	if option.Or(0) != 4 {
+		panic("qualified imported option variant")
+	}
+	if option.Variant() != "Some" {
+		panic("imported generic variant")
+	}
+	if enumlib.NewResult().Or(0) != 7 {
+		panic("non-generic imported enum method")
+	}
+	if enumlib.NewOption().Or(0) != 9 {
+		panic("generic imported enum method")
+	}
+}

--- a/test/enumimport.go
+++ b/test/enumimport.go
@@ -1,0 +1,9 @@
+// rundir
+
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Test enum methods through imported, including generic, enum types.
+
+package ignored

--- a/test/enumprivate.dir/enumlib.go
+++ b/test/enumprivate.dir/enumlib.go
@@ -1,0 +1,11 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package enumlib
+
+type Option[T any] enum {
+	Some { Value T }
+	None
+	hidden
+}

--- a/test/enumprivate.dir/main.go
+++ b/test/enumprivate.dir/main.go
@@ -1,0 +1,15 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import "./enumlib"
+
+func incomplete(option enumlib.Option[int]) {
+	switch option { // ERROR "non-exhaustive enum switch.*hidden"
+	case Some:
+	case None:
+	case nil:
+	}
+}

--- a/test/enumprivate.go
+++ b/test/enumprivate.go
@@ -1,0 +1,9 @@
+// errorcheckdir
+
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Verify that private variants of imported generic enums remain in export data.
+
+package ignored


### PR DESCRIPTION
Add algebraic enum types with payload variants, exhaustive switches,
generic support, and compiler, runtime, and standard tooling support.

Design: https://github.com/golang/proposal/pull/60

For example:

```go
type Result[T any] enum {
	Ok { Value T }
	Err { Err error }
}

func printResult(result Result[int]) {
	switch result {
	case Ok:
		fmt.Println(result.Value)
	case Err:
		fmt.Println(result.Err)
	case nil:
		fmt.Println("unset")
	}
}

func example() {
	result := Result[int].Ok{Value: 42}
	printResult(result)
	fmt.Println(result.Variant()) // "Ok"
}
```

Go+ (https://github.com/goonward/goplus) is an installable experimental
fork implementing the change end to end. It provides downloadable
toolchains and editor integrations, and serves as the working proof of
concept for this proposal.

Updates #19412
