### PR TITLE
doc/asm: fix HTML markup

### DIFF
--- a/doc/asm.html
+++ b/doc/asm.html
@@ -475,11 +475,12 @@ to a specified boundary by padding with no-op instructions.
 It is currently supported on arm64, amd64, ppc64, loong64 and riscv64.
 
 For example, the start of the <code>MOVD</code> instruction below is aligned to 32 bytes:
+</p>
+
 <pre>
 PCALIGN $32
 MOVD $2, R0
 </pre>
-</p>
 
 <h3 id="data-offsets">Interacting with Go types and constants</h3>
 


### PR DESCRIPTION
The pre tag autoclosed the p tag, so some HTML parsers complain about the
"extra" closing p tag.