### PR TITLE
crypto/tls: add tlsmldsa GODEBUG setting

### DIFF
--- a/doc/godebug.md
+++ b/doc/godebug.md
@@ -210,6 +210,15 @@ enforcement of Extended Master Secret in FIPS 140-3 mode. There is no change in
 default behavior. This setting was backported to Go 1.26.6 and Go 1.25.13.
 We plan to remove this setting in Go 1.31.
 
+Go 1.27 enabled the ML-DSA signature algorithms
+([`MLDSA44`, `MLDSA65`, and `MLDSA87`](/pkg/crypto/tls/#MLDSA44)) by default
+in TLS 1.3, advertising them in the signature_algorithms and
+signature_algorithms_cert extensions and accepting them from the peer.
+The default can be reverted using the `tlsmldsa` setting, added in Go 1.28,
+for example when dealing with TLS middleboxes that reject unrecognized
+signature algorithms. Modules declaring Go 1.26 or earlier default to
+`tlsmldsa=0`.
+
 ### Go 1.26
 
 Go 1.26 added a new `httpcookiemaxnum` setting that controls the maximum number

--- a/doc/next/6-stdlib/99-minor/crypto/tls/81199.md
+++ b/doc/next/6-stdlib/99-minor/crypto/tls/81199.md
@@ -1,0 +1,5 @@
+The new `tlsmldsa` GODEBUG setting controls whether the ML-DSA signature
+algorithms ([MLDSA44], [MLDSA65], and [MLDSA87]), enabled by default in Go 1.27,
+are advertised and accepted. `tlsmldsa=0` disables them, for compatibility with
+TLS middleboxes that reject unrecognized signature algorithms, and is now the
+default for modules declaring Go 1.26 or earlier. See [#81199](/issue/81199).

--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -429,7 +429,8 @@ const (
 	// EdDSA algorithms.
 	Ed25519 SignatureScheme = 0x0807
 
-	// ML-DSA algorithms.
+	// ML-DSA algorithms. Only supported in TLS 1.3. The tlsmldsa GODEBUG
+	// setting controls whether they are advertised and accepted by default.
 	MLDSA44 SignatureScheme = 0x0904
 	MLDSA65 SignatureScheme = 0x0905
 	MLDSA87 SignatureScheme = 0x0906
@@ -1802,6 +1803,9 @@ func isDisabledSignatureAlgorithm(version uint16, s SignatureScheme, isCert bool
 
 	switch s {
 	case MLDSA44, MLDSA65, MLDSA87:
+		// tlsmldsa=0 is applied in defaultSupportedSignatureAlgorithms, not
+		// here, so a local ML-DSA certificate stays usable if the peer allows it.
+		//
 		// ML-DSA is not available in FIPS 140-3 module v1.0.0.
 		if fips140.Version() == "v1.0.0" {
 			return true

--- a/src/crypto/tls/defaults.go
+++ b/src/crypto/tls/defaults.go
@@ -42,12 +42,15 @@ func curvePreferenceOrder() []CurveID {
 	}
 }
 
+// tlsmldsa=0 restores the pre-Go 1.27 default signature algorithms.
+var tlsmldsa = godebug.New("tlsmldsa")
+
 // defaultSupportedSignatureAlgorithms returns the signature and hash algorithms that
 // the code advertises and supports in a TLS 1.2+ ClientHello and in a TLS 1.2+
 // CertificateRequest. The two fields are merged to match with TLS 1.3.
 // Note that in TLS 1.2, the ECDSA algorithms are not constrained to P-256, etc.
 func defaultSupportedSignatureAlgorithms() []SignatureScheme {
-	return []SignatureScheme{
+	sigAlgs := []SignatureScheme{
 		MLDSA44,
 		MLDSA65,
 		MLDSA87,
@@ -64,6 +67,12 @@ func defaultSupportedSignatureAlgorithms() []SignatureScheme {
 		PKCS1WithSHA1,
 		ECDSAWithSHA1,
 	}
+	if tlsmldsa.Value() == "0" {
+		sigAlgs = slices.DeleteFunc(sigAlgs, func(s SignatureScheme) bool {
+			return s == MLDSA44 || s == MLDSA65 || s == MLDSA87
+		})
+	}
+	return sigAlgs
 }
 
 func supportedCipherSuites(aesGCMPreferred bool) []uint16 {

--- a/src/crypto/tls/tls_test.go
+++ b/src/crypto/tls/tls_test.go
@@ -2340,6 +2340,48 @@ func TestSupportedSignatureAlgorithmsMLDSAGating(t *testing.T) {
 	}
 }
 
+// TestSupportedSignatureAlgorithmsTLSMLDSA checks that tlsmldsa=0 removes
+// ML-DSA from what's advertised and accepted, and nothing else, while a local
+// ML-DSA certificate can still be selected.
+func TestSupportedSignatureAlgorithmsTLSMLDSA(t *testing.T) {
+	cryptotest.MustMinimumFIPS140ModuleVersion(t, "v1.26.0")
+
+	isMLDSA := func(s SignatureScheme) bool {
+		return s == MLDSA44 || s == MLDSA65 || s == MLDSA87
+	}
+	want := supportedSignatureAlgorithms(VersionTLS12, VersionTLS13)
+	wantCert := supportedSignatureAlgorithmsCert(VersionTLS12, VersionTLS13)
+	if !slices.ContainsFunc(want, isMLDSA) || !slices.ContainsFunc(wantCert, isMLDSA) {
+		if fips140tls.Required() {
+			t.Skip("ML-DSA is not allowed by the FIPS 140-3 policy")
+		}
+		t.Fatal("ML-DSA is not advertised by default")
+	}
+	want = slices.DeleteFunc(want, isMLDSA)
+	wantCert = slices.DeleteFunc(wantCert, isMLDSA)
+
+	testenv.SetGODEBUG(t, "tlsmldsa=0")
+
+	if got := supportedSignatureAlgorithms(VersionTLS12, VersionTLS13); !slices.Equal(got, want) {
+		t.Errorf("supportedSignatureAlgorithms = %v, want %v", got, want)
+	}
+	if got := supportedSignatureAlgorithmsCert(VersionTLS12, VersionTLS13); !slices.Equal(got, wantCert) {
+		t.Errorf("supportedSignatureAlgorithmsCert = %v, want %v", got, wantCert)
+	}
+
+	if got, err := selectSignatureScheme(VersionTLS13, &testMLDSA44Cert, []SignatureScheme{MLDSA44}); err != nil || got != MLDSA44 {
+		t.Errorf("selectSignatureScheme with a local ML-DSA certificate = %v, %v; want MLDSA44, nil", got, err)
+	}
+
+	serverConfig := testConfigServer()
+	serverConfig.Certificates = []Certificate{testMLDSA44Cert}
+	if _, _, err := testHandshake(t, testConfigClient(), serverConfig); err == nil {
+		t.Error("handshake with an ML-DSA certificate unexpectedly succeeded")
+	} else if !strings.Contains(err.Error(), "signature algorithms") {
+		t.Errorf("handshake with an ML-DSA certificate failed with %v; want a signature algorithms error", err)
+	}
+}
+
 func TestHandshakeMLDSA(t *testing.T) {
 	for _, tt := range []struct {
 		name   string

--- a/src/internal/godebugs/table.go
+++ b/src/internal/godebugs/table.go
@@ -62,6 +62,7 @@ var All = []Info{
 	{Name: "rsa1024min", Package: "crypto/rsa", Changed: 24, Old: "0"},
 	{Name: "tarinsecurepath", Package: "archive/tar"},
 	{Name: "tlsmaxrsasize", Package: "crypto/tls"},
+	{Name: "tlsmldsa", Package: "crypto/tls", Changed: 27, Old: "0", Opaque: true},
 	{Name: "tlsmlkem", Package: "crypto/tls", Changed: 24, Old: "0", Opaque: true},
 	{Name: "tlssecpmlkem", Package: "crypto/tls", Changed: 26, Old: "0", Opaque: true},
 	{Name: "tlssha1", Package: "crypto/tls", Changed: 25, Old: "1"},


### PR DESCRIPTION
Setting tlsmldsa=0 disables the ML-DSA signature algorithms.

Fixes https://github.com/golang/go/issues/81199