### PR TITLE
doc: fix outdated links and typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,13 +7,13 @@ It is the work of hundreds of contributors. We appreciate your help!
 ## Before filing an issue
 
 If you are unsure whether you have found a bug, please consider asking in the [golang-nuts mailing
-list](https://groups.google.com/forum/#!forum/golang-nuts) or [other forums](https://golang.org/help/) first. If
+list](https://groups.google.com/forum/#!forum/golang-nuts) or [other forums](https://go.dev/help) first. If
 the behavior you are seeing is confirmed as a bug or issue, it can easily be re-raised in the issue tracker.
 
 ## Filing issues
 
 Sensitive security-related issues should be reported to [security@golang.org](mailto:security@golang.org).
-See the [security policy](https://golang.org/security) for details.
+See the [security policy](https://go.dev/doc/security/) for details.
 
 The recommended way to file an issue is by running `go bug`.
 Otherwise, when filing an issue, make sure to answer these five questions:
@@ -28,7 +28,7 @@ For change proposals, see [Proposing Changes To Go](https://go.dev/s/proposal-pr
 
 ## Contributing code
 
-Please read the [Contribution Guidelines](https://golang.org/doc/contribute.html) before sending patches.
+Please read the [Contribution Guidelines](https://go.dev/doc/contribute) before sending patches.
 
 Unless otherwise noted, the Go source files are distributed under
 the BSD-style license found in the LICENSE file.

--- a/doc/godebug.md
+++ b/doc/godebug.md
@@ -214,7 +214,7 @@ We plan to remove this setting in Go 1.31.
 
 Go 1.26 added a new `httpcookiemaxnum` setting that controls the maximum number
 of cookies that net/http will accept when parsing HTTP headers. If the number of
-cookie in a header exceeds the number set in `httpcookiemaxnum`, cookie parsing
+cookies in a header exceeds the number set in `httpcookiemaxnum`, cookie parsing
 will fail early. The default value is `httpcookiemaxnum=3000`. Setting
 `httpcookiemaxnum=0` will allow the cookie parsing to accept an indefinite
 number of cookies. To avoid denial of service attacks, this setting and default
@@ -286,7 +286,7 @@ and so removed the [`runtimecontentionstacks` setting](/pkg/runtime#hdr-Environm
 Go 1.25 (starting with Go 1.25 RC 2) disabled build information stamping when
 multiple VCS are detected due to concerns around VCS injection attacks. This
 behavior and setting was backported to Go 1.24.5 and Go 1.23.11. This behavior
-can be renabled with the setting `allowmultiplevcs=1`.
+can be reenabled with the setting `allowmultiplevcs=1`.
 
 ### Go 1.24
 


### PR DESCRIPTION
This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://go.dev/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible, ideally 72 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at around 72 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/vscode-go#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them

### description
Fix two typos and update an outdated golang.org URL to go.dev
in the documentation. This keeps the documentation up to date and improves readability.

### changed files (2)
[CONTRIBUTING.md](https://github.com/golang/go/blob/master/CONTRIBUTING.md)
[godebug.md](https://github.com/golang/go/blob/master/doc/godebug.md)