### PR TITLE
runtime: correct chansend block parameter comment

### DIFF
--- a/src/runtime/chan.go
+++ b/src/runtime/chan.go
@@ -161,18 +161,10 @@ func chansend1(c *hchan, elem unsafe.Pointer) {
 	chansend(c, elem, true, sys.GetCallerPC())
 }
 
-/*
- * generic single channel send/recv
- * If block is not nil,
- * then the protocol will not
- * sleep but return if it could
- * not complete.
- *
- * sleep can wake up with g.param == nil
- * when a channel involved in the sleep has
- * been closed.  it is easiest to loop and re-run
- * the operation; we'll see that it's now closed.
- */
+// chansend sends the element pointed to by ep on channel c.
+// A send on a closed channel panics.
+// If block == false and the send cannot proceed immediately, it returns false.
+// Otherwise, it waits as needed for the send to complete and returns true.
 func chansend(c *hchan, ep unsafe.Pointer, block bool, callerpc uintptr) bool {
 	if c == nil {
 		if !block {


### PR DESCRIPTION
The chansend signature now uses a boolean block parameter, but the
comment still describes the previous pointer-based API and g.param
wake-up mechanism.

Update the comment to describe the current blocking and return behavior
and the panic on a send to a closed channel.

Tests were not run because this is a comment-only change.