### PR TITLE
runtime: netpoll: fix 32-bit little-endian eventfd type confusion

### DIFF
--- a/src/runtime/netpoll_epoll.go
+++ b/src/runtime/netpoll_epoll.go
@@ -18,6 +18,21 @@ var (
 	netpollWakeSig atomic.Uint32      // used to avoid duplicate calls of netpollBreak
 )
 
+// netpollPackData stores pd and its fdseq in the epoll data field of ev as
+// a taggedPointer. A nil pd marks the netpollBreak eventfd: netpollopen always
+// registers a non-nil *pollDesc, so netpollUnpackData can tell the two apart
+// by the pointer alone, on any word size or endianness.
+func netpollPackData(ev *linux.EpollEvent, pd *pollDesc, fdseq uintptr) {
+	*(*taggedPointer)(unsafe.Pointer(&ev.Data)) = taggedPointerPack(unsafe.Pointer(pd), fdseq)
+}
+
+// netpollUnpackData returns the pollDesc and fdseq stored by netpollPackData.
+// pd is nil for the netpollBreak eventfd.
+func netpollUnpackData(ev *linux.EpollEvent) (pd *pollDesc, fdseq uintptr) {
+	tp := *(*taggedPointer)(unsafe.Pointer(&ev.Data))
+	return (*pollDesc)(tp.pointer()), tp.tag()
+}
+
 func netpollinit() {
 	var errno uintptr
 	epfd, errno = linux.EpollCreate1(linux.EPOLL_CLOEXEC)
@@ -33,7 +48,7 @@ func netpollinit() {
 	ev := linux.EpollEvent{
 		Events: linux.EPOLLIN,
 	}
-	*(**uintptr)(unsafe.Pointer(&ev.Data)) = &netpollEventFd
+	netpollPackData(&ev, nil, 0)
 	errno = linux.EpollCtl(epfd, linux.EPOLL_CTL_ADD, efd, &ev)
 	if errno != 0 {
 		println("runtime: epollctl failed with", errno)
@@ -49,8 +64,7 @@ func netpollIsPollDescriptor(fd uintptr) bool {
 func netpollopen(fd uintptr, pd *pollDesc) uintptr {
 	var ev linux.EpollEvent
 	ev.Events = linux.EPOLLIN | linux.EPOLLOUT | linux.EPOLLRDHUP | linux.EPOLLET
-	tp := taggedPointerPack(unsafe.Pointer(pd), pd.fdseq.Load())
-	*(*taggedPointer)(unsafe.Pointer(&ev.Data)) = tp
+	netpollPackData(&ev, pd, pd.fdseq.Load())
 	return linux.EpollCtl(epfd, linux.EPOLL_CTL_ADD, int32(fd), &ev)
 }
 
@@ -137,7 +151,9 @@ retry:
 			continue
 		}
 
-		if *(**uintptr)(unsafe.Pointer(&ev.Data)) == &netpollEventFd {
+		pd, tag := netpollUnpackData(&ev)
+		// pd == nil denotes a netpollBreak eventfd.
+		if pd == nil {
 			if ev.Events != linux.EPOLLIN {
 				println("runtime: netpoll: eventfd ready for", ev.Events)
 				throw("runtime: netpoll: eventfd ready for something unexpected")
@@ -163,9 +179,6 @@ retry:
 			mode += 'w'
 		}
 		if mode != 0 {
-			tp := *(*taggedPointer)(unsafe.Pointer(&ev.Data))
-			pd := (*pollDesc)(tp.pointer())
-			tag := tp.tag()
 			if pd.fdseq.Load() == tag {
 				pd.setEventErr(ev.Events == linux.EPOLLERR, tag)
 				delta += netpollready(&toRun, pd, mode)


### PR DESCRIPTION
netpoll must distinguish the netpollBreak eventfd from a socket fd. It does so by comparing ev.Data against &netpollEventFd: if they are equal the event is for the eventfd, otherwise it is for a socket and ev.Data holds a tagged pointer made up of a *pollDesc and an fdseq.

On 64-bit systems this works as expected, but on 32-bit little-endian systems it can lead to type confusion.

netpollinit stores the address of netpollEventFd as a uintptr:

	*(**uintptr)(unsafe.Pointer(&ev.Data)) = &netpollEventFd

so for the eventfd only the lower half of ev.Data is written: ev.Data[0:4] holds &netpollEventFd and ev.Data[4:8] is left untouched. netpollopen, in contrast, stores a full tagged pointer, so that ev.Data[0:4] holds fdseq and ev.Data[4:8] holds the *pollDesc.

Because a uintptr is only 4 bytes on 32-bit systems, the comparison in netpoll:

	if *(**uintptr)(unsafe.Pointer(&ev.Data)) == &netpollEventFd {

tests only ev.Data[0:4], so for a socket it effectively compares fdseq against the address of netpollEventFd. In the vast majority of cases the two differ and the fd types are distinguished correctly.

However, in a program that runs for a long time or opens many sockets, fdseq can eventually grow large enough to equal &netpollEventFd. When that happens netpoll mistakes a socket for the eventfd and the runtime aborts with a fatal error such as:

	runtime: netpoll: eventfd ready for 5
	fatal error: runtime: netpoll: eventfd ready for something unexpected

Fix this by using the tagged-pointer encoding for both cases and detecting the eventfd by its nil *pollDesc.