### PR TITLE
crypto/x509: work around SecPolicyCreateSSL when executable dir is missing

### DIFF
--- a/src/crypto/x509/root_darwin.go
+++ b/src/crypto/x509/root_darwin.go
@@ -8,10 +8,18 @@ import (
 	"crypto/x509/internal/macos"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
 )
 
 // macOS has no default SSL_CERT_{FILE,DIR} paths.
 var certFiles, certDirectories []string
+
+// secPolicyMu serializes SecPolicyCreateSSL against repairExecutableDir
+// cleanup so concurrent verifiers cannot remove a directory another call
+// still needs.
+var secPolicyMu sync.Mutex
 
 func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate, err error) {
 	certs := macos.CFArrayCreateMutable()
@@ -37,9 +45,20 @@ func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate
 
 	policies := macos.CFArrayCreateMutable()
 	defer macos.ReleaseCFArray(policies)
+	// SecPolicyCreateSSL returns NULL when the directory containing this
+	// process's executable is missing (macOS Security.framework quirk).
+	// That commonly happens with "go run" after the go command deletes its
+	// temporary build directory while a child process is still running.
+	// The directory must exist during the SecPolicyCreateSSL call; we recreate
+	// it temporarily if needed and remove any empty directories we created.
+	// See go.dev/issue/68557 and go.dev/issue/54590.
+	secPolicyMu.Lock()
+	cleanup := repairExecutableDir()
 	sslPolicy, err := macos.SecPolicyCreateSSL(opts.DNSName)
+	cleanup()
+	secPolicyMu.Unlock()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("x509: %w (the directory containing this executable may be missing; see https://go.dev/issue/68557)", err)
 	}
 	macos.CFArrayAppendValue(policies, sslPolicy)
 
@@ -127,4 +146,51 @@ func exportCertificate(cert macos.CFRef) (*Certificate, error) {
 		return nil, err
 	}
 	return ParseCertificate(data)
+}
+
+// repairExecutableDir recreates the directory containing the running
+// executable if it is missing. The returned cleanup removes any empty
+// directories that were created, deepest first.
+func repairExecutableDir() (cleanup func()) {
+	cleanup = func() {}
+	exe, err := os.Executable()
+	if err != nil {
+		return cleanup
+	}
+	dir := filepath.Dir(exe)
+	if fi, err := os.Stat(dir); err == nil && fi.IsDir() {
+		return cleanup
+	}
+
+	// Record missing ancestors so cleanup only removes what we create.
+	var missing []string
+	for cur := dir; ; {
+		fi, err := os.Stat(cur)
+		if err == nil {
+			if !fi.IsDir() {
+				return cleanup
+			}
+			break
+		}
+		missing = append(missing, cur)
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			break
+		}
+		cur = parent
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return cleanup
+	}
+	return func() {
+		for _, d := range missing {
+			entries, err := os.ReadDir(d)
+			if err != nil || len(entries) > 0 {
+				return
+			}
+			if err := os.Remove(d); err != nil {
+				return
+			}
+		}
+	}
 }

--- a/src/crypto/x509/root_darwin_test.go
+++ b/src/crypto/x509/root_darwin_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package x509
+
+import (
+	"bytes"
+	"fmt"
+	"internal/testenv"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSecPolicyCreateSSLMissingExecutableDir covers go.dev/issue/68557:
+// on macOS, SecPolicyCreateSSL returns NULL when the directory containing
+// the running executable has been removed (as happens when a process started
+// via "go run" outlives the go command's temporary build directory).
+func TestSecPolicyCreateSSLMissingExecutableDir(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS_MISSING_EXE_DIR") == "1" {
+		missingExecutableDirHelper()
+		return
+	}
+
+	testenv.MustHaveExec(t)
+
+	exe := testenv.Executable(t)
+	dir, err := os.MkdirTemp("", "x509-missing-exe-dir-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Intentionally not using t.TempDir: we remove this directory while the
+	// helper is still running.
+	defer os.RemoveAll(dir)
+
+	helper := filepath.Join(dir, "helper")
+	// Prefer a symlink so we do not copy a large test binary (expensive and
+	// can get the helper killed under memory pressure during "go test std").
+	if err := os.Symlink(exe, helper); err != nil {
+		if err := copyFile(helper, exe); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(helper, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cmd := exec.Command(helper, "-test.run=^TestSecPolicyCreateSSLMissingExecutableDir$")
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS_MISSING_EXE_DIR=1")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Give the helper time to start, then remove its executable directory.
+	time.Sleep(200 * time.Millisecond)
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("helper failed: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "OK") {
+		t.Fatalf("helper did not report OK\nstdout: %s\nstderr: %s", stdout.String(), stderr.String())
+	}
+	// repairExecutableDir must not leave the temporary executable directory behind.
+	if fi, err := os.Stat(dir); err == nil && fi.IsDir() {
+		t.Fatalf("repair left behind executable directory %q", dir)
+	}
+}
+
+func missingExecutableDirHelper() {
+	// Wait for the parent to remove our executable directory.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		exe, err := os.Executable()
+		if err == nil {
+			if _, err := os.Stat(filepath.Dir(exe)); err != nil {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			fmt.Fprintln(os.Stderr, "timeout waiting for executable directory to disappear")
+			os.Exit(1)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	leaf, err := certificateFromPEM(googleLeaf)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parse cert: %v\n", err)
+		os.Exit(1)
+	}
+	_, err = leaf.Verify(VerifyOptions{DNSName: "www.google.com"})
+	if err != nil && strings.Contains(err.Error(), "SecPolicyCreateSSL") {
+		fmt.Fprintf(os.Stderr, "Verify: %v\n", err)
+		os.Exit(1)
+	}
+	// Success means we got past SecPolicyCreateSSL. Verification may still
+	// fail for unrelated reasons (expired test cert, etc.).
+	fmt.Println("OK")
+	os.Exit(0)
+}
+
+func copyFile(dst, src string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}


### PR DESCRIPTION
On macOS, Security.framework returns NULL from SecPolicyCreateSSL when the
directory containing the running executable no longer exists. That commonly
happens with "go run" after the go command deletes its temporary build
directory while a child process is still running.

Fixes #68557