### PR TITLE
runtime: don't emit write barrier for code pointers in itabInit

### DIFF
--- a/src/runtime/iface.go
+++ b/src/runtime/iface.go
@@ -201,6 +201,11 @@ func (t *itabTableType) add(m *itab) {
 // If !firstTime, itabInit will not write anything to m.Fun (see issue 65962).
 // It is ok to call this multiple times on the same m, even concurrently
 // (although it will only be called once with firstTime==true).
+//
+// itabInit stores only code pointers, so it must not emit a write barrier;
+// //go:nowritebarrier enforces that (see the methods store below).
+//
+//go:nowritebarrier
 func itabInit(m *itab, firstTime bool) string {
 	inter := m.Inter
 	typ := m.Type
@@ -214,7 +219,10 @@ func itabInit(m *itab, firstTime bool) string {
 	nt := int(x.Mcount)
 	xmhdr := unsafe.Slice((*abi.Method)(add(unsafe.Pointer(x), uintptr(x.Moff))), nt)
 	j := 0
-	methods := unsafe.Slice((*unsafe.Pointer)(unsafe.Pointer(&m.Fun[0])), ni)
+	// These are code pointers, not heap pointers. Use a uintptr slice so the
+	// store emits no write barrier: on wasm a code pointer can look like a
+	// heap pointer and make the GC crash (see issue 80472).
+	methods := unsafe.Slice(&m.Fun[0], ni)
 	var fun0 unsafe.Pointer
 imethods:
 	for k := 0; k < ni; k++ {
@@ -240,7 +248,7 @@ imethods:
 					if k == 0 {
 						fun0 = ifn // we'll set m.Fun[0] at the end
 					} else if firstTime {
-						methods[k] = ifn
+						methods[k] = uintptr(ifn)
 					}
 					continue imethods
 				}


### PR DESCRIPTION
itabInit filled m.Fun by storing code pointers through an
unsafe.Pointer slice, which makes the compiler emit a write barrier.
On wasm a code PC is a function index shifted left 16 bits, a small
value that can fall inside a live heap span, so the GC mistakes it
for a bad heap pointer and crashes.

Store through a uintptr slice instead so no write barrier is emitted,
and mark itabInit //go:nowritebarrier so the same mistake fails to
compile.

Fixes #80472


