### PR TITLE
cmd/compile: truncate uint64 indices for imm8 jump tables

### DIFF
--- a/src/cmd/compile/internal/ssagen/intrinsics.go
+++ b/src/cmd/compile/internal/ssagen/intrinsics.go
@@ -1976,6 +1976,14 @@ func opLen4_31(op ssa.Op, t *types.Type) func(s *state, n *ir.CallExpr, args []*
 }
 
 func immJumpTable(s *state, idx *ssa.Value, intrinsicCall *ir.CallExpr, genOp func(*state, int)) *ssa.Value {
+	if !idx.Type.IsKind(types.TUINT8) && !idx.Type.IsKind(types.TUINT64) {
+		panic("immJumpTable expects uint8 or uint64 value")
+	}
+	if idx.Type.IsKind(types.TUINT64) {
+		// Match the constant path and keep the jump table index in range.
+		idx = s.conv(nil, idx, idx.Type, types.Types[types.TUINT8])
+	}
+
 	if base.Ctxt.Retpoline {
 		// Note spectre=all implies retpoline which requires binary search instead of table switch.
 		return branchTableImm8(s, idx, intrinsicCall, genOp)
@@ -1983,10 +1991,6 @@ func immJumpTable(s *state, idx *ssa.Value, intrinsicCall *ir.CallExpr, genOp fu
 
 	// Make blocks we'll need.
 	bEnd := s.f.NewBlock(block.BlockPlain)
-
-	if !idx.Type.IsKind(types.TUINT8) && !idx.Type.IsKind(types.TUINT64) {
-		panic("immJumpTable expects uint8 or uint64 value")
-	}
 
 	// We will exhaust 0-255, so no need to check the bounds.
 	t := types.Types[types.TUINTPTR]

--- a/src/simd/archsimd/internal/simd_test/shift_amd64_test.go
+++ b/src/simd/archsimd/internal/simd_test/shift_amd64_test.go
@@ -127,6 +127,13 @@ func TestShiftAllConcat(t *testing.T) {
 		func(x, y archsimd.Int32x4) archsimd.Int32x4 { return x.ShiftAllRightConcatMod32(y, hide(128)) },
 		map2(sarc(hide(128))))
 
+	testInt32x4Binary(t,
+		func(x, y archsimd.Int32x4) archsimd.Int32x4 { return x.ShiftAllRightConcatMod32(y, 256) },
+		map2(sarc(256)))
+	testInt32x4Binary(t,
+		func(x, y archsimd.Int32x4) archsimd.Int32x4 { return x.ShiftAllRightConcatMod32(y, hide(256)) },
+		map2(sarc(hide(256))))
+
 	// Unsigned ShiftAllRightConcat
 	usarc := func(shift uint64) func(x, y uint32) uint32 {
 		return func(x, y uint32) uint32 {


### PR DESCRIPTION
Variable uint64 arguments lowered through immJumpTable were converted
directly to uintptr. Since the generated table has 256 entries, values
above 255 could dispatch outside the table and corrupt control flow. With
-spectre=ret, the binary-search fallback instead selected case 255,
differing from constant lowering.

Convert uint64 indices to uint8 before either dispatch path, matching
imm8 constant encoding. Extend the ShiftAllRightConcatMod32 tests through
the first out-of-range value.

Tests:

- GOEXPERIMENT=simd ./bin/go test simd/...
- GOEXPERIMENT=simd ./bin/go test -short cmd/compile/...
- GOEXPERIMENT=simd ./bin/go vet cmd/compile/internal/ssagen simd/...
- linux/amd64 PoC, ordinary and -spectre=ret dispatch

Fixes #80522.