### PR TITLE
crypto/hpke: document sequence counter size

### DIFF
--- a/src/crypto/hpke/hpke.go
+++ b/src/crypto/hpke/hpke.go
@@ -28,14 +28,16 @@ type context struct {
 
 // Sender is a sending HPKE context. It is instantiated with a specific KEM
 // encapsulation key (i.e. the public key), and it is stateful, incrementing the
-// nonce counter for each [Sender.Seal] call.
+// nonce counter for each [Sender.Seal] call. The counter is 64 bits, which is
+// enough not to overflow for 500 years at 1ns per operation.
 type Sender struct {
 	*context
 }
 
 // Recipient is a receiving HPKE context. It is instantiated with a specific KEM
 // decapsulation key (i.e. the secret key), and it is stateful, incrementing the
-// nonce counter for each successful [Recipient.Open] call.
+// nonce counter for each successful [Recipient.Open] call. The counter is 64
+// bits, which is enough not to overflow for 500 years at 1ns per operation.
 type Recipient struct {
 	*context
 }


### PR DESCRIPTION
Document that HPKE sender and recipient sequence counters are 64 bits,
which is enough not to overflow for 500 years at 1ns per operation.

Fixes #80342.