### PR TITLE
encoding/json/v2: use the any fast path under v1 merge semantics

### DIFF
--- a/src/encoding/json/v2/arshal_any.go
+++ b/src/encoding/json/v2/arshal_any.go
@@ -60,7 +60,8 @@ func marshalValueAny(enc *jsontext.Encoder, val any, mo *jsonopts.Struct) error 
 // unmarshalValueAny unmarshals a JSON value as a Go any.
 // This assumes that there are no special formatting directives
 // for any possible nested value.
-// Duplicate names must be rejected since this does not implement merging.
+// A duplicate name discards the previously unmarshaled value rather than
+// merging into it, so callers must only use this when that is acceptable.
 func unmarshalValueAny(dec *jsontext.Decoder, uo *jsonopts.Struct) (any, error) {
 	switch k := dec.PeekKind(); k {
 	case '{':
@@ -196,7 +197,7 @@ func unmarshalObjectAny(dec *jsontext.Decoder, uo *jsonopts.Struct) (map[string]
 		name := tok.String()
 
 		// Manually check for duplicate names.
-		if _, ok := obj[name]; ok {
+		if _, ok := obj[name]; ok && !uo.Flags.Get(jsonflags.AllowDuplicateNames) {
 			// TODO: Unread the object name.
 			name := export.Decoder(dec).PreviousTokenOrValue()
 			err := newDuplicateNameError(dec.StackPointer(), nil, dec.InputOffset()-len64(name))
@@ -209,7 +210,7 @@ func unmarshalObjectAny(dec *jsontext.Decoder, uo *jsonopts.Struct) (map[string]
 			if isFatalError(err, uo.Flags) {
 				return obj, err
 			}
-			errUnmarshal = cmp.Or(err, errUnmarshal)
+			errUnmarshal = cmp.Or(errUnmarshal, err)
 		}
 	}
 	if _, err := dec.ReadToken(); err != nil {

--- a/src/encoding/json/v2/arshal_default.go
+++ b/src/encoding/json/v2/arshal_default.go
@@ -1899,10 +1899,11 @@ func makeInterfaceArshaler(t reflect.Type) *arshaler {
 			// Optimize for the any type if there are no special options.
 			// We do not care about stringified numbers since JSON strings
 			// are always unmarshaled into an any value as Go strings.
-			// Duplicate name check must be enforced since unmarshalValueAny
-			// does not implement merge semantics.
+			// unmarshalValueAny discards the previous value on a duplicate
+			// name, so it is only usable when that is the desired semantics.
 			if optimizeCommon &&
-				t == anyType && !uo.Flags.Get(jsonflags.AllowDuplicateNames|jsonflags.FormatTag) &&
+				t == anyType && !uo.Flags.Get(jsonflags.FormatTag) &&
+				(!uo.Flags.Get(jsonflags.AllowDuplicateNames) || uo.Flags.Get(jsonflags.MergeWithLegacySemantics)) &&
 				(uo.Unmarshalers == nil || !uo.Unmarshalers.(*Unmarshalers).fromAny) {
 				v, err := unmarshalValueAny(dec, uo)
 				// We must check for nil interface values up front.

--- a/src/encoding/json/v2_diff_test.go
+++ b/src/encoding/json/v2_diff_test.go
@@ -827,6 +827,85 @@ func TestDuplicateNames(t *testing.T) {
 	}
 }
 
+// TestDuplicateNamesAny is the [TestDuplicateNames] case for an any target.
+//
+// It is kept separate because unmarshaling into any does not use the
+// reflect-based arshaler that a struct target uses. Under v1 semantics it
+// takes a hand-written fast path that implements last-one-wins rather than
+// merge semantics, so both targets need coverage to keep them in agreement.
+func TestDuplicateNamesAny(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want any // v1 only; v2 must report an error
+	}{
+		{"Flat", `{"N":1,"N":2}`, map[string]any{"N": 2.0}},
+		{"TypeChanges", `{"N":"x","N":true}`, map[string]any{"N": true}},
+		{"LastIsNull", `{"N":1,"N":null}`, map[string]any{"N": nil}},
+		{"FirstIsNull", `{"N":null,"N":1}`, map[string]any{"N": 1.0}},
+		// v1 discards the earlier value entirely rather than merging into it,
+		// so "A" from the first object must not survive.
+		{"Objects", `{"N":{"A":1},"N":{"B":2}}`, map[string]any{"N": map[string]any{"B": 2.0}}},
+		{"Nested", `{"N":{"A":1,"A":2}}`, map[string]any{"N": map[string]any{"A": 2.0}}},
+		{"InArray", `[{"N":1,"N":2}]`, []any{map[string]any{"N": 2.0}}},
+	}
+	for _, json := range jsonPackages {
+		for _, tt := range tests {
+			t.Run(path.Join("Unmarshal", tt.name, json.Version), func(t *testing.T) {
+				var got any
+				err := json.Unmarshal([]byte(tt.in), &got)
+				switch {
+				case json.Version == "v2":
+					if err == nil {
+						t.Fatal("json.Unmarshal error is nil, want non-nil")
+					}
+				case err != nil:
+					t.Fatalf("json.Unmarshal error: %v", err)
+				case !reflect.DeepEqual(got, tt.want):
+					t.Fatalf("json.Unmarshal = %v, want %v", got, tt.want)
+				}
+			})
+		}
+	}
+}
+
+// TestReportFirstErrorAny checks that unmarshaling into an any reports the
+// first non-fatal error in a JSON object rather than the last.
+//
+// Under v1 semantics a value that cannot be represented is not fatal, so
+// decoding continues and the errors accumulate. Arrays, maps and structs all
+// keep the first one; an any target must agree with them.
+func TestReportFirstErrorAny(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string // substring identifying which value is reported
+	}{
+		{"Object", `{"a":1e1000,"b":2e1000}`, "1e1000"},
+		{"ObjectNested", `{"o":{"a":1e1000,"b":2e1000}}`, "1e1000"},
+		{"ObjectCrossLevel", `{"o":{"a":1e1000},"b":2e1000}`, "1e1000"},
+		{"Array", `[1e1000,2e1000]`, "1e1000"},
+		{"ArrayOfObjects", `[{"a":1e1000},{"b":2e1000}]`, "1e1000"},
+	}
+	for _, json := range jsonPackages {
+		for _, tt := range tests {
+			t.Run(path.Join("Unmarshal", tt.name, json.Version), func(t *testing.T) {
+				var got any
+				err := json.Unmarshal([]byte(tt.in), &got)
+				if err == nil {
+					t.Fatal("json.Unmarshal error is nil, want non-nil")
+				}
+				if !strings.Contains(err.Error(), tt.want) {
+					t.Fatalf("json.Unmarshal error = %v, want it to mention %s", err, tt.want)
+				}
+				if strings.Contains(err.Error(), "2e1000") {
+					t.Fatalf("json.Unmarshal error = %v, want it to report only the first error", err)
+				}
+			})
+		}
+	}
+}
+
 // In v1, unmarshaling a JSON null into a non-empty value was inconsistent
 // in that sometimes it would be ignored and other times clear the value.
 // In v2, unmarshaling a JSON null into a non-empty value would consistently


### PR DESCRIPTION
Unmarshaling into an any can use unmarshalValueAny, which builds
map[string]any and []any directly, or the generic reflect-based arshaler,
which allocates an addressable key and value for every object member.

The fast path was gated on AllowDuplicateNames being unset. That flag is
part of DefaultOptionsV1, so under v1 the gate never held and every
encoding/json.Unmarshal into an any took the reflect-based path.

The gate exists because unmarshalValueAny cannot merge, but merging only
happens under v2. With MergeWithLegacySemantics the reflect-based path
discards the previous value, which is what unmarshalObjectAny already
does, so widen the gate to admit that case. Only v2 semantics with
AllowDuplicateNames set and MergeWithLegacySemantics unset still needs
merging, and keeps the old path.

unmarshalObjectAny becomes reachable under v1 as a result. It rejected
duplicate names unconditionally, so make that conditional to match the
reflect-based path. It also kept the last non-fatal error in an object
rather than the first, contrary to ReportErrorsWithLegacySemantics, which
documents that "when unmarshal returns, only the first semantic error is
reported". Swap the cmp.Or operands so an any target agrees with
unmarshalArrayAny, makeMapArshaler, and the documented behavior. That line
was already reachable with v1 options and AllowDuplicateNames(false), so
this is a user-visible fix for that configuration.

goos: darwin
goarch: arm64
pkg: encoding/json/v2
cpu: Apple M2 Pro
                                               │     old      │                 new                 │
                                               │    sec/op    │   sec/op     vs base                │
Testdata/CanadaGeometry/Unmarshal/Interface-10    3.566m ± 1%   2.325m ± 2%  -34.80% (p=0.000 n=10)
Testdata/CitmCatalog/Unmarshal/Interface-10       8.549m ± 2%   5.438m ± 2%  -36.39% (p=0.000 n=10)
Testdata/GolangSource/Unmarshal/Interface-10      20.65m 2%  -39.58% (p=0.000 n=10)
Testdata/StringEscaped/Unmarshal/Interface-10     274.3µ ± 2%   268.3µ ± 1%   -2.18% (p=0.002 n=10)
Testdata/StringUnicode/Unmarshal/Interface-10     61.88µ ± 1%   57.41µ ± 6%   -7.22% (p=0.002 n=10)
Testdata/SyntheaFhir/Unmarshal/Interface-10      12.128m ± 3%   7.521m ± 2%  -37.99% (p=0.000 n=10)
Testdata/TwitterStatus/Unmarshal/Interface-10     3.910m ± 3%   2.714m ± 2%  -30.58% (p=0.000 n=10)
geomean                                           2.434m        1.747m       -28.25%

                                               │      old      │                 new                  │
                                               │     B/op      │     B/op      vs base                │
Testdata/CanadaGeometry/Unmarshal/Interface-10   1280.2Ki ± 0%   988.8Ki ± 0%  -22.76% (p=0.000 n=10)
Testdata/CitmCatalog/Unmarshal/Interface-10       5.290Mi ± 0%   4.736Mi ± 0%  -10.47% (p=0.000 n=10)
Testdata/GolangSource/Unmarshal/Interface-10      7.455Mi ± 0%   6.6=10)
Testdata/StringEscaped/Unmarshal/Interface-10     69.68Ki ± 0%   69.40Ki ± 0%   -0.40% (p=0.000 n=10)
Testdata/StringUnicode/Unmarshal/Interface-10     26.58Ki ± 0%   26.31Ki ± 0%   -1.03% (p=0.000 n=10)
Testdata/SyntheaFhir/Unmarshal/Interface-10       7.453Mi ± 0%   6.600Mi ± 0%  -11.44% (p=0.000 n=10)
Testdata/TwitterStatus/Unmarshal/Interface-10     1.971Mi ± 0%   1.907Mi ± 0%   -3.28% (p=0.000 n=10)
geomean                                           1.036Mi        966.7Ki        -8.86%

                                               │     old      │                 new                 │
                                               │  allocs/op   │  allocs/op   vs base                │
Testdata/CanadaGeometry/Unmarshal/Interface-10    59.85k ± 0%   37.90k ± 0%  -36.68% (p=0.000 n=10)
Testdata/CitmCatalog/Unmarshal/Interface-10      114.25k ± 0%   81.01k ± 0%  -29.09% (p=0.000 n=10)
Testdata/GolangSource/Unmarshal/Interface-10      257.8k ± 0%   218.8k ± 0%  -15.11% (p=0.000 n=10)
Testdata/StringEscaped/Unmarshal/Interface-10      325.0 ± 0%    299.0 ± 0%   -8.00% (p=0.000 n=10)
Testdata/StringUnicode/Unmarshal/Interface-10      207.0 ± 0%    181.0 ± 0%  -12.56% (p=0.000 n=10)
Testdata/SyntheaFhir/Unmarshal/Interface-10       163.2k ± 0%   117.5k ± 0%  -28.00% (p=0.000 n=10)
Testdata/TwitterStatus/Unmarshal/Interface-10     38.28k ± 0%   28.10k ± 0%  -26.59% (p=0.000 n=10)
geomean                                           18.50k        14.26k       -22.89%

These are BENCHMARK_VERSION=v1 numbers, under v2 the benchmark is
unchanged, since v2 already used the fast path.

Updates #80270