### PR TITLE
mime/multipart: return error from Part.Close

### DIFF
--- a/src/mime/multipart/multipart.go
+++ b/src/mime/multipart/multipart.go
@@ -323,8 +323,8 @@ func matchAfterPrefix(buf, prefix []byte, readErr error) int {
 }
 
 func (p *Part) Close() error {
-	io.Copy(io.Discard, p)
-	return nil
+	_, err := io.Copy(io.Discard, p)
+	return err
 }
 
 // Reader is an iterator over parts in a MIME multipart body.


### PR DESCRIPTION
## Summary
- `Part.Close` discarded the error from `io.Copy` when draining the remaining part body; return that error to the caller.

## Test plan
- [ ] `go test mime/multipart`