### PR TITLE
encoding/asn1: check Bytes slice length in BitString.At

### DIFF
--- a/src/encoding/asn1/asn1.go
+++ b/src/encoding/asn1/asn1.go
@@ -168,7 +168,7 @@ type BitString struct {
 // At returns the bit at the given index. If the index is out of range it
 // returns 0.
 func (b BitString) At(i int) int {
-	if i < 0 || i >= b.BitLength {
+	if i < 0 || i >= b.BitLength || i/8 >= len(b.Bytes) {
 		return 0
 	}
 	x := i / 8
@@ -180,7 +180,7 @@ func (b BitString) At(i int) int {
 // slice may share memory with the BitString.
 func (b BitString) RightAlign() []byte {
 	shift := uint(8 - (b.BitLength % 8))
-	if shift == 8 || len(b.Bytes) == 0 {
+	if b.BitLength <= 0 || shift == 8 || len(b.Bytes) == 0 {
 		return b.Bytes
 	}
 

--- a/src/encoding/asn1/asn1_test.go
+++ b/src/encoding/asn1/asn1_test.go
@@ -200,6 +200,16 @@ func TestBitStringAt(t *testing.T) {
 	if bs.At(17) != 0 {
 		t.Error("#6: Failed")
 	}
+
+	// Test truncated or empty Bytes slice where BitLength exceeds slice capacity.
+	truncated := BitString{[]byte{0x82}, 16}
+	if truncated.At(10) != 0 {
+		t.Errorf("truncated.At(10) = %d; want 0", truncated.At(10))
+	}
+	empty := BitString{nil, 16}
+	if empty.At(0) != 0 {
+		t.Errorf("empty.At(0) = %d; want 0", empty.At(0))
+	}
 }
 
 type bitStringRightAlignTest struct {
@@ -215,6 +225,8 @@ var bitStringRightAlignTests = []bitStringRightAlignTest{
 	{[]byte{0xce}, 8, []byte{0xce}},
 	{[]byte{0xce, 0x47}, 16, []byte{0xce, 0x47}},
 	{[]byte{0x34, 0x50}, 12, []byte{0x03, 0x45}},
+	{[]byte{0x80}, -1, []byte{0x80}},
+	{[]byte{}, -5, []byte{}},
 }
 
 func TestBitStringRightAlign(t *testing.T) {


### PR DESCRIPTION
BitString.At documentation states that it returns 0 if the index is
out of range. However, it only checks i >= b.BitLength without verifying
that i/8 is within len(b.Bytes), causing a runtime panic when BitLength
exceeds the slice capacity or when Bytes is nil/empty.

Similarly, BitString.RightAlign now safely handles non-positive
BitLength values.

Fixes #81234