### PR TITLE
net/smtp: parse EHLO extension keywords case-insensitively

### DIFF
--- a/src/net/smtp/smtp.go
+++ b/src/net/smtp/smtp.go
@@ -139,7 +139,7 @@ func (c *Client) ehlo() error {
 		extList = extList[1:]
 		for _, line := range extList {
 			k, v, _ := strings.Cut(line, " ")
-			ext[k] = v
+			ext[strings.ToUpper(k)] = v
 		}
 	}
 	if mechs, ok := ext["AUTH"]; ok {

--- a/src/net/smtp/smtp_test.go
+++ b/src/net/smtp/smtp_test.go
@@ -530,6 +530,26 @@ QUIT
 			t.Fatalf("Got:\n%s\nExpected:\n%s", actualcmds, client)
 		}
 	})
+
+	t.Run("ehlo mixed case extensions", func(t *testing.T) {
+		const basicServer = `250-mx.google.com at your service
+250-starttls
+250-aUtH LOGIN PLAIN
+250 Ok
+`
+
+		c, _, _ := fake(basicServer)
+
+		if err := c.Hello("localhost"); err != nil {
+			t.Fatalf("EHLO failed: %s", err)
+		}
+		if ok, _ := c.Extension("STARTTLS"); !ok {
+			t.Fatalf("Should support STARTTLS")
+		}
+		if ok, args := c.Extension("auth"); !ok || args != "LOGIN PLAIN" {
+			t.Fatalf("Should support AUTH, got ok=%v args=%q", ok, args)
+		}
+	})
 }
 
 func TestNewClient(t *testing.T) {


### PR DESCRIPTION
RFC 5321 section 4.1.1.1 requires EHLO extension keywords to be
recognized and processed case-insensitively. The client currently
stores keywords verbatim in the extension map, so a server (or
active attacker) that advertises "starttls" or "auth" in lower
or mixed case causes Extension and StartTLS to miss the capability.
For STARTTLS this silently downgrades the connection to plaintext,
letting credentials sent via Auth be exposed.

Normalize keywords to upper case when parsing the EHLO response so
lookups against the map (which are already upper-cased by
Extension) succeed regardless of the case used on the wire.

Fixes #78749