### PR TITLE
net/http: treat reader-originated HTTP/2 StreamError as terminal

### DIFF
--- a/src/net/http/internal/http2/frame.go
+++ b/src/net/http/internal/http2/frame.go
@@ -453,8 +453,32 @@ func (fc *frameCache) getDataFrame() *DataFrame {
 	return &fc.dataFrame
 }
 
+// framerReadError distinguishes an error returned by the Framer's underlying
+// reader from an error produced while parsing a frame.
+type framerReadError struct {
+	err error
+}
+
+func (e framerReadError) Error() string { return e.err.Error() }
+func (e framerReadError) Unwrap() error { return e.err }
+
+type framerReader struct {
+	io.Reader
+}
+
+func (r framerReader) Read(p []byte) (n int, err error) {
+	n, err = r.Reader.Read(p)
+	if _, ok := err.(StreamError); ok {
+		err = framerReadError{err}
+	}
+	return n, err
+}
+
 // NewFramer returns a Framer that writes frames to w and reads them from r.
 func NewFramer(w io.Writer, r io.Reader) *Framer {
+	if r != nil {
+		r = framerReader{r}
+	}
 	fr := &Framer{
 		w:                 w,
 		r:                 r,

--- a/src/net/http/internal/http2/frame_test.go
+++ b/src/net/http/internal/http2/frame_test.go
@@ -6,6 +6,7 @@ package http2
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -1586,6 +1587,74 @@ func TestReadFrameForHeaderUnexpectedEOF(t *testing.T) {
 	_, err = fr.ReadFrameForHeader(fh)
 	if err != io.ErrUnexpectedEOF {
 		t.Fatalf("ReadFrameForHeader with short body = %v; want io.ErrUnexpectedEOF", err)
+	}
+}
+
+type returningErrorReader struct {
+	err error
+}
+
+func (r returningErrorReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func TestFramerWrapsReaderStreamError(t *testing.T) {
+	streamErr := StreamError{StreamID: 1, Code: ErrCodeInternal}
+	frameHeader := []byte{
+		0, 0, 1, // payload length
+		byte(FrameData),
+		0,          // flags
+		0, 0, 0, 1, // stream ID
+	}
+	tests := []struct {
+		name string
+		r    io.Reader
+	}{
+		{
+			name: "header",
+			r:    returningErrorReader{streamErr},
+		},
+		{
+			name: "payload",
+			r:    io.MultiReader(bytes.NewReader(frameHeader), returningErrorReader{streamErr}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewFramer(nil, tt.r).ReadFrame()
+			if _, ok := err.(StreamError); ok {
+				t.Fatalf("ReadFrame error has type StreamError; want wrapped error")
+			}
+			var got StreamError
+			if !errors.As(err, &got) {
+				t.Fatalf("ReadFrame error = %T %v; want error wrapping StreamError", err, err)
+			}
+			if got != streamErr {
+				t.Fatalf("ReadFrame error wraps %v; want %v", got, streamErr)
+			}
+			if !terminalReadFrameError(err) {
+				t.Fatalf("terminalReadFrameError(%v) = false; want true", err)
+			}
+		})
+	}
+}
+
+func TestFramerLeavesParsedStreamErrorUnwrapped(t *testing.T) {
+	// A WINDOW_UPDATE with a zero increment is a stream error when its
+	// stream ID is non-zero.
+	frame := []byte{
+		0, 0, 4, // payload length
+		byte(FrameWindowUpdate),
+		0,          // flags
+		0, 0, 0, 1, // stream ID
+		0, 0, 0, 0, // increment
+	}
+	_, err := NewFramer(nil, bytes.NewReader(frame)).ReadFrame()
+	if _, ok := err.(StreamError); !ok {
+		t.Fatalf("ReadFrame error = %T %v; want StreamError", err, err)
+	}
+	if terminalReadFrameError(err) {
+		t.Fatalf("terminalReadFrameError(%v) = true; want false", err)
 	}
 }
 


### PR DESCRIPTION
An HTTP/2 StreamError returned by a Framer underlying reader has the
same concrete type as one produced while parsing the current connection.
With nested transports, an outer HTTP/2 read loop can therefore mistake
a sticky connection error for a recoverable stream error and spin.

This implements the provenance boundary suggested in #80567: wrap only
reader-originated StreamError values. Parser-generated values stay
direct, while the wrapper preserves the error text and errors.As support.

The regression covers errors returned while reading frame headers and
payloads. A control verifies that a locally parsed StreamError remains
recoverable.

The issue reproducer measured 6,218,486 underlying reads per 100 ms on
the unmodified implementation and zero with this change.

Tests:

- ./bin/go test net/http/internal/http2 net/http -count=1
- ./bin/go test -race net/http/internal/http2 -count=1
- ./bin/go vet net/http/internal/http2 net/http

Fixes #80567.