### PR TITLE
archive/tar: split computeChecksum around the checksum field

### DIFF
--- a/src/archive/tar/format.go
+++ b/src/archive/tar/format.go
@@ -235,10 +235,16 @@ func (b *block) setFormat(format Format) {
 // signed byte values.
 // We compute and return both.
 func (b *block) computeChecksum() (unsigned, signed int64) {
-	for i, c := range b {
-		if 148 <= i && i < 156 {
-			c = ' ' // Treat the checksum field itself as all spaces.
-		}
+	for _, c := range b[:148] {
+		unsigned += int64(c)
+		signed += int64(int8(c))
+	}
+	// Treat the checksum field itself (bytes 148 to 155, inclusive)
+	// as if it were all spaces.
+	const chksumSpaces = 8 * int64(' ')
+	unsigned += chksumSpaces
+	signed += chksumSpaces
+	for _, c := range b[156:] {
 		unsigned += int64(c)
 		signed += int64(int8(c))
 	}


### PR DESCRIPTION
computeChecksum summed all 512 header bytes with a per-byte range
test substituting spaces for the checksum field at bytes 148 to 155.
The field's position is constant, so sum the bytes before and after
it in two branch-free loops and add the field's contribution
directly: 8*' ' for both sums, since int64(' ') and int64(int8(' '))
are both 32.

The checksum is computed when reading and when writing every header.

goos: darwin
goarch: arm64
pkg: archive/tar
cpu: Apple M2 Pro
                 │ old.hdr.txt │             new.hdr.txt             │
                 │   sec/op    │   sec/op     vs base                │
/Writer/USTAR-10   1.623µ ± 5%   1.357µ ± 3%  -16.39% (p=0.000 n=25)
/Writer/GNU-10     1.939µ ± 4%   1.702µ ± 2%  -12.22% (p=0.000 n=25)
/Writer/PAX-10     3.625µ ± 3%   3.079µ ± 2%  -15.06% (p=0.000 n=25)
/Reader/USTAR-10   2.024µ ± 4%   1.873µ ± 4%   -7.46% (p=0.000 n=25)
/Reader/GNU-10     917.7n ± 2%   829.3n ± 3%   -9.63% (p=0.000 n=25)
/Reader/PAX-10     4.346µ ± 2%   4.185µ ± 6%   -3.70% (p=0.017 n=25)
geomean            2.125µ        1.894µ       -10.85%

B/op and allocs/op are unchanged.

Fixes #80635
