### PR TITLE
cmd/compile: break the false dependency of scalar SSE merges on amd64

### DIFF
--- a/src/cmd/compile/internal/amd64/ssa.go
+++ b/src/cmd/compile/internal/amd64/ssa.go
@@ -983,13 +983,24 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 		ssagen.AddAux2(&p.To, v, sc.Off64())
 	case ssa.OpAMD64MOVLQSX, ssa.OpAMD64MOVWQSX, ssa.OpAMD64MOVBQSX, ssa.OpAMD64MOVLQZX, ssa.OpAMD64MOVWQZX, ssa.OpAMD64MOVBQZX,
 		ssa.OpAMD64CVTTSS2SL, ssa.OpAMD64CVTTSD2SL, ssa.OpAMD64CVTTSS2SQ, ssa.OpAMD64CVTTSD2SQ,
-		ssa.OpAMD64CVTSS2SD, ssa.OpAMD64CVTSD2SS, ssa.OpAMD64VPBROADCASTB, ssa.OpAMD64PMOVMSKB:
+		ssa.OpAMD64VPBROADCASTB, ssa.OpAMD64PMOVMSKB:
 		opregreg(s, v.Op.Asm(), v.Reg(), v.Args[0].Reg())
-	case ssa.OpAMD64CVTSL2SD, ssa.OpAMD64CVTSQ2SD, ssa.OpAMD64CVTSQ2SS, ssa.OpAMD64CVTSL2SS:
+	case ssa.OpAMD64CVTSL2SD, ssa.OpAMD64CVTSQ2SD, ssa.OpAMD64CVTSQ2SS, ssa.OpAMD64CVTSL2SS,
+		ssa.OpAMD64CVTSS2SD, ssa.OpAMD64CVTSD2SS, ssa.OpAMD64SQRTSD, ssa.OpAMD64SQRTSS:
 		r := v.Reg()
-		// Break false dependency on destination register.
-		opregreg(s, x86.AXORPS, r, r)
-		opregreg(s, v.Op.Asm(), r, v.Args[0].Reg())
+		x := v.Args[0].Reg()
+		if r != x {
+			// These instructions write only the low element of the destination
+			// and leave the rest of the register alone, so the destination is an
+			// input to that merge. We never want those upper bits, which makes
+			// the dependency false: it serializes the instruction behind whatever
+			// wrote the register last. Break it with a zero idiom, as the
+			// POPCNT family below does.
+			// A source in an integer register can never equal the destination,
+			// so the conversions from integers always break the dependency.
+			opregreg(s, x86.AXORPS, r, r)
+		}
+		opregreg(s, v.Op.Asm(), r, x)
 	case ssa.OpAMD64MOVQi2f, ssa.OpAMD64MOVQf2i, ssa.OpAMD64MOVLi2f, ssa.OpAMD64MOVLf2i:
 		var p *obj.Prog
 		switch v.Op {
@@ -1491,7 +1502,10 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 		p.To.Type = obj.TYPE_REG
 		p.To.Reg = v.Reg0()
 
-	case ssa.OpAMD64BSFQ, ssa.OpAMD64BSRQ, ssa.OpAMD64BSFL, ssa.OpAMD64BSRL, ssa.OpAMD64SQRTSD, ssa.OpAMD64SQRTSS:
+	case ssa.OpAMD64BSFQ, ssa.OpAMD64BSRQ, ssa.OpAMD64BSFL, ssa.OpAMD64BSRL:
+		// Note that BSF/BSR leave the destination alone when the source is
+		// zero, so unlike the scalar SSE merges above their dependency on it
+		// is real and must not be broken.
 		p := s.Prog(v.Op.Asm())
 		p.From.Type = obj.TYPE_REG
 		p.From.Reg = v.Args[0].Reg()
@@ -1499,12 +1513,17 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 		switch v.Op {
 		case ssa.OpAMD64BSFQ, ssa.OpAMD64BSRQ:
 			p.To.Reg = v.Reg0()
-		case ssa.OpAMD64BSFL, ssa.OpAMD64BSRL, ssa.OpAMD64SQRTSD, ssa.OpAMD64SQRTSS:
+		case ssa.OpAMD64BSFL, ssa.OpAMD64BSRL:
 			p.To.Reg = v.Reg()
 		}
 	case ssa.OpAMD64LoweredRound32F, ssa.OpAMD64LoweredRound64F:
 		// input is already rounded
 	case ssa.OpAMD64ROUNDSD, ssa.OpAMD64ROUNDSS:
+		if r := v.Reg(); r != v.Args[0].Reg() {
+			// Merges into the destination's upper bits like the conversions
+			// above; break the false dependency that creates.
+			opregreg(s, x86.AXORPS, r, r)
+		}
 		p := s.Prog(v.Op.Asm())
 		val := v.AuxInt
 		// 0 means math.RoundToEven, 1 Floor, 2 Ceil, 3 Trunc

--- a/test/codegen/floats.go
+++ b/test/codegen/floats.go
@@ -377,3 +377,44 @@ func isNegNormal(x float64) bool {
 	// riscv64:"FCLASSD"
 	return x <= -2.2250738585072014e-308
 }
+
+// ------------------------------------ //
+//    Scalar SSE false dependencies     //
+// ------------------------------------ //
+
+// These instructions write only the low element of their destination and
+// merge into the rest of it, which makes the destination a false input.
+// Zero it first, unless it is also the source.
+
+func cvtSS2SDBreaksFalseDep(x float32) (float64, float32) {
+	// amd64:"XORPS" "CVTSS2SD"
+	return float64(x), x
+}
+
+func cvtSD2SSBreaksFalseDep(x float64) (float32, float64) {
+	// amd64:"XORPS" "CVTSD2SS"
+	return float32(x), x
+}
+
+func sqrtBreaksFalseDep(x float64) (float64, float64) {
+	// amd64:"XORPS" "SQRTSD"
+	return math.Sqrt(x), x
+}
+
+func floorBreaksFalseDep(x float64) (float64, float64) {
+	// amd64:"XORPS" "ROUNDSD"
+	return math.Floor(x), x
+}
+
+// Converting in place, the destination is the source: the dependency is real
+// and zeroing would destroy the input.
+
+func cvtSS2SDInPlaceKeepsDep(x float32) float64 {
+	// amd64:"CVTSS2SD" -"XORPS"
+	return float64(x)
+}
+
+func sqrtInPlaceKeepsDep(x float64) float64 {
+	// amd64:"SQRTSD" -"XORPS"
+	return math.Sqrt(x)
+}


### PR DESCRIPTION
CVTSS2SD, CVTSD2SS, SQRTSD/SS and ROUNDSD/SS write only the low element
of their destination and leave the rest of the register alone -- the SDM
spells each of them "DEST[127:64] (unmodified)" -- which makes the
destination an input to that merge. Scalars kept in vector registers
never want those upper bits, so the dependency is false, and it
serializes the instruction behind whatever wrote the register last:

        CVTSS2SD X0, X2   // waits on X2's previous producer

Zero the destination first, exactly as the conversions from integer
registers and the POPCNT family already do:

        XORPS    X2, X2
        CVTSS2SD X0, X2

Not when the destination is also the source, where the dependency is
real and zeroing would destroy the input. The conversions from integers
take a source in a general-purpose register, so that test can never fire
for them and they keep breaking the dependency unconditionally as
before. SQRTSD and SQRTSS move out of the BSF/BSR case they shared:
those two leave their destination alone when the source is zero, so
theirs is a real dependency, the same distinction that keeps them out of
the POPCNT case.

The win shows up wherever a merge sits on a loop-carried chain, which is
what a float32 round trip through the float64 rounding intrinsics is.
Existing math benchmarks, medians of 8 interleaved runs on an AMD Ryzen
AI MAX+ 395:

        Floor32         0.465ns -> 0.202ns   -56.6%
        RoundToEven32   0.715ns -> 0.311ns   -56.5%
        Trunc32         0.471ns -> 0.215ns   -54.4%
        Abs32           0.557ns -> 0.395ns   -29.1%
        RoundToEven     0.549ns -> 0.396ns   -28.0%
        Ceil32          0.493ns -> 0.399ns   -19.1%
        Nextafter32     1.486ns -> 1.430ns    -3.8%

Across all 79 math benchmarks nothing else moves on code this changes.
Logb, Nextafter64 and Trunc do read slower, but their machine code is
byte for byte what it was and only its address moved, so that is
alignment, not this CL; Ilogb reads faster for the same reason.

cmd/go grows 153 bytes over 19 functions and no function shrinks.
x86lint's "missing SSE dependency break" findings on cmd/go fall from 49
to 3, all three in hand-written assembly this cannot reach: two of those
carry a real dependency through the integer register the conversion
reads, and the third is a fallback path.