### PR TITLE
cmd/compile/internal/devirtualize: teach devirt about callee results

### DIFF
--- a/src/cmd/compile/internal/base/debug.go
+++ b/src/cmd/compile/internal/base/debug.go
@@ -86,6 +86,7 @@ type DebugFlags struct {
 	PGOInlineBudget       int    `help:"inline budget for hot functions" concurrent:"ok"`
 	PGODevirtualize       int    `help:"enable profile-guided devirtualization; 0 to disable, 1 to enable interface devirtualization, 2 to enable function devirtualization" concurrent:"ok"`
 	RangeFuncCheck        int    `help:"insert code to check behavior of range iterator functions" concurrent:"ok"`
+	RetDevirt             int    `help:"enable return-value devirtualization" concurrent:"ok"`
 	VariableMakeHash      string `help:"hash value for debugging stack allocation of variable-sized make results" concurrent:"ok"`
 	VariableMakeThreshold int    `help:"threshold in bytes for possible stack allocation of variable-sized make results" concurrent:"ok"`
 	WrapGlobalMapDbg      int    `help:"debug trace output for global map init wrapping"`

--- a/src/cmd/compile/internal/devirtualize/devirtualize.go
+++ b/src/cmd/compile/internal/devirtualize/devirtualize.go
@@ -193,150 +193,32 @@ func concreteType(s *State, n ir.Node) (typ *types.Type) {
 		}()
 	}
 
-	typ = concreteType1(s, n, make(map[*ir.Name]struct{}))
-	if typ == &noType {
-		return nil
+	set := s.exprTypeSet(nil, n, make(map[*ir.Name]struct{}))
+	for _, t := range set {
+		switch t {
+		case nilType:
+			// A nil member is fine here: calling a method on a nil interface
+			// panics no matter what, which we preserved with a UseNilPanic.
+			continue
+		case unknownType:
+			return nil
+		}
+		if typ != nil && typ != t {
+			return nil // assigned with a different type
+		}
+		typ = t
 	}
+
 	if typ != nil && typ.IsInterface() {
 		base.FatalfAt(n.Pos(), "typ.IsInterface() = true; want = false; typ = %v", typ)
 	}
 	return typ
 }
 
-// noType is a sentinel value returned by [concreteType1].
-var noType types.Type
-
-// concreteType1 analyzes the node n and returns its concrete type if it is statically known.
-// Otherwise, it returns a nil Type, indicating that a concrete type was not determined.
-// When n is known to be statically nil or a self-assignment is detected, it returns a sentinel [noType] type instead.
-func concreteType1(s *State, n ir.Node, seen map[*ir.Name]struct{}) (outT *types.Type) {
-	nn := n // for debug messages
-
-	if concreteTypeDebug {
-		defer func() {
-			t := "&noType"
-			if outT != &noType {
-				t = outT.String()
-			}
-			if outT == nil {
-				t = "<nil> (unknown static type)"
-			}
-			base.Warn("concreteType1(%v) -> %v", nn, t)
-		}()
-	}
-
-	for {
-		if concreteTypeDebug {
-			base.Warn("concreteType1(%v): analyzing %v", nn, n)
-		}
-
-		if !n.Type().IsInterface() {
-			return n.Type()
-		}
-
-		switch n1 := n.(type) {
-		case *ir.ConvExpr:
-			if n1.Op() == ir.OCONVNOP {
-				if !n1.Type().IsInterface() || !types.Identical(n1.Type().Underlying(), n1.X.Type().Underlying()) {
-					// As we check (directly before this switch) whether n is an interface, thus we should only reach
-					// here for iface conversions where both operands are the same.
-					base.FatalfAt(n1.Pos(), "not identical/interface types found n1.Type = %v; n1.X.Type = %v", n1.Type(), n1.X.Type())
-				}
-				n = n1.X
-				continue
-			}
-			if n1.Op() == ir.OCONVIFACE {
-				n = n1.X
-				continue
-			}
-		case *ir.InlinedCallExpr:
-			if n1.Op() == ir.OINLCALL {
-				n = n1.SingleResult()
-				continue
-			}
-		case *ir.ParenExpr:
-			n = n1.X
-			continue
-		case *ir.TypeAssertExpr:
-			n = n1.X
-			continue
-		}
-		break
-	}
-
-	if n.Op() != ir.ONAME {
-		return nil
-	}
-
-	name := n.(*ir.Name).Canonical()
-	if name.Class != ir.PAUTO {
-		return nil
-	}
-
-	if name.Op() != ir.ONAME {
-		base.FatalfAt(name.Pos(), "name.Op = %v; want = ONAME", n.Op())
-	}
-
-	// name.Curfn must be set, as we checked name.Class != ir.PAUTO before.
-	if name.Curfn == nil {
-		base.FatalfAt(name.Pos(), "name.Curfn = nil; want not nil")
-	}
-
-	if name.Addrtaken() {
-		return nil // conservatively assume it's reassigned with a different type indirectly
-	}
-
-	if _, ok := seen[name]; ok {
-		return &noType // Already analyzed assignments to name, no need to do that twice.
-	}
-	seen[name] = struct{}{}
-
-	if concreteTypeDebug {
-		base.Warn("concreteType1(%v): analyzing assignments to %v", nn, name)
-	}
-
-	var typ *types.Type
-	for _, v := range s.assignments(name) {
-		var t *types.Type
-		switch v := v.(type) {
-		case *types.Type:
-			t = v
-		case ir.Node:
-			t = concreteType1(s, v, seen)
-			if t == &noType {
-				continue
-			}
-		}
-		if t == nil {
-			return nil // unknown concrete type
-		}
-
-		// Methods are only declared on named types, and each named type
-		// is represented by a unique [*types.Type], thus pointer comparison
-		// is fine here.
-		//
-		// The only scenario where [types.IdenticalStrict] could help here is with
-		// unnamed struct types that embed another type (e.g. foo = struct { Impl }{}).
-		// However, such patterns are uncommon and not worth the additional complexity
-		// in the devirtualizer.
-		if typ != nil && typ != t {
-			return nil // assigned with a different type
-		}
-
-		typ = t
-	}
-
-	if typ == nil {
-		// Variable either declared with zero value, or only assigned with nil.
-		return &noType
-	}
-
-	return typ
-}
-
 // assignment can be one of:
 // - nil - assignment from an interface type.
 // - *types.Type - assignment from a concrete type (non-interface).
+// - result - assignment from one interface-typed result of a call.
 // - ir.Node - assignment from an ir.Node.
 //
 // In most cases assignment should be an [ir.Node], but in cases where we
@@ -346,11 +228,21 @@ func concreteType1(s *State, n ir.Node, seen map[*ir.Name]struct{}) (outT *types
 // slice being ranged-over).
 type assignment any
 
+// A result is an assignment from the index'th result of call.
+//
+// It stands in for the call's result until the call is either inlined
+// (see [State.InlinedCall], which replaces the assignment with the
+// inlined call's ReturnVar) or resolved through the callee's result
+// types recorded by [State.AnalyzeResultTypes].
+type result struct {
+	call  *ir.CallExpr
+	index int
+}
+
 // State holds precomputed state for use in [StaticCall].
 type State struct {
 	// ifaceAssignments maps interface variables to all their assignments
 	// defined inside functions stored in the analyzedFuncs set.
-	// Note: it does not include direct assignments to nil.
 	ifaceAssignments map[*ir.Name][]assignment
 
 	// ifaceCallExprAssigns stores every [*ir.CallExpr], which has an interface
@@ -388,8 +280,8 @@ func (s *State) InlinedCall(fun *ir.Func, origCall *ir.CallExpr, inlinedCall *ir
 	// Update assignments to reference the new ReturnVars of the inlined call.
 	for _, ref := range refs {
 		vt := &s.ifaceAssignments[ref.name][ref.assignmentIndex]
-		if *vt != nil {
-			base.Fatalf("unexpected non-nil assignment")
+		if cr, ok := (*vt).(result); !ok || cr.call != origCall {
+			base.Fatalf("unexpected assignment %v; want a result of %v", *vt, origCall)
 		}
 		if concreteTypeDebug {
 			base.Warn(
@@ -472,11 +364,7 @@ func (s *State) analyze(nodes ir.Nodes) {
 			if a != nil && a.IsInterface() {
 				assignment = nil // non-concrete type
 			}
-		case ir.Node:
-			// nil assignment, we can safely ignore them, see [StaticCall].
-			if ir.IsNil(a) {
-				return nil, -1
-			}
+		case result, ir.Node:
 		default:
 			base.Fatalf("unexpected type: %v", assignment)
 		}
@@ -492,6 +380,22 @@ func (s *State) analyze(nodes ir.Nodes) {
 	var do func(n ir.Node)
 	do = func(n ir.Node) {
 		switch n.Op() {
+		case ir.ODCL:
+			// A declaration without an initializer starts the
+			// variable at its zero value, and the zero value of an
+			// interface is nil. Receiver devirtualization does not
+			// care (concreteType discards nil members), but the
+			// result-type analysis must see it: a function that
+			// conditionally assigns a concrete type to such a
+			// variable and returns it can still return nil.
+			//
+			// Autotmps are definitely assigned before use, and
+			// initialized declarations record their assignment
+			// separately.
+			n := n.(*ir.Decl)
+			if v := n.X; !v.AutoTemp() && !declInitialized(v) {
+				assign(v, nilType)
+			}
 		case ir.OAS:
 			n := n.(*ir.AssignStmt)
 			if rhs := n.Y; rhs != nil {
@@ -504,7 +408,11 @@ func (s *State) analyze(nodes ir.Nodes) {
 				}
 				if call, ok := rhs.(*ir.CallExpr); ok && call.Fun != nil {
 					retTyp := call.Fun.Type().Results()[0].Type
-					n, idx := assign(n.X, retTyp)
+					a := assignment(retTyp)
+					if retTyp.IsInterface() {
+						a = result{call, 0}
+					}
+					n, idx := assign(n.X, a)
 					if n != nil && retTyp.IsInterface() {
 						// We have a call expression, that returns an interface, store it for later evaluation.
 						// In case this func gets inlined later, we will update the assignment (added before)
@@ -549,7 +457,11 @@ func (s *State) analyze(nodes ir.Nodes) {
 			if call, ok := rhs.(*ir.CallExpr); ok {
 				for i, p := range n.Lhs {
 					retTyp := call.Fun.Type().Results()[i].Type
-					n, idx := assign(p, retTyp)
+					a := assignment(retTyp)
+					if retTyp.IsInterface() {
+						a = result{call, i}
+					}
+					n, idx := assign(p, a)
 					if n != nil && retTyp.IsInterface() {
 						// We have a call expression, that returns an interface, store it for later evaluation.
 						// In case this func gets inlined later, we will update the assignment (added before)
@@ -611,4 +523,20 @@ func (s *State) analyze(nodes ir.Nodes) {
 		}
 	}
 	ir.VisitList(nodes, do)
+}
+
+// declInitialized reports whether v's declaration supplies a value,
+// making v's zero value unobservable.
+//
+// It is conservative: declaration forms it does not recognize, like
+// range and type-switch variables, report false, adding a spurious
+// nil member to the variable's type set.
+func declInitialized(v *ir.Name) bool {
+	switch defn := v.Defn.(type) {
+	case *ir.AssignStmt:
+		return defn.Y != nil
+	case *ir.AssignListStmt:
+		return true
+	}
+	return false
 }

--- a/src/cmd/compile/internal/devirtualize/export.go
+++ b/src/cmd/compile/internal/devirtualize/export.go
@@ -1,0 +1,214 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package devirtualize
+
+import (
+	"cmd/compile/internal/base"
+	"cmd/compile/internal/ir"
+	"cmd/compile/internal/types"
+)
+
+// This file moves result sets and split variants across package
+// boundaries.
+//
+// Both live on [ir.Func], recorded during the interleaved pass and
+// exported when export data is finalized, the same way escape tags
+// and inlining costs travel: the linker rewrites each function's
+// funcExt record with an [ExportedResults], and the reader turns the
+// record back into the same ResultTypeSets and DevirtVariant fields
+// the pass fills for local functions. A caller in another package
+// then devirtualizes through an imported function exactly as it
+// would through a local one, including calling the imported f.dv
+// variant, which the linker resolves to the copy compiled in the
+// defining package.
+//
+// Set members cross packages as pkgbits object references: a member
+// is a pointer chain over a named, non-instantiated type, encoded as
+// its depth plus a relocation to the type's object, which also forces
+// the object into the export data. A member that cannot be encoded
+// this way makes the whole slot unknown rather than an incomplete
+// set, since a set claims to list every possible dynamic type.
+// Resolution failures on the reading side degrade to unknown the same
+// way.
+
+// An ExportedResults is a function's result sets and split variant,
+// as written into its funcExt record.
+type ExportedResults struct {
+	Slots []ExportedSet
+	Split *ExportedSplit
+}
+
+// An ExportedSet is one result slot's type set in exportable form.
+type ExportedSet struct {
+	Members []ExportedType
+	HasNil  bool
+	Unknown bool
+}
+
+// An ExportedType names one concrete set member.
+type ExportedType struct {
+	Depth int // pointer depth over the named type
+	Sym   *types.Sym
+}
+
+// An ExportedSplit describes a function's devirtualized variant.
+type ExportedSplit struct {
+	// Devirt reports, per result slot, whether the variant returns
+	// the slot's single concrete type unboxed. The type itself is
+	// the slot's set member.
+	Devirt []bool
+
+	// ParamNotes holds the variant's parameter escape tags, in
+	// receiver-then-parameters order.
+	ParamNotes []string
+}
+
+// ExportFor reports fn's record for export data, or nil if fn has
+// nothing recorded.
+func ExportFor(fn *ir.Func) *ExportedResults {
+	rts := fn.ResultTypeSets
+	if rts == nil {
+		return nil
+	}
+
+	er := &ExportedResults{Slots: make([]ExportedSet, len(rts))}
+	for i, set := range rts {
+		er.Slots[i] = exportSet(set)
+	}
+
+	if fdv := fn.DevirtVariant; fdv != nil {
+		split := &ExportedSplit{Devirt: make([]bool, len(rts))}
+		for i, f := range fdv.Type().Results() {
+			split.Devirt[i] = !f.Type.IsInterface() && fn.Type().Results()[i].Type.IsInterface()
+		}
+		for _, f := range fdv.Type().Params() {
+			split.ParamNotes = append(split.ParamNotes, f.Note)
+		}
+		er.Split = split
+	}
+	return er
+}
+
+// exportSet converts one type set into exportable form.
+func exportSet(set typeSet) ExportedSet {
+	if len(set) == 0 {
+		// No returned value was seen; importers must treat that as
+		// unknown, see [typeSet].
+		return ExportedSet{Unknown: true}
+	}
+
+	var es ExportedSet
+	for _, t := range set {
+		switch t {
+		case nilType:
+			es.HasNil = true
+			continue
+		case unknownType:
+			return ExportedSet{Unknown: true}
+		}
+
+		depth := 0
+		base := t
+		for base.IsPtr() {
+			base = base.Elem()
+			depth++
+		}
+
+		sym := base.Sym()
+		if sym == nil || sym.Pkg == nil || sym.Pkg.Path == "" || base.IsFullyInstantiated() {
+			// Unnamed, universe, or instantiated types have no
+			// object to reference.
+			//
+			// TODO(mcy): instantiated types could be encoded as a
+			// base object plus type arguments.
+			return ExportedSet{Unknown: true}
+		}
+		es.Members = append(es.Members, ExportedType{Depth: depth, Sym: sym})
+	}
+	return es
+}
+
+// An ImportedSet is one result slot's type set as decoded by the
+// reader, with members already resolved to types.
+type ImportedSet struct {
+	Members []*types.Type
+	HasNil  bool
+	Unknown bool
+}
+
+// ImportResults records the result sets of an imported function.
+func ImportResults(fn *ir.Func, sets []ImportedSet) {
+	rts := make([]typeSet, len(sets))
+	for i, is := range sets {
+		if is.Unknown {
+			rts[i] = typeSet{unknownType}
+			continue
+		}
+		var set typeSet
+		for _, t := range is.Members {
+			set = set.Add(t)
+		}
+		if is.HasNil {
+			set = set.Add(nilType)
+		}
+		rts[i] = set
+	}
+	fn.ResultTypeSets = rts
+}
+
+// ImportSplit records the devirtualized variant of an imported
+// function, reconstructing its stub from fn's signature and result
+// sets.
+//
+// It must run after [ImportResults] for fn.
+func ImportSplit(fn *ir.Func, devirt []bool, paramNotes []string) {
+	rts := fn.ResultTypeSets
+	if rts == nil || len(devirt) != len(rts) {
+		return
+	}
+
+	clone := func(f *types.Field, typ *types.Type) *types.Field {
+		res := types.NewField(f.Pos, f.Sym, typ)
+		res.SetIsDDD(f.IsDDD())
+		return res
+	}
+
+	recvParams := fn.Type().RecvParams()
+	params := make([]*types.Field, len(recvParams))
+	for i, f := range recvParams {
+		params[i] = clone(f, f.Type)
+		if i < len(paramNotes) {
+			params[i].Note = paramNotes[i]
+		}
+	}
+
+	results := make([]*types.Field, len(fn.Type().Results()))
+	for i, f := range fn.Type().Results() {
+		typ := f.Type
+		if devirt[i] {
+			set := rts[i]
+			if len(set) != 1 || set[0] == nilType || set[0] == unknownType {
+				// The record and the sets disagree; drop the split
+				// rather than guess.
+				return
+			}
+			typ = set[0]
+		}
+		results[i] = clone(f, typ)
+	}
+
+	sym := fn.Sym().Pkg.Lookup(fn.Sym().Name + ".dv")
+	fdv := ir.NewFunc(fn.Pos(), fn.Nname.Pos(), sym, types.NewSignature(nil, params, results))
+	fdv.ABI = fn.ABI
+
+	fn.DevirtVariant = fdv
+	fdv.DevirtOriginal = fn
+	fdv.ResultTypeSets = rts
+	fdv.Inl = fn.Inl
+
+	if concreteTypeDebug {
+		base.Warn("ImportSplit(%v): variant %v", fn, fdv)
+	}
+}

--- a/src/cmd/compile/internal/devirtualize/split.go
+++ b/src/cmd/compile/internal/devirtualize/split.go
@@ -1,0 +1,447 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package devirtualize
+
+import (
+	"cmd/compile/internal/base"
+	"cmd/compile/internal/inline"
+	"cmd/compile/internal/ir"
+	"cmd/compile/internal/typecheck"
+	"cmd/compile/internal/types"
+)
+
+// This file implements return-value devirtualization: splitting a function into
+// a devirtualized variant plus a boxing thunk.
+//
+// A function f whose recorded result set is a single concrete type T still
+// returns it boxed in an interface, so every caller pays for the boxing and,
+// without [StaticCall]'s rewrite, an indirect call for each method used on the
+// result and the entailing heap escapes. Splitting moves f's body into a new
+// function f.dv whose result type is T itself, and rebuilds f as a thunk that
+// calls f.dv and boxes the result:
+//
+//	func f(args) I    { return I(f.dv(args)) }
+//	func f.dv(args) T { ...original body, returns unboxed... }
+//
+// f keeps its symbol, signature, and inline body, so func values, itabs,
+// reflection, and importers see no difference. Static calls to
+// f are then rewritten by [StaticResults] to call f.dv directly and
+// re-box at the call site, where the boxing is visible to the caller's own
+// analysis and often melts away, or at least enables some stack promotion.
+
+// SplitResultFunc splits fn if its recorded result sets prove that an
+// interface-typed result always holds one concrete type.
+//
+// It reports the devirtualized variant, or nil when fn is left alone.
+// The caller is responsible for pass bookkeeping of the new function;
+// its body is fn's old body, moved, and so may hold state private to
+// the running pass (such as the interleaved pass's ParenExprs).
+func (s *State) SplitResultFunc(fn *ir.Func) *ir.Func {
+	devirt := s.splitResultTypes(fn)
+	if devirt == nil {
+		return nil
+	}
+
+	if fn.IsClosure() {
+		// A capturing closure's variant would need the capture
+		// context forwarded; instead, callers see through closure
+		// calls via the recorded result sets alone.
+		return nil
+	}
+
+	if fn.Pragma != 0 || fn.Wrapper() || fn.WasmImport != nil || fn.WasmExport != nil {
+		// Pragmas change calling or scheduling behavior in ways a
+		// split cannot be assumed to preserve: nosplit stack limits,
+		// cgo argument pinning, and so on. A plain //go:noinline is
+		// also respected, as splitting rewrites the function much
+		// like inlining would.
+		return nil
+	}
+
+	if fn.Sym().Linkname != "" || base.Flag.CompilingRuntime {
+		// Currently we skip splitting in -+ to avoid potential surprises.
+		// The runtime generally does not make use of interfaces, because
+		// implicit allocation is forbidden.
+		return nil
+	}
+
+	if fn.Inl != nil && fn.Inl.Cost < inline.MinSplitCost {
+		// Cheap and inlinable; leave it to the inliner.
+		return nil
+	}
+
+	// The thunk forwards the receiver and every parameter by name,
+	// and blank or anonymous ones cannot be read.
+	//
+	// TODO(mcy): synthesize zero values for those instead.
+	for _, p := range fn.Type().RecvParams() {
+		n, ok := p.Nname.(*ir.Name)
+		if !ok || n.Sym() == nil || n.Sym().IsBlank() {
+			return nil
+		}
+	}
+
+	reads, closures := scanBody(fn)
+
+	// A named result that the body reads cannot change type. The
+	// analysis already treats results assigned outside of return
+	// statements as unknown, so references here are rare shapes like
+	// a result read after an assignment inside a return expression,
+	// or a result captured by value in a function literal; drop just
+	// those slots.
+	for _, n := range reads {
+		for i, f := range fn.Type().Results() {
+			if f.Nname == n {
+				devirt[i] = nil
+			}
+		}
+	}
+
+	can := false
+	for _, t := range devirt {
+		can = can || t != nil
+	}
+	if !can {
+		return nil
+	}
+
+	fdv := s.buildSplit(fn, devirt, closures)
+
+	fn.DevirtVariant = fdv
+	fdv.DevirtOriginal = fn
+	fdv.ResultTypeSets = fn.ResultTypeSets
+
+	// The variant has no export-data body of its own. When the
+	// original is inlinable, a call to the variant inlines as the
+	// original's body with the devirtualized results unboxed; see
+	// noder's unifiedInlineCall.
+	fdv.Inl = fn.Inl
+
+	if base.Flag.LowerM != 0 {
+		base.WarnfAt(fn.Pos(), "splitting %v into %v", fn, fdv)
+	}
+	return fdv
+}
+
+// splitResultTypes reports, per result slot of fn, the concrete type
+// to devirtualize that slot to, or nil for slots to leave alone.
+//
+// A nil slice means no slot qualifies.
+func (s *State) splitResultTypes(fn *ir.Func) []*types.Type {
+	rts := fn.ResultTypeSets
+	if rts == nil {
+		return nil
+	}
+
+	var devirt []*types.Type
+	for i, set := range rts {
+		if len(set) != 1 || set[0] == nilType || set[0] == unknownType {
+			continue
+		}
+		if devirt == nil {
+			devirt = make([]*types.Type, len(rts))
+		}
+		devirt[i] = set[0]
+	}
+	return devirt
+}
+
+// scanBody finds the named result parameters that fn's body reads,
+// and the function literals it contains, at any nesting depth.
+//
+// The walk does not descend into the literals' bodies by itself, so
+// a result they capture is counted as read through their
+// ClosureVars. The Defn link is the one to check: at any depth it
+// names the canonical variable, where Outer names the capture one
+// level up.
+func scanBody(fn *ir.Func) (reads []*ir.Name, closures []*ir.Func) {
+	var scan func(body ir.Nodes)
+	scan = func(body ir.Nodes) {
+		ir.VisitList(body, func(n ir.Node) {
+			switch n := n.(type) {
+			case *ir.Name:
+				if n.Class == ir.PPARAMOUT {
+					reads = append(reads, n)
+				}
+			case *ir.ClosureExpr:
+				closures = append(closures, n.Func)
+				for _, cv := range n.Func.ClosureVars {
+					if defn, ok := cv.Defn.(*ir.Name); ok && defn.Class == ir.PPARAMOUT {
+						reads = append(reads, defn)
+					}
+				}
+				scan(n.Func.Body)
+			}
+		})
+	}
+	scan(fn.Body)
+	return reads, closures
+}
+
+// buildSplit moves fn's body into a new devirtualized variant and
+// rebuilds fn as a thunk around it.
+func (s *State) buildSplit(fn *ir.Func, devirt []*types.Type, closures []*ir.Func) *ir.Func {
+	pos := fn.Pos()
+
+	// The variant's signature is fn's with the devirtualized result
+	// types substituted. The fields are fresh so that DeclareParams
+	// can bind new parameter names owned by the variant.
+	clone := func(f *types.Field, typ *types.Type) *types.Field {
+		res := types.NewField(f.Pos, f.Sym, typ)
+		res.SetIsDDD(f.IsDDD())
+		return res
+	}
+
+	// A method's receiver is promoted to a leading parameter of the
+	// variant, the way shaped methods promote theirs: only static
+	// calls reach the variant, so nothing needs it to be a method,
+	// and the method itself stays behind as the thunk that itabs
+	// point to.
+	params := make([]*types.Field, len(fn.Type().RecvParams()))
+	for i, f := range fn.Type().RecvParams() {
+		params[i] = clone(f, f.Type)
+	}
+
+	results := make([]*types.Field, len(fn.Type().Results()))
+	for i, f := range fn.Type().Results() {
+		typ := f.Type
+		if devirt[i] != nil {
+			typ = devirt[i]
+		}
+		results[i] = clone(f, typ)
+	}
+
+	sym := fn.Sym().Pkg.Lookup(fn.Sym().Name + ".dv")
+	fdv := ir.NewFunc(pos, fn.Nname.Pos(), sym, types.NewSignature(nil, params, results))
+	fdv.SetDupok(fn.Dupok())
+	typecheck.DeclFunc(fdv)
+
+	// Move the body, the locals, and the body-scoped debug info.
+	fdv.Body, fn.Body = fn.Body, nil
+	fdv.Parents, fn.Parents = fn.Parents, nil
+	fdv.Marks, fn.Marks = fn.Marks, nil
+	fdv.Endlineno = fn.Endlineno
+	fdv.Label = fn.Label
+
+	keep := fn.Dcl[:0]
+	for _, n := range fn.Dcl {
+		if n.Class == ir.PAUTO {
+			n.Curfn = fdv
+			fdv.Dcl = append(fdv.Dcl, n)
+		} else {
+			keep = append(keep, n)
+		}
+	}
+	fn.Dcl = keep
+
+	// The moved body still names fn's parameters; retarget it to the
+	// variant's. Result parameters are rebound too: a retained named
+	// result (an interface slot that did not qualify) may be read or
+	// assigned by the body. Devirtualized slots get a mapping as
+	// well, but it is never exercised, since slots the body reads
+	// were dropped from devirt above.
+	subst := make(map[*ir.Name]*ir.Name)
+	for i, f := range fn.Type().RecvParams() {
+		subst[f.Nname.(*ir.Name)] = fdv.Type().Params()[i].Nname.(*ir.Name)
+	}
+	for i, f := range fn.Type().Results() {
+		if old, ok := f.Nname.(*ir.Name); ok {
+			subst[old] = fdv.Type().Results()[i].Nname.(*ir.Name)
+		}
+	}
+
+	var edit func(ir.Node) ir.Node
+	edit = func(n ir.Node) ir.Node {
+		if n, ok := n.(*ir.Name); ok {
+			if repl, ok := subst[n]; ok {
+				return repl
+			}
+			return n
+		}
+		// WithHidden: the reader stows dictionary and runtime-type
+		// operands in fields EditChildren skips, like IndexExpr.RType,
+		// and those reference the parameters too.
+		ir.EditChildrenWithHidden(n, edit)
+		return n
+	}
+	for i, n := range fdv.Body {
+		fdv.Body[i] = edit(n)
+	}
+
+	// Update captures to point at the new function. Both links need
+	// rebinding: Outer names the capture one level up, and Defn the
+	// canonical variable, which Name.Canonical follows; a nested
+	// literal's Defn reaches fn's parameters directly even when its
+	// Outer does not.
+	for _, cf := range closures {
+		if cf.ClosureParent == fn {
+			cf.ClosureParent = fdv
+		}
+		for _, cv := range cf.ClosureVars {
+			if repl, ok := subst[cv.Outer]; ok {
+				cv.Outer = repl
+			}
+			if defn, ok := cv.Defn.(*ir.Name); ok {
+				if repl, ok := subst[defn]; ok {
+					cv.Defn = repl
+				}
+			}
+		}
+	}
+
+	// Unbox the devirtualized slots at every return: strip the
+	// boxing conversion where one is directly present, and extract
+	// the value word otherwise. The extraction is unchecked: the
+	// analysis proved the dynamic type, and a checked assertion
+	// would survive to run time whenever the boxing site is not
+	// visible in this function, such as a value returned by a
+	// recorded callee that did not itself split.
+	ir.VisitList(fdv.Body, func(n ir.Node) {
+		ret, ok := n.(*ir.ReturnStmt)
+		if !ok {
+			return
+		}
+		if len(ret.Results) != len(devirt) {
+			base.FatalfAt(ret.Pos(), "split function %v has a bare return", fdv)
+		}
+		for i, t := range devirt {
+			if t == nil {
+				continue
+			}
+			e := ret.Results[i]
+			for {
+				if p, ok := e.(*ir.ParenExpr); ok {
+					e = p.X
+					continue
+				}
+				break
+			}
+			if conv, ok := e.(*ir.ConvExpr); ok && conv.Op() == ir.OCONVIFACE && types.Identical(conv.X.Type(), t) {
+				// The conversion node may hold the statements that
+				// define its operand: rewriting "return g()" for a
+				// multi-valued g leaves the call and its temporaries
+				// in the implicit conversion's init list. Hoist them
+				// onto the return statement rather than dropping
+				// them with the conversion.
+				ret.PtrInit().Append(ir.TakeInit(conv)...)
+				ret.Results[i] = conv.X
+				continue
+			}
+			ret.Results[i] = Unbox(ret.Results[i], t)
+		}
+	})
+
+	typecheck.FinishFuncBody()
+
+	// Rebuild fn as the boxing thunk. Typechecking inserts appropriate
+	// boxing conversions.
+	ir.WithFunc(fn, func() {
+		recvParams := fn.Type().RecvParams()
+		args := make([]ir.Node, len(recvParams))
+		for i, f := range recvParams {
+			args[i] = f.Nname.(*ir.Name)
+		}
+		call := typecheck.Call(pos, fdv.Nname, args, fn.Type().IsVariadic())
+
+		ret := ir.NewReturnStmt(pos, nil)
+		ret.Results = []ir.Node{call}
+		fn.Body = []ir.Node{ret}
+		typecheck.Stmts(fn.Body)
+	})
+
+	return fdv
+}
+
+// Unbox extracts the value of concrete type t from an interface
+// value known to hold it, with no runtime check.
+func Unbox(v ir.Node, t *types.Type) ir.Node {
+	idata := ir.NewUnaryExpr(v.Pos(), ir.OIDATA, v)
+	idata.SetTypecheck(1)
+	if types.IsDirectIface(t) {
+		idata.SetType(t)
+		return idata
+	}
+
+	// The value is boxed behind a pointer, and the proven dynamic
+	// type also proves the interface is not nil, so the load cannot
+	// fault.
+	idata.SetType(types.NewPtr(t))
+	deref := ir.NewStarExpr(v.Pos(), idata)
+	deref.SetType(t)
+	deref.SetTypecheck(1)
+	return deref
+}
+
+// StaticResults rewrites a static call to a split function into a
+// call of its devirtualized variant, re-boxing the results at the
+// call site.
+//
+// The rewrite is returned as an OINLCALL, as if the thunk left
+// behind by [State.SplitResultFunc] had been inlined there: the
+// boxing conversions sit in ReturnVars, where the caller's
+// concrete-type analysis sees them, so method calls on the results
+// devirtualize in turn.
+func StaticResults(s *State, curfn *ir.Func, call *ir.CallExpr) *ir.InlinedCallExpr {
+	if call.GoDefer || call.Op() != ir.OCALLFUNC {
+		// A go or defer statement needs a plain call.
+		return nil
+	}
+	callee := staticCallee(call)
+	if callee == nil {
+		return nil
+	}
+	fdv := callee.DevirtVariant
+	if fdv == nil {
+		return nil
+	}
+
+	pos := call.Pos()
+	origResults := callee.Type().Results()
+	origType := call.Type()
+
+	// Retarget the call and update its type for the new result
+	// stack offsets, as [StaticCall] does.
+	call.Fun = fdv.Nname
+	types.CheckSize(fdv.Type())
+	switch ft := fdv.Type(); ft.NumResults() {
+	case 1:
+		call.SetType(ft.Result(0).Type)
+	default:
+		call.SetType(ft.ResultsTuple())
+	}
+
+	results := fdv.Type().Results()
+	tmps := make([]ir.Node, len(results))
+	retvars := make([]ir.Node, len(results))
+	for i, f := range results {
+		tmp := typecheck.TempAt(pos, curfn, f.Type)
+		tmps[i] = tmp
+		if orig := origResults[i].Type; orig.IsInterface() && !f.Type.IsInterface() {
+			retvars[i] = typecheck.AssignConv(tmp, orig, "devirtualized result")
+		} else {
+			retvars[i] = tmp
+		}
+	}
+
+	var as ir.Node
+	if len(tmps) == 1 {
+		n := ir.NewAssignStmt(pos, tmps[0], call)
+		n.SetTypecheck(1)
+		as = n
+	} else {
+		n := ir.NewAssignListStmt(pos, ir.OAS2FUNC, tmps, []ir.Node{call})
+		n.SetTypecheck(1)
+		as = n
+	}
+
+	inl := ir.NewInlinedCallExpr(pos, []ir.Node{as}, retvars)
+	inl.SetType(origType)
+	inl.SetTypecheck(1)
+
+	if base.Flag.LowerM != 0 {
+		base.WarnfAt(pos, "devirtualizing call to %v", fdv)
+	}
+	return inl
+}

--- a/src/cmd/compile/internal/devirtualize/typeset.go
+++ b/src/cmd/compile/internal/devirtualize/typeset.go
@@ -1,0 +1,312 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package devirtualize
+
+import (
+	"cmd/compile/internal/base"
+	"cmd/compile/internal/ir"
+	"cmd/compile/internal/types"
+)
+
+// This file implements a type-set analysis shared by both interface
+// devirtualizers.
+//
+// exprTypeSet determines the set of dynamic types an interface-typed
+// expression may hold, following conversions, inlined calls, and the
+// assignments [State.analyze] records for local variables.
+//
+// AnalyzeResultTypes determines, for every interface-typed result of
+// every function, the set of dynamic types the function's return
+// statements supply for that result. A function whose set is one
+// concrete type is a devirtualization opportunity for its callers:
+// exprTypeSet resolves static calls through the recorded sets, so a
+// method call on the result can be rewritten into a direct call by
+// [StaticCall] without inlining the function's body. A set like
+// {*T, nil} could become a guarded opportunity, for error or nil
+// results in particular (currently not implemented).
+//
+// The interleaved devirtualization and inlining pass drives the
+// analysis bottom-up, one scc at a time. When a return statement returns the
+// results of a static call, the callee has hopefully been analyzed already,
+// so we can use its dynamic result sets to analyze that call itself.
+// Currently, we do not try to break sccs in this analysis.
+//
+// Unlike receiver devirtualization, the return-value analysis must
+// treat the nil interface as a dynamic type of its own. concreteType
+// may ignore nil members because calling a method on a nil interface
+// panics no matter what. A caller of a returned interface value may
+// instead compare it against nil, so a function that returns both nil
+// and *T values must not be recorded as always returning *T. This is
+// why [State.analyze] records nil assignments and exprTypeSet tracks
+// them as set members, with concreteType alone discarding them.
+
+// typeSet is the working alias for [ir.TypeSet]; the type and its
+// sentinels live in ir so that [ir.Func] can hold them.
+type typeSet = ir.TypeSet
+
+// Sentinels for typeSet.
+var nilType, unknownType = ir.TypeSetNil, ir.TypeSetUnknown
+
+// exprTypeSet adds the abstract dynamic types of the expression e
+// into set.
+//
+// Recursive; seen guards against cycles.
+func (s *State) exprTypeSet(set typeSet, e ir.Node, seen map[*ir.Name]struct{}) (out typeSet) {
+	nn := e // for debug messages
+
+	if concreteTypeDebug {
+		defer func() {
+			base.Warn("exprTypeSet(%v) -> {%v}", nn, out)
+		}()
+	}
+
+	for {
+		if concreteTypeDebug {
+			base.Warn("exprTypeSet(%v): analyzing %v", nn, e)
+		}
+
+		if !e.Type().IsInterface() {
+			return set.Add(e.Type())
+		}
+
+		switch n := e.(type) {
+		case *ir.ConvExpr:
+			if n.Op() == ir.OCONVNOP {
+				if !n.Type().IsInterface() || !types.Identical(n.Type().Underlying(), n.X.Type().Underlying()) {
+					// As we check (directly before this switch) whether n is an interface, thus we should only reach
+					// here for iface conversions where both operands are the same.
+					base.FatalfAt(n.Pos(), "not identical/interface types found n.Type = %v; n.X.Type = %v", n.Type(), n.X.Type())
+				}
+				e = n.X
+				continue
+			}
+			if n.Op() == ir.OCONVIFACE {
+				e = n.X
+				continue
+			}
+		case *ir.InlinedCallExpr:
+			if n.Op() == ir.OINLCALL {
+				e = n.SingleResult()
+				continue
+			}
+		case *ir.ParenExpr:
+			e = n.X
+			continue
+		case *ir.TypeAssertExpr:
+			e = n.X
+			continue
+		}
+		break
+	}
+
+	if ir.IsNil(e) {
+		return set.Add(nilType)
+	}
+
+	switch e := e.(type) {
+	case *ir.CallExpr:
+		return s.callResultTypeSet(set, e, 0)
+	case *ir.Name:
+		return s.nameTypeSet(set, e, seen)
+	}
+
+	return set.Add(unknownType)
+}
+
+// nameTypeSet adds the abstract dynamic types of every assignment to
+// the local variable n into set.
+func (s *State) nameTypeSet(set typeSet, n *ir.Name, seen map[*ir.Name]struct{}) typeSet {
+	name := n.Canonical()
+	if name.Class != ir.PAUTO {
+		return set.Add(unknownType)
+	}
+
+	if name.Op() != ir.ONAME {
+		base.FatalfAt(name.Pos(), "name.Op = %v; want = ONAME", n.Op())
+	}
+
+	// name.Curfn must be set, as we checked name.Class != ir.PAUTO before.
+	if name.Curfn == nil {
+		base.FatalfAt(name.Pos(), "name.Curfn = nil; want not nil")
+	}
+
+	if name.Addrtaken() {
+		return set.Add(unknownType) // conservatively assume it's reassigned with a different type indirectly
+	}
+
+	if _, ok := seen[name]; ok {
+		return set // already analyzed assignments to name; a cycle adds no members
+	}
+	seen[name] = struct{}{}
+
+	if concreteTypeDebug {
+		base.Warn("nameTypeSet: analyzing assignments to %v", name)
+	}
+
+	for _, v := range s.assignments(name) {
+		switch v := v.(type) {
+		case nil:
+			set = set.Add(unknownType)
+		case *types.Type:
+			set = set.Add(v)
+		case result:
+			set = s.callResultTypeSet(set, v.call, v.index)
+		case ir.Node:
+			set = s.exprTypeSet(set, v, seen)
+		}
+	}
+	return set
+}
+
+// callResultTypeSet adds the abstract dynamic types of the i'th result of a
+// call into set, using the result sets recorded for the statically known callee
+// by [State.AnalyzeResultTypes].
+func (s *State) callResultTypeSet(set typeSet, call *ir.CallExpr, i int) typeSet {
+	callee := staticCallee(call)
+	if callee == nil {
+		if concreteTypeDebug {
+			base.Warn("callResultTypeSet(%v): callee not statically known", call)
+		}
+		return set.Add(unknownType)
+	}
+
+	rts := callee.ResultTypeSets
+	if rts == nil || len(rts[i]) == 0 {
+		if concreteTypeDebug {
+			base.Warn("callResultTypeSet(%v): no recorded result types for %v", call, callee)
+		}
+		return set.Add(unknownType)
+	}
+
+	if concreteTypeDebug {
+		base.Warn("callResultTypeSet(%v): result #%d of %v is {%v}", call, i, callee, rts[i])
+	}
+	for _, t := range rts[i] {
+		set = set.Add(t)
+	}
+	return set
+}
+
+// staticCallee finds the function a call statically resolves to, or
+// nil if the callee is not statically known.
+func staticCallee(call *ir.CallExpr) *ir.Func {
+	if call.Op() != ir.OCALLFUNC {
+		return nil
+	}
+
+	switch fun := ir.StaticValue(call.Fun); fun.Op() {
+	case ir.ONAME:
+		if fun := fun.(*ir.Name); fun.Class == ir.PFUNC {
+			return fun.Func
+		}
+	case ir.OMETHEXPR:
+		if name := ir.MethodExprName(fun); name != nil {
+			return name.Func
+		}
+	}
+	return nil
+}
+
+// AnalyzeResultTypes records the sets of dynamic types fn's interface-typed
+// results may hold.
+//
+// It must run after fn's body has reached its final form for the interleaved
+// pass, and after the functions fn calls have been analyzed; the pass's
+// bottom-up walk over strongly connected components provides both.
+func (s *State) AnalyzeResultTypes(fn *ir.Func) {
+	if len(fn.Body) == 0 {
+		return // Impl in assembly or elsewhere, result type unknowable.
+	}
+
+	results := fn.Type().Results()
+	hasIface := false
+	for _, f := range results {
+		if f.Type.IsInterface() {
+			hasIface = true
+			break
+		}
+	}
+	if !hasIface {
+		return // Nothing to do.
+	}
+
+	// Add the returned value's abstract types into rets at every
+	// return statement, and watch for defers along the way. The walk
+	// does not descend into closure bodies, so every ORETURN seen
+	// here returns from fn itself.
+	rets := make([]typeSet, len(results))
+	hasDefer := false
+	ir.VisitList(fn.Body, func(n ir.Node) {
+		switch n.Op() {
+		case ir.ODEFER:
+			hasDefer = true
+		case ir.ORETURN:
+			ret := n.(*ir.ReturnStmt)
+			if len(ret.Results) != len(rets) {
+				// A bare return reads the named result variables, whose
+				// assignments this analysis does not follow. Multi-valued
+				// "return g()" does not reach here: typecheck has already
+				// rewritten it into temporaries defined by an OAS2FUNC,
+				// which exprTypeSet follows through their recorded
+				// assignments.
+				//
+				// TODO(mcy): follow assignments to named results;
+				// [State.analyze] only tracks PAUTO variables today.
+				for i := range rets {
+					if results[i].Type.IsInterface() {
+						rets[i] = rets[i].Add(unknownType)
+					}
+				}
+				return
+			}
+
+			for i, e := range ret.Results {
+				if results[i].Type.IsInterface() {
+					rets[i] = s.exprTypeSet(rets[i], e, make(map[*ir.Name]struct{}))
+				}
+			}
+		}
+	})
+
+	if hasDefer {
+		// A deferred call may recover a panic, making fn return the
+		// zero value of every result, and the zero value of an
+		// interface is nil. The recorded sets would be missing nil.
+		//
+		// This cannot use fn.HasDefer, which walk has not set yet.
+		//
+		// TODO(mcy): relax this. A defer only invalidates the
+		// analysis when it can call recover or write to a named
+		// result. When every result is unnamed, a recover only adds
+		// nil to each set; and a deferred static call to a function
+		// known not to recover changes nothing at all.
+		if concreteTypeDebug {
+			base.Warn("AnalyzeResultTypes(%v): has defer, results not recorded", fn)
+		}
+		return
+	}
+
+	fn.ResultTypeSets = rets
+
+	if concreteTypeDebug {
+		for i, set := range rets {
+			if results[i].Type.IsInterface() {
+				base.Warn("AnalyzeResultTypes(%v): result #%d = {%v}", fn, i, set)
+			}
+		}
+	}
+
+	if base.Flag.LowerM != 0 {
+		for i, set := range rets {
+			switch {
+			case len(set) == 0, set[0] == unknownType:
+			case len(set) == 1:
+				base.WarnfAt(fn.Pos(), "result #%d of %v is always %s", i, fn, set)
+			default:
+				base.WarnfAt(fn.Pos(), "result #%d of %v is one of %v", i, fn, set)
+			}
+		}
+	}
+}

--- a/src/cmd/compile/internal/inline/inl.go
+++ b/src/cmd/compile/internal/inline/inl.go
@@ -58,6 +58,14 @@ const (
 	inlineBigFunctionNodes      = 5000                 // Functions with this many nodes are considered "big".
 	inlineBigFunctionMaxCost    = 20                   // Max cost of inlinee when inlining into a "big" function.
 	inlineClosureCalledOnceCost = 10 * inlineMaxBudget // if a closure is just called once, inline it.
+
+	// MinSplitCost is the smallest cost at which return-value
+	// devirtualization splits a function. A cheaper function inlines
+	// at most call sites anyway, exposing its returns to the caller's
+	// analysis directly; splitting it would only add a symbol and
+	// defeat inlining of the devirtualized call, since the variant
+	// has no inline body.
+	MinSplitCost = inlineMaxBudget / 2
 )
 
 var (

--- a/src/cmd/compile/internal/inline/interleaved/interleaved.go
+++ b/src/cmd/compile/internal/inline/interleaved/interleaved.go
@@ -133,6 +133,17 @@ func DevirtualizeAndInlinePackage(pkg *ir.Package, profile *pgoir.Profile) {
 
 			}
 		}
+
+		if base.Debug.RetDevirt != 0 {
+			// The bodies in this component are now final for this
+			// pass, so record which of their interface-typed results
+			// always hold a single dynamic type. Functions in later
+			// components are then analyzed through their static
+			// calls into this one.
+			for _, fn := range list {
+				state.AnalyzeResultTypes(fn)
+			}
+		}
 	})
 
 	ir.CurFunc = nil
@@ -233,12 +244,12 @@ func (s *inlClosureState) edit(state *devirtualize.State, i int) (*ir.CallExpr, 
 	// resolve, but because things can change it
 	// must be re-checked.
 	callee, count := s.resolve(state, i)
-	if count <= 0 {
-		return nil, nil
+	if count > 0 {
+		if inlCall := inline.TryInlineCall(s.fn, call, s.bigCaller, s.profile, count == 1 && callee.ClosureParent != nil); inlCall != nil {
+			return call, inlCall
+		}
 	}
-	if inlCall := inline.TryInlineCall(s.fn, call, s.bigCaller, s.profile, count == 1 && callee.ClosureParent != nil); inlCall != nil {
-		return call, inlCall
-	}
+
 	return nil, nil
 }
 

--- a/src/cmd/compile/internal/inline/interleaved/interleaved.go
+++ b/src/cmd/compile/internal/inline/interleaved/interleaved.go
@@ -143,6 +143,21 @@ func DevirtualizeAndInlinePackage(pkg *ir.Package, profile *pgoir.Profile) {
 			for _, fn := range list {
 				state.AnalyzeResultTypes(fn)
 			}
+
+			// Split qualifying functions into a devirtualized
+			// variant plus a boxing thunk. Later components call the
+			// variant directly, via the rewrite in edit.
+			for _, fn := range list {
+				fdv := state.SplitResultFunc(fn)
+				if fdv == nil {
+					continue
+				}
+
+				// The variant took over fn's body, and with it this
+				// pass's ParenExprs; register state for it so the
+				// final unparenthesize pass covers the moved body.
+				inlState[fdv] = &inlClosureState{fn: fdv, parens: inlState[fn].parens}
+			}
 		}
 	})
 
@@ -250,6 +265,22 @@ func (s *inlClosureState) edit(state *devirtualize.State, i int) (*ir.CallExpr, 
 		}
 	}
 
+	// Not inlined; try rewriting a static call to a split function
+	// into a call of its devirtualized variant. The rewrite has the
+	// shape of an inlined thunk, so the fixpoint treats it exactly
+	// like an inlined call: state.InlinedCall exposes the concrete
+	// result types, later rounds may still inline the variant should
+	// this site's conditions change, and method calls on the results
+	// devirtualize either way.
+	//
+	// Order matters, and the obvious-seeming alternative loses:
+	// rewriting before trying to inline sends inlinable callees
+	// through box-unbox-rebox churn at every already-inlinable call
+	// site, and measurably regresses allocation-heavy code, while
+	// the rewrite's winnings come from the sites inlining declines.
+	if inlCall := devirtualize.StaticResults(state, s.fn, call); inlCall != nil {
+		return call, inlCall
+	}
 	return nil, nil
 }
 

--- a/src/cmd/compile/internal/ir/func.go
+++ b/src/cmd/compile/internal/ir/func.go
@@ -101,6 +101,24 @@ type Func struct {
 
 	Inl *Inline
 
+	// ResultTypeSets, if non-nil, records for each result of this
+	// function the set of dynamic types it may hold. Maintained by
+	// the devirtualize package, including across package boundaries.
+	ResultTypeSets []TypeSet
+
+	// DevirtVariant, if non-nil, is this function's devirtualized
+	// variant f.dv, split off by the devirtualize package. It has
+	// this function's body, unboxed interface results, and any
+	// receiver promoted to a leading parameter; this function is a
+	// thunk around it.
+	DevirtVariant *Func
+
+	// DevirtOriginal, if non-nil, is the function this variant was
+	// split from. The variant has no body of its own in export data,
+	// so the inliner inlines the original's body and unboxes the
+	// devirtualized results.
+	DevirtOriginal *Func
+
 	// RangeParent, if non-nil, is the first non-range body function containing
 	// the closure for the body of a range function.
 	RangeParent *Func

--- a/src/cmd/compile/internal/ir/sizeof_test.go
+++ b/src/cmd/compile/internal/ir/sizeof_test.go
@@ -20,7 +20,7 @@ func TestSizeof(t *testing.T) {
 		_32bit uintptr // size on 32bit platforms
 		_64bit uintptr // size on 64bit platforms
 	}{
-		{Func{}, 188, 312},
+		{Func{}, 208, 352},
 		{Name{}, 96, 160},
 		{miniExpr{}, 32, 48},
 		{miniNode{}, 12, 12},

--- a/src/cmd/compile/internal/ir/typeset.go
+++ b/src/cmd/compile/internal/ir/typeset.go
@@ -1,0 +1,86 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ir
+
+import (
+	"slices"
+	"strings"
+
+	"cmd/compile/internal/types"
+)
+
+// A TypeSet is the set of dynamic types an interface-typed value may
+// hold, as computed and consumed by the devirtualize package.
+//
+// Members are concrete types, TypeSetNil, or TypeSetUnknown. A set
+// containing TypeSetUnknown holds nothing else, since unknown
+// subsumes every other member; its presence can always be checked by
+// ts[0] == TypeSetUnknown. TypeSet(nil) records that no value has
+// been seen, which consumers must treat as unknown, not as proof
+// that no value exists.
+//
+// The type lives here rather than in devirtualize so that [Func] can
+// hold one, like it holds an [Inline].
+type TypeSet []*types.Type
+
+// Sentinel members: the nil interface, treated as a dynamic type of
+// its own, and the unknown dynamic type.
+var (
+	typeSetNil, typeSetUnknown types.Type
+
+	TypeSetNil     = &typeSetNil
+	TypeSetUnknown = &typeSetUnknown
+)
+
+// typeSetLimit is the largest set tracked for one value; a set that
+// would grow past it collapses to unknown.
+const typeSetLimit = 4
+
+// Add returns the set extended by the abstract dynamic type t.
+func (ts TypeSet) Add(t *types.Type) TypeSet {
+	if len(ts) == 1 && ts[0] == TypeSetUnknown {
+		return ts
+	}
+
+	// Unknown subsumes all types. Also, a shaped type is one which is dependent
+	// on a type dictionary (e.g. go.shape.uint64 within a generic stencil), so
+	// we must treat it as unknown.
+	if t == TypeSetUnknown || t.HasShape() {
+		return TypeSet{TypeSetUnknown}
+	}
+
+	// Pointer identity can treat two occurrences of the same unnamed
+	// composite type as distinct members, since those need not share
+	// a *types.Type. Types with methods are named or pointers to
+	// named types and are represented uniquely, so for the types this
+	// analysis cares about, pointer identity is exact.
+	if slices.Contains(ts, t) {
+		return ts
+	}
+	if len(ts) >= typeSetLimit {
+		return TypeSet{TypeSetUnknown}
+	}
+	return append(ts, t)
+}
+
+// String formats the set for debug output and diagnostics.
+func (ts TypeSet) String() string {
+	names := make([]string, len(ts))
+	for i, t := range ts {
+		names[i] = typeSetName(t)
+	}
+	return strings.Join(names, ", ")
+}
+
+// typeSetName formats one abstract dynamic type for diagnostics.
+func typeSetName(t *types.Type) string {
+	switch t {
+	case TypeSetNil:
+		return "<nil>"
+	case TypeSetUnknown:
+		return "<unknown>"
+	}
+	return t.String()
+}

--- a/src/cmd/compile/internal/noder/linker.go
+++ b/src/cmd/compile/internal/noder/linker.go
@@ -10,6 +10,7 @@ import (
 	"io"
 
 	"cmd/compile/internal/base"
+	"cmd/compile/internal/devirtualize"
 	"cmd/compile/internal/ir"
 	"cmd/compile/internal/reflectdata"
 	"cmd/compile/internal/types"
@@ -303,6 +304,47 @@ func (l *linker) relocFuncExt(w *pkgbits.Encoder, name *ir.Name) {
 		w.Bool(inl.CanDelayResults)
 		if buildcfg.Experiment.NewInliner {
 			w.String(inl.Properties)
+		}
+	}
+
+	// Return-value devirtualization: the function's result type sets
+	// and its split variant, if any. A member references its named
+	// type's object, which also forces the object into the export
+	// data; a member whose object is unavailable degrades its slot to
+	// unknown.
+	if er := devirtualize.ExportFor(name.Func); w.Bool(er != nil) {
+		w.Len(len(er.Slots))
+		for _, slot := range er.Slots {
+			unknown := slot.Unknown
+			var pris []pkgReaderIndex
+			if !unknown {
+				for _, m := range slot.Members {
+					pri, ok := objReader[m.Sym]
+					if !ok {
+						unknown = true
+						break
+					}
+					pris = append(pris, pri)
+				}
+			}
+			if w.Bool(unknown) {
+				continue
+			}
+			w.Len(len(pris))
+			for i, pri := range pris {
+				w.Len(slot.Members[i].Depth)
+				w.Reloc(pkgbits.SectionObj, l.relocObj(pri.pr, pri.idx))
+			}
+			w.Bool(slot.HasNil)
+		}
+		if split := er.Split; w.Bool(split != nil) {
+			for _, d := range split.Devirt {
+				w.Bool(d)
+			}
+			w.Len(len(split.ParamNotes))
+			for _, note := range split.ParamNotes {
+				w.String(note)
+			}
 		}
 	}
 

--- a/src/cmd/compile/internal/noder/reader.go
+++ b/src/cmd/compile/internal/noder/reader.go
@@ -1258,10 +1258,81 @@ func (r *reader) funcExt(name *ir.Name, method *types.Sym) {
 				fn.Inl.Properties = r.String()
 			}
 		}
+
+		r.retDevirt(fn)
 	} else {
 		r.addBody(name.Func, method)
 	}
 	r.Sync(pkgbits.SyncEOF)
+}
+
+// retDevirt reads fn's return-value devirtualization record: its
+// result type sets and split variant.
+//
+// The record is always consumed; it is only registered when
+// -d=retdevirt is set, so that devirtualization verdicts with the
+// flag off match a compiler without the records.
+func (r *reader) retDevirt(fn *ir.Func) {
+	if !r.Bool() {
+		return
+	}
+
+	sets := make([]devirtualize.ImportedSet, r.Len())
+	for i := range sets {
+		is := &sets[i]
+		if r.Bool() {
+			is.Unknown = true
+			continue
+		}
+		nmembers := r.Len()
+		for j := 0; j < nmembers; j++ {
+			depth := r.Len()
+			idx := r.Reloc(pkgbits.SectionObj)
+
+			var typ *types.Type
+			if n, err := r.p.objIdxMayFail(idx, nil, nil, false); err == nil {
+				if nn, ok := n.(*ir.Name); ok && nn.Op() == ir.OTYPE {
+					typ = nn.Type()
+				}
+			}
+			if typ == nil {
+				// An unresolvable member invalidates the whole set:
+				// a partial set would claim to be exhaustive.
+				is.Unknown = true
+				continue
+			}
+
+			for k := 0; k < depth; k++ {
+				typ = types.NewPtr(typ)
+			}
+			is.Members = append(is.Members, typ)
+		}
+		is.HasNil = r.Bool()
+		if is.Unknown {
+			is.Members = nil
+		}
+	}
+
+	var devirt []bool
+	var notes []string
+	if r.Bool() {
+		devirt = make([]bool, len(sets))
+		for i := range devirt {
+			devirt[i] = r.Bool()
+		}
+		notes = make([]string, r.Len())
+		for i := range notes {
+			notes[i] = r.String()
+		}
+	}
+
+	if base.Debug.RetDevirt == 0 {
+		return
+	}
+	devirtualize.ImportResults(fn, sets)
+	if devirt != nil {
+		devirtualize.ImportSplit(fn, devirt, notes)
+	}
 }
 
 func (r *reader) typeExt(name *ir.Name) {

--- a/src/cmd/compile/internal/noder/reader.go
+++ b/src/cmd/compile/internal/noder/reader.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"cmd/compile/internal/base"
+	"cmd/compile/internal/devirtualize"
 	"cmd/compile/internal/dwarfgen"
 	"cmd/compile/internal/inline"
 	"cmd/compile/internal/inline/interleaved"
@@ -3668,6 +3669,12 @@ func (r *reader) pkgObjs(target *ir.Package) []*ir.Name {
 // unifiedHaveInlineBody reports whether we have the function body for
 // fn, so we can inline it.
 func unifiedHaveInlineBody(fn *ir.Func) bool {
+	if orig := fn.DevirtOriginal; orig != nil {
+		// A devirtualized variant inlines through its original's
+		// body.
+		fn = orig
+	}
+
 	if fn.Inl == nil {
 		return false
 	}
@@ -3681,6 +3688,21 @@ var inlgen = 0
 // unifiedInlineCall implements inline.NewInline by re-reading the function
 // body from its Unified IR export data.
 func unifiedInlineCall(callerfn *ir.Func, call *ir.CallExpr, fn *ir.Func, inlIndex int, profile *pgoir.Profile) *ir.InlinedCallExpr {
+	if orig := fn.DevirtOriginal; orig != nil {
+		// A devirtualized variant is its original's body with the
+		// boxing removed from the devirtualized results, so inline
+		// the original and unbox those results. The unchecked
+		// extraction is sound for the same reason the split's was:
+		// the recorded result sets prove the dynamic type.
+		res := unifiedInlineCall(callerfn, call, orig, inlIndex, profile)
+		for i, f := range fn.Type().Results() {
+			if !f.Type.IsInterface() && orig.Type().Results()[i].Type.IsInterface() {
+				res.ReturnVars[i] = devirtualize.Unbox(res.ReturnVars[i], f.Type)
+			}
+		}
+		return res
+	}
+
 	pri, ok := bodyReaderFor(fn)
 	if !ok {
 		base.FatalfAt(call.Pos(), "cannot inline call to %v: missing inline body", fn)

--- a/src/cmd/compile/internal/noder/unified.go
+++ b/src/cmd/compile/internal/noder/unified.go
@@ -439,6 +439,24 @@ func readPackage(pr *pkgReader, importpkg *types.Pkg, localStub bool) {
 		r.Sync(pkgbits.SyncEOF)
 	}
 
+	if base.Debug.RetDevirt != 0 {
+		// Return-value devirtualization records reference concrete
+		// types that are often unexported, and the loop above only
+		// indexes the public root's objects. Index every object in
+		// the data, so that the linker can re-export the rest when a
+		// record in this compilation's own output refers to one.
+		for idx, n := index(0), index(pr.NumElems(pkgbits.SectionObj)); idx < n; idx++ {
+			path, name, code := pr.PeekObj(idx)
+			if code == pkgbits.ObjStub {
+				continue
+			}
+			sym := types.NewPkg(path, "").Lookup(name)
+			if _, ok := objReader[sym]; !ok {
+				objReader[sym] = pkgReaderIndex{pr, idx, nil, nil, nil}
+			}
+		}
+	}
+
 	if !localStub {
 		r := pr.newReader(pkgbits.SectionMeta, pkgbits.PrivateRootIdx, pkgbits.SyncPrivate)
 

--- a/src/cmd/compile/internal/walk/convert.go
+++ b/src/cmd/compile/internal/walk/convert.go
@@ -41,6 +41,15 @@ func walkConvInterface(n *ir.ConvExpr, init *ir.Nodes) ir.Node {
 
 	n.X = walkExpr(n.X, init)
 
+	// Boxing a value that was just unboxed from an identically typed
+	// interface is the original interface value. Return-value
+	// devirtualization produces this roundtrip when an inlined
+	// variant's unboxed result is re-boxed at the call site; for
+	// indirectly boxed types the roundtrip would otherwise allocate.
+	if x := unboxedFrom(n.X, n.Type()); x != nil {
+		return x
+	}
+
 	fromType := n.X.Type()
 	toType := n.Type()
 	if !fromType.IsInterface() && !ir.IsBlank(ir.CurFunc.Nname) {
@@ -624,4 +633,24 @@ func walkSliceToArray(n *ir.ConvExpr, init *ir.Nodes) ir.Node {
 	deref.SetBounded(true)
 
 	return walkExpr(deref, init)
+}
+
+// unboxedFrom reports the interface value that v extracts a concrete
+// value from, if boxing that value into typ reproduces it exactly:
+// v must be the devirtualize package's unchecked unboxing of an
+// interface of the same type, over an operand safe to reevaluate.
+func unboxedFrom(v ir.Node, typ *types.Type) ir.Node {
+	idata := v
+	if deref, ok := v.(*ir.StarExpr); ok {
+		idata = deref.X
+	}
+	u, ok := idata.(*ir.UnaryExpr)
+	if !ok || u.Op() != ir.OIDATA {
+		return nil
+	}
+	x, ok := u.X.(*ir.Name)
+	if !ok || !types.Identical(x.Type(), typ) {
+		return nil
+	}
+	return x
 }

--- a/test/retdevirt.go
+++ b/test/retdevirt.go
@@ -1,0 +1,198 @@
+// errorcheck -0 -m -d=retdevirt
+
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Test the analysis half of return-value devirtualization: which
+// interface-typed results are recorded as always holding a single
+// dynamic type.
+
+package p
+
+type I interface{ M() }
+
+type T struct{ x int }
+
+//go:noinline
+func (*T) M() {}
+
+type U struct{ x int }
+
+//go:noinline
+func (*U) M() {}
+
+//go:noinline
+func noop() {}
+
+// A direct return of a single concrete type.
+
+//go:noinline
+func newT() I { // ERROR "result #0 of newT is always \*T"
+	return &T{} // ERROR "&T{} escapes to heap"
+}
+
+// Propagation through a static call to an analyzed function.
+
+//go:noinline
+func newTIndirect() I { // ERROR "result #0 of newTIndirect is always \*T"
+	return newT()
+}
+
+// nil is a dynamic type of its own.
+
+//go:noinline
+func newNil() I { // ERROR "result #0 of newNil is always <nil>"
+	return nil
+}
+
+// Mixing nil with a concrete type records both: callers may compare
+// the result against nil, so the concrete type alone would be wrong.
+
+//go:noinline
+func newTOrNil(b bool) I { // ERROR "result #0 of newTOrNil is one of <nil>, \*T"
+	if b {
+		return nil
+	}
+	return &T{} // ERROR "&T{} escapes to heap"
+}
+
+// Two concrete types.
+
+//go:noinline
+func newTOrU(b bool) I { // ERROR "result #0 of newTOrU is one of \*U, \*T"
+	if b {
+		return &U{} // ERROR "&U{} escapes to heap"
+	}
+	return &T{} // ERROR "&T{} escapes to heap"
+}
+
+// A defer may recover, replacing the result with nil.
+
+//go:noinline
+func newTDefer() I {
+	defer noop()
+	return &T{} // ERROR "&T{} escapes to heap"
+}
+
+// Bare returns read named results, which are not followed yet.
+
+//go:noinline
+func newTNamed() (r I) {
+	r = &T{} // ERROR "&T{} escapes to heap"
+	return
+}
+
+// An interface-typed value of unknown dynamic type.
+
+//go:noinline
+func passthrough(x I) I { // ERROR "leaking param: x to result ~r0 level=0"
+	return x
+}
+
+// Multiple results are analyzed independently.
+
+//go:noinline
+func pair() (I, error) { // ERROR "result #0 of pair is always \*T" "result #1 of pair is always <nil>"
+	return &T{}, nil // ERROR "&T{} escapes to heap"
+}
+
+// Multi-valued propagation through "return g()".
+
+//go:noinline
+func pairIndirect() (I, error) { // ERROR "result #0 of pairIndirect is always \*T" "result #1 of pairIndirect is always <nil>"
+	return pair()
+}
+
+// A concrete result of the callee converted to an interface result of
+// the caller by a multi-valued return.
+
+//go:noinline
+func concretePair() (*T, error) { // ERROR "result #1 of concretePair is always <nil>"
+	return &T{}, nil // ERROR "&T{} escapes to heap"
+}
+
+//go:noinline
+func pairFromConcrete() (I, error) { // ERROR "result #0 of pairFromConcrete is always \*T" "result #1 of pairFromConcrete is always <nil>"
+	return concretePair()
+}
+
+// A local with a single assignment is followed to its value.
+
+//go:noinline
+func newTLocal() I { // ERROR "result #0 of newTLocal is always \*T"
+	var v I = &T{} // ERROR "&T{} escapes to heap"
+	return v
+}
+
+// A declaration without an initializer contributes nil: the zero
+// value of an interface variable is observable when no assignment
+// runs. This is load-bearing for correctness; see the split test.
+
+//go:noinline
+func newTOrZero(b bool) I { // ERROR "result #0 of newTOrZero is one of <nil>, \*T"
+	var v I
+	if b {
+		v = &T{} // ERROR "&T{} escapes to heap"
+	}
+	return v
+}
+
+// A reassigned local contributes every assignment to the set.
+
+//go:noinline
+func newTOrULocal(b bool) I { // ERROR "result #0 of newTOrULocal is one of \*T, \*U"
+	var v I = &T{} // ERROR "&T{} escapes to heap"
+	if b {
+		v = &U{} // ERROR "&U{} escapes to heap"
+	}
+	return v
+}
+
+// The recorded result sets feed receiver devirtualization: a method
+// call on the result of a static call to an analyzed function becomes
+// a direct call, with no inlining involved.
+
+//go:noinline
+func callM() {
+	v := newT()
+	v.M() // ERROR "devirtualizing v.M to \*T"
+}
+
+// Recursive functions see no recorded types for their own component.
+
+//go:noinline
+func recursive(n int) I {
+	if n == 0 {
+		return &T{} // ERROR "&T{} escapes to heap"
+	}
+	return recursive(n - 1)
+}
+
+// A shaped function whose result does not depend on the dictionary is
+// recorded like any other function, and its callers devirtualize.
+
+//go:noinline
+func newTShaped[X any]() I { // ERROR "result #0 of newTShaped\[go\.shape\.int\] is always \*T" "result #0 of newTShaped\[int\] is always \*T"
+	return &T{} // ERROR "&T{} escapes to heap"
+}
+
+// A result whose dynamic type depends on the dictionary is unknown.
+
+type box[X any] struct{ x X }
+
+//go:noinline
+func (*box[X]) M() {}
+
+//go:noinline
+func newBox[X any]() I {
+	return &box[X]{} // ERROR "escapes to heap"
+}
+
+//go:noinline
+func callShaped() {
+	v := newTShaped[int]()
+	v.M() // ERROR "devirtualizing v.M to \*T"
+	w := newBox[int]()
+	w.M()
+}

--- a/test/retdevirt_split.go
+++ b/test/retdevirt_split.go
@@ -1,0 +1,211 @@
+// errorcheck -0 -m -d=retdevirt
+
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Test the transform half of return-value devirtualization: which
+// functions split into a devirtualized variant plus a thunk, and how
+// static calls to them are rewritten.
+
+package p
+
+type I interface{ M() int }
+
+type T struct{ x int }
+
+//go:noinline
+func (t *T) M() int { return t.x } // ERROR "t does not escape"
+
+//go:noinline
+func grow() {}
+
+// Non-inlinable and always one concrete type: splits.
+
+func newT(n int) I { // ERROR "result #0 of newT is always \*T" "splitting newT into newT\.dv"
+	if n < 0 {
+		grow()
+		grow()
+	}
+	return &T{x: n} // ERROR "&T{...} escapes to heap"
+}
+
+// An argless variant, for the defer test below.
+
+var neg bool
+
+func newT0() I { // ERROR "result #0 of newT0 is always \*T" "splitting newT0 into newT0\.dv"
+	if neg {
+		grow()
+		grow()
+	}
+	return &T{} // ERROR "&T{} escapes to heap"
+}
+
+// The rewrite exposes the concrete type, so the method call on the
+// result devirtualizes with no inlining involved.
+
+//go:noinline
+func use() int {
+	v := newT(1) // ERROR "devirtualizing call to newT\.dv"
+	return v.M() // ERROR "devirtualizing v.M to \*T"
+}
+
+// Only the qualifying result slot changes type; the always-nil error
+// slot keeps its interface type.
+
+func newTPair(n int) (I, error) { // ERROR "result #0 of newTPair is always \*T" "result #1 of newTPair is always <nil>" "splitting newTPair into newTPair\.dv"
+	if n < 0 {
+		grow()
+		grow()
+	}
+	return &T{x: n}, nil // ERROR "&T{...} escapes to heap"
+}
+
+//go:noinline
+func usePair() int {
+	v, err := newTPair(1) // ERROR "devirtualizing call to newTPair\.dv"
+	if err != nil {
+		return 0
+	}
+	return v.M() // ERROR "devirtualizing v.M to \*T"
+}
+
+// Small and inlinable: left to the inliner, which exposes the
+// concrete type by inlining the body instead.
+
+func newTSmall() I { // ERROR "can inline newTSmall" "result #0 of newTSmall is always \*T"
+	return &T{} // ERROR "&T{} escapes to heap"
+}
+
+//go:noinline
+func useSmall() int {
+	v := newTSmall() // ERROR "inlining call to newTSmall" "&T{} does not escape"
+	return v.M()     // ERROR "devirtualizing v.M to \*T"
+}
+
+// A pragma disables splitting; the result set is still recorded.
+
+//go:noinline
+func newTNoinline(n int) I { // ERROR "result #0 of newTNoinline is always \*T"
+	if n < 0 {
+		grow()
+		grow()
+	}
+	return &T{x: n} // ERROR "&T{...} escapes to heap"
+}
+
+// A deferred call to a split function is normalized into a
+// synthesized closure first (its results alone force that), and the
+// call inside the closure is rewritten like any other; the closure
+// still runs at return. StaticResults refuses the rewrite for the
+// plain deferred calls that skip normalization.
+
+//go:noinline
+func useDefer() {
+	defer newT0() // ERROR "can inline useDefer\.deferwrap1" "devirtualizing call to newT0\.dv"
+}
+
+// Methods split too: the receiver is promoted to a leading parameter
+// of the variant, and the method itself stays behind as the thunk
+// that itabs, method values, and reflection use.
+
+type maker struct{ n int }
+
+func (m *maker) Make() I { // ERROR "m does not escape" "result #0 of \(\*maker\)\.Make is always \*T" "splitting \(\*maker\)\.Make into \(\*maker\)\.Make\.dv"
+	if m.n < 0 {
+		grow()
+		grow()
+	}
+	return &T{x: m.n} // ERROR "&T{...} escapes to heap"
+}
+
+//go:noinline
+func useMethod(m *maker) int { // ERROR "m does not escape"
+	v := m.Make() // ERROR "devirtualizing call to \(\*maker\)\.Make\.dv"
+	return v.M()  // ERROR "devirtualizing v.M to \*T"
+}
+
+// Devirtualizations chain: the interface receiver devirtualizes,
+// which makes the method call static, which rewrites it to the
+// variant, which devirtualizes the method call on its result.
+
+type mk interface{ Make() I }
+
+//go:noinline
+func useChain(m *maker) int { // ERROR "m does not escape"
+	var i mk = m
+	v := i.Make() // ERROR "devirtualizing i.Make to \*maker" "devirtualizing call to \(\*maker\)\.Make\.dv"
+	return v.M()  // ERROR "devirtualizing v.M to \*T"
+}
+
+// Shaped functions split per shape; the dictionary is forwarded like
+// any parameter, and the sets are dictionary-independent by
+// construction. The extra messages come from the instantiation
+// wrapper, whose body's call is rewritten like any other.
+
+func newTStencil[X any](n int) I { // ERROR "result #0 of newTStencil\[go\.shape\.int\] is always \*T" "splitting newTStencil\[go\.shape\.int\] into newTStencil\[go\.shape\.int\]\.dv" "result #0 of newTStencil\[int\] is always \*T" "can inline newTStencil\[int\]" "devirtualizing call to newTStencil\[go\.shape\.int\]\.dv"
+	if n < 0 {
+		grow()
+		grow()
+	}
+	return &T{x: n} // ERROR "&T{...} escapes to heap"
+}
+
+//go:noinline
+func useStencil() int {
+	v := newTStencil[int](1) // ERROR "devirtualizing call to newTStencil\[go\.shape\.int\]\.dv"
+	return v.M()             // ERROR "devirtualizing v.M to \*T"
+}
+
+// A body with function literals splits too: captures of moved locals
+// keep their identity, and captures of substituted parameters are
+// rebound.
+
+func newTClosure(n int) I { // ERROR "result #0 of newTClosure is always \*T" "splitting newTClosure into newTClosure\.dv"
+	double := n * 2
+	cb := func() int { return n + double } // ERROR "can inline newTClosure\.func1"
+	if n < 0 {
+		grow()
+		grow()
+	}
+	return &T{x: cb()} // ERROR "&T{...} escapes to heap" "inlining call to newTClosure\.func1"
+}
+
+//go:noinline
+func useClosure() int {
+	v := newTClosure(3) // ERROR "devirtualizing call to newTClosure\.dv"
+	return v.M()        // ERROR "devirtualizing v.M to \*T"
+}
+
+// A named result captured by a literal cannot change type; its slot
+// is dropped and, it being the only one, the function is not split.
+
+func newTCaptured(n int) (r I) { // ERROR "result #0 of newTCaptured is always \*T"
+	probe := func() I { return r } // ERROR "can inline newTCaptured\.func1" "func literal does not escape"
+	_ = probe
+	if n < 0 {
+		grow()
+		grow()
+	}
+	return &T{x: n} // ERROR "&T{...} escapes to heap"
+}
+
+// A mid-cost function is inlinable and also splits. At call sites
+// the inliner reaches first, so the original inlines as before; the
+// variant serves the sites inlining declines, and can itself inline
+// through the original's body should such a site's conditions later
+// allow it.
+
+func newTMid(n int) I { // ERROR "can inline newTMid" "result #0 of newTMid is always \*T" "splitting newTMid into newTMid\.dv"
+	if n < 0 {
+		grow()
+	}
+	return &T{x: n} // ERROR "&T{...} escapes to heap"
+}
+
+//go:noinline
+func useMid() int {
+	v := newTMid(1) // ERROR "inlining call to newTMid" "&T{...} does not escape"
+	return v.M()    // ERROR "devirtualizing v.M to \*T"
+}

--- a/test/retdevirt_split_run.go
+++ b/test/retdevirt_split_run.go
@@ -1,0 +1,246 @@
+// run -gcflags=-d=retdevirt
+
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Check the runtime semantics of split functions: boxing, nil
+// comparisons, type assertions, indirect calls through the thunk,
+// and defer timing through the normalized closure.
+
+package main
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type I interface{ M() int }
+
+type T struct{ x int }
+
+//go:noinline
+func (t *T) M() int { return t.x }
+
+//go:noinline
+func grow() {}
+
+var order []int
+
+// Non-inlinable via two calls; splits under -d=retdevirt.
+func newT(n int) I {
+	order = append(order, n)
+	if n < -1000 {
+		grow()
+		grow()
+	}
+	return &T{x: n}
+}
+
+func newTPair(n int) (I, error) {
+	if n < -1000 {
+		grow()
+		grow()
+	}
+	return &T{x: n}, nil
+}
+
+type maker struct{ n int }
+
+func (m *maker) Make() I {
+	if m.n < -1000 {
+		grow()
+		grow()
+	}
+	return &T{x: m.n}
+}
+
+func (m maker) MakeVal() I {
+	if m.n < -1000 {
+		grow()
+		grow()
+	}
+	return &T{x: m.n + 1}
+}
+
+type mk interface{ Make() I }
+
+func deferCheck() {
+	defer newT(10)
+	order = append(order, 1)
+}
+
+// Shaped constructor: one body per shape, dictionary forwarded.
+func newG[X any](n int) I {
+	if n < -1000 {
+		grow()
+		grow()
+	}
+	return &T{x: n}
+}
+
+// Closure-bearing constructor: captures a parameter and a local.
+func newCB(n int) I {
+	double := n * 2
+	cb := func() int { return n + double }
+	if n < -1000 {
+		grow()
+		grow()
+	}
+	return &T{x: cb()}
+}
+
+// The named result is captured by the literal; its slot must keep
+// its interface type, and the capture must observe the final value.
+func newCap(n int) (I, func() I) {
+	var probe func() I
+	f := func() (r I) {
+		probe = func() I { return r }
+		if n < -1000 {
+			grow()
+			grow()
+		}
+		r = &T{x: n}
+		return r
+	}
+	v := f()
+	return v, probe
+}
+
+// A value type boxed indirectly: unboxing it loads through the data
+// pointer rather than taking the word itself.
+type big struct{ a, b, c int }
+
+func (v big) M() int { return v.a + v.b + v.c }
+
+// Recorded {big} but not split, so the split callers of mkBig unbox
+// a value whose boxing site they cannot see.
+//
+//go:noinline
+func mkBig(n int) I {
+	if n < -1000 {
+		grow()
+		grow()
+	}
+	return big{a: n, b: n, c: n}
+}
+
+func viaBig(n int) I {
+	if n < -1000 {
+		grow()
+		grow()
+	}
+	return mkBig(n)
+}
+
+// Mid-cost: inlinable and split, so calls inline the variant. The
+// value-type result exercises the inlined deref unboxing.
+func midBig(n int) I {
+	if n < -1000 {
+		grow()
+	}
+	return big{a: n, b: n, c: n}
+}
+
+func midT(n int) I {
+	if n < -1000 {
+		grow()
+	}
+	return &T{x: n}
+}
+
+type errno int
+
+func (errno) Error() string { return "errno" }
+
+// The internal/syscall/unix.Getaddrinfo shape: an interface variable
+// declared at its zero value and only conditionally assigned. The
+// nil member recorded for the declaration must prevent the split.
+func maybeErr(b bool) (int, error) {
+	if b {
+		grow()
+		grow()
+	}
+	var err error
+	if b {
+		err = errno(7)
+	}
+	return 42, err
+}
+
+func main() {
+	check := func(cond bool, msg string) {
+		if !cond {
+			panic(msg)
+		}
+	}
+
+	v := newT(7)
+	check(v != nil, "v == nil")
+	check(v.M() == 7, "v.M() != 7")
+
+	w, err := newTPair(3)
+	check(err == nil, "err != nil")
+	check(w.M() == 3, "w.M() != 3")
+
+	_, ok := v.(*T)
+	check(ok, "v.(*T) failed")
+	check(fmt.Sprintf("%T", v) == "*main.T", "wrong dynamic type")
+
+	// Indirect calls go through the boxing thunk.
+	fp := newT
+	check(fp(9).M() == 9, "fp(9).M() != 9")
+
+	// So does reflection.
+	rv := reflect.ValueOf(newT).Call([]reflect.Value{reflect.ValueOf(11)})
+	check(rv[0].Interface().(I).M() == 11, "reflect call failed")
+
+	// A deferred call with arguments runs at return, not at the
+	// defer statement.
+	order = nil
+	deferCheck()
+	check(len(order) == 2 && order[0] == 1 && order[1] == 10, "defer ran at the wrong time")
+
+	// Split methods: direct call, method value, interface dispatch
+	// through the thunk, and reflection through the thunk.
+	m := &maker{n: 5}
+	check(m.Make().M() == 5, "method call")
+	check(maker{n: 5}.MakeVal().M() == 6, "value receiver method call")
+	mv := m.Make
+	check(mv().M() == 5, "method value")
+	var mi mk = m
+	check(mi.Make().M() == 5, "interface dispatch")
+	rm := reflect.ValueOf(m).MethodByName("Make").Call(nil)
+	check(rm[0].Interface().(I).M() == 5, "reflect method call")
+
+	// Shaped and closure-bearing constructors behave identically
+	// when split.
+	check(newG[int](21).M() == 21, "shaped int")
+	check(newG[string](22).M() == 22, "shaped string")
+	check(newCB(5).M() == 15, "closure capture")
+	v2, probe := newCap(3)
+	check(v2.M() == 3, "captured result value")
+	check(probe().M() == 3, "capture observes the result")
+
+	// Inlined variants: pointer and indirectly boxed value results.
+	check(midT(31).M() == 31, "inlined variant, pointer result")
+	check(midBig(4).M() == 12, "inlined variant, value result")
+	mv2 := midBig(2)
+	if b3, ok := mv2.(big); !ok || b3.M() != 6 {
+		panic("inlined variant identity")
+	}
+
+	// Indirectly boxed value types survive the unchecked unboxing.
+	check(viaBig(4).M() == 12, "indirect unbox")
+	bv := viaBig(2)
+	if b2, ok := bv.(big); !ok || b2.M() != 6 {
+		panic("indirect unbox identity")
+	}
+
+	// The zero value of a conditionally assigned error result stays
+	// a nil interface.
+	n, err2 := maybeErr(false)
+	check(n == 42 && err2 == nil, "zero-value error result is not nil")
+	_, err3 := maybeErr(true)
+	check(err3 != nil, "assigned error result is nil")
+}

--- a/test/retdevirt_xpkg.dir/a.go
+++ b/test/retdevirt_xpkg.dir/a.go
@@ -1,0 +1,35 @@
+package a
+
+type I interface{ M() int }
+
+type impl struct{ x int }
+
+//go:noinline
+func (p *impl) M() int { return p.x } // ERROR "p does not escape"
+
+//go:noinline
+func pad() {}
+
+func New(n int) I { // ERROR "result #0 of New is always \*impl" "splitting New into New\.dv"
+	if n < 0 {
+		pad()
+		pad()
+	}
+	return &impl{x: n} // ERROR "&impl{...} escapes to heap"
+}
+
+type myErr struct{}
+
+//go:noinline
+func (*myErr) Error() string { return "myErr" }
+
+// Exported as {*myErr, nil}; not split, but callers can reason about
+// the receiver.
+func Check(n int) error { // ERROR "result #0 of Check is one of \*myErr, <nil>"
+	if n < 0 {
+		pad()
+		pad()
+		return &myErr{} // ERROR "&myErr{} escapes to heap"
+	}
+	return nil
+}

--- a/test/retdevirt_xpkg.dir/b.go
+++ b/test/retdevirt_xpkg.dir/b.go
@@ -1,0 +1,9 @@
+package b
+
+import "./a"
+
+//go:noinline
+func Use() int {
+	v := a.New(1) // ERROR "devirtualizing call to a\.New\.dv"
+	return v.M()  // ERROR "devirtualizing v.M to \*a\.impl"
+}

--- a/test/retdevirt_xpkg.go
+++ b/test/retdevirt_xpkg.go
@@ -1,0 +1,10 @@
+// errorcheckdir -0 -m -d=retdevirt
+
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Test that result type sets and split variants cross package
+// boundaries through export data.
+
+package ignored

--- a/test/retdevirt_xpkg_run.dir/a.go
+++ b/test/retdevirt_xpkg_run.dir/a.go
@@ -1,0 +1,32 @@
+package a
+
+type I interface{ M() int }
+
+type impl struct{ x int }
+
+//go:noinline
+func (p *impl) M() int { return p.x }
+
+//go:noinline
+func pad() {}
+
+func New(n int) I {
+	if n < 0 {
+		pad()
+		pad()
+	}
+	return &impl{x: n}
+}
+
+type myErr struct{}
+
+func (*myErr) Error() string { return "myErr" }
+
+func Check(n int) error {
+	if n < 0 {
+		pad()
+		pad()
+		return &myErr{}
+	}
+	return nil
+}

--- a/test/retdevirt_xpkg_run.dir/main.go
+++ b/test/retdevirt_xpkg_run.dir/main.go
@@ -1,0 +1,27 @@
+package main
+
+import "./a"
+
+func main() {
+	v := a.New(7)
+	if v == nil {
+		panic("nil result")
+	}
+	if v.M() != 7 {
+		panic("wrong result")
+	}
+
+	// The thunk still serves func values.
+	fp := a.New
+	if fp(9).M() != 9 {
+		panic("func value")
+	}
+
+	// Error-shaped results keep their nil semantics.
+	if err := a.Check(1); err != nil {
+		panic("err should be nil")
+	}
+	if err := a.Check(-1); err == nil {
+		panic("err should be non-nil")
+	}
+}

--- a/test/retdevirt_xpkg_run.go
+++ b/test/retdevirt_xpkg_run.go
@@ -1,0 +1,10 @@
+// rundir -d=retdevirt
+
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Check the runtime semantics of calling split functions across a
+// package boundary.
+
+package ignored


### PR DESCRIPTION
This teaches the devirtualization analysis to record sets of possible
concrete types for function results of interface type. This information
is used both to discover new devirtualization opportunities, and to
enable "unboxing splitting", wherein functions with devirtualizable
results return such results in unboxed form when possible, enabling
stack-promotion of allocations, among other things.

This change does no negatively affect existing programs that do not use
interfaces very much, but it does provide modest improvements to many
programs. In particular, I observed a 12% drop in allocated bytes in
stress tests of Buf's compiler suite with this change.

Some surveys of the results of improved devirtualization and the
resulting unboxing of results follow, for non-test builds of a few
different codebases.

- std: 2.3x call devirts, 167 .dv splits, 257 unboxed results
- gc: 2.5x call devirts, 117 .dv splits, 234 unboxed results
- buf: 15.5x call devirts, 87 .dv splits, 2859 (!) unboxed results
- etcd: 10.2x call devirts, 91 .dv splits, 583 unboxed results
- k8s: 2.9x call devirts, 1374 (!!!) .dv splits, 1984 (!) unboxed results

All of the new analysis and transformations are gated behind
-d=retdevirt.

Fixes #74392