### PR TITLE
html/template: treat await and yield as regexp preceders

### DIFF
--- a/src/html/template/escape_test.go
+++ b/src/html/template/escape_test.go
@@ -279,6 +279,16 @@ func TestEscape(t *testing.T) {
 			`<button onclick='alert(/foo\u002bbar/.test(""))'>`,
 		},
 		{
+			"jsReAwait",
+			`<script>async function f() { await /{{"/"}}/.test("x"); }</script>`,
+			`<script>async function f() { await /\//.test("x"); }</script>`,
+		},
+		{
+			"jsReYield",
+			`<script>function* g() { yield /{{"/"}}/; }</script>`,
+			`<script>function* g() { yield /\//; }</script>`,
+		},
+		{
 			"jsReBlank",
 			`<script>alert(/{{""}}/.test(""));</script>`,
 			`<script>alert(/(?:)/.test(""));</script>`,

--- a/src/html/template/js.go
+++ b/src/html/template/js.go
@@ -109,6 +109,12 @@ func nextJSCtx(s []byte, preceding jsCtx) jsCtx {
 // regexpPrecederKeywords is a set of reserved JS keywords that can precede a
 // regular expression in JS source.
 var regexpPrecederKeywords = map[string]bool{
+	// await and yield are contextual keywords (operators only inside
+	// async functions and generators respectively), but treating them
+	// as regexp preceders matches the ECMAScript grammar there, and
+	// misreading a division after an identifier named await or yield
+	// only selects the stricter regexp escaper.
+	"await":      true,
 	"break":      true,
 	"case":       true,
 	"continue":   true,
@@ -123,6 +129,7 @@ var regexpPrecederKeywords = map[string]bool{
 	"try":        true,
 	"typeof":     true,
 	"void":       true,
+	"yield":      true,
 }
 
 var jsonMarshalType = reflect.TypeFor[json.Marshaler]()

--- a/src/html/template/js_test.go
+++ b/src/html/template/js_test.go
@@ -65,6 +65,12 @@ func TestNextJsCtx(t *testing.T) {
 		{jsCtxRegexp, "return\t"},
 		{jsCtxRegexp, "return\n"},
 		{jsCtxRegexp, "return\u2028"},
+		// The contextual keywords await, in async functions, and
+		// yield, in generators, precede regexps too.
+		{jsCtxRegexp, "await"},
+		{jsCtxRegexp, "await "},
+		{jsCtxRegexp, "yield"},
+		{jsCtxRegexp, "yield\n"},
 		// Identifiers can be divided and cannot validly be preceded by
 		// a regular expressions. Semicolon insertion cannot happen
 		// between an identifier and a regular expression on a new line
@@ -77,6 +83,8 @@ func TestNextJsCtx(t *testing.T) {
 		{jsCtxDivOp, "x\n"},
 		{jsCtxDivOp, "x\u2028"},
 		{jsCtxDivOp, "preturn"},
+		{jsCtxDivOp, "xyield"},
+		{jsCtxDivOp, "awaits"},
 		// Numbers precede div ops.
 		{jsCtxDivOp, "0"},
 		// Dots that are part of a number are div preceders.


### PR DESCRIPTION
A slash after the contextual keywords await and yield starts a
regular expression literal, but nextJSCtx classified it as a
division operator because regexpPrecederKeywords predates ES2015.
An action interpolated inside such a literal was escaped with
jsValEscaper instead of jsRegexpEscaper, so a value containing a
slash closed the literal early.

Add await and yield to regexpPrecederKeywords. Misreading a
division after an identifier named await or yield only selects
the stricter regexp escaper.

Fixes #80897