### PR TITLE
cmd/go: avoid misleading git fatal message in a repo with no commits

### DIFF
--- a/src/cmd/go/internal/vcs/vcs.go
+++ b/src/cmd/go/internal/vcs/vcs.go
@@ -234,15 +234,17 @@ func gitStatus(vcsGit *Cmd, rootDir string) (Status, error) {
 	}
 	uncommitted := len(out) > 0
 
-	// "git status" works for empty repositories, but "git log" does not.
-	// Assume there are no commits in the repo when "git log" fails with
-	// uncommitted files and skip tagging revision / committime.
+	// "git status" works for empty repositories, but "git log" fails with
+	// "fatal: your current branch '<branch>' does not have any commits yet"
+	// if there are no commits (see golang.org/issue/52263). Pass
+	// --ignore-missing so that git instead succeeds with no output, and
+	// leave the revision and commit time empty in that case.
 	var rev string
 	var commitTime time.Time
-	out, err = vcsGit.runOutputVerboseOnly(rootDir, "-c log.showsignature=false log -1 --format=%H:%ct")
+	out, err = vcsGit.runOutputVerboseOnly(rootDir, "-c log.showsignature=false log -1 --format=%H:%ct --ignore-missing HEAD --")
 	if err != nil && !uncommitted {
 		return Status{}, err
-	} else if err == nil {
+	} else if err == nil && len(out) > 0 {
 		rev, commitTime, err = parseRevTime(out)
 		if err != nil {
 			return Status{}, err

--- a/src/cmd/go/testdata/script/build_v_git_repository_empty.txt
+++ b/src/cmd/go/testdata/script/build_v_git_repository_empty.txt
@@ -1,0 +1,24 @@
+# Regression test for https://go.dev/issue/52263.
+# When the module is in a git repository with no commits yet,
+# 'go build -v' should not print git's misleading message
+# "fatal: your current branch '...' does not have any commits yet".
+
+[short] skip 'builds and links a binary'
+[!git] skip
+
+exec git init
+exec git config user.email gopher@golang.org
+exec git config user.name 'J.R. Gopher'
+
+go build -v
+stderr example.com/test
+! stderr 'fatal:.*does not have any commits yet'
+
+-- go.mod --
+module example.com/test
+
+go 1.18
+-- main.go --
+package main
+
+func main() {}


### PR DESCRIPTION
In a git repository with no commits, "go build -v" prints git's
misleading message

    fatal: your current branch 'main' does not have any commits yet

and a repository with no commits and a clean status fails to build
with "error obtaining VCS status".

Pass --ignore-missing and name HEAD explicitly so that git succeeds
with no output when there are no commits, and skip stamping the
revision and commit time in that case.

The abandoned CL 399828 by Filippo Rossi fixed this with
"git rev-list -n 1 --all", which can report a commit other than the
one checked out when the repository has more than one branch.
"log --ignore-missing HEAD" keeps the stamped revision unchanged for
repositories with commits.

Fixes #52263
