### PR TITLE
cmd/go: reject cgo -sectcreate linker flags by default

### DIFF
--- a/src/cmd/go/internal/work/security.go
+++ b/src/cmd/go/internal/work/security.go
@@ -223,7 +223,7 @@ var validLinkerFlags = []*lazyregexp.Regexp{
 	re(`-Wl,-rpath(-link)?[=,]([^,@\-][^,]*)`),
 	re(`-Wl,-s`),
 	re(`-Wl,-search_paths_first`),
-	re(`-Wl,-sectcreate,([^,@\-][^,]*),([^,@\-][^,]*),([^,@\-][^,]*)`),
+	re(`-Wl,-sectcreate,__RESTRICT,__restrict,/dev/null`),
 	re(`-Wl,--start-group`),
 	re(`-Wl,-?-static`),
 	re(`-Wl,-?-subsystem,(native|windows|console|posix|xbox)`),

--- a/src/cmd/go/internal/work/security_test.go
+++ b/src/cmd/go/internal/work/security_test.go
@@ -202,7 +202,6 @@ var goodLinkerFlags = [][]string{
 	{"-L", "framework"},
 	{"-framework", "Chocolate"},
 	{"-v"},
-	{"-Wl,-sectcreate,__TEXT,__info_plist,${SRCDIR}/Info.plist"},
 	{"-Wl,-framework", "-Wl,Chocolate"},
 	{"-Wl,-framework,Chocolate"},
 	{"-Wl,-unresolved-symbols=ignore-all"},
@@ -220,9 +219,9 @@ var goodLinkerFlags = [][]string{
 	{"-Wl,-framework,."},
 	{"-Wl,-rpath,."},
 	{"-Wl,-rpath-link,."},
-	{"-Wl,-sectcreate,.,.,."},
 	{"-Wl,-syslibroot,."},
 	{"-Wl,-undefined,."},
+	{"-Wl,-sectcreate,__RESTRICT,__restrict,/dev/null"},
 }
 
 var badLinkerFlags = [][]string{
@@ -289,6 +288,9 @@ var badLinkerFlags = [][]string{
 	{"-Wl,-e="},
 	{"-Wl,-e,"},
 	{"-Wl,-R,-flag"},
+	{"-Wl,-sectcreate,.,.,."},
+	{"-Wl,-sectcreate,__TEXT,__info_plist,${SRCDIR}/Info.plist"},
+	{"-Wl,-sectcreate,__TEXT,__info,/etc/hosts"},
 	{"-Wl,--push-state,"},
 	{"-Wl,--push-state,@foo"},
 	{"-fplugin=./-Wl,--push-state,-R.so"},

--- a/src/cmd/go/testdata/script/darwin_sectcreate_ldflag.txt
+++ b/src/cmd/go/testdata/script/darwin_sectcreate_ldflag.txt
@@ -1,0 +1,34 @@
+[!GOOS:darwin] skip
+[!cgo] skip
+
+go build -o safe-bin ./safe
+
+! go build
+stderr '^ldflag: invalid flag in #cgo LDFLAGS: -Wl,-sectcreate,__TEXT,__info,.*info.txt'
+
+env CGO_LDFLAGS_ALLOW=-Wl,-sectcreate,.*
+go build
+
+-- go.mod --
+module ldflag
+
+go 1.26
+
+-- main.go --
+package main
+
+// #cgo LDFLAGS: -Wl,-sectcreate,__TEXT,__info,${SRCDIR}/info.txt
+import "C"
+
+func main() {}
+
+-- safe/main.go --
+package main
+
+// #cgo LDFLAGS: -Wl,-sectcreate,__RESTRICT,__restrict,/dev/null
+import "C"
+
+func main() {}
+
+-- info.txt --
+trusted local input


### PR DESCRIPTION
The Darwin linker -sectcreate option reads a file and embeds its contents.
The existing cgo linker allowlist accepts this option, so a dependency can
make go build read an arbitrary file available to the build process.

Reject file-backed -Wl,-sectcreate,... flags in package-provided #cgo
LDFLAGS by default. Preserve the established
-Wl,-sectcreate,__RESTRICT,__restrict,/dev/null hardening form because it
does not expose useful file contents. Trusted uses can explicitly opt in
with CGO_LDFLAGS_ALLOW, as with other rejected flags.

Add a script test for default rejection, explicit opt-in, and the preserved
hardening form.

Fixes #78750.