### PR TITLE
cmd/compile: avoid double-counting inlined call nodes

### DIFF
--- a/src/cmd/compile/internal/inline/inl.go
+++ b/src/cmd/compile/internal/inline/inl.go
@@ -648,7 +648,10 @@ opSwitch:
 				//
 				// TODO: in the case of a single-call closure, the inlining budget here is potentially much, much larger.
 				//
-				v.budget -= callee.Inl.Cost
+				// The normal node cost below already charges for the call.
+				// Replace that cost with the inline body cost instead of
+				// charging for both the body and the call that disappears.
+				v.budget -= callee.Inl.Cost - 1
 				break
 			}
 		}

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -282,6 +282,7 @@ func (v Value) Bool() bool {
 	return *(*bool)(v.ptr)
 }
 
+//go:noinline
 func (v Value) panicNotBool() {
 	v.mustBe(Bool)
 }


### PR DESCRIPTION
When computing a function's inline cost, an inlinable call subtracts the
callee's inline body cost. The visitor then applies the normal one-unit cost
for the call node, resulting in a total cost of `callee.Inl.Cost+1`.

Compensate for the normal node charge so the call contributes exactly the
cost of the body that replaces it.

A boundary probe previously had cost 81 with an inline budget of 80. With
this change its cost is 80.

This makes `reflect.Value.panicNotBool` newly eligible for inlining, which
would prevent `reflect.Value.Bool` from being inlined. Keep that cold panic
path outlined explicitly, matching reflect's `panicNotMap` helper.
