### PR TITLE
fmt: skip the interface conversion in printValue for method-less types

### DIFF
--- a/src/fmt/errors_test.go
+++ b/src/fmt/errors_test.go
@@ -114,3 +114,41 @@ func splitErr(err error) []error {
 type errString string
 
 func (e errString) Error() string { return string(e) }
+
+func TestErrorfSharpWBadVerb(t *testing.T) {
+	noVetErrorf := fmt.Errorf
+
+	for _, test := range []struct {
+		name string
+		err  error
+		want string
+	}{{
+		name: "nil fields",
+		err:  noVetErrorf("%#w", errAttrs{}),
+		want: `fmt_test.errAttrs{Attrs:%!w(map[string]string=map[string]string(nil)), ` +
+			`Path:%!w([]string=[]string(nil))}`,
+	}, {
+		name: "populated fields",
+		err: noVetErrorf("%#w", errAttrs{
+			Attrs: map[string]string{"k": "v"},
+			Path:  []string{"a"},
+		}),
+		want: `fmt_test.errAttrs{Attrs:%!w(map[string]string=map[string]string{"k":"v"}), ` +
+			`Path:%!w([]string=[]string{"a"})}`,
+	}, {
+		name: "%w without # is wrapped, not marked",
+		err:  noVetErrorf("%w", errAttrs{}),
+		want: "attrs",
+	}} {
+		if got := test.err.Error(); got != test.want {
+			t.Errorf("%s: err.Error() = %q, want %q", test.name, got, test.want)
+		}
+	}
+}
+
+type errAttrs struct {
+	Attrs map[string]string
+	Path  []string
+}
+
+func (errAttrs) Error() string { return "attrs" }

--- a/src/fmt/fmt_test.go
+++ b/src/fmt/fmt_test.go
@@ -1442,6 +1442,20 @@ func BenchmarkSprintfStructure(b *testing.B) {
 	})
 }
 
+func BenchmarkSprintfSliceInt(b *testing.B) {
+	s := []int{1, 2, 3, 4, 5, 6, 7, 8}
+	for b.Loop() {
+		_ = Sprintf("%v", s)
+	}
+}
+
+func BenchmarkSprintfSliceStringer(b *testing.B) {
+	s := []I{1, 2, 3, 4, 5, 6, 7, 8}
+	for b.Loop() {
+		_ = Sprintf("%v", s)
+	}
+}
+
 func BenchmarkManyArgs(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		var buf bytes.Buffer
@@ -1502,7 +1516,7 @@ var mallocTest = []struct {
 	{0, `Fprintf(buf, "%x")`, func() { mallocBuf.Reset(); Fprintf(&mallocBuf, "%x", 1<<16) }},
 	{0, `Fprintf(buf, "%x")`, func() { mallocBuf.Reset(); i := 1 << 16; Fprintf(&mallocBuf, "%x", i) }},
 	{1, `Fprintf(buf, "%x")`, func() { mallocBuf.Reset(); i := 1 << 16; Fprintf(&mallocBuf, "%x", noliteral(i)) }},
-	{4, `Fprintf(buf, "%v")`, func() { mallocBuf.Reset(); s := []int{1, 2}; Fprintf(&mallocBuf, "%v", s) }},
+	{2, `Fprintf(buf, "%v")`, func() { mallocBuf.Reset(); s := []int{1, 2}; Fprintf(&mallocBuf, "%v", s) }},
 	{0, `Fprintf(buf, "%v")`, func() { mallocBuf.Reset(); type P struct{ x, y int }; Fprintf(&mallocBuf, "%v", P{1, 2}) }},
 	{1, `Fprintf(buf, "%v")`, func() { mallocBuf.Reset(); type P struct{ x, y int }; Fprintf(&mallocBuf, "%v", noliteral(P{1, 2})) }},
 	{2, `Fprintf(buf, "%80000s")`, func() { mallocBuf.Reset(); Fprintf(&mallocBuf, "%80000s", "hello") }}, // large buffer (>64KB)

--- a/src/fmt/print.go
+++ b/src/fmt/print.go
@@ -755,7 +755,11 @@ func (p *pp) printArg(arg any, verb rune) {
 // It does not handle 'p' and 'T' verbs because these should have been already handled by printArg.
 func (p *pp) printValue(value reflect.Value, verb rune, depth int) {
 	// Handle values with special methods if not already handled by printArg (depth == 0).
-	if depth > 0 && value.IsValid() && value.CanInterface() {
+	// A method-less type implements none of those interfaces, so skip building arg for
+	// it. An interface value gets another chance in the Interface case below. %w still
+	// goes through, because handleMethods prints the %!w marker for a misused verb.
+	if depth > 0 && value.IsValid() && value.CanInterface() &&
+		(value.Type().NumMethod() > 0 || verb == 'w') {
 		arg := value.Interface() // TODO(thepudds): Currently causes value to escape.
 		if p.handleMethods(arg, value, verb) {
 			return


### PR DESCRIPTION
printValue converts every value it walks into an interface so that
handleMethods can test it for Formatter, GoStringer, error and Stringer.
All four require a method, so for a type that has none the interface is
built, declined four times and thrown away.

Every element of a slice and every field reached through a pointer is
addressable, so Sprintf("%v", []int{1..8}) performs eight heap
allocations to produce eight interfaces that match nothing.

Gate the conversion on value.Type().NumMethod() > 0. A type with no
methods cannot satisfy any of the four interfaces.

The gate also admits verb 'w', the one case handleMethods reports
without a method. TestErrorfSharpWBadVerb pins currnet behavior
the package had no %#w coverage.

goos: darwin
goarch: arm64
pkg: fmt
cpu: Apple M2 Pro
                          │     old      │                 new                  │
                          │    sec/op    │    sec/op     vs base                │
SprintfPadding-10           18.11n ±  7%   18.14n ±  9%        ~ (p=0.510 n=25)
SprintfEmpty-10             3.279n ± 11%   3.337n ± 14%        ~ (p=0.488 n=25)
SprintfString-10            8.329n ±  7%   8.304n ±  9%        ~ (p=0.658 n=25)
SprintfTruncateString-10    16.57n ±  3%   16.77n ±  7%        ~ (p=0.554 n=25)
SprintfTruncateBytes-10     16.78n ±  5%   16.52n ±  7%        ~ (p=0.700 n=25)
SprintfSlowParsingPath-10   8.990n ±  7%   8.979n ±  7%        ~ (p=0.867 n=25)
SprintfQuoteString-10       47.67n ±  6%   47.47n ±  4%        ~ (p=0.878 n=25)
SprintfInt-10               6.236n ± 10%   6.513n ± 15%        ~ (p=0.204 n=25)
SprintfIntInt-10            12.74n ±  5%   12.79n ± 9%         ~ (p=0.485 n=25)
SprintfPrefixedInt-10       33.16n ±  4%   33.69n ±  5%        ~ (p=0.564 n=25)
SprintfFloat-10             14.60n ± 10%   15.36n ±  9%        ~ (p=0.309 n=25)
SprintfComplex-10           31.21n ± 10%   30.48n ±  5%        ~ (p=0.863 n=25)
SprintfBoolean-10           8.291n ±  9%   7.546n ± 15%        ~ (p=0.631 n=25)
SprintfHexString-10         37.07n ±  2%   37.14n ±  3%        ~ (p=0.755 n=25)
SprintfHexBytes-10          48.97n ±  3%   48.12n ±  2%        ~ (p=0.416 n=25)
SprintfBytes-10             71.03n ±  7%   72.11n ±  4%        ~ (p=0.829 n=25)
SprintfStringer-10          44.35n ±  9%   43.35n ±  8%        ~ (p=0.754 n=25)
SprintfStructure-10         140.3n ±  4%   105.4n ±  4%  -24.88% (p=0.000 n=25)
SprintfSliceInt-10          350.8n ±  1%   196.4n ±  1%  -44.01% (p=0.000 n=25)
SprintfSliceStringer-10     764.2n ± 1%    788.5n ±  1%   +3.18% (p=0.000 n=25)

allocs/op: SprintfSliceInt 10 to 2, SprintfStructure 5 to 4,
SprintfSliceStringer unchanged at 18. B/op: 112 to 48, 160 to 136, 200
unchanged.

Fixes #81014