### PR TITLE
compress/flate: do not emit the preset dictionary into the output

### DIFF
--- a/src/compress/flate/deflate.go
+++ b/src/compress/flate/deflate.go
@@ -250,6 +250,7 @@ func (d *compressor) fillWindow(b []byte) {
 	// Update window information.
 	d.windowEnd += n
 	s.index = n
+	d.blockStart = d.windowEnd
 }
 
 // findMatch finds the longest match starting at pos in the hash chain starting

--- a/src/compress/flate/deflate_test.go
+++ b/src/compress/flate/deflate_test.go
@@ -494,6 +494,40 @@ func TestWriterDict(t *testing.T) {
 	}
 }
 
+// TestWriterDictIncompressible checks that the preset dictionary is never
+// emitted into the output. Incompressible input makes the raw-window stored
+// fallback in writeBlock win over the tokens; that window used to start at
+// blockStart == 0 and leak the dictionary into the first block.
+// See https://go.dev/issue/80538
+func TestWriterDictIncompressible(t *testing.T) {
+	data := make([]byte, 763)
+	rand.New(rand.NewSource(42)).Read(data)
+	dict := []byte("0123456789abcdefghij")
+	for l := range BestCompression + 1 {
+		t.Run(fmt.Sprintf("level=%d", l), func(t *testing.T) {
+			var b bytes.Buffer
+			w, err := NewWriterDict(&b, l, dict)
+			if err != nil {
+				t.Fatalf("NewWriterDict: %v", err)
+			}
+			if _, err := w.Write(data); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+			got, err := io.ReadAll(NewReaderDict(&b, dict))
+			if err != nil {
+				t.Fatalf("NewReaderDict: %v", err)
+			}
+			if !bytes.Equal(got, data) {
+				t.Errorf("round trip mismatch: got %d bytes, want %d (dictionary emitted: %v)",
+					len(got), len(data), bytes.HasPrefix(got, dict))
+			}
+		})
+	}
+}
+
 // See https://golang.org/issue/2508
 func TestRegression2508(t *testing.T) {
 	if testing.Short() {

--- a/src/compress/flate/deflate_test.go
+++ b/src/compress/flate/deflate_test.go
@@ -494,12 +494,9 @@ func TestWriterDict(t *testing.T) {
 	}
 }
 
-// TestWriterDictIncompressible checks that the preset dictionary is never
-// emitted into the output. Incompressible input makes the raw-window stored
-// fallback in writeBlock win over the tokens; that window used to start at
-// blockStart == 0 and leak the dictionary into the first block.
-// See https://go.dev/issue/80538
-func TestWriterDictIncompressible(t *testing.T) {
+// TestNonCompressedBlockDoesntLeakDict checks that the dictionary isn't sent when
+// sending a non-compressed block. See https://go.dev/issue/80538
+func TestNonCompressedBlockDoesntLeakDict(t *testing.T) {
 	data := make([]byte, 763)
 	rand.New(rand.NewSource(42)).Read(data)
 	dict := []byte("0123456789abcdefghij")
@@ -523,6 +520,9 @@ func TestWriterDictIncompressible(t *testing.T) {
 			if !bytes.Equal(got, data) {
 				t.Errorf("round trip mismatch: got %d bytes, want %d (dictionary emitted: %v)",
 					len(got), len(data), bytes.HasPrefix(got, dict))
+			}
+			if b.Len() != 0 {
+				t.Errorf("compressed stream not fully consumed: %d bytes left", b.Len())
 			}
 		})
 	}


### PR DESCRIPTION
When using a dictionary, fillWindow was not setting blockStart, which
caused a non-compressed block in first position to write the dictionary.
This mixup can happen because window stores both the look back window
and the block we are about to write. Set blockStart to skip over the
dictionary if we have to write the window.

Fixes #80538
