### PR TITLE
archive/tar: check for non-ASCII bytes without decoding runes

### DIFF
--- a/src/archive/tar/reader.go
+++ b/src/archive/tar/reader.go
@@ -405,9 +405,11 @@ func (tr *Reader) readHeader() (*Header, *block, error) {
 
 			// For Format detection, check if block is properly formatted since
 			// the parser is more liberal than what USTAR actually permits.
-			notASCII := func(r rune) bool { return r >= 0x80 }
-			if bytes.IndexFunc(tr.blk[:], notASCII) >= 0 {
-				hdr.Format = FormatUnknown // Non-ASCII characters in block.
+			for _, c := range tr.blk[:] {
+				if c >= 0x80 {
+					hdr.Format = FormatUnknown // Non-ASCII characters in block.
+					break
+				}
 			}
 			nul := func(b []byte) bool { return int(b[len(b)-1]) == 0 }
 			if !(nul(v7.size()) && nul(v7.mode()) && nul(v7.uid()) && nul(v7.gid()) &&


### PR DESCRIPTION
readHeader used bytes.IndexFunc with a rune predicate to reject USTAR
and PAX headers containing non-ASCII bytes, making an uninlinable
indirect call for every byte of the 512-byte block. Scanning the
bytes directly rejects exactly the same blocks: ASCII bytes decode
one at a time, so the old scan always reached the first byte >= 0x80,
where DecodeRune returns a rune >= 0x80 (possibly RuneError).

goos: darwin
goarch: arm64
pkg: archive/tar
cpu: Apple M2 Pro
                 │     old     │             new                     │
                 │   sec/op    │   sec/op     vs base                │
/Reader/USTAR-10   1.955µ ± 1%   1.098µ ± 1%  -43.84% (p=0.000 n=25)
/Reader/GNU-10     909.5n ± 1%   904.9n ± 1%        ~ (p=0.211 n=25)
/Reader/PAX-10     4.331µ ± 1%   2.569µ ± 1%  -40.68% (p=0.000 n=25)
geomean            1.975µ        1.367µ       -30.79%

Fixes #80633