### PR TITLE
html/template: track regexp context after JavaScript statements

### DIFF
--- a/src/html/template/context.go
+++ b/src/html/template/context.go
@@ -22,6 +22,14 @@ type context struct {
 	delim   delim
 	urlPart urlPart
 	jsCtx   jsCtx
+	// jsParenStack records whether each open parenthesis starts the condition
+	// of a control statement. A slash after the matching close parenthesis can
+	// start a regular expression literal instead of a division operator.
+	jsParenStack []bool
+	// jsPreceder tracks a control keyword waiting for its opening parenthesis,
+	// or a member-access dot waiting for an identifier. It distinguishes those
+	// cases when comments separate the tokens.
+	jsPreceder jsPreceder
 	// jsBraceDepth contains the current depth, for each JS template literal
 	// string interpolation expression, of braces we've seen. This is used to
 	// determine if the next } will close a JS template literal string
@@ -38,7 +46,7 @@ func (c context) String() string {
 	if c.err != nil {
 		err = c.err
 	}
-	return fmt.Sprintf("{%v %v %v %v %v %v %v %v}", c.state, c.delim, c.urlPart, c.jsCtx, c.jsBraceDepth, c.attr, c.element, err)
+	return fmt.Sprintf("{%v %v %v %v %v %v %v %v %v %v}", c.state, c.delim, c.urlPart, c.jsCtx, c.jsParenStack, c.jsPreceder, c.jsBraceDepth, c.attr, c.element, err)
 }
 
 // eq reports whether two contexts are equal.
@@ -47,6 +55,8 @@ func (c context) eq(d context) bool {
 		c.delim == d.delim &&
 		c.urlPart == d.urlPart &&
 		c.jsCtx == d.jsCtx &&
+		slices.Equal(c.jsParenStack, d.jsParenStack) &&
+		c.jsPreceder == d.jsPreceder &&
 		slices.Equal(c.jsBraceDepth, d.jsBraceDepth) &&
 		c.attr == d.attr &&
 		c.element == d.element &&
@@ -70,6 +80,12 @@ func (c context) mangle(templateName string) string {
 	if c.jsCtx != jsCtxRegexp {
 		s += "_" + c.jsCtx.String()
 	}
+	if c.jsParenStack != nil {
+		s += fmt.Sprintf("_jsParenStack(%v)", c.jsParenStack)
+	}
+	if c.jsPreceder != jsPrecederNone {
+		s += fmt.Sprintf("_jsPreceder(%d)", c.jsPreceder)
+	}
 	if c.jsBraceDepth != nil {
 		s += fmt.Sprintf("_jsBraceDepth(%v)", c.jsBraceDepth)
 	}
@@ -85,6 +101,7 @@ func (c context) mangle(templateName string) string {
 // clone returns a copy of c with the same field values.
 func (c context) clone() context {
 	clone := c
+	clone.jsParenStack = slices.Clone(c.jsParenStack)
 	clone.jsBraceDepth = slices.Clone(c.jsBraceDepth)
 	return clone
 }
@@ -250,6 +267,16 @@ const (
 // jsCtx determines whether a '/' starts a regular expression literal or a
 // division operator.
 type jsCtx uint8
+
+// jsPreceder tracks tokens that affect how a later keyword or parenthesis is
+// interpreted, even when comments occur between the tokens.
+type jsPreceder uint8
+
+const (
+	jsPrecederNone jsPreceder = iota
+	jsPrecederControl
+	jsPrecederMember
+)
 
 //go:generate stringer -type jsCtx
 

--- a/src/html/template/escape.go
+++ b/src/html/template/escape.go
@@ -241,6 +241,7 @@ func (e *escaper) escapeAction(c context, n *parse.ActionNode) context {
 		s = append(s, "_html_template_jsvalescaper")
 		// A slash after a value starts a div operator.
 		c.jsCtx = jsCtxDivOp
+		c.jsPreceder = jsPrecederNone
 	case stateJSDqStr, stateJSSqStr:
 		s = append(s, "_html_template_jsstrescaper")
 	case stateJSTmplLit:

--- a/src/html/template/escape_test.go
+++ b/src/html/template/escape_test.go
@@ -284,6 +284,56 @@ func TestEscape(t *testing.T) {
 			`<script>alert(/(?:)/.test(""));</script>`,
 		},
 		{
+			"jsReAfterBlockOpen",
+			`<script>if (true) {/{{"/;alert(1)//"}}/g.test("x")}</script>`,
+			`<script>if (true) {/\/;alert\(1\)\/\//g.test("x")}</script>`,
+		},
+		{
+			"jsReAfterControlCondition",
+			`<script>if ((true)) /{{"/;alert(1)//"}}/g.test("x")</script>`,
+			`<script>if ((true)) /\/;alert\(1\)\/\//g.test("x")</script>`,
+		},
+		{
+			"jsReAfterDynamicControlCondition",
+			`<script>while ({{.T}}) /{{"/;alert(1)//"}}/g.test("x")</script>`,
+			`<script>while ( true ) /\/;alert\(1\)\/\//g.test("x")</script>`,
+		},
+		{
+			"jsReAfterCommentedControlCondition",
+			`<script>if /* comment */ (f("x")) /{{"/;alert(1)//"}}/g.test("x")</script>`,
+			`<script>if   (f("x")) /\/;alert\(1\)\/\//g.test("x")</script>`,
+		},
+		{
+			"jsReAfterForCondition",
+			`<script>for (; true; ) /{{"/;alert(1)//"}}/g.test("x")</script>`,
+			`<script>for (; true; ) /\/;alert\(1\)\/\//g.test("x")</script>`,
+		},
+		{
+			"jsReAfterForAwaitCondition",
+			`<script>async function f(xs) { for /* comment */ await (const x of xs) /{{"/;alert(1)//"}}/g.test(x) }</script>`,
+			`<script>async function f(xs) { for   await (const x of xs) /\/;alert\(1\)\/\//g.test(x) }</script>`,
+		},
+		{
+			"jsDivisionAfterCall",
+			`<script>var x = f() / {{"/"}};</script>`,
+			`<script>var x = f() / "/";</script>`,
+		},
+		{
+			"jsDivisionAfterAwaitCall",
+			`<script>async function f() { return await g() / {{"/"}} }</script>`,
+			`<script>async function f() { return await g() / "/" }</script>`,
+		},
+		{
+			"jsDivisionAfterKeywordPropertyCall",
+			`<script>var x = obj.if(true) / {{"/"}};</script>`,
+			`<script>var x = obj.if(true) / "/";</script>`,
+		},
+		{
+			"jsDivisionAfterCommentedKeywordPropertyCall",
+			`<script>var x = obj. /* comment */ if(true) / {{"/"}};</script>`,
+			`<script>var x = obj.   if(true) / "/";</script>`,
+		},
+		{
 			"jsReAmbigOk",
 			`<script>{{if true}}var x = 1{{end}}</script>`,
 			// The {if} ends in an ambiguous jsCtx but there is
@@ -1662,15 +1712,15 @@ func TestEscapeText(t *testing.T) {
 		},
 		{
 			`<script>document.write("<script>`,
-			context{state: stateJSDqStr, element: elementScript},
+			context{state: stateJSDqStr, element: elementScript, jsParenStack: []bool{false}},
 		},
 		{
 			`<script>document.write("<script>alert(1)</script>`,
-			context{state: stateJSDqStr, element: elementScript},
+			context{state: stateJSDqStr, element: elementScript, jsParenStack: []bool{false}},
 		},
 		{
 			`<script>document.write("<script>alert(1)<!--`,
-			context{state: stateJSDqStr, element: elementScript},
+			context{state: stateJSDqStr, element: elementScript, jsParenStack: []bool{false}},
 		},
 		{
 			`<script>document.write("<script>alert(1)</Script>");`,
@@ -1864,7 +1914,7 @@ func TestEscapeText(t *testing.T) {
 		},
 		{
 			"<script>function f() {`${ function f() { `${1}` } }`}",
-			context{state: stateJS, element: elementScript, jsCtx: jsCtxDivOp},
+			context{state: stateJS, element: elementScript, jsCtx: jsCtxRegexp},
 		},
 		{
 			"<script>`${ { `` }",
@@ -1876,11 +1926,11 @@ func TestEscapeText(t *testing.T) {
 		},
 		{
 			"<script>var foo = `${ foo({ a: { c: `${",
-			context{state: stateJS, element: elementScript, jsBraceDepth: []int{2, 0}},
+			context{state: stateJS, element: elementScript, jsParenStack: []bool{false}, jsBraceDepth: []int{2, 0}},
 		},
 		{
 			"<script>var foo = `${ foo({ a: { c: `${ {{.}} }` }, b: ",
-			context{state: stateJS, element: elementScript, jsBraceDepth: []int{1}},
+			context{state: stateJS, element: elementScript, jsParenStack: []bool{false}, jsBraceDepth: []int{1}},
 		},
 		{
 			"<script>`${ `}",

--- a/src/html/template/js.go
+++ b/src/html/template/js.go
@@ -32,10 +32,17 @@ const jsWhitespace = "\f\n\r\t\v\u0020\u00a0\u1680\u2000\u2001\u2002\u2003\u2004
 // JavaScript 2.0 lexical grammar and requires one token of lookbehind:
 // https://www.mozilla.org/js/language/js20-2000-07/rationale/syntax.html
 func nextJSCtx(s []byte, preceding jsCtx) jsCtx {
+	ctx, _ := nextJSCtxAndPreceder(s, preceding, jsPrecederNone)
+	return ctx
+}
+
+// nextJSCtxAndPreceder is nextJSCtx with additional tracking for tokens whose
+// meaning must survive intervening whitespace or comments.
+func nextJSCtxAndPreceder(s []byte, preceding jsCtx, precedingPreceder jsPreceder) (jsCtx, jsPreceder) {
 	// Trim all JS whitespace characters
 	s = bytes.TrimRight(s, jsWhitespace)
 	if len(s) == 0 {
-		return preceding
+		return preceding, precedingPreceder
 	}
 
 	// All cases below are in the single-byte UTF-8 group.
@@ -51,31 +58,31 @@ func nextJSCtx(s []byte, preceding jsCtx) jsCtx {
 		if (n-start)&1 == 1 {
 			// Reached for trailing minus signs since "---" is the
 			// same as "-- -".
-			return jsCtxRegexp
+			return jsCtxRegexp, jsPrecederNone
 		}
-		return jsCtxDivOp
+		return jsCtxDivOp, jsPrecederNone
 	case '.':
 		// Handle "42."
 		if n != 1 && '0' <= s[n-2] && s[n-2] <= '9' {
-			return jsCtxDivOp
+			return jsCtxDivOp, jsPrecederNone
 		}
-		return jsCtxRegexp
+		return jsCtxRegexp, jsPrecederMember
 	// Suffixes for all punctuators from section 7.7 of the language spec
 	// that only end binary operators not handled above.
 	case ',', '<', '>', '=', '*', '%', '&', '|', '^', '?':
-		return jsCtxRegexp
+		return jsCtxRegexp, jsPrecederNone
 	// Suffixes for all punctuators from section 7.7 of the language spec
 	// that are prefix operators not handled above.
 	case '!', '~':
-		return jsCtxRegexp
+		return jsCtxRegexp, jsPrecederNone
 	// Matches all the punctuators from section 7.7 of the language spec
 	// that are open brackets not handled above.
 	case '(', '[':
-		return jsCtxRegexp
+		return jsCtxRegexp, jsPrecederNone
 	// Matches all the punctuators from section 7.7 of the language spec
 	// that precede expression starts.
 	case ':', ';', '{':
-		return jsCtxRegexp
+		return jsCtxRegexp, jsPrecederNone
 	// CAVEAT: the close punctuators ('}', ']', ')') precede div ops and
 	// are handled in the default except for '}' which can precede a
 	// division op as in
@@ -83,12 +90,11 @@ func nextJSCtx(s []byte, preceding jsCtx) jsCtx {
 	// which is valid, but, in practice, developers don't divide object
 	// literals, so our heuristic works well for code like
 	//    function () { ... }  /foo/.test(x) && sideEffect();
-	// The ')' punctuator can precede a regular expression as in
-	//     if (b) /foo/.test(x) && ...
-	// but this is much less likely than
+	// Control statement parentheses are tracked separately by tJS. Other ')'
+	// punctuators usually precede division operators, as in
 	//     (a + b) / c
 	case '}':
-		return jsCtxRegexp
+		return jsCtxRegexp, jsPrecederNone
 	default:
 		// Look for an IdentifierName and see if it is a keyword that
 		// can precede a regular expression.
@@ -96,14 +102,39 @@ func nextJSCtx(s []byte, preceding jsCtx) jsCtx {
 		for j > 0 && isJSIdentPart(rune(s[j-1])) {
 			j--
 		}
-		if regexpPrecederKeywords[string(s[j:])] {
-			return jsCtxRegexp
+		keyword := string(s[j:])
+		prefix := bytes.TrimRight(s[:j], jsWhitespace)
+		member := (precedingPreceder == jsPrecederMember && len(prefix) == 0) ||
+			(len(prefix) != 0 && prefix[len(prefix)-1] == '.')
+		if controlPrecederKeywords[keyword] && !member {
+			return jsCtxRegexp, jsPrecederControl
+		}
+		if keyword == "await" && !member {
+			// In a for-await-of statement, await may be separated from for by
+			// whitespace or a comment. Preserve the pending control condition
+			// until its opening parenthesis.
+			_, p := nextJSCtxAndPreceder(prefix, preceding, precedingPreceder)
+			if p == jsPrecederControl {
+				return jsCtxRegexp, jsPrecederControl
+			}
+		}
+		if regexpPrecederKeywords[keyword] && !member {
+			return jsCtxRegexp, jsPrecederNone
 		}
 	}
 	// Otherwise is a punctuator not listed above, or
 	// a string which precedes a div op, or an identifier
 	// which precedes a div op.
-	return jsCtxDivOp
+	return jsCtxDivOp, jsPrecederNone
+}
+
+// controlPrecederKeywords introduce a parenthesized condition followed by a
+// statement. That statement may begin with a regular expression literal.
+var controlPrecederKeywords = map[string]bool{
+	"for":   true,
+	"if":    true,
+	"while": true,
+	"with":  true,
 }
 
 // regexpPrecederKeywords is a set of reserved JS keywords that can precede a

--- a/src/html/template/js_test.go
+++ b/src/html/template/js_test.go
@@ -104,6 +104,36 @@ func TestNextJsCtx(t *testing.T) {
 	}
 }
 
+func TestNextJSCtxAndPreceder(t *testing.T) {
+	tests := []struct {
+		name              string
+		s                 string
+		precedingPreceder jsPreceder
+		wantCtx           jsCtx
+		wantPreceder      jsPreceder
+	}{
+		{"control keyword", "if", jsPrecederNone, jsCtxRegexp, jsPrecederControl},
+		{"keyword property", "obj.if", jsPrecederNone, jsCtxDivOp, jsPrecederNone},
+		{"spaced keyword property", "obj. if", jsPrecederNone, jsCtxDivOp, jsPrecederNone},
+		{"commented keyword property", "if", jsPrecederMember, jsCtxDivOp, jsPrecederNone},
+		{"for await", "for await", jsPrecederNone, jsCtxRegexp, jsPrecederControl},
+		{"commented for await", "await", jsPrecederControl, jsCtxRegexp, jsPrecederControl},
+		{"await property", "await", jsPrecederMember, jsCtxDivOp, jsPrecederNone},
+		{"regexp keyword property", "return", jsPrecederMember, jsCtxDivOp, jsPrecederNone},
+		{"whitespace", " \t", jsPrecederControl, jsCtxDivOp, jsPrecederControl},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, p := nextJSCtxAndPreceder([]byte(test.s), jsCtxDivOp, test.precedingPreceder)
+			if ctx != test.wantCtx || p != test.wantPreceder {
+				t.Fatalf("nextJSCtxAndPreceder(%q, %v, %v) = (%v, %v), want (%v, %v)",
+					test.s, jsCtxDivOp, test.precedingPreceder, ctx, p, test.wantCtx, test.wantPreceder)
+			}
+		})
+	}
+}
+
 type jsonErrType struct{}
 
 func (e *jsonErrType) MarshalJSON() ([]byte, error) {

--- a/src/html/template/transition.go
+++ b/src/html/template/transition.go
@@ -282,19 +282,22 @@ func tURL(c context, s []byte) (context, int) {
 
 // tJS is the context transition function for the JS state.
 func tJS(c context, s []byte) (context, int) {
-	i := bytes.IndexAny(s, "\"`'/{}<-#")
+	i := bytes.IndexAny(s, "\"`'/{}()<-#")
 	if i == -1 {
 		// Entire input is non string, comment, regexp tokens.
-		c.jsCtx = nextJSCtx(s, c.jsCtx)
+		c.jsCtx, c.jsPreceder = nextJSCtxAndPreceder(s, c.jsCtx, c.jsPreceder)
 		return c, len(s)
 	}
-	c.jsCtx = nextJSCtx(s[:i], c.jsCtx)
+	c.jsCtx, c.jsPreceder = nextJSCtxAndPreceder(s[:i], c.jsCtx, c.jsPreceder)
 	switch s[i] {
 	case '"':
+		c.jsPreceder = jsPrecederNone
 		c.state, c.jsCtx = stateJSDqStr, jsCtxRegexp
 	case '\'':
+		c.jsPreceder = jsPrecederNone
 		c.state, c.jsCtx = stateJSSqStr, jsCtxRegexp
 	case '`':
+		c.jsPreceder = jsPrecederNone
 		c.state, c.jsCtx = stateJSTmplLit, jsCtxRegexp
 	case '/':
 		switch {
@@ -303,8 +306,10 @@ func tJS(c context, s []byte) (context, int) {
 		case i+1 < len(s) && s[i+1] == '*':
 			c.state, i = stateJSBlockCmt, i+1
 		case c.jsCtx == jsCtxRegexp:
+			c.jsPreceder = jsPrecederNone
 			c.state = stateJSRegexp
 		case c.jsCtx == jsCtxDivOp:
+			c.jsPreceder = jsPrecederNone
 			c.jsCtx = jsCtxRegexp
 		default:
 			return context{
@@ -322,25 +327,57 @@ func tJS(c context, s []byte) (context, int) {
 	case '<':
 		if i+3 < len(s) && bytes.Equal(commentStart, s[i:i+4]) {
 			c.state, i = stateJSHTMLOpenCmt, i+3
+		} else {
+			c.jsPreceder = jsPrecederNone
 		}
 	case '-':
 		if i+2 < len(s) && bytes.Equal(commentEnd, s[i:i+3]) {
 			c.state, i = stateJSHTMLCloseCmt, i+2
+		} else {
+			c.jsPreceder = jsPrecederNone
 		}
 	// ECMAScript also supports "hashbang" comment lines, see Section 12.5.
 	case '#':
 		if i+1 < len(s) && s[i+1] == '!' {
 			c.state, i = stateJSLineCmt, i+1
+		} else {
+			c.jsPreceder = jsPrecederNone
+		}
+	case '(':
+		c.jsParenStack = append(c.jsParenStack, c.jsPreceder == jsPrecederControl)
+		c.jsPreceder = jsPrecederNone
+		c.jsCtx = jsCtxRegexp
+	case ')':
+		c.jsPreceder = jsPrecederNone
+		if n := len(c.jsParenStack); n != 0 {
+			control := c.jsParenStack[n-1]
+			if n == 1 {
+				c.jsParenStack = nil
+			} else {
+				c.jsParenStack = c.jsParenStack[:n-1]
+			}
+			if control {
+				c.jsCtx = jsCtxRegexp
+			} else {
+				c.jsCtx = jsCtxDivOp
+			}
+		} else {
+			c.jsCtx = jsCtxDivOp
 		}
 	case '{':
+		c.jsPreceder = jsPrecederNone
 		// We only care about tracking brace depth if we are inside of a
 		// template literal.
 		if len(c.jsBraceDepth) == 0 {
+			c.jsCtx = jsCtxRegexp
 			return c, i + 1
 		}
 		c.jsBraceDepth[len(c.jsBraceDepth)-1]++
+		c.jsCtx = jsCtxRegexp
 	case '}':
+		c.jsPreceder = jsPrecederNone
 		if len(c.jsBraceDepth) == 0 {
+			c.jsCtx = jsCtxRegexp
 			return c, i + 1
 		}
 		// There are no cases where a brace can be escaped in the JS context
@@ -349,6 +386,7 @@ func tJS(c context, s []byte) (context, int) {
 		// fully fledged parsers will just fail anyway.
 		c.jsBraceDepth[len(c.jsBraceDepth)-1]--
 		if c.jsBraceDepth[len(c.jsBraceDepth)-1] >= 0 {
+			c.jsCtx = jsCtxRegexp
 			return c, i + 1
 		}
 		c.jsBraceDepth = c.jsBraceDepth[:len(c.jsBraceDepth)-1]


### PR DESCRIPTION
The JavaScript context tracker treats top-level braces specially and
classifies every closing parenthesis as preceding division. As a result,
actions inside regexp literals after a block open or control statement use
the value escaper. Slash characters in untrusted input can then terminate
the literal and inject JavaScript.

Set regexp context after braces. Track parenthesis pairs that belong to if,
for, while, and with statements, including for-await-of. Track member
access separately so keyword-named methods remain division contexts.

Add regressions for the reported XSS patterns, nested and dynamic control
conditions, and ordinary call and property division.

Fixes #80435