### PR TITLE
encoding/base64: add RISC-V assembly for base64 encoding

### DIFF
--- a/src/encoding/base64/base64.go
+++ b/src/encoding/base64/base64.go
@@ -152,18 +152,14 @@ func (enc *Encoding) Encode(dst, src []byte) {
 	// outside of the loop to speed up the encoder.
 	_ = enc.encode
 
-	for len(src) >= 3 {
-		// Convert 3x 8bit source bytes into 4 bytes
-		val := uint(src[0])<<16 | uint(src[1])<<8 | uint(src[2])
-
-		_ = dst[3] // Eliminate bounds checks below.
-		dst[0] = enc.encode[val>>18&0x3F]
-		dst[1] = enc.encode[val>>12&0x3F]
-		dst[2] = enc.encode[val>>6&0x3F]
-		dst[3] = enc.encode[val&0x3F]
-
-		src = src[3:]
-		dst = dst[4:]
+	n := (len(src) / 3) * 3
+	if n > 0 {
+		// encodeChunk does not check the destination length; validate it
+		// here so a short dst panics like the Go loop below would.
+		_ = dst[n/3*4-1]
+		encodeChunk(&enc.encode, &dst[0], &src[0], n)
+		src = src[n:]
+		dst = dst[n/3*4:]
 	}
 
 	// Add the remaining small block (if any).

--- a/src/encoding/base64/base64_asm.go
+++ b/src/encoding/base64/base64_asm.go
@@ -1,0 +1,10 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build riscv64 && !purego
+
+package base64
+
+//go:noescape
+func encodeChunk(encode *[64]byte, dst, src *byte, n int)

--- a/src/encoding/base64/base64_noasm.go
+++ b/src/encoding/base64/base64_noasm.go
@@ -1,0 +1,30 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !riscv64 || purego
+
+package base64
+
+import "unsafe"
+
+func encodeChunk(encode *[64]byte, dst, src *byte, n int) {
+	// encodeChunk assembly is written using pointers and n. Back to slices.
+	dstb := unsafe.Slice(dst, n/3*4)
+	srcb := unsafe.Slice(src, n)
+
+	si := 0
+	di := 0
+	for si < n {
+		// Convert 3x 8bit source bytes into 4 bytes
+		val := uint(srcb[si+0])<<16 | uint(srcb[si+1])<<8 | uint(srcb[si+2])
+
+		dstb[di+0] = encode[val>>18&0x3F]
+		dstb[di+1] = encode[val>>12&0x3F]
+		dstb[di+2] = encode[val>>6&0x3F]
+		dstb[di+3] = encode[val&0x3F]
+
+		si += 3
+		di += 4
+	}
+}

--- a/src/encoding/base64/base64_riscv64.s
+++ b/src/encoding/base64/base64_riscv64.s
@@ -1,0 +1,219 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !purego
+
+#include "asm_riscv64.h"
+#include "go_asm.h"
+#include "textflag.h"
+
+// func encodeChunk(encode *[64]byte, dst, src *byte, n int)
+//
+// On entry (ABI0 calling convention), stack layout:
+//   encode+0(FP)    - *[64]byte (8 bytes)
+//   dst+8(FP)       - *byte     (8 bytes)
+//   src+16(FP)      - *byte     (8 bytes)
+//   n+24(FP)        - int       (8 bytes)
+//
+// Register usage:
+//   X5  = encode table base (preserved across loop)
+//   X6  = src pointer
+//   X7  = dst pointer
+//   X28 = remaining count (n)
+//   X30 = $12 (loop constant)
+//   X31 = assembler temp (do not use)
+
+TEXT ·encodeChunk(SB),NOSPLIT,$0-32
+	MOV	n+24(FP), X28	// X28 = n
+	BEQZ	X28, ret
+
+	MOV	encode+0(FP), X5	// X5  = encode table base
+	MOV	dst+8(FP), X7		// X7  = dst pointer
+	MOV	src+16(FP), X6		// X6  = src pointer
+
+	// Scalar 4x loop: per-byte MOVBU loads, no wide loads, no REV8.
+	PCALIGN	$16
+scalar_4x:
+	MOV	$12, X30
+	BLT	X28, X30, tail
+
+	PCALIGN	$16
+scalar_loop4:
+	// Group 1: src[0..2] -> dst[0..3]
+	MOVBU	(X6), X10
+	MOVBU	1(X6), X11
+	MOVBU	2(X6), X12
+	SLLI	$16, X10, X10
+	SLLI	$8, X11, X11
+	OR	X11, X10, X10
+	OR	X12, X10, X10
+
+	SRLI	$18, X10, X11
+	ANDI	$0x3F, X11, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, (X7)
+
+	SRLI	$12, X10, X11
+	ANDI	$0x3F, X11, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, 1(X7)
+
+	SRLI	$6, X10, X11
+	ANDI	$0x3F, X11, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, 2(X7)
+
+	ANDI	$0x3F, X10, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, 3(X7)
+
+	// Group 2: src[3..5] -> dst[4..7]
+	MOVBU	3(X6), X10
+	MOVBU	4(X6), X11
+	MOVBU	5(X6), X12
+	SLLI	$16, X10, X10
+	SLLI	$8, X11, X11
+	OR	X11, X10, X10
+	OR	X12, X10, X10
+
+	SRLI	$18, X10, X11
+	ANDI	$0x3F, X11, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, 4(X7)
+
+	SRLI	$12, X10, X11
+	ANDI	$0x3F, X11, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, 5(X7)
+
+	SRLI	$6, X10, X11
+	ANDI	$0x3F, X11, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, 6(X7)
+
+	ANDI	$0x3F, X10, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, 7(X7)
+
+	// Group 3: src[6..8] -> dst[8..11]
+	MOVBU	6(X6), X10
+	MOVBU	7(X6), X11
+	MOVBU	8(X6), X12
+	SLLI	$16, X10, X10
+	SLLI	$8, X11, X11
+	OR	X11, X10, X10
+	OR	X12, X10, X10
+
+	SRLI	$18, X10, X11
+	ANDI	$0x3F, X11, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, 8(X7)
+
+	SRLI	$12, X10, X11
+	ANDI	$0x3F, X11, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, 9(X7)
+
+	SRLI	$6, X10, X11
+	ANDI	$0x3F, X11, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, 10(X7)
+
+	ANDI	$0x3F, X10, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, 11(X7)
+
+	// Group 4: src[9..11] -> dst[12..15]
+	MOVBU	9(X6), X10
+	MOVBU	10(X6), X11
+	MOVBU	11(X6), X12
+	SLLI	$16, X10, X10
+	SLLI	$8, X11, X11
+	OR	X11, X10, X10
+	OR	X12, X10, X10
+
+	SRLI	$18, X10, X11
+	ANDI	$0x3F, X11, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, 12(X7)
+
+	SRLI	$12, X10, X11
+	ANDI	$0x3F, X11, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, 13(X7)
+
+	SRLI	$6, X10, X11
+	ANDI	$0x3F, X11, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, 14(X7)
+
+	ANDI	$0x3F, X10, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, 15(X7)
+
+	ADD	$12, X6
+	ADD	$16, X7
+	ADD	$-12, X28
+	BGE	X28, X30, scalar_loop4
+
+	BEQZ	X28, ret
+
+	// Tail: remaining < 12 bytes, one group per iteration
+	PCALIGN	$16
+tail:
+	MOVBU	(X6), X10
+	MOVBU	1(X6), X11
+	MOVBU	2(X6), X12
+
+	SLLI	$16, X10, X10
+	SLLI	$8, X11, X11
+	OR	X11, X10, X10
+	OR	X12, X10, X10
+
+	SRLI	$18, X10, X11
+	ANDI	$0x3F, X11, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, (X7)
+
+	SRLI	$12, X10, X11
+	ANDI	$0x3F, X11, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, 1(X7)
+
+	SRLI	$6, X10, X11
+	ANDI	$0x3F, X11, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, 2(X7)
+
+	ANDI	$0x3F, X10, X11
+	ADD	X5, X11, X11
+	MOVBU	(X11), X11
+	MOVB	X11, 3(X7)
+
+	ADD	$3, X6
+	ADD	$4, X7
+	ADD	$-3, X28
+	BNEZ	X28, tail
+
+ret:
+	RET

--- a/src/encoding/base64/base64_test.go
+++ b/src/encoding/base64/base64_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/rand"
 	"reflect"
 	"runtime/debug"
 	"strconv"
@@ -120,6 +121,17 @@ func TestEncode(t *testing.T) {
 			testEqual(t, `AppendEncode("lead", %q) = %q, want %q`, p.decoded, string(dst), "lead"+tt.conv(p.encoded))
 		}
 	}
+}
+
+func TestEncodeShortDst(t *testing.T) {
+	src := make([]byte, 12)
+	dst := make([]byte, 1)
+	defer func() {
+		if recover() == nil {
+			t.Error("Encode with short dst did not panic")
+		}
+	}()
+	StdEncoding.Encode(dst, src)
 }
 
 func TestEncoder(t *testing.T) {
@@ -624,5 +636,21 @@ func TestDecoderRaw(t *testing.T) {
 	dec3, err := io.ReadAll(r)
 	if err != nil || !bytes.Equal(dec3, want) {
 		t.Errorf("reading NewDecoder(URLEncoding, %q) = %x, %v, want %x, nil", source+"==", dec3, err, want)
+	}
+}
+
+// TestEncodeAllLengths verifies the assembly encodeChunk across every
+// small input length: lengths 12 and up exercise the 4x loop, lengths
+// 3..9 the tail loop, and the 1-2 byte remainder is handled in Go.
+func TestEncodeAllLengths(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	for n := 1; n <= 256; n++ {
+		src := make([]byte, n)
+		rng.Read(src)
+		enc := StdEncoding.EncodeToString(src)
+		dec, err := StdEncoding.DecodeString(enc)
+		if err != nil || !bytes.Equal(dec, src) {
+			t.Fatalf("len=%d: round-trip: %v", n, err)
+		}
 	}
 }


### PR DESCRIPTION
This change extracts the hot path of encoding/base64.Encode into a dedicated encodeChunk() 
assembly function for RISC-V.

goos: linux
goarch: riscv64
pkg: encoding/json
cpu: Spacemit(R) X60
                       │          bench_before.txt           │   bench_after.txt                         │
                       │                  sec/op                   │      sec/op        vs base               │
MarshalBytes/32                                        2.175µ ± 1%         2.138µ ± 1%   -1.72% (p=0.004 n=6)
MarshalBytes/256                                       4.777µ ± 1%         3.944µ ± 2%  -17.45% (p=0.002 n=6)
MarshalBytes/4096                                      36.75µ ± 2%         32.70µ ± 2%  -11.02% (p=0.002 n=6)
MarshalBytesError/32                                   2.416m ± 1%         2.400m ± 2%        ~ (p=0.394 n=6)
MarshalBytesError/256                                  2.380m ± 3%         2.409m ± 2%        ~ (p=0.394 n=6)
MarshalBytesError/4096                                 2.469m ± 2%         2.457m ± 1%        ~ (p=0.589 n=6)
geomean                                                132.5µ              125.6µ        -5.28%