### PR TITLE
html/template: clone context for range re-entry

### DIFF
--- a/src/html/template/escape.go
+++ b/src/html/template/escape.go
@@ -537,7 +537,7 @@ func (e *escaper) escapeBranch(c context, n *parse.BranchNode, nodeName string) 
 		// We check that executing n.List once results in the same context
 		// as executing n.List twice.
 		e.rangeContext = &rangeContext{outer: e.rangeContext}
-		c1, _ := e.escapeListConditionally(c0, n.List, nil)
+		c1, _ := e.escapeListConditionally(c0.clone(), n.List, nil)
 		c0 = join(c0, c1, n, nodeName)
 		if c0.state == stateError {
 			e.rangeContext = e.rangeContext.outer

--- a/src/html/template/escape_test.go
+++ b/src/html/template/escape_test.go
@@ -1232,6 +1232,10 @@ func TestErrors(t *testing.T) {
 			"<script>var a = `{{if .X}}a{{else}}b{{end}}`</script>",
 			``,
 		},
+		{
+			"<script>var x = `${ {{range .Items}} { {{else}} { { {{end}} } } {{.X}}}`</script>",
+			`on range loop re-entry: {{range}} branches end in different contexts`,
+		},
 	}
 	for _, test := range tests {
 		buf := new(bytes.Buffer)


### PR DESCRIPTION
The range re-entry escape-analysis pass reused the jsBraceDepth
backing slice from the first pass. This allowed the second pass to
mutate the first-pass context and miss mismatched JavaScript template
literal brace depth.
Clone the context before the second pass so that range re-entry is
checked against an independent context. Add a regression test covering
golang/go#80161.
Tests:
go test html/template -count=1
Fixes #80161 