### PR TITLE
internal/runtime,math,runtime: fix source file paths in comments

### DIFF
--- a/src/internal/runtime/cgroup/cgroup.go
+++ b/src/internal/runtime/cgroup/cgroup.go
@@ -448,7 +448,7 @@ func unescapedLen(in []byte) int {
 //
 // Returns the number of bytes written to out.
 //
-// Also see escapePath in cgroup_linux_test.go.
+// Also see escapePath in cgroup_test.go.
 func unescapePath(out []byte, in []byte) (int, error) {
 	var outi, ini int
 	for ini < len(in) {

--- a/src/internal/runtime/maps/map.go
+++ b/src/internal/runtime/maps/map.go
@@ -265,7 +265,7 @@ type Map struct {
 }
 
 // Use 64-bit hash on 64-bit systems, except on Wasm, where we use
-// 32-bit hash (see runtime/hash32.go).
+// 32-bit hash (see runtime_hash32.go).
 const Use64BitHash = goarch.PtrSize == 8 && goarch.IsWasm == 0
 
 func depthToShift(depth uint8) uint8 {

--- a/src/math/big/decimal.go
+++ b/src/math/big/decimal.go
@@ -9,12 +9,12 @@
 // decimal and rounding.
 //
 // The key observation and some code (shr) is borrowed from
-// strconv/decimal.go: conversion of binary fractional values can be done
+// internal/strconv/decimal.go: conversion of binary fractional values can be done
 // precisely in multi-precision decimal because 2 divides 10 (required for
 // >> of mantissa); but conversion of decimal floating-point values cannot
 // be done precisely in binary representation.
 //
-// In contrast to strconv/decimal.go, only right shift is implemented in
+// In contrast to internal/strconv/decimal.go, only right shift is implemented in
 // decimal format - left shift can be done precisely in binary format.
 
 package big

--- a/src/math/big/floatconv_test.go
+++ b/src/math/big/floatconv_test.go
@@ -237,7 +237,7 @@ func TestFloat64Text(t *testing.T) {
 		{1024.0, 'p', 0, "0x.8p+11"},
 		{-1024.0, 'p', 0, "-0x.8p+11"},
 
-		// all test cases below from strconv/ftoa_test.go
+		// all test cases below from internal/strconv/ftoa_test.go
 		{1, 'e', 5, "1.00000e+00"},
 		{1, 'f', 5, "1.00000"},
 		{1, 'g', 5, "1"},

--- a/src/math/big/ratconv_test.go
+++ b/src/math/big/ratconv_test.go
@@ -351,7 +351,7 @@ var float64inputs = []string{
 	"75224575729e-45",
 	"459926601011e+15",
 
-	// Constants plundered from strconv/atof_test.go.
+	// Constants plundered from internal/strconv/atof_test.go.
 
 	"0",
 	"1",

--- a/src/math/sincos.go
+++ b/src/math/sincos.go
@@ -4,7 +4,7 @@
 
 package math
 
-// Coefficients _sin[] and _cos[] are found in pkg/math/sin.go.
+// Coefficients _sin[] and _cos[] are found in sin.go.
 
 // Sincos returns Sin(x), Cos(x).
 //

--- a/src/runtime/_mkmalloc/mksizeclasses.go
+++ b/src/runtime/_mkmalloc/mksizeclasses.go
@@ -36,7 +36,7 @@ import (
 	"math/bits"
 )
 
-// Generate internal/runtime/gc/msize.go
+// Generate internal/runtime/gc/sizeclasses.go
 
 func generateSizeClasses(classes []class) []byte {
 	flag.Parse()

--- a/src/runtime/alg.go
+++ b/src/runtime/alg.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	// We use 32-bit hash on Wasm, see hash32.go.
+	// We use 32-bit hash on Wasm, see internal/runtime/maps/runtime_hash32.go.
 	hashSize = (1-goarch.IsWasm)*goarch.PtrSize + goarch.IsWasm*4
 	c0       = uintptr((8-hashSize)/4*2860486313 + (hashSize-4)/4*33054211828000289)
 	c1       = uintptr((8-hashSize)/4*3267000013 + (hashSize-4)/4*23344194077549503)
@@ -24,8 +24,8 @@ func trimHash(h uintptr) uintptr {
 	if goarch.IsWasm != 0 {
 		// On Wasm, we use 32-bit hash, despite that uintptr is 64-bit.
 		// memhash* always returns a uintptr with high 32-bit being 0
-		// (see hash32.go). We trim the hash in other places where we
-		// compute the hash manually, e.g. in interhash.
+		// (see internal/runtime/maps/runtime_hash32.go).
+		// We trim the hash in other places where we compute the hash manually, e.g. in interhash.
 		return uintptr(uint32(h))
 	}
 	return h

--- a/src/runtime/chan_test.go
+++ b/src/runtime/chan_test.go
@@ -595,7 +595,7 @@ func TestMultiConsumer(t *testing.T) {
 func TestShrinkStackDuringBlockedSend(t *testing.T) {
 	// make sure that channel operations still work when we are
 	// blocked on a channel send and we shrink the stack.
-	// NOTE: this test probably won't fail unless stack1.go:stackDebug
+	// NOTE: this test probably won't fail unless stack.go:stackDebug
 	// is set to >= 1.
 	const n = 10
 	c := make(chan int)

--- a/src/runtime/mbitmap.go
+++ b/src/runtime/mbitmap.go
@@ -1211,7 +1211,7 @@ func (s *mspan) isFreeOrNewlyAllocated(index uintptr) bool {
 func (s *mspan) divideByElemSize(n uintptr) uintptr {
 	const doubleCheck = false
 
-	// See explanation in mksizeclasses.go's computeDivMagic.
+	// See explanation in runtime/_mkmalloc/mksizeclasses.go's computeDivMagic.
 	q := uintptr((uint64(n) * uint64(s.divMul)) >> 32)
 
 	if doubleCheck && q != n/s.elemsize {

--- a/src/runtime/msize.go
+++ b/src/runtime/msize.go
@@ -5,7 +5,7 @@
 // Malloc small size classes.
 //
 // See malloc.go for overview.
-// See also mksizeclasses.go for how we decide what size classes to use.
+// See also runtime/_mkmalloc/mksizeclasses.go for how we decide what size classes to use.
 
 package runtime
 

--- a/src/runtime/traceevent.go
+++ b/src/runtime/traceevent.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Trace event writing API for trace2runtime.go.
+// Trace event writing API for traceruntime.go.
 
 package runtime
 

--- a/src/runtime/type.go
+++ b/src/runtime/type.go
@@ -525,7 +525,7 @@ func moduleTypelinks(md *moduledata) []*_type {
 	td := md.types
 
 	// We have to increment by the pointer size to match the
-	// increment in cmd/link/internal/data.go createRelroSect
+	// increment in cmd/link/internal/ld/data.go createRelroSect
 	// in allocateDataSections.
 	//
 	// The linker doesn't do that increment when runtime.types


### PR DESCRIPTION
Correct outdated file paths in comments to match current codebase.
