### PR TITLE
cmd/compile/internal/ssa: elide redundant 32-bit zero extensions on arm64

### DIFF
--- a/src/cmd/compile/internal/ssa/rewrite.go
+++ b/src/cmd/compile/internal/ssa/rewrite.go
@@ -1395,6 +1395,10 @@ func ZeroUpper32Bits(x *Value, depth int) bool {
 		OpARM64MULW, OpARM64MNEGW, OpARM64UDIVW, OpARM64DIVW, OpARM64UMODW,
 		OpARM64MADDW, OpARM64MSUBW, OpARM64RORW, OpARM64RORWconst:
 		return true
+	case OpARM64MOVWUreg, OpARM64MOVWUload, OpARM64MOVWUloadidx, OpARM64MOVWUloadidx4,
+		OpARM64MOVHUreg, OpARM64MOVHUload, OpARM64MOVHUloadidx, OpARM64MOVHUloadidx2,
+		OpARM64MOVBUreg, OpARM64MOVBUload, OpARM64MOVBUloadidx:
+		return true
 	case OpArg: // note: but not ArgIntReg
 		// amd64 always loads args from the stack unsigned.
 		// most other architectures load them sign/zero extended based on the type.


### PR DESCRIPTION
ZeroUpper32Bits knows about arm64's W-form ALU results, but not about its
zero-extending loads and register moves. The late lower rule
(MOVWUreg x) && ZeroUpper32Bits(x, 3) => x therefore never fires for a
value that came from MOVWUload/MOVHUload/MOVBUload or from a narrower
MOV*Ureg.

With a single use the extension still folds away, via
(MOVWUreg x:(MOVWUload _ _)) => (MOVDreg x) and
(MOVDreg x) && x.Uses == 1 => (MOVDnop x). With a second consumer -- a
loaded uint32 field used both as a slice index and in a bounds compare,
the regexp onepass shape -- the MOVDreg survives as a real MOVD Rx,Ry
register copy.

Add the arm64 zero-extending loads and register moves to
ZeroUpper32Bits, mirroring the byte and halfword op lists that CL 804064
adds to ZeroUpper56Bits and ZeroUpper48Bits. The two changes are
independent; this one applies on its own.

Measured at 7b4aab82eb with go build -a -gcflags=-S std at
GOARCH=arm64: 117 fewer register copies (runtime -36, regexp -26,
internal/zstd -11, internal/coverage/cformat -8) for -592 bytes of
function text across 26 packages, with a single-copy regression in
errors.

Updates #43357
