### PR TITLE
debug/elf: report size in FormatError for invalid shnum

### DIFF
--- a/src/debug/elf/file.go
+++ b/src/debug/elf/file.go
@@ -441,7 +441,7 @@ func NewFile(r io.ReaderAt) (*File, error) {
 
 		if shnum == 0 {
 			if size < uint64(SHN_LORESERVE) {
-				return nil, &FormatError{shoff, "invalid ELF shnum contained in sh_size", shnum}
+				return nil, &FormatError{shoff, "invalid ELF shnum contained in sh_size", size}
 			}
 			shnum = int(size)
 		}


### PR DESCRIPTION
When e_shnum is 0, the real section count is in sh_size. The FormatError for an invalid value was reporting shnum (always 0) instead of size.
