### PR TITLE
syscall: enforce Landlock before re-shuffling file descriptors

### DIFF
--- a/src/syscall/exec_linux.go
+++ b/src/syscall/exec_linux.go
@@ -580,6 +580,22 @@ func forkAndExecInChild1(argv0 *byte, argv, envv []*byte, chroot, dir *byte, att
 		}
 	}
 
+	// Call prctl(PR_SET_NO_NEW_PRIVS).
+	if sys.NoNewPrivs {
+		_, _, err1 = RawSyscall6(SYS_PRCTL, PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0, 0)
+		if err1 != 0 {
+			goto childerror
+		}
+	}
+
+	// Enforce a Landlock policy if requested.
+	if sys.UseLandlock {
+		_, _, err1 = RawSyscall(_SYS_landlock_restrict_self, uintptr(sys.LandlockFD), uintptr(sys.LandlockFlags), 0)
+		if err1 != 0 {
+			goto childerror
+		}
+	}
+
 	// Pass 1: look for fd[i] < i and move those up above len(fd)
 	// so that pass 2 won't stomp on an fd it needs later.
 	if pipe < nextfd {
@@ -666,22 +682,6 @@ func forkAndExecInChild1(argv0 *byte, argv, envv []*byte, chroot, dir *byte, att
 		_, _, err1 = RawSyscall6(SYS_PRLIMIT64, 0, RLIMIT_NOFILE, 0, uintptr(unsafe.Pointer(&lim)), 0, 0)
 		if err1 != 0 || (lim.Cur == rlim.Max-1 && lim.Max == rlim.Max) {
 			RawSyscall6(SYS_PRLIMIT64, 0, RLIMIT_NOFILE, uintptr(unsafe.Pointer(rlim)), 0, 0, 0)
-		}
-	}
-
-	// Call prctl(PR_SET_NO_NEW_PRIVS).
-	if sys.NoNewPrivs {
-		_, _, err1 = RawSyscall6(SYS_PRCTL, PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0, 0)
-		if err1 != 0 {
-			goto childerror
-		}
-	}
-
-	// Enforce a Landlock policy if requested.
-	if sys.UseLandlock {
-		_, _, err1 = RawSyscall(_SYS_landlock_restrict_self, uintptr(sys.LandlockFD), uintptr(sys.LandlockFlags), 0)
-		if err1 != 0 {
-			goto childerror
 		}
 	}
 

--- a/src/syscall/exec_linux_test.go
+++ b/src/syscall/exec_linux_test.go
@@ -758,42 +758,58 @@ func TestLandlockRestrictSelf(t *testing.T) {
 		LANDLOCK_ACCESS_FS_MAKE_DIR     = 1 << 7
 	)
 
-	// Check if Landlock is supported.
-	_, _, errno := syscall.Syscall(SYS_LANDLOCK_CREATE_RULESET, 0, 0, LANDLOCK_CREATE_RULESET_VERSION)
-	if errno != 0 {
-		t.Skipf("Kernel does not support Landlock: %v", errno)
-	}
+	for _, tt := range []struct {
+		Name       string
+		ExtraFiles []*os.File
+	}{
+		{
+			Name: "Simple",
+		},
+		{
+			Name:       "WithExtraFiles",
+			ExtraFiles: {os.Stdout, os.Stdout, os.Stdout, os.Stdout, os.Stdout},
+		},
+	} {
+		t.Run(tt.Name, func(t *testing.T) {
+			// Check if Landlock is supported.
+			_, _, errno := syscall.Syscall(SYS_LANDLOCK_CREATE_RULESET, 0, 0, LANDLOCK_CREATE_RULESET_VERSION)
+			if errno != 0 {
+				t.Skipf("Kernel does not support Landlock: %v", errno)
+			}
 
-	// Create a ruleset restricting directory creation with no allow rules,
-	// effectively denying directory creation everywhere.
-	type landlockRulesetAttr struct {
-		handledAccessFS uint64
-	}
-	attr := landlockRulesetAttr{
-		handledAccessFS: LANDLOCK_ACCESS_FS_MAKE_DIR,
-	}
-	rulesetFD, _, errno := syscall.Syscall(SYS_LANDLOCK_CREATE_RULESET, uintptr(unsafe.Pointer(&attr)), unsafe.Sizeof(attr), 0)
-	if errno != 0 {
-		t.Fatalf("landlock_create_ruleset: %v", errno)
-	}
-	defer syscall.Close(int(rulesetFD))
+			// Create a ruleset restricting directory creation with no allow rules,
+			// effectively denying directory creation everywhere.
+			type landlockRulesetAttr struct {
+				handledAccessFS uint64
+			}
+			attr := landlockRulesetAttr{
+				handledAccessFS: LANDLOCK_ACCESS_FS_MAKE_DIR,
+			}
+			rulesetFD, _, errno := syscall.Syscall(SYS_LANDLOCK_CREATE_RULESET, uintptr(unsafe.Pointer(&attr)), unsafe.Sizeof(attr), 0)
+			if errno != 0 {
+				t.Fatalf("landlock_create_ruleset: %v", errno)
+			}
+			defer syscall.Close(int(rulesetFD))
 
-	d := t.TempDir()
-	exe := testenv.Executable(t)
-	cmd := testenv.Command(t, exe, "-test.run=^TestLandlockRestrictSelf$", d)
-	cmd.Env = append(cmd.Environ(), "GO_WANT_HELPER_PROCESS=1")
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		NoNewPrivs:    true,
-		UseLandlock:   true,
-		LandlockFD:    int(rulesetFD),
-		LandlockFlags: 0,
-	}
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Subprocess failed: %v\n%s", err, out)
-	}
-	got := strings.TrimSpace(string(out))
-	if want := "EACCES"; got != want {
-		t.Errorf("Subprocess output: got %q, want %q", got, want)
+			d := t.TempDir()
+			exe := testenv.Executable(t)
+			cmd := testenv.Command(t, exe, "-test.run=^TestLandlockRestrictSelf$", d)
+			cmd.Env = append(cmd.Environ(), "GO_WANT_HELPER_PROCESS=1")
+			cmd.ExtraFiles = tt.ExtraFiles
+			cmd.SysProcAttr = &syscall.SysProcAttr{
+				NoNewPrivs:    true,
+				UseLandlock:   true,
+				LandlockFD:    int(rulesetFD),
+				LandlockFlags: 0,
+			}
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("Subprocess failed: %v\n%s", err, out)
+			}
+			got := strings.TrimSpace(string(out))
+			if want := "EACCES"; got != want {
+				t.Errorf("Subprocess output: got %q, want %q", got, want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Because Landlock enforcement uses a file descriptor as well, it is
better done before these file descriptors change their identities.

Without this fix, when passing additional ExtraFiles, the
landlock_restrict_self(2) syscall may use the wrong file descriptor.

Add a regression test as well.

Updates landlock-lsm/go-landlock#45
Updates #68595