### PR TITLE
text/template: escape percent signs in error locations

### DIFF
--- a/src/text/template/exec.go
+++ b/src/text/template/exec.go
@@ -138,7 +138,7 @@ func (s *state) errorf(format string, args ...any) {
 		format = fmt.Sprintf("template: %s: %s", name, format)
 	} else {
 		location, context := s.tmpl.ErrorContext(s.node)
-		format = fmt.Sprintf("template: %s: executing %q at <%s>: %s", location, name, doublePercent(context), format)
+		format = fmt.Sprintf("template: %s: executing %q at <%s>: %s", doublePercent(location), name, doublePercent(context), format)
 	}
 	panic(ExecError{
 		Name: s.tmpl.Name(),

--- a/src/text/template/exec_test.go
+++ b/src/text/template/exec_test.go
@@ -1009,6 +1009,19 @@ func TestExecError(t *testing.T) {
 	}
 }
 
+func TestExecErrorPercentInTemplateName(t *testing.T) {
+	tmpl := Must(New("%s.tmpl").Option("missingkey=error").Parse("{{ .MissingKey }}"))
+	var b bytes.Buffer
+	err := tmpl.Execute(&b, map[string]string{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	const want = `template: %s.tmpl:1:3: executing "%s.tmpl" at <.MissingKey>: map has no entry for key "MissingKey"`
+	if got := err.Error(); got != want {
+		t.Errorf("expected\n%q\ngot\n%q", want, got)
+	}
+}
+
 type CustomError struct{}
 
 func (*CustomError) Error() string { return "heyo !" }


### PR DESCRIPTION
Error locations include the template ParseName and are later passed to
fmt.Errorf. A percent sign in a template name can therefore be treated as
a format directive and consume an argument intended for the execution
error.

Escape percent signs in the location returned by ErrorContext, matching
the existing handling for the template name and expression context. Add
a regression test using %s.tmpl with missingkey=error to cover the
complete error text.

Fixes #80718