### PR TITLE
bufio: add fast path to WriteString for strings that fit in the buffer

### DIFF
--- a/src/bufio/bufio.go
+++ b/src/bufio/bufio.go
@@ -745,11 +745,22 @@ func (b *Writer) WriteRune(r rune) (size int, err error) {
 // If the count is less than len(s), it also returns an error explaining
 // why the write is short.
 func (b *Writer) WriteString(s string) (int, error) {
+	if b.err != nil {
+		return 0, b.err
+	}
+
+	if len(s) <= b.Available() {
+		// Fast path: the whole string fits in the buffer.
+		n := copy(b.buf[b.n:], s)
+		b.n += n
+		return n, nil
+	}
+
 	var sw io.StringWriter
 	tryStringWriter := true
 
 	nn := 0
-	for len(s) > b.Available() && b.err == nil {
+	for {
 		var n int
 		if b.Buffered() == 0 && sw == nil && tryStringWriter {
 			// Check at most once whether b.wr is a StringWriter.
@@ -767,6 +778,9 @@ func (b *Writer) WriteString(s string) (int, error) {
 		}
 		nn += n
 		s = s[n:]
+		if len(s) <= b.Available() || b.err != nil {
+			break
+		}
 	}
 	if b.err != nil {
 		return nn, b.err

--- a/src/bufio/bufio.go
+++ b/src/bufio/bufio.go
@@ -745,36 +745,55 @@ func (b *Writer) WriteRune(r rune) (size int, err error) {
 // If the count is less than len(s), it also returns an error explaining
 // why the write is short.
 func (b *Writer) WriteString(s string) (int, error) {
-	var sw io.StringWriter
-	tryStringWriter := true
+	if b.err != nil {
+		return 0, b.err
+	}
 
-	nn := 0
-	for len(s) > b.Available() && b.err == nil {
+	if len(s) <= b.Available() {
+		// Fast path: the whole string fits in the buffer.
+		n := copy(b.buf[b.n:], s)
+		b.n += n
+		return n, nil
+	}
+
+	sw, ok := b.wr.(io.StringWriter)
+
+	total := 0
+	if ok && b.Buffered() == 0 {
+		// Large write, empty buffer, and the underlying writer supports
+		// WriteString: forward the write to the underlying StringWriter.
+		// This avoids an extra copy.
 		var n int
-		if b.Buffered() == 0 && sw == nil && tryStringWriter {
-			// Check at most once whether b.wr is a StringWriter.
-			sw, tryStringWriter = b.wr.(io.StringWriter)
+		n, b.err = sw.WriteString(s)
+		if n == len(s) || b.err != nil {
+			return n, b.err
 		}
-		if b.Buffered() == 0 && tryStringWriter {
-			// Large write, empty buffer, and the underlying writer supports
-			// WriteString: forward the write to the underlying StringWriter.
-			// This avoids an extra copy.
+		total = n
+		s = s[n:]
+	}
+
+	for {
+		var n int
+		if ok && b.Buffered() == 0 {
 			n, b.err = sw.WriteString(s)
 		} else {
 			n = copy(b.buf[b.n:], s)
 			b.n += n
 			b.Flush()
 		}
-		nn += n
+		total += n
 		s = s[n:]
+		if len(s) <= b.Available() || b.err != nil {
+			break
+		}
 	}
 	if b.err != nil {
-		return nn, b.err
+		return total, b.err
 	}
 	n := copy(b.buf[b.n:], s)
 	b.n += n
-	nn += n
-	return nn, nil
+	total += n
+	return total, nil
 }
 
 // ReadFrom implements [io.ReaderFrom]. If the underlying writer

--- a/src/bufio/bufio_test.go
+++ b/src/bufio/bufio_test.go
@@ -1997,3 +1997,20 @@ func BenchmarkWriterFlush(b *testing.B) {
 		bw.Flush()
 	}
 }
+
+func BenchmarkWriteString(b *testing.B) {
+	small := strings.Repeat("x", 50)
+	huge := strings.Repeat("x", 8<<10)
+	for _, tc := range []struct{ name, s string }{
+		{"small", small},
+		{"huge", huge},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			bw := NewWriter(io.Discard)
+			for b.Loop() {
+				bw.WriteString(tc.s)
+			}
+		})
+	}
+}


### PR DESCRIPTION
WriteString sets up its io.StringWriter fallback before checking
whether the string simply fits in the remaining buffer space, which
is the common case. The setup is not free: the interface value is
zeroed and state is spilled on every call, including the calls that
never use the fallback, making WriteString measurably slower than
Write for an identical payload that fits.

Handle the fits-in-buffer case first. The fallback loop then only
runs when the string does not fit, so its condition is known true on
entry: test it at the bottom of the loop instead so it is not
evaluated twice. The fallback path gets slightly faster as well.

goos: darwin
goarch: arm64
pkg: bufio
cpu: Apple M2 Pro
                        │     old     │                 new                 │
                        │   sec/op    │   sec/op     vs base                │
ReaderCopyNoWriteTo-10    2.729µ ± 2%   2.708µ ± 1%        ~ (p=0.904 n=25)
ReaderWriteToOptimal-10   330.6n ± 1%   334.0n ± 2%        ~ (p=0.140 n=25)
WriterCopyOptimal-10      53.65n ± 0%   53.99n ± 1%        ~ (p=0.073 n=25)
WriterCopyUnoptimal-10    57.32n ± 2%   56.16n ± 1%        ~ (p=0.092 n=25)
WriterCopyNoReadFrom-10   2.702µ ± 1%   2.694µ ± 2%        ~ (p=0.690 n=25)
WriterEmpty-10            693.7n ± 1%   693.9n ± 1%        ~ (p=0.600 n=25)
WriterFlush-10            5.236n ± 0%   4.896n ± 0%   -6.49% (p=0.000 n=25)
WriteString/small-10      4.966n ± 0%   3.694n ± 0%  -25.61% (p=0.000 n=25)
WriteString/huge-10       5.985n ± 0%   3.898n ± 0%  -34.87% (p=0.000 n=25)
geomean                   97.68n        89.31n        -8.57%

B/op and allocs/op are unchanged.

Fixes #80692