### PR TITLE
os: some examples use functions obviated by errors.Is

### DIFF
--- a/src/os/example_test.go
+++ b/src/os/example_test.go
@@ -246,7 +246,7 @@ func ExampleWriteFile() {
 
 func ExampleMkdir() {
 	err := os.Mkdir("testdir", 0750)
-	if err != nil && !os.IsExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrExist) {
 		log.Fatal(err)
 	}
 	err = os.WriteFile("testdir/testfile.txt", []byte("Hello, Gophers!"), 0660)


### PR DESCRIPTION
Fixes #77643

This corrects `if err != nil && !os.IsExist(err) {` to `if err != nil && !errors.Is(err, fs.ErrExist) {` in `src/os/example_test.go`, as reported in #77643.

The change is intentionally minimal and only touches the exact phrase reported in the issue.

Fixes #77643