### PR TITLE
crypto/tls: make deleting a missing session cache key a no-op

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -1730,6 +1730,10 @@ func (c *lruSessionCache) Put(sessionKey string, cs *ClientSessionState) {
 		return
 	}
 
+	if cs == nil {
+		return
+	}
+
 	if c.q.Len() < c.capacity {
 		entry := &lruSessionCacheEntry{sessionKey, cs}
 		c.m[sessionKey] = c.q.PushFront(entry)

--- a/src/crypto/tls/handshake_client_test.go
+++ b/src/crypto/tls/handshake_client_test.go
@@ -1205,6 +1205,32 @@ func TestLRUClientSessionCache(t *testing.T) {
 	}
 }
 
+func TestLRUClientSessionCacheDeleteMissingKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		capacity int
+	}{
+		{"cache not full", 2},
+		{"cache full", 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cache := NewLRUClientSessionCache(test.capacity)
+			var cs ClientSessionState
+			cache.Put("present", &cs)
+
+			cache.Put("missing", nil)
+
+			if s, ok := cache.Get("missing"); ok || s != nil {
+				t.Errorf(`after deleting a key that is not in the cache, Get("missing") = %p, %v; want nil, false`, s, ok)
+			}
+			if s, ok := cache.Get("present"); !ok || s != &cs {
+				t.Errorf(`after deleting a key that is not in the cache, Get("present") = %p, %v; want %p, true`, s, ok, &cs)
+			}
+		})
+	}
+}
+
 func TestKeyLogTLS12(t *testing.T) {
 	var serverBuf, clientBuf bytes.Buffer
 


### PR DESCRIPTION
lruSessionCache.Put is documented to remove the entry for sessionKey
when cs is nil, but it only did so if the key was already in the cache.
Otherwise it inserted an entry with a nil state, evicting the least
recently used entry if the cache was full.

Fixes #79861