### PR TITLE
cmd/compile: avoid range clear when target depends on index

### DIFF
--- a/src/cmd/compile/internal/walk/range.go
+++ b/src/cmd/compile/internal/walk/range.go
@@ -482,6 +482,44 @@ func mapClear(m, rtyp ir.Node) ir.Node {
 	return typecheck.Stmt(n)
 }
 
+// arrayRangeClearTargetSafe reports whether evaluating n once before the loop
+// produces the same clear target as evaluating it on every loop iteration.
+func arrayRangeClearTargetSafe(n ir.Node) bool {
+	if !n.Type().IsArray() {
+		return !ir.Any(n, readsMemory)
+	}
+
+	return arrayRangeClearAddressSafe(n)
+}
+
+// arrayRangeClearAddressSafe reports whether n's address is stable. Pointer
+// and slice values used to compute the address must not be reloadable from
+// memory that an earlier loop iteration could overwrite.
+func arrayRangeClearAddressSafe(n ir.Node) bool {
+	switch n.Op() {
+	case ir.ONAME:
+		return true
+	case ir.ODOT:
+		return arrayRangeClearAddressSafe(n.(*ir.SelectorExpr).X)
+	case ir.ODOTPTR:
+		return !ir.Any(n.(*ir.SelectorExpr).X, readsMemory)
+	case ir.ODEREF:
+		return !ir.Any(n.(*ir.StarExpr).X, readsMemory)
+	case ir.OINDEX:
+		n := n.(*ir.IndexExpr)
+		var baseSafe bool
+		if n.X.Type().IsArray() {
+			baseSafe = arrayRangeClearAddressSafe(n.X)
+		} else {
+			baseSafe = !ir.Any(n.X, readsMemory)
+		}
+		return baseSafe && !ir.Any(n.Index, readsMemory)
+	case ir.OCONVNOP:
+		return arrayRangeClearAddressSafe(n.(*ir.ConvExpr).X)
+	}
+	return false
+}
+
 // Lower n into runtime·memclr if possible, for
 // fast zeroing of slices and arrays (issue 5373).
 // Look for instances of
@@ -511,11 +549,28 @@ func arrayRangeClear(loop *ir.RangeStmt, v1, v2, a ir.Node) ir.Node {
 		return nil
 	}
 	stmt := stmt1.(*ir.AssignStmt)
+	if !ir.IsZero(stmt.Y) {
+		return nil
+	}
 	if stmt.X.Op() != ir.OINDEX {
 		return nil
 	}
 	lhs := stmt.X.(*ir.IndexExpr)
 	x := lhs.X
+	if !ir.SameSafeExpr(lhs.Index, v1) {
+		return nil
+	}
+	// arrayClear evaluates x only once. Reject side effects and target selectors
+	// that could be modified by one of the loop assignments.
+	if !ir.SameSafeExpr(x, x) || !arrayRangeClearTargetSafe(x) {
+		return nil
+	}
+	// The range loop assigns a new value to v1 before each iteration, so the
+	// clear target must not use v1 directly or indirectly (issue 80519).
+	name, ok := v1.(*ir.Name)
+	if !ok || !name.OnStack() || name.Addrtaken() || ir.Any(x, func(n ir.Node) bool { return ir.Uses(n, name) }) {
+		return nil
+	}
 
 	// Get constant number of iterations for int and array cases.
 	n := int64(-1)
@@ -540,14 +595,6 @@ func arrayRangeClear(loop *ir.RangeStmt, v1, v2, a ir.Node) ir.Node {
 		if !ir.SameSafeExpr(x, a) {
 			return nil
 		}
-	}
-
-	if !ir.SameSafeExpr(lhs.Index, v1) {
-		return nil
-	}
-
-	if !ir.IsZero(stmt.Y) {
-		return nil
 	}
 
 	return arrayClear(stmt.Pos(), x, loop)

--- a/test/codegen/issue52635.go
+++ b/test/codegen/issue52635.go
@@ -4,8 +4,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Test that optimized range memclr works with pointers to arrays.
-// The clears get inlined, see https://github.com/golang/go/issues/56997
+// Test that optimized range memclr works when the clear target has a stable
+// address. Pointer and slice fields must remain ordinary loops because their
+// values can change through storage cleared by an earlier iteration.
 
 package codegen
 
@@ -18,25 +19,25 @@ type T struct {
 func (t *T) f() {
 	for i := range t.a {
 		// amd64:-".*runtime.memclrNoHeapPointers"
-		// amd64:`MOVUPS X15,`
+		// amd64:-`MOVUPS X15,`
 		t.a[i] = 0
 	}
 
 	for i := range *t.a {
 		// amd64:-".*runtime.memclrNoHeapPointers"
-		// amd64:`MOVUPS X15,`
+		// amd64:-`MOVUPS X15,`
 		t.a[i] = 0
 	}
 
 	for i := range t.a {
 		// amd64:-".*runtime.memclrNoHeapPointers"
-		// amd64:`MOVUPS X15,`
+		// amd64:-`MOVUPS X15,`
 		(*t.a)[i] = 0
 	}
 
 	for i := range *t.a {
 		// amd64:-".*runtime.memclrNoHeapPointers"
-		// amd64:`MOVUPS X15,`
+		// amd64:-`MOVUPS X15,`
 		(*t.a)[i] = 0
 	}
 
@@ -46,7 +47,7 @@ func (t *T) f() {
 		t.b[i] = 0
 	}
 
-	// amd64:".*runtime.memclrNoHeapPointers"
+	// amd64:-".*runtime.memclrNoHeapPointers"
 	for i := range t.s {
 		t.s[i] = 0
 	}

--- a/test/fixedbugs/issue80519.go
+++ b/test/fixedbugs/issue80519.go
@@ -1,0 +1,136 @@
+// run
+
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"runtime"
+	"unsafe"
+)
+
+var aliased = [3][3]int{{9, 9, 9}, {1, 9, 9}, {9, 9, 9}}
+var unsafeAliased [3]unsafe.Pointer
+
+type unsafeFieldTarget struct {
+	array *[4]uintptr
+	pad   [3]uintptr
+}
+
+//go:noinline
+func clearAliased() {
+	keyp := &aliased[1][0]
+	for i := range 3 {
+		aliased[*keyp][i] = 0
+	}
+}
+
+//go:noinline
+func clearUnsafeAliased() {
+	target := (*[3]unsafe.Pointer)(unsafe.Pointer(&unsafeAliased[0]))
+	unsafeAliased[0] = unsafe.Pointer(target)
+	targetp := (**[3]unsafe.Pointer)(unsafe.Pointer(&unsafeAliased[0]))
+	for i := range 3 {
+		(**targetp)[i] = nil
+	}
+}
+
+//go:noinline
+func clearUnsafeField(t *unsafeFieldTarget) {
+	for i := range t.array {
+		t.array[i] = 0
+	}
+}
+
+//go:noinline
+func clearUnsafeSlice() {
+	var values []uintptr
+	values = unsafe.Slice((*uintptr)(unsafe.Pointer(&values)), 3)
+	for i := range values {
+		values[i] = 0
+	}
+}
+
+func main() {
+	want := [3][2]int{{0, 2}, {3, 0}, {5, 6}}
+
+	rows := [3][2]int{{1, 2}, {3, 4}, {5, 6}}
+	key := 2
+	for key = range 2 {
+		rows[key][key] = 0
+	}
+	if rows != want || key != 1 {
+		panic("range clear with assigned index variable")
+	}
+
+	rows = [3][2]int{{1, 2}, {3, 4}, {5, 6}}
+	for key := range 2 {
+		rows[key][key] = 0
+	}
+	if rows != want {
+		panic("range clear with declared index variable")
+	}
+
+	slices := [3][]int{{1, 2}, {3, 4}, {5, 6}}
+	key = 0
+	for key = range slices[key] {
+		slices[key][key] = 0
+	}
+	if slices[0][0] != 0 || slices[0][1] != 2 || slices[1][0] != 3 || slices[1][1] != 0 || key != 1 {
+		panic("range clear with index-dependent slice")
+	}
+
+	rows = [3][2]int{{1, 2}, {3, 4}, {5, 6}}
+	key = 0
+	keyp := &key
+	for key = range 2 {
+		rows[*keyp][key] = 0
+	}
+	if rows != want || key != 1 {
+		panic("range clear with indirect index dependency")
+	}
+
+	clearAliased()
+	if aliased != [3][3]int{{9, 0, 0}, {0, 9, 9}, {9, 9, 9}} {
+		panic("range clear target changed through cleared memory")
+	}
+
+	panicked := false
+	func() {
+		defer func() {
+			panicked = recover() != nil
+		}()
+		clearUnsafeAliased()
+	}()
+	if !panicked {
+		panic("range clear target changed through unsafe pointer")
+	}
+
+	fieldTarget := unsafeFieldTarget{}
+	fieldTarget.array = (*[4]uintptr)(unsafe.Pointer(&fieldTarget))
+	panicked = false
+	func() {
+		defer func() {
+			panicked = recover() != nil
+		}()
+		clearUnsafeField(&fieldTarget)
+	}()
+	if !panicked {
+		panic("range clear target changed through unsafe pointer field")
+	}
+
+	if runtime.GOARCH != "wasm" {
+		panicked = false
+		func() {
+			defer func() {
+				panicked = recover() != nil
+			}()
+			clearUnsafeSlice()
+		}()
+		if !panicked {
+			panic("range clear target changed through unsafe slice header")
+		}
+	}
+}


### PR DESCRIPTION
The range-clear optimization replaces a loop with one clear of the object
selected before assigning the final range index. If the clear target depends
on that index or on memory it overwrites, later iterations can select a
different object.

This change requires the range index to be stack-local, not address-taken,
and absent from the clear target. It also distinguishes stable inline-array
addresses from pointer or slice values that the original loop could reload
from mutable memory.

The regression covers direct, indirect, slice, and self-aliasing dependencies.
It includes unsafe double-dereference, pointer-field, and address-taken slice
header cases that failed with the previously optimized compiler but passed
with optimizations disabled.

The focused testdir regression, its checkptr=2 variant, go vet, and the full
short cmd/compile/... suite pass. The updated linux/amd64 assembly test verifies
that pointer and slice fields remain ordinary loops while a stable inline array
still uses the optimized clear.

Fixes #80519.