### PR TITLE
net/http: clear io.EOF when Close drains a server request body 

### DIFF
--- a/src/net/http/serve_test.go
+++ b/src/net/http/serve_test.go
@@ -8479,3 +8479,34 @@ func TestServerRequestBodyLength(t *testing.T) {
 		})
 	}
 }
+
+// A handler may close the request body itself. When it has not read the body
+// to EOF, Close drains the remainder; reaching the end of the body is the
+// expected outcome and must not be reported to the caller as an error.
+func TestServerRequestBodyCloseAfterPartialRead(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		closeErr := make(chan error, 1)
+		st := newHTTP1ServerTest(t, func(w ResponseWriter, req *Request) {
+			// Read part of the body, leaving the rest for Close to drain.
+			if _, err := io.ReadFull(req.Body, make([]byte, 2)); err != nil {
+				closeErr <- fmt.Errorf("reading request body: %v", err)
+				return
+			}
+			closeErr <- req.Body.Close()
+		})
+		conn := st.dial()
+		conn.writeMessage(
+			"POST / HTTP/1.1",
+			"Host: example.tld",
+			"Content-Length: 4",
+			"",
+			"test",
+		)
+		if got, want := conn.readResponse().StatusCode, 200; got != want {
+			t.Fatalf("got response %v, want %v", got, want)
+		}
+		if err := <-closeErr; err != nil {
+			t.Errorf("Request.Body.Close() = %v, want nil", err)
+		}
+	})
+}

--- a/src/net/http/transfer.go
+++ b/src/net/http/transfer.go
@@ -1012,6 +1012,9 @@ func (b *body) Close() error {
 			if err == io.EOF && n <= maxPostHandlerReadBytes {
 				b.earlyClose = false
 				b.sawEOF = true
+				// Reaching the end of the body is the expected
+				// outcome here, not an error to report to the caller.
+				err = nil
 			}
 		}
 	default:


### PR DESCRIPTION
CL 794640 consolidated the server's request body draining into
(*body).Close and dropped the assignment that cleared io.EOF after a
successful drain. A handler that stops reading before EOF and then
closes the body now observes io.EOF from Close, where earlier releases
returned nil. Draining the remainder of the body is the success path
here, so report no error.

Fixes #80964
