### PR TITLE
crypto/rand: fix typo in comment

### DIFF
--- a/src/crypto/rand/rand.go
+++ b/src/crypto/rand/rand.go
@@ -23,7 +23,7 @@ import (
 //
 //   - On Linux, FreeBSD, Dragonfly, and Solaris, Reader uses getrandom(2).
 //   - On legacy Linux (< 3.17), Reader opens /dev/urandom on first use.
-//   - On macOS, iOS, and OpenBSD Reader, uses arc4random_buf(3).
+//   - On macOS, iOS, and OpenBSD, Reader uses arc4random_buf(3).
 //   - On NetBSD, Reader uses the kern.arandom sysctl.
 //   - On Windows, Reader uses the ProcessPrng API.
 //   - On js/wasm, Reader uses the Web Crypto API.


### PR DESCRIPTION
otherwise "OpenBSD Reader" seems a platform name.