### PR TITLE
crypto/x509: reject overflowing OID first subidentifier

### DIFF
--- a/src/crypto/x509/oid.go
+++ b/src/crypto/x509/oid.go
@@ -53,17 +53,19 @@ func newOIDFromDER(der []byte) (OID, bool) {
 
 // OIDFromInts creates a new OID using ints, each integer is a separate component.
 func OIDFromInts(oid []uint64) (OID, error) {
-	if len(oid) < 2 || oid[0] > 2 || (oid[0] < 2 && oid[1] >= 40) {
+	if len(oid) < 2 || oid[0] > 2 || (oid[0] < 2 && oid[1] >= 40) ||
+		(oid[0] == 2 && oid[1] > math.MaxUint64-80) {
 		return OID{}, errInvalidOID
 	}
 
-	length := base128IntLength(oid[0]*40 + oid[1])
+	firstSubidentifier := oid[0]*40 + oid[1]
+	length := base128IntLength(firstSubidentifier)
 	for _, v := range oid[2:] {
 		length += base128IntLength(v)
 	}
 
 	der := make([]byte, 0, length)
-	der = appendBase128Int(der, oid[0]*40+oid[1])
+	der = appendBase128Int(der, firstSubidentifier)
 	for _, v := range oid[2:] {
 		der = appendBase128Int(der, v)
 	}

--- a/src/crypto/x509/oid_test.go
+++ b/src/crypto/x509/oid_test.go
@@ -127,6 +127,18 @@ func TestInvalidOID(t *testing.T) {
 	}
 }
 
+func TestOIDFromIntsFirstSubidentifierOverflow(t *testing.T) {
+	if _, err := OIDFromInts([]uint64{2, math.MaxUint64 - 80}); err != nil {
+		t.Fatalf("OIDFromInts rejected largest representable first subidentifier: %v", err)
+	}
+
+	for _, second := range []uint64{math.MaxUint64 - 79, math.MaxUint64} {
+		if oid, err := OIDFromInts([]uint64{2, second}); err == nil {
+			t.Errorf("OIDFromInts([2 %d]) = (%v, nil); want an error", second, oid)
+		}
+	}
+}
+
 func TestOIDEqual(t *testing.T) {
 	var cases = []struct {
 		oid  OID


### PR DESCRIPTION
OIDFromInts combines the first two arcs as `oid[0]*40 + oid[1]` in a uint64. For `2.x` OIDs with a sufficiently large second arc, that addition wraps and returns a different OID without an error.

Reject values whose combined first subidentifier cannot be represented. The boundary test keeps `2.(MaxUint64-80)` valid and rejects the first overflowing value and `MaxUint64`.

Fixes #79857.

Tests:
- `go test crypto/x509 -count=1`