### PR TITLE
html/template: handle CDATA in foreign script elements

### DIFF
--- a/src/html/template/context.go
+++ b/src/html/template/context.go
@@ -29,8 +29,15 @@ type context struct {
 	jsBraceDepth []int
 	attr         attr
 	element      element
-	n            parse.Node // for range break/continue
-	err          *Error
+	// htmlNamespaces tracks foreign namespace boundaries, HTML integration
+	// points, and same-name shadows needed to close the correct boundary.
+	htmlNamespaces  []htmlNamespaceFrame
+	scriptInForeign bool
+	scriptCDATA     bool
+	tagInForeign    bool
+	tagName         string
+	n               parse.Node // for range break/continue
+	err             *Error
 }
 
 func (c context) String() string {
@@ -38,7 +45,7 @@ func (c context) String() string {
 	if c.err != nil {
 		err = c.err
 	}
-	return fmt.Sprintf("{%v %v %v %v %v %v %v %v}", c.state, c.delim, c.urlPart, c.jsCtx, c.jsBraceDepth, c.attr, c.element, err)
+	return fmt.Sprintf("{%v %v %v %v %v %v %v %v %v %v %v %q %v}", c.state, c.delim, c.urlPart, c.jsCtx, c.jsBraceDepth, c.attr, c.element, c.htmlNamespaces, c.scriptInForeign, c.scriptCDATA, c.tagInForeign, c.tagName, err)
 }
 
 // eq reports whether two contexts are equal.
@@ -50,6 +57,11 @@ func (c context) eq(d context) bool {
 		slices.Equal(c.jsBraceDepth, d.jsBraceDepth) &&
 		c.attr == d.attr &&
 		c.element == d.element &&
+		slices.Equal(c.htmlNamespaces, d.htmlNamespaces) &&
+		c.scriptInForeign == d.scriptInForeign &&
+		c.scriptCDATA == d.scriptCDATA &&
+		c.tagInForeign == d.tagInForeign &&
+		c.tagName == d.tagName &&
 		c.err == d.err
 }
 
@@ -57,7 +69,7 @@ func (c context) eq(d context) bool {
 // from template names mangled with different contexts.
 func (c context) mangle(templateName string) string {
 	// The mangled name for the default context is the input templateName.
-	if c.state == stateText {
+	if c.state == stateText && len(c.htmlNamespaces) == 0 {
 		return templateName
 	}
 	s := templateName + "$htmltemplate_" + c.state.String()
@@ -79,6 +91,21 @@ func (c context) mangle(templateName string) string {
 	if c.element != elementNone {
 		s += "_" + c.element.String()
 	}
+	if c.htmlNamespaces != nil {
+		s += fmt.Sprintf("_htmlNamespaces(%v)", c.htmlNamespaces)
+	}
+	if c.scriptInForeign {
+		s += "_scriptInForeign"
+	}
+	if c.scriptCDATA {
+		s += "_scriptCDATA"
+	}
+	if c.tagInForeign {
+		s += "_tagInForeign"
+	}
+	if c.tagName != "" {
+		s += "_tagName(" + c.tagName + ")"
+	}
 	return s
 }
 
@@ -86,7 +113,19 @@ func (c context) mangle(templateName string) string {
 func (c context) clone() context {
 	clone := c
 	clone.jsBraceDepth = slices.Clone(c.jsBraceDepth)
+	clone.htmlNamespaces = slices.Clone(c.htmlNamespaces)
 	return clone
+}
+
+type htmlNamespaceFrame struct {
+	tag         string
+	foreign     bool // The effective namespace is foreign rather than HTML.
+	math        bool // The foreign namespace is MathML rather than SVG.
+	integration bool // This is an integration point, not a same-name shadow.
+}
+
+func (c context) inForeignContent() bool {
+	return len(c.htmlNamespaces) != 0 && c.htmlNamespaces[len(c.htmlNamespaces)-1].foreign
 }
 
 // state describes a high-level HTML parser state.

--- a/src/html/template/escape.go
+++ b/src/html/template/escape.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"maps"
 	"regexp"
+	"slices"
 	"text/template"
 	"text/template/parse"
 )
@@ -835,6 +836,25 @@ func (e *escaper) escapeText(c context, n *parse.TextNode) context {
 // s, then returns the context after those tokens and the unprocessed suffix.
 func contextAfterText(c context, s []byte) (context, int) {
 	if c.delim == delimNone {
+		if c.element == elementScript && c.scriptInForeign {
+			if c.scriptCDATA {
+				if i := bytes.Index(s, cdataEnd); i == 0 {
+					c.scriptCDATA = false
+					return c, len(cdataEnd)
+				} else if i > 0 {
+					return transitionFunc[c.state](c, s[:i])
+				}
+				return transitionFunc[c.state](c, s)
+			}
+			if i := bytes.Index(s, cdataStart); i == 0 {
+				c.scriptCDATA = true
+				return c, len(cdataStart)
+			} else if i > 0 {
+				if end := indexTagEnd(s, specialTagEndMarkers[c.element]); end == -1 || i < end {
+					return transitionFunc[c.state](c, s[:i])
+				}
+			}
+		}
 		c1, i := tSpecialTagEnd(c, s)
 		if i == 0 {
 			// A special end tag (`</script>`) has been seen and
@@ -891,7 +911,15 @@ func contextAfterText(c context, s []byte) (context, int) {
 	}
 	// On exiting an attribute, we discard all state information
 	// except the state and element.
-	return context{state: stateTag, element: element}, i
+	return context{
+		state:           stateTag,
+		element:         element,
+		htmlNamespaces:  slices.Clone(c.htmlNamespaces),
+		scriptInForeign: c.scriptInForeign,
+		scriptCDATA:     c.scriptCDATA,
+		tagInForeign:    c.tagInForeign,
+		tagName:         c.tagName,
+	}, i
 }
 
 // editActionNode records a change to an action pipeline for later commit.

--- a/src/html/template/escape_test.go
+++ b/src/html/template/escape_test.go
@@ -811,6 +811,162 @@ func TestEscape(t *testing.T) {
 	}
 }
 
+func TestEscapeForeignCDATA(t *testing.T) {
+	const (
+		value     = `<b>${alert(1)}</b>`
+		jsValue   = `\u003cb\u003e\u0024\u007balert(1)\u007d\u003c\/b\u003e`
+		htmlValue = `&lt;b&gt;${alert(1)}&lt;/b&gt;`
+	)
+	tests := []struct {
+		name, input, want string
+	}{
+		{
+			"svg script",
+			"<svg><script><![CDATA[1</script/>`{{.}}`]]></script></svg>",
+			"<svg><script><![CDATA[1</script/>`" + jsValue + "`]]></script></svg>",
+		},
+		{
+			"nested mixed-case SVG script",
+			"<SvG><g><ScRiPt><![CDATA[1</ScRiPt/>`{{.}}`]]></ScRiPt></g></SvG>",
+			"<SvG><g><ScRiPt><![CDATA[1</ScRiPt/>`" + jsValue + "`]]></ScRiPt></g></SvG>",
+		},
+		{
+			"SVG integration point closes before script",
+			"<svg><title>x</title><script><![CDATA[1</script/>`{{.}}`]]></script></svg>",
+			"<svg><title>x</title><script><![CDATA[1</script/>`" + jsValue + "`]]></script></svg>",
+		},
+		{
+			"nested SVG in HTML integration point",
+			"<svg><foreignObject><svg><script><![CDATA[1</script/>`{{.}}`]]></script></svg></foreignObject></svg>",
+			"<svg><foreignObject><svg><script><![CDATA[1</script/>`" + jsValue + "`]]></script></svg></foreignObject></svg>",
+		},
+		{
+			"nested SVG with same tag name",
+			"<svg><svg></svg><script><![CDATA[1</script/>`{{.}}`]]></script></svg>",
+			"<svg><svg></svg><script><![CDATA[1</script/>`" + jsValue + "`]]></script></svg>",
+		},
+		{
+			"self-closing SVG",
+			"<svg/><script><![CDATA[1</script/>`{{.}}`]]></script>",
+			"<svg/><script><![CDATA[1</script/>`" + htmlValue + "`]]></script>",
+		},
+		{
+			"self-closing foreign child",
+			"<svg><g/><script><![CDATA[1</script/>`{{.}}`]]></script></svg>",
+			"<svg><g/><script><![CDATA[1</script/>`" + jsValue + "`]]></script></svg>",
+		},
+		{
+			"HTML integration point",
+			"<svg><foreignObject><script><![CDATA[1</script/>`{{.}}`]]></script></foreignObject></svg>",
+			"<svg><foreignObject><script><![CDATA[1</script/>`" + htmlValue + "`]]></script></foreignObject></svg>",
+		},
+		{
+			"nested HTML integration point tag name",
+			"<svg><foreignObject><foreignObject></foreignObject><script><![CDATA[1</script/>`{{.}}`]]></script></foreignObject></svg>",
+			"<svg><foreignObject><foreignObject></foreignObject><script><![CDATA[1</script/>`" + htmlValue + "`]]></script></foreignObject></svg>",
+		},
+		{
+			"MathML annotation without HTML encoding",
+			"<math><annotation-xml><script><![CDATA[1</script/>`{{.}}`]]></script></annotation-xml></math>",
+			"<math><annotation-xml><script><![CDATA[1</script/>`" + jsValue + "`]]></script></annotation-xml></math>",
+		},
+		{
+			"MathML annotation HTML integration point",
+			"<math><annotation-xml encoding='text&#x2f;html'><script><![CDATA[1</script/>`{{.}}`]]></script></annotation-xml></math>",
+			"<math><annotation-xml encoding='text&#x2f;html'><script><![CDATA[1</script/>`" + htmlValue + "`]]></script></annotation-xml></math>",
+		},
+		{
+			"MathML text integration exception",
+			"<math><mtext><mglyph><script><![CDATA[1</script/>`{{.}}`]]></script></mglyph></mtext></math>",
+			"<math><mtext><mglyph><script><![CDATA[1</script/>`" + jsValue + "`]]></script></mglyph></mtext></math>",
+		},
+		{
+			"nested MathML integration tag name",
+			"<math><mtext><mtext><mglyph><script><![CDATA[1</script/>`{{.}}`]]></script></mglyph></mtext></mtext></math>",
+			"<math><mtext><mtext><mglyph><script><![CDATA[1</script/>`" + htmlValue + "`]]></script></mglyph></mtext></mtext></math>",
+		},
+		{
+			"SVG child of MathML annotation",
+			"<math><annotation-xml><svg><foreignObject><script><![CDATA[1</script/>`{{.}}`]]></script></foreignObject></svg></annotation-xml></math>",
+			"<math><annotation-xml><svg><foreignObject><script><![CDATA[1</script/>`" + htmlValue + "`]]></script></foreignObject></svg></annotation-xml></math>",
+		},
+		{
+			"foreign-content breakout tag",
+			"<svg><div><script><![CDATA[1</script/>`{{.}}`]]></script></div></svg>",
+			"<svg><div><script><![CDATA[1</script/>`" + htmlValue + "`]]></script></div></svg>",
+		},
+		{
+			"breakout after nested foreign tag name",
+			"<svg><svg><div><script><![CDATA[1</script/>`{{.}}`]]></script></div></svg></svg>",
+			"<svg><svg><div><script><![CDATA[1</script/>`" + htmlValue + "`]]></script></div></svg></svg>",
+		},
+		{
+			"foreign font without breakout attributes",
+			"<svg><font><script><![CDATA[1</script/>`{{.}}`]]></script></font></svg>",
+			"<svg><font><script><![CDATA[1</script/>`" + jsValue + "`]]></script></font></svg>",
+		},
+		{
+			"font breakout attribute",
+			"<svg><font color=red><script><![CDATA[1</script/>`{{.}}`]]></script></font></svg>",
+			"<svg><font color=red><script><![CDATA[1</script/>`" + htmlValue + "`]]></script></font></svg>",
+		},
+		{
+			"ordinary HTML script",
+			"<script><![CDATA[1</script/>`{{.}}`]]></script>",
+			"<script><![CDATA[1</script/>`" + htmlValue + "`]]></script>",
+		},
+		{
+			"after foreign CDATA",
+			"<svg><script><![CDATA[var x = 1;]]>var y = `{{.}}`;</script></svg>",
+			"<svg><script><![CDATA[var x = 1;]]>var y = `" + jsValue + "`;</script></svg>",
+		},
+		{
+			"template invocation in foreign CDATA",
+			"{{define \"value\"}}`{{.}}`{{end}}<svg><script><![CDATA[1</script/>{{template \"value\" .}}]]></script></svg>",
+			"<svg><script><![CDATA[1</script/>`" + jsValue + "`]]></script></svg>",
+		},
+		{
+			"template specialized for HTML and foreign text",
+			"{{define \"script\"}}<script><![CDATA[1</script/>`{{.}}`]]></script>{{end}}<svg>{{template \"script\" .}}</svg>{{template \"script\" .}}",
+			"<svg><script><![CDATA[1</script/>`" + jsValue + "`]]></script></svg><script><![CDATA[1</script/>`" + htmlValue + "`]]></script>",
+		},
+		{
+			"conditional in foreign CDATA",
+			"<svg><script><![CDATA[{{if true}}console.log(1{{else}}console.log(1{{end}}</script/>`{{.}}`]]></script></svg>",
+			"<svg><script><![CDATA[console.log(1</script/>`" + jsValue + "`]]></script></svg>",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tmpl := Must(New(test.name).Parse(test.input))
+			var out strings.Builder
+			if err := tmpl.Execute(&out, value); err != nil {
+				t.Fatal(err)
+			}
+			if got := out.String(); got != test.want {
+				t.Fatalf("escaped output: want\n\t%q\ngot\n\t%q", test.want, got)
+			}
+		})
+	}
+}
+
+func TestEscapeForeignRecursiveTemplate(t *testing.T) {
+	type node struct {
+		Next *node
+	}
+	tmpl := Must(New("root").Parse(`{{define "rec"}}<g>{{if .}}x{{template "rec" .Next}}{{end}}</g>{{end}}<svg>{{template "rec" .}}</svg>`))
+	data := &node{Next: &node{Next: &node{}}}
+	var out strings.Builder
+	if err := tmpl.Execute(&out, data); err != nil {
+		t.Fatal(err)
+	}
+	const want = `<svg><g>x<g>x<g>x<g></g></g></g></g></svg>`
+	if got := out.String(); got != want {
+		t.Fatalf("output: want %q, got %q", want, got)
+	}
+}
+
 func TestEscapeMap(t *testing.T) {
 	data := map[string]string{
 		"html":     `<h1>Hi!</h1>`,

--- a/src/html/template/html.go
+++ b/src/html/template/html.go
@@ -7,6 +7,7 @@ package template
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"strings"
 	"unicode/utf8"
 )
@@ -218,7 +219,15 @@ func stripTags(html string) string {
 			// Consume any quote.
 			i1++
 		}
-		c, i = context{state: stateTag, element: c.element}, i1
+		c, i = context{
+			state:           stateTag,
+			element:         c.element,
+			htmlNamespaces:  slices.Clone(c.htmlNamespaces),
+			scriptInForeign: c.scriptInForeign,
+			scriptCDATA:     c.scriptCDATA,
+			tagInForeign:    c.tagInForeign,
+			tagName:         c.tagName,
+		}, i1
 	}
 	if allText {
 		return html

--- a/src/html/template/transition.go
+++ b/src/html/template/transition.go
@@ -6,6 +6,8 @@ package template
 
 import (
 	"bytes"
+	"html"
+	"slices"
 	"strings"
 )
 
@@ -48,6 +50,215 @@ var transitionFunc = [...]func(context, []byte) (context, int){
 
 var commentStart = []byte("<!--")
 var commentEnd = []byte("-->")
+var cdataStart = []byte("<![CDATA[")
+var cdataEnd = []byte("]]>")
+
+func contextWithHTMLState(c context, state state) context {
+	namespaces := slices.Clone(c.htmlNamespaces)
+	if len(namespaces) == 0 {
+		namespaces = nil
+	}
+	return context{
+		state:          state,
+		htmlNamespaces: namespaces,
+	}
+}
+
+func isForeignBreakoutTag(tag string) bool {
+	switch tag {
+	case "b", "big", "blockquote", "body", "br", "center", "code", "dd", "div", "dl", "dt", "em", "embed", "h1", "h2", "h3", "h4", "h5", "h6", "head", "hr", "i", "img", "li", "listing", "menu", "meta", "nobr", "ol", "p", "pre", "ruby", "s", "small", "span", "strong", "strike", "sub", "sup", "table", "tt", "u", "ul", "var":
+		return true
+	}
+	return false
+}
+
+func isHTMLIntegrationPoint(tag string, math bool) bool {
+	if math {
+		return isMathMLTextIntegrationPoint(tag)
+	}
+	switch tag {
+	case "desc", "foreignobject", "title":
+		return true
+	}
+	return false
+}
+
+func isMathMLTextIntegrationPoint(tag string) bool {
+	switch tag {
+	case "mi", "mo", "mn", "ms", "mtext":
+		return true
+	}
+	return false
+}
+
+// annotationXMLIsHTMLIntegration reports whether static attributes make an
+// annotation-xml element an HTML integration point. A dynamically split tag
+// stays foreign, which preserves the stricter escaping for this bug class.
+func annotationXMLIsHTMLIntegration(s []byte) bool {
+	for i := 0; ; {
+		i = eatWhiteSpace(s, i)
+		if i == len(s) {
+			return false
+		}
+		if s[i] == '>' || s[i] == '/' && i+1 < len(s) && s[i+1] == '>' {
+			return false
+		}
+		j, err := eatAttrName(s, i)
+		if err != nil || j == i {
+			return false
+		}
+		name := strings.ToLower(string(s[i:j]))
+		i = eatWhiteSpace(s, j)
+		if i == len(s) {
+			return false
+		}
+		if s[i] != '=' {
+			continue
+		}
+		i = eatWhiteSpace(s, i+1)
+		if i == len(s) {
+			return false
+		}
+		var value string
+		if s[i] == '\'' || s[i] == '"' {
+			quote := s[i]
+			i++
+			j = bytes.IndexByte(s[i:], quote)
+			if j == -1 {
+				return false
+			}
+			value = string(s[i : i+j])
+			i += j + 1
+		} else {
+			j = bytes.IndexAny(s[i:], " \t\n\f\r>")
+			if j == -1 {
+				return false
+			}
+			value = string(s[i : i+j])
+			i += j
+		}
+		if name == "encoding" {
+			value = html.UnescapeString(value)
+			return strings.EqualFold(value, "text/html") ||
+				strings.EqualFold(value, "application/xhtml+xml")
+		}
+	}
+}
+
+// A font start tag only breaks out of foreign content when one of these three
+// attributes is present. Dynamically split attributes stay foreign.
+func foreignFontBreaksOut(s []byte) bool {
+	for i := 0; ; {
+		i = eatWhiteSpace(s, i)
+		if i == len(s) || s[i] == '>' || s[i] == '/' && i+1 < len(s) && s[i+1] == '>' {
+			return false
+		}
+		j, err := eatAttrName(s, i)
+		if err != nil || j == i {
+			return false
+		}
+		switch strings.ToLower(string(s[i:j])) {
+		case "color", "face", "size":
+			return true
+		}
+		i = eatWhiteSpace(s, j)
+		if i == len(s) {
+			return false
+		}
+		if s[i] != '=' {
+			continue
+		}
+		i = eatWhiteSpace(s, i+1)
+		if i == len(s) {
+			return false
+		}
+		if s[i] == '\'' || s[i] == '"' {
+			quote := s[i]
+			i++
+			j = bytes.IndexByte(s[i:], quote)
+			if j == -1 {
+				return false
+			}
+			i += j + 1
+		} else {
+			j = bytes.IndexAny(s[i:], " \t\n\f\r>")
+			if j == -1 {
+				return false
+			}
+			i += j
+		}
+	}
+}
+
+func hasHTMLNamespaceTag(c context, tag string) bool {
+	for _, frame := range c.htmlNamespaces {
+		if frame.tag == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// updateHTMLNamespaces maintains the subset of the HTML open-elements stack
+// that can change whether subsequent content is parsed as HTML or foreign.
+func updateHTMLNamespaces(c context, tag string, end, forceIntegration, forceBreakout, forceForeign, foreignMath bool) context {
+	c.htmlNamespaces = slices.Clone(c.htmlNamespaces)
+	if end {
+		for i := len(c.htmlNamespaces) - 1; i >= 0; i-- {
+			if c.htmlNamespaces[i].tag == tag {
+				c.htmlNamespaces = c.htmlNamespaces[:i]
+				break
+			}
+		}
+		if len(c.htmlNamespaces) == 0 {
+			c.htmlNamespaces = nil
+		}
+		return c
+	}
+
+	for c.inForeignContent() && (forceBreakout || isForeignBreakoutTag(tag)) {
+		c.htmlNamespaces = c.htmlNamespaces[:len(c.htmlNamespaces)-1]
+		if len(c.htmlNamespaces) == 0 {
+			c.htmlNamespaces = nil
+		}
+	}
+	if forceForeign {
+		c.htmlNamespaces = append(c.htmlNamespaces, htmlNamespaceFrame{
+			tag:     tag,
+			foreign: true,
+			math:    foreignMath,
+		})
+		return c
+	}
+	if c.inForeignContent() {
+		frame := c.htmlNamespaces[len(c.htmlNamespaces)-1]
+		if forceIntegration || isHTMLIntegrationPoint(tag, frame.math) {
+			c.htmlNamespaces = append(c.htmlNamespaces, htmlNamespaceFrame{
+				tag:         tag,
+				math:        frame.math,
+				integration: true,
+			})
+		} else if (tag == "annotation-xml" && frame.math) || hasHTMLNamespaceTag(c, tag) {
+			c.htmlNamespaces = append(c.htmlNamespaces, htmlNamespaceFrame{
+				tag:     tag,
+				foreign: true,
+				math:    frame.math,
+			})
+		}
+		return c
+	}
+	if tag == "svg" || tag == "math" {
+		c.htmlNamespaces = append(c.htmlNamespaces, htmlNamespaceFrame{
+			tag:     tag,
+			foreign: true,
+			math:    tag == "math",
+		})
+	} else if hasHTMLNamespaceTag(c, tag) {
+		math := len(c.htmlNamespaces) != 0 && c.htmlNamespaces[len(c.htmlNamespaces)-1].math
+		c.htmlNamespaces = append(c.htmlNamespaces, htmlNamespaceFrame{tag: tag, math: math})
+	}
+	return c
+}
 
 // tText is the context transition function for the text state.
 func tText(c context, s []byte) (context, int) {
@@ -57,7 +268,7 @@ func tText(c context, s []byte) (context, int) {
 		if i < k || i+1 == len(s) {
 			return c, len(s)
 		} else if i+4 <= len(s) && bytes.Equal(commentStart, s[i:i+4]) {
-			return context{state: stateHTMLCmt}, i + 4
+			return contextWithHTMLState(c, stateHTMLCmt), i + 4
 		}
 		i++
 		end := false
@@ -69,11 +280,37 @@ func tText(c context, s []byte) (context, int) {
 		}
 		j, e := eatTagName(s, i)
 		if j != i {
+			tag := strings.ToLower(string(s[i:j]))
+			wasForeign := c.inForeignContent()
+			var top htmlNamespaceFrame
+			if len(c.htmlNamespaces) != 0 {
+				top = c.htmlNamespaces[len(c.htmlNamespaces)-1]
+			}
+			fontBreakout := !end && wasForeign && tag == "font" && foreignFontBreaksOut(s[j:])
+			annotationSVG := !end && top.math && (top.foreign || top.integration) && top.tag == "annotation-xml" && tag == "svg"
+			mathMLException := !end && top.integration && top.math && isMathMLTextIntegrationPoint(top.tag) &&
+				(tag == "mglyph" || tag == "malignmark")
+			forceForeign := annotationSVG || mathMLException
+			tagInForeign := forceForeign || (wasForeign && !fontBreakout && !isForeignBreakoutTag(tag)) ||
+				!wasForeign && (tag == "svg" || tag == "math")
+			annotationIntegration := !end && wasForeign && tag == "annotation-xml" &&
+				c.htmlNamespaces[len(c.htmlNamespaces)-1].math && annotationXMLIsHTMLIntegration(s[j:])
+			c = updateHTMLNamespaces(c, tag, end, annotationIntegration, fontBreakout, forceForeign, mathMLException)
 			if end {
 				e = elementNone
 			}
 			// We've found an HTML tag.
-			return context{state: stateTag, element: e}, j
+			c.state = stateTag
+			c.element = e
+			c.tagInForeign = !end && tagInForeign
+			if c.tagInForeign {
+				c.tagName = tag
+			} else {
+				c.tagName = ""
+			}
+			c.scriptInForeign = !end && e == elementScript && c.tagInForeign
+			c.scriptCDATA = false
+			return c, j
 		}
 		k = j
 	}
@@ -99,12 +336,20 @@ func tTag(c context, s []byte) (context, int) {
 		// Treat <meta> specially, because it doesn't have an end tag, and we
 		// want to transition into the correct state/element for it.
 		if c.element == elementMeta {
-			return context{state: stateText, element: elementNone}, i + 1
+			return contextWithHTMLState(c, stateText), i + 1
 		}
 		return context{
-			state:   elementContentType[c.element],
-			element: c.element,
+			state:           elementContentType[c.element],
+			element:         c.element,
+			htmlNamespaces:  slices.Clone(c.htmlNamespaces),
+			scriptInForeign: c.scriptInForeign,
 		}, i + 1
+	}
+	if c.tagInForeign && s[i] == '/' && i+1 < len(s) && s[i+1] == '>' {
+		if n := len(c.htmlNamespaces); n != 0 && c.htmlNamespaces[n-1].tag == c.tagName {
+			c.htmlNamespaces = slices.Clone(c.htmlNamespaces[:n-1])
+		}
+		return contextWithHTMLState(c, stateText), i + 2
 	}
 	j, err := eatAttrName(s, i)
 	if err != nil {
@@ -141,7 +386,15 @@ func tTag(c context, s []byte) (context, int) {
 	} else {
 		state = stateAfterName
 	}
-	return context{state: state, element: c.element, attr: attr}, j
+	return context{
+		state:           state,
+		element:         c.element,
+		attr:            attr,
+		htmlNamespaces:  slices.Clone(c.htmlNamespaces),
+		scriptInForeign: c.scriptInForeign,
+		tagInForeign:    c.tagInForeign,
+		tagName:         c.tagName,
+	}, j
 }
 
 // tAttrName is the context transition function for stateAttrName.
@@ -202,7 +455,7 @@ func tBeforeValue(c context, s []byte) (context, int) {
 // tHTMLCmt is the context transition function for stateHTMLCmt.
 func tHTMLCmt(c context, s []byte) (context, int) {
 	if i := bytes.Index(s, commentEnd); i != -1 {
-		return context{}, i + 3
+		return contextWithHTMLState(c, stateText), i + 3
 	}
 	return c, len(s)
 }
@@ -232,7 +485,8 @@ func tSpecialTagEnd(c context, s []byte) (context, int) {
 			return c, len(s)
 		}
 		if i := indexTagEnd(s, specialTagEndMarkers[c.element]); i != -1 {
-			return context{}, i
+			d := contextWithHTMLState(c, stateText)
+			return updateHTMLNamespaces(d, string(specialTagEndMarkers[c.element]), true, false, false, false, false), i
 		}
 	}
 	return c, len(s)


### PR DESCRIPTION
HTML tokenizers recognize CDATA sections when the current node is SVG or
MathML. An apparent closing script tag inside such a section is text, but
html/template currently ends its script context there. A later action is
therefore HTML-escaped instead of JavaScript-escaped. In a template literal,
attacker-controlled interpolation can execute.

This change tracks the foreign namespace transitions that affect CDATA,
including HTML integration points and breakout tags, and preserves the
JavaScript context until the CDATA section ends. Dynamically ambiguous
attributes retain the stricter JavaScript-escaping direction.

The issue reproducer was confirmed on current master. With an inert local
payload that assigned 1337 to a sentinel, headless Chrome changed the sentinel
from 0 to 1337. The patched rendering escaped the interpolation syntax and the
sentinel remained 0.

Validation included the complete short standard-library suite, ten
race-enabled html/template runs, 100 ordinary html/template runs, and go vet.

Fixes #62617.
