### PR TITLE
runtime: remove stackcheck from openbsd/riscv64

### DIFF
--- a/src/runtime/sys_openbsd_riscv64.s
+++ b/src/runtime/sys_openbsd_riscv64.s
@@ -50,7 +50,6 @@ TEXT runtime·mstart_stub(SB),NOSPLIT,$200
 	MOV	m_g0(X10), g
 	CALL	runtime·save_g(SB)
 
-	CALL	runtime·stackcheck(SB)	// fault if stack check is wrong
 	CALL	runtime·mstart(SB)
 
 	// Restore callee-save registers.


### PR DESCRIPTION
CL 541735 added runtime·stackcheck to mstart_stub on openbsd/riscv64,
but on OpenBSD (and any other platform backed by OS-allocated stacks)
mp.g0.stack.hi and mp.g0.stack.lo are both zero at that point. As a
result the port is currently broken.

No other OpenBSD architecture currently calls stackcheck.