### PR TITLE
time: accept four-digit UTC offsets in Parse

### DIFF
--- a/src/time/format.go
+++ b/src/time/format.go
@@ -1023,6 +1023,11 @@ func skip(value, prefix string) (string, error) {
 // same layout losslessly, but the exact instant used in the representation will
 // differ by the actual zone offset. To avoid such problems, prefer time layouts
 // that use a numeric zone offset, or use [ParseInLocation].
+//
+// When an MST element matches a numeric UTC offset in the input, such as
+// "+03", "-0930", or a "GMT" offset like "GMT+02" or "GMT-0530", the "GMT"
+// form fixes the zone at that offset, while a bare numeric offset is recorded
+// like an unknown abbreviation, with a zero offset.
 func Parse(layout, value string) (Time, error) {
 	// Optimize for RFC3339 as it accounts for over half of all representations.
 	if layout == RFC3339 || layout == RFC3339Nano {
@@ -1422,7 +1427,13 @@ func parse(layout, value string, defaultLocation, local *Location) (Time, error)
 		// Otherwise, create fake zone with unknown offset.
 		if len(zoneName) > 3 && zoneName[:3] == "GMT" {
 			offset, _ = atoi(zoneName[3:]) // Guaranteed OK by parseGMT.
-			offset *= 3600
+			// zoneName is "GMT" followed by a signed offset of the form
+			// ±H, ±HH or ±HHMM; only the four-digit form carries minutes.
+			if digits := len(zoneName) - 4; digits == 4 {
+				offset = (offset/100)*3600 + (offset%100)*60
+			} else {
+				offset *= 3600
+			}
 		}
 		zoneNameCopy := stringslite.Clone(zoneName) // avoid leaking the input value
 		t.setLoc(FixedZone(zoneNameCopy, offset))
@@ -1456,7 +1467,7 @@ func parseTimeZone(value string) (length int, ok bool) {
 		length = parseGMT(value)
 		return length, true
 	}
-	// Special Case 3: Some time zones are not named, but have +/-00 format
+	// Special Case 3: Some time zones are not named, but have +/-00 or +/-0000 format
 	if value[0] == '+' || value[0] == '-' {
 		length = parseSignedOffset(value)
 		ok := length > 0 // parseSignedOffset returns 0 in case of bad input
@@ -1491,8 +1502,8 @@ func parseTimeZone(value string) (length int, ok bool) {
 }
 
 // parseGMT parses a GMT time zone. The input string is known to start "GMT".
-// The function checks whether that is followed by a sign and a number in the
-// range -23 through +23 excluding zero.
+// The function checks whether that is followed by a signed offset accepted by
+// parseSignedOffset, such as "+03" or "-0930".
 func parseGMT(value string) int {
 	value = value[3:]
 	if len(value) == 0 {
@@ -1502,8 +1513,9 @@ func parseGMT(value string) int {
 	return 3 + parseSignedOffset(value)
 }
 
-// parseSignedOffset parses a signed timezone offset (e.g. "+03" or "-04").
-// The function checks for a signed number in the range -23 through +23 excluding zero.
+// parseSignedOffset parses a signed timezone offset (e.g. "+03" or "-0930").
+// The function checks for a signed number in the range [-23, +23] for a one-
+// or two-digit offset, and in the range [-2359, +2359] for a four-digit offset.
 // Returns length of the found offset string or 0 otherwise.
 func parseSignedOffset(value string) int {
 	sign := value[0]
@@ -1516,7 +1528,11 @@ func parseSignedOffset(value string) int {
 	if err != nil || value[1:] == rem {
 		return 0
 	}
-	if x > 23 {
+
+	// Accept only one- or two-digit hour offsets, or four-digit hour-minute
+	// offsets; reject other digit counts such as "+007" or "+00700".
+	ndigits := len(value) - len(rem) - 1
+	if (ndigits == 2 && x > 23) || ndigits == 3 || (ndigits == 4 && x > 2359) || ndigits > 4 {
 		return 0
 	}
 	return len(value) - len(rem)

--- a/src/time/format_test.go
+++ b/src/time/format_test.go
@@ -304,6 +304,7 @@ var parseTests = []ParseTest{
 
 	// GMT with offset.
 	{"GMT-8", UnixDate, "Fri Feb  5 05:00:57 GMT-8 2010", true, true, 1, 0},
+	{"GMT-0800", UnixDate, "Fri Feb  5 05:00:57 GMT-0800 2010", true, true, 1, 0},
 
 	// Accept any number of fractional second digits (including none) for .999...
 	// In Go 1, .999... was completely ignored in the format, meaning the first two
@@ -617,6 +618,20 @@ var parseTimeZoneTests = []ParseTimeZoneTest{
 	{"+14", 3, true},
 	{"+23", 3, true},
 	{"+24", 0, false},
+	{"+0000", 5, true},
+	{"+0430", 5, true},
+	{"-0930", 5, true},
+	{"-2359", 5, true},
+	{"+000", 0, false},
+	{"+001", 0, false},
+	{"-2400", 0, false},
+	{"+2400", 0, false},
+	{"+2530", 0, false},
+	{"+00451", 0, false},
+	{"+09999", 0, false},
+	{"+999999", 0, false},
+	{"-000999999", 0, false},
+	{"0bbb", 0, false},
 }
 
 func TestParseTimeZone(t *testing.T) {
@@ -627,6 +642,41 @@ func TestParseTimeZone(t *testing.T) {
 		} else if length != test.length {
 			t.Errorf("expected %d for %q got %d", test.length, test.value, length)
 		}
+	}
+}
+
+func TestParseGMTHHMMOffset(t *testing.T) {
+	// A GMT zone may carry an hour or hour-minute offset; the resulting
+	// fixed zone must record the correct number of seconds east of UTC,
+	// and malformed offsets must be rejected. See #26032.
+	for _, tt := range []struct {
+		zone    string
+		offset  int
+		wantErr bool
+	}{
+		{zone: "GMT+7", offset: 7 * 3600},
+		{zone: "GMT-5", offset: -5 * 3600},
+		{zone: "GMT+0630", offset: 6*3600 + 30*60},
+		{zone: "GMT-0930", offset: -(9*3600 + 30*60)},
+		{zone: "GMT+09999", wantErr: true},
+		{zone: "GMT-000999999", wantErr: true},
+		{zone: "GMT+999999", wantErr: true},
+	} {
+		t.Run(tt.zone, func(t *testing.T) {
+			tm, err := Parse("2006 MST", "2010 "+tt.zone)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Parse(%q) = %v, want error", tt.zone, tm)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Parse(%q) failed: %v", tt.zone, err)
+			}
+			if _, offset := tm.Zone(); offset != tt.offset {
+				t.Errorf("offset = %d, want %d", offset, tt.offset)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
parseSignedOffset accepted only one- or two-digit hour offsets, so a
layout using the MST element could not parse zones written as +HHMM,
for example "+0630" or "-0930".

Accept one-, two-, and four-digit signed offsets, validating the
four-digit form against [-2359, +2359] and rejecting other digit
counts such as "+007". For the GMT+HHMM form, derive the fixed-zone
offset from the hours and minutes instead of multiplying the whole
HHMM value by 3600.

Fixes #26032