### PR TITLE
runtime: recompute timer channel send delay from a fresh clock reading

### DIFF
--- a/src/runtime/time.go
+++ b/src/runtime/time.go
@@ -1124,6 +1124,14 @@ func (t *timer) unlockAndRun(now int64, bubble *synctestBubble) {
 	} else {
 		next = 0
 	}
+	if t.isChan && bubble == nil {
+		// now is read once per timers.run pass and can be stale by
+		// the time this timer runs. The value sent on the channel is
+		// derived from delay (see time.sendTime), so recompute it
+		// with a fresh clock reading. next above deliberately keeps
+		// the caller's clock so rescheduling is unchanged.
+		delay = nanotime() - t.when
+	}
 	ts := t.ts
 	t.when = next
 	if t.state&timerHeaped != 0 {
@@ -1202,9 +1210,6 @@ func (t *timer) unlockAndRun(now int64, bubble *synctestBubble) {
 		}
 	}
 
-	if t.isChan && bubble == nil {
-		delay += nanotime() - now
-	}
 	f(arg, seq, delay)
 
 	if t.isChan {

--- a/src/runtime/time.go
+++ b/src/runtime/time.go
@@ -1202,6 +1202,9 @@ func (t *timer) unlockAndRun(now int64, bubble *synctestBubble) {
 		}
 	}
 
+	if t.isChan && bubble == nil {
+		delay += nanotime() - now
+	}
 	f(arg, seq, delay)
 
 	if t.isChan {


### PR DESCRIPTION
time.sendTime reconstructs the delivered value as Now().Add(-delta),
but unlockAndRun computes delta from a cached clock read, so the work
between that read and the send lands in the delivered value as
one-sided, load-dependent error. Recompute delta immediately before
the send, matching its documented definition, nanotime() - t.when, at
the moment of use.

Fixes #80893
