### PR TITLE
net/http: close connections for requests with conflicting framing

### DIFF
--- a/src/net/http/readrequest_test.go
+++ b/src/net/http/readrequest_test.go
@@ -197,6 +197,7 @@ var reqTests = []reqTest{
 			ProtoMajor:       1,
 			ProtoMinor:       1,
 			Header:           Header{},
+			Close:            true,
 			ContentLength:    -1,
 			Host:             "foo.com",
 			RequestURI:       "/",

--- a/src/net/http/serve_test.go
+++ b/src/net/http/serve_test.go
@@ -1459,6 +1459,18 @@ func TestClientCanClose(t *testing.T) {
 	}))
 }
 
+func TestTransferEncodingContentLengthClosesConnection(t *testing.T) {
+	testTCPConnectionCloses(t, "POST / HTTP/1.1\r\nHost: foo\r\nTransfer-Encoding: chunked\r\nContent-Length: 9999\r\n\r\n3\r\nfoo\r\n0\r\n\r\n", HandlerFunc(func(w ResponseWriter, r *Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("reading request body: %v", err)
+		}
+		if got, want := string(body), "foo"; got != want {
+			t.Errorf("request body = %q; want %q", got, want)
+		}
+	}))
+}
+
 // TestHandlersCanSetConnectionClose verifies that handlers can force a connection to close,
 // even for HTTP/1.1 requests.
 func TestHandlersCanSetConnectionClose11(t *testing.T) {

--- a/src/net/http/transfer.go
+++ b/src/net/http/transfer.go
@@ -535,9 +535,16 @@ func readTransfer(msg any, r *bufio.Reader, maxTrailerHeaders int64) (err error)
 		return err
 	}
 
+	hasContentLength := t.Header.has("Content-Length")
 	realLength, err := fixLength(isResponse, t.StatusCode, t.RequestMethod, t.Header, t.Chunked)
 	if err != nil {
 		return err
+	}
+	if !isResponse && t.Chunked && hasContentLength {
+		// RFC 9112, section 6.1: A server may process a request with both
+		// Transfer-Encoding and Content-Length, but must close the connection
+		// after responding.
+		t.Close = true
 	}
 	if isResponse && t.RequestMethod == "HEAD" {
 		if n, err := parseContentLength(t.Header["Content-Length"]); err != nil {


### PR DESCRIPTION
Fixes #80942

RFC 9112 requires a server that processes a request containing both `Transfer-Encoding` and `Content-Length` to close the connection after responding.

Previously, `fixLength` removed `Content-Length` in favor of chunked framing without preserving that the conflicting header had been present. The server therefore treated the connection as reusable.

This change records the presence of `Content-Length` before normalizing the framing headers and marks accepted chunked requests as connection-closing. Chunked framing still determines the request body, and invalid content lengths remain rejected.

Regression coverage verifies both the parsed request state and the end-to-end server connection behavior.

Tests:

- `./bin/go test net/http/... -count=1`
