### PR TITLE
html/template: set division context when a template literal closes

### DIFF
--- a/src/html/template/escape_test.go
+++ b/src/html/template/escape_test.go
@@ -1826,7 +1826,7 @@ func TestEscapeText(t *testing.T) {
 		},
 		{
 			"<script>var a = `${``",
-			context{state: stateJS, element: elementScript, jsBraceDepth: []int{0}},
+			context{state: stateJS, element: elementScript, jsCtx: jsCtxDivOp, jsBraceDepth: []int{0}},
 		},
 		{
 			"<script>var a = `${`}",
@@ -2312,6 +2312,49 @@ func TestCVE202656858(t *testing.T) {
 			tmpl:  "<script>`${ (function(){}/{{.}}/g.test(x)) }`</script>",
 			input: "a.b",
 			want:  "<script>`${ (function(){}/a\\.b/g.test(x)) }`</script>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl := Must(New("test").Parse(tt.tmpl))
+			var buf bytes.Buffer
+			if err := tmpl.Execute(&buf, tt.input); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			if got := buf.String(); got != tt.want {
+				t.Errorf("got:  %s\nwant: %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTmplLitCloseDivCtx(t *testing.T) {
+	// Issue #81117: after a template literal closes, a '/' starts a
+	// division, not a regexp literal, so a following action must be
+	// escaped as a value.
+	tests := []struct {
+		name  string
+		tmpl  string
+		input string
+		want  string
+	}{
+		{
+			name:  "division after template literal",
+			tmpl:  "<script>let x = `a`/{{.}}/b;</script>",
+			input: "alert`1`",
+			want:  "<script>let x = `a`/\"alert`1`\"/b;</script>",
+		},
+		{
+			name:  "division after template literal with interpolation",
+			tmpl:  "<script>let x = `${()=>{}}`/{{.}}/b;</script>",
+			input: "alert`1`",
+			want:  "<script>let x = `${()=>{}}`/\"alert`1`\"/b;</script>",
+		},
+		{
+			name:  "division after nested template literal",
+			tmpl:  "<script>let x = `${`a`/{{.}}/b}`;</script>",
+			input: "alert`1`",
+			want:  "<script>let x = `${`a`/\"alert`1`\"/b}`;</script>",
 		},
 	}
 	for _, tt := range tests {

--- a/src/html/template/transition.go
+++ b/src/html/template/transition.go
@@ -386,8 +386,9 @@ func tJSTmpl(c context, s []byte) (context, int) {
 				return c, i + 2
 			}
 		case '`':
-			// end
-			c.state = stateJS
+			// End of the template literal. A template literal is a value,
+			// so a '/' after it starts a division, not a regexp literal.
+			c.state, c.jsCtx = stateJS, jsCtxDivOp
 			return c, i + 1
 		}
 		k = i + 1


### PR DESCRIPTION
A '/' that follows a JavaScript template literal starts a division,
not a regexp literal, but tJSTmpl left jsCtx unchanged when it saw
the closing backtick. The context stayed jsCtxRegexp from when the
literal opened, so a template action after the literal was escaped
as regexp text and its value was written without quotes:

  <script>let x = `a`/{{.}}/b;</script>

executed with the value "alert`1`" produced

  <script>let x = `a`/alert`1`/b;</script>

Set jsCtx to jsCtxDivOp when the closing backtick is reached, the
same way tJSDelimited does when a JS string or regexp closes.

Fixes #81117
