### PR TITLE
internal/cpu: enable ARM64 feature detection on ios

### DIFF
--- a/src/internal/cpu/cpu_arm64_darwin.go
+++ b/src/internal/cpu/cpu_arm64_darwin.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build arm64 && darwin && !ios
+//go:build arm64 && darwin
 
 package cpu
 

--- a/src/internal/cpu/cpu_arm64_other.go
+++ b/src/internal/cpu/cpu_arm64_other.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build arm64 && !linux && !freebsd && !android && (!darwin || ios) && !openbsd && !windows
+//go:build arm64 && !linux && !freebsd && !android && !darwin && !openbsd && !windows
 
 package cpu
 

--- a/src/internal/cpu/cpu_darwin.go
+++ b/src/internal/cpu/cpu_darwin.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build darwin && !ios
+//go:build darwin
 
 package cpu
 


### PR DESCRIPTION
ios/arm64 builds cpu_arm64_other.go, where osInit is empty, so all
ARM64 features are reported as unavailable and the crypto packages
use their generic implementations. On an iOS 26.5 simulator AES-GCM
goes from 192 MB/s to 9048 MB/s with this change.

The features cpu_arm64_darwin.go sets unconditionally (AES, PMULL,
SHA1, SHA2) hold for every arm64 Apple device. The sysctls it reads
work on ios too: runtime/os_darwin.go builds for GOOS=ios and pushes
sysctlbynameInt32 into internal/cpu. Only cpu_darwin.go, which holds
sysctlEnabled, was left out of the ios build. A sysctl that is not
available returns false, which is the current behavior.

golang.org/x/sys/cpu already detects these features on ios.

Fixes #80931