### PR TITLE
crypto/ecdsa: validate legacy custom-curve keys

### DIFF
--- a/src/crypto/ecdsa/ecdsa_legacy.go
+++ b/src/crypto/ecdsa/ecdsa_legacy.go
@@ -91,6 +91,19 @@ func signLegacy(priv *PrivateKey, csprng io.Reader, hash []byte) (sig []byte, er
 	}
 
 	c := priv.Curve
+	N := c.Params().N
+	if N.Sign() == 0 {
+		return nil, errZeroParam
+	}
+	if priv.D.Sign() <= 0 {
+		return nil, errors.New("ecdsa: private key scalar is zero or negative")
+	}
+	if priv.D.Cmp(N) >= 0 {
+		return nil, errors.New("ecdsa: private key scalar too large")
+	}
+	if !c.IsOnCurve(priv.X, priv.Y) {
+		return nil, errors.New("ecdsa: invalid public key")
+	}
 
 	// A cheap version of hedged signatures, for the deprecated path.
 	var seed [32]byte
@@ -106,10 +119,6 @@ func signLegacy(priv *PrivateKey, csprng io.Reader, hash []byte) (sig []byte, er
 	csprng = rand.NewChaCha8(seed)
 
 	// SEC 1, Version 2.0, Section 4.1.3
-	N := c.Params().N
-	if N.Sign() == 0 {
-		return nil, errZeroParam
-	}
 	var k, kInv, r, s *big.Int
 	for {
 		for {
@@ -175,6 +184,9 @@ func verifyLegacy(pub *PublicKey, hash []byte, sig []byte) bool {
 		return false
 	}
 	if r.Cmp(N) >= 0 || s.Cmp(N) >= 0 {
+		return false
+	}
+	if !c.IsOnCurve(pub.X, pub.Y) {
 		return false
 	}
 

--- a/src/crypto/ecdsa/ecdsa_test.go
+++ b/src/crypto/ecdsa/ecdsa_test.go
@@ -779,9 +779,20 @@ func testInvalidPublicKeys(t *testing.T, curve elliptic.Curve) {
 	})
 	t.Run("NotOnCurve", func(t *testing.T) {
 		k, _ := GenerateKey(curve, rand.Reader)
-		k.X = k.X.Add(k.X, big.NewInt(1))
+		hash := []byte("testing")
+		sig, err := SignASN1(rand.Reader, k, hash)
+		if err != nil {
+			t.Fatal(err)
+		}
+		k.X = new(big.Int).Add(k.X, big.NewInt(1))
 		if _, err := k.Bytes(); err == nil {
 			t.Errorf("PublicKey.Bytes accepted not on curve")
+		}
+		if _, err := SignASN1(rand.Reader, k, hash); err == nil {
+			t.Errorf("SignASN1 accepted not on curve")
+		}
+		if VerifyASN1(&k.PublicKey, hash, sig) {
+			t.Errorf("VerifyASN1 accepted not on curve")
 		}
 
 		b := make([]byte, 1+2*(curve.Params().BitSize+7)/8)
@@ -811,6 +822,11 @@ func testInvalidPrivateKeys(t *testing.T, curve elliptic.Curve) {
 		if _, err := k.Bytes(); err == nil {
 			t.Errorf("PrivateKey.Bytes accepted zero key")
 		}
+		valid, _ := GenerateKey(curve, rand.Reader)
+		valid.D = new(big.Int)
+		if _, err := SignASN1(rand.Reader, valid, []byte("testing")); err == nil {
+			t.Errorf("SignASN1 accepted zero key")
+		}
 
 		b := make([]byte, (curve.Params().BitSize+7)/8)
 		if _, err := ParseRawPrivateKey(curve, b); err == nil {
@@ -829,6 +845,16 @@ func testInvalidPrivateKeys(t *testing.T, curve elliptic.Curve) {
 		k.D.FillBytes(b)
 		if _, err := ParseRawPrivateKey(curve, b); err == nil {
 			t.Errorf("ParseRawPrivateKey accepted overflow key")
+		}
+		if _, err := SignASN1(rand.Reader, k, []byte("testing")); err == nil {
+			t.Errorf("SignASN1 accepted overflow key")
+		}
+	})
+	t.Run("Negative", func(t *testing.T) {
+		k, _ := GenerateKey(curve, rand.Reader)
+		k.D = big.NewInt(-1)
+		if _, err := SignASN1(rand.Reader, k, []byte("testing")); err == nil {
+			t.Errorf("SignASN1 accepted negative key")
 		}
 	})
 	t.Run("Length", func(t *testing.T) {


### PR DESCRIPTION
The NIST curve path already rejects private scalars outside [1, N-1]
and public points that are not on the curve. The legacy custom-curve
path did neither, allowing signatures with invalid private keys and
panicking while verifying with an invalid public key.

Apply the same scalar and on-curve checks before custom-curve
operations. Add coverage for zero, negative, and oversized private
scalars and for off-curve public points.

Benchstat over 10 samples on an Apple M4 Pro found no allocation
regression and no statistically significant verification slowdown. The
sequential signing samples varied in favor of the patched build, so they
also show no measurable regression but are not treated as a speedup.

Tests run:

- go test crypto/ecdsa
- go test -race crypto/ecdsa
- go vet crypto/ecdsa
- go test crypto/...
- invalid-key tests with count=100
- crypto/ecdsa with GOFIPS140=latest and GOFIPS140=v1.0.0
- src/all.bash passed the package, compiler, runtime, and current FIPS
  suites; later optional matrix jobs stopped when the local temporary
  volume filled, with no test assertion failure

Fixes #22210
