### PR TITLE
encoding/json/v2: reduce allocations when checking IsZero

### DIFF
--- a/src/encoding/json/v2/bench_test.go
+++ b/src/encoding/json/v2/bench_test.go
@@ -278,6 +278,12 @@ var arshalTestdata = []struct {
 	raw:  []byte(`"2006-01-02T22:04:05Z"`),
 	val:  addr(time.Unix(1136239445, 0).UTC()),
 	new:  func() any { return new(time.Time) },
+}, {
+	name:   "OmitZeroMethod",
+	raw:    []byte(`{}`),
+	val:    new(omitZeroStruct),
+	new:    func() any { return new(omitZeroStruct) },
+	skipV1: true,
 }}
 
 type textArshaler struct{ _ [4]int }
@@ -316,6 +322,25 @@ func (*jsonArshalerV2) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	}
 	return err
 }
+
+type omitZeroStruct struct {
+	A zeroAlways    `json:"a,omitzero"`
+	B zeroAlwaysPtr `json:"b,omitzero"`
+}
+
+type zeroAlways struct {
+	// Just so the struct has some size to allocate
+	A int
+}
+
+func (zeroAlways) IsZero() bool { return true }
+
+type zeroAlwaysPtr struct {
+	// Just so the struct has some size to allocate
+	A int
+}
+
+func (*zeroAlwaysPtr) IsZero() bool { return true }
 
 func TestBenchmarkUnmarshal(t *testing.T) { runUnmarshal(t) }
 func BenchmarkUnmarshal(b *testing.B)     { runUnmarshal(b) }

--- a/src/encoding/json/v2/fields.go
+++ b/src/encoding/json/v2/fields.go
@@ -229,10 +229,10 @@ func makeStructFields(root reflect.Type) (fs structFields, serr *SemanticError) 
 						// Avoid panics calling IsZero on nil pointer.
 						return va.IsNil() || va.Interface().(isZeroer).IsZero()
 					}
-				case sf.Type.Implements(isZeroerType):
-					f.isZero = func(va addressableValue) bool { return va.Interface().(isZeroer).IsZero() }
 				case reflect.PointerTo(sf.Type).Implements(isZeroerType):
 					f.isZero = func(va addressableValue) bool { return va.Addr().Interface().(isZeroer).IsZero() }
+				case sf.Type.Implements(isZeroerType):
+					f.isZero = func(va addressableValue) bool { return va.Interface().(isZeroer).IsZero() }
 				}
 
 				// Provide a function that can determine whether the value would


### PR DESCRIPTION
When checking whether an omitzero field is zero via an IsZero method,
calling Interface() on a value type causes a heap allocation due to
interface boxing.

Reorder the switch cases to check if reflect.PointerTo(sf.Type)
implements the isZeroer interface before checking sf.Type directly.
Because pointer method sets include value methods, this allows using
va.Addr().Interface(), which avoids boxing value types and eliminates
the extra allocation per field.

goos: darwin
goarch: arm64
pkg: encoding/json/v2
cpu: Apple M4
                            │ before.txt  │             after.txt             │
                            │   sec/op    │   sec/op     vs base              │
Unmarshal/OmitZeroMethod-10   54.21n ± 2%   53.76n ± 1%  -0.84% (p=0.028 n=8)
Marshal/OmitZeroMethod-10     76.76n ± 0%   76.70n ± 1%       ~ (p=0.442 n=8)
geomean                       64.51n        64.21n       -0.46%

                            │  before.txt  │             after.txt              │
                            │     B/s      │     B/s       vs base              │
Unmarshal/OmitZeroMethod-10   35.19Mi ± 1%   35.49Mi ± 1%  +0.85% (p=0.026 n=8)
Marshal/OmitZeroMethod-10     24.85Mi ± 1%   24.87Mi ± 2%       ~ (p=0.426 n=8)
geomean                       29.57Mi        29.71Mi       +0.46%

                            │ before.txt  │              after.txt              │
                            │    B/op     │    B/op     vs base                 │
Unmarshal/OmitZeroMethod-10    16.00 ± 0%   16.00 ± 0%        ~ (p=1.000 n=8) ¹
Marshal/OmitZeroMethod-10     16.000 ± 0%   8.000 ± 0%  -50.00% (p=0.000 n=8)
geomean                        16.00        11.31       -29.29%
¹ all samples are equal

                            │ before.txt │              after.txt              │
                            │ allocs/op  │ allocs/op   vs base                 │
Unmarshal/OmitZeroMethod-10   1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=8) ¹
Marshal/OmitZeroMethod-10     2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=8)
geomean                       1.414        1.000       -29.29%
¹ all samples are equal

Fixes #80868 