### PR TITLE
cmd/compile/internal/syntax: fix VarDecl.String output format

### DIFF
--- a/src/cmd/compile/internal/syntax/nodes.go
+++ b/src/cmd/compile/internal/syntax/nodes.go
@@ -128,7 +128,7 @@ func (d *TypeDecl) String() string {
 }
 
 func (d *VarDecl) String() string {
-	return fmt.Sprintf("FuncDecl{NameList:%v}", d.NameList)
+	return fmt.Sprintf("VarDecl{NameList:%v}", d.NameList)
 }
 
 type decl struct{ node }


### PR DESCRIPTION
## Summary
- `VarDecl.String` incorrectly formatted the output as `FuncDecl{NameList:...}` instead of `VarDecl{NameList:...}`.

## Test plan
- [ ] `go test cmd/compile/internal/syntax`