### PR TITLE
archive/tar: return ErrHeader on PAX UID/GID integer overflow

### DIFF
--- a/src/archive/tar/reader.go
+++ b/src/archive/tar/reader.go
@@ -7,6 +7,7 @@ package tar
 import (
 	"bytes"
 	"io"
+	"math"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -276,10 +277,16 @@ func mergePAX(hdr *Header, paxHdrs map[string]string) (err error) {
 			hdr.Gname = v
 		case paxUid:
 			id64, err = strconv.ParseInt(v, 10, 64)
-			hdr.Uid = int(id64) // Integer overflow possible
+			if err != nil || id64 > math.MaxInt || id64 < math.MinInt {
+				return ErrHeader
+			}
+			hdr.Uid = int(id64)
 		case paxGid:
 			id64, err = strconv.ParseInt(v, 10, 64)
-			hdr.Gid = int(id64) // Integer overflow possible
+			if err != nil || id64 > math.MaxInt || id64 < math.MinInt {
+				return ErrHeader
+			}
+			hdr.Gid = int(id64)
 		case paxAtime:
 			hdr.AccessTime, err = parsePAXTime(v)
 		case paxMtime:

--- a/src/archive/tar/reader_test.go
+++ b/src/archive/tar/reader_test.go
@@ -1702,3 +1702,50 @@ func TestDisableInsecurePathCheck(t *testing.T) {
 		t.Fatalf("tr.Next with tarinsecurepath=1: got name %q, want %q", h.Name, name)
 	}
 }
+
+func TestMergePAXIntegerOverflow(t *testing.T) {
+	vectors := []struct {
+		paxHdrs map[string]string
+		wantErr bool
+	}{
+		{map[string]string{paxUid: "0"}, false},
+		{map[string]string{paxUid: "1000"}, false},
+		{map[string]string{paxUid: "4294967296"}, math.MaxInt < 4294967296},
+		{map[string]string{paxGid: "4294967296"}, math.MaxInt < 4294967296},
+		{map[string]string{paxUid: "2147483648"}, math.MaxInt < 2147483648},
+		{map[string]string{paxGid: "2147483648"}, math.MaxInt < 2147483648},
+		{map[string]string{paxUid: "9223372036854775808"}, true},
+	}
+
+	for _, tt := range vectors {
+		testname := fmt.Sprintf("%v", tt.paxHdrs)
+		t.Run(testname, func(t *testing.T) {
+			hdr := new(Header)
+			err := mergePAX(hdr, tt.paxHdrs)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("Expected a non-nil error")
+				}
+				if !errors.Is(err, ErrHeader) {
+					t.Fatalf("Expected error of type ErrHeader, got instead %v", err)
+				}
+				if hdr.Gid != 0 {
+					t.Fatalf("Gid was unexpectedly set after error: %v", hdr.Gid)
+				}
+				if hdr.Uid != 0 {
+					t.Fatalf("Uid was unexpectedly set after error: %v", hdr.Uid)
+				}
+			} else if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if hdr.Gid < 0 {
+				t.Fatalf("Gid was unexpectedly set after overflow: %v", hdr.Gid)
+			}
+			if hdr.Uid < 0 {
+				t.Fatalf("Uid was unexpectedly set after overflow: %v", hdr.Uid)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
In mergePAX, paxUid and paxGid records are parsed as int64 via
strconv.ParseInt, but are subsequently cast directly to platform-native
int without bounds checking. On 32-bit platforms, values >= 2^32 silently
truncate (e.g. uid=4294967296 truncates to 0) or wrap to negative numbers.

This change verifies that the parsed int64 fits within [math.MinInt,
math.MaxInt] and returns ErrHeader if out of bounds.

Fixes #81129