### PR TITLE
sort: use fmt.Scan in Search guessing game example

### DIFF
--- a/src/sort/search.go
+++ b/src/sort/search.go
@@ -50,7 +50,7 @@ package sort
 //		fmt.Printf("Pick an integer from 0 to 100.\n")
 //		answer := sort.Search(100, func(i int) bool {
 //			fmt.Printf("Is your number <= %d? ", i)
-//			fmt.Scanf("%s", &s)
+//			fmt.Scan(&s)
 //			return s != "" && s[0] == 'y'
 //		})
 //		fmt.Printf("Your number is %d.\n", answer)


### PR DESCRIPTION
The GuessingGame example in the sort.Search doc comment reads each
answer with fmt.Scanf("%s", &s) and ignores the returned error.

fmt.Scanf requires newlines in the input to match newlines in the
format, so it fails with "unexpected newline" when the user presses
Enter without typing anything, and on Windows, where the console
sends CRLF, on every other question. Because the error is ignored,
s keeps the previous answer and the game silently gives a wrong
result.

Use fmt.Scan instead, which treats newlines in the input as spaces.

Updates #23562