### PR TITLE
encoding/json/v2: fix panic on nil embedded pointer in Unmarshal

### DIFF
--- a/src/encoding/json/v2/arshal_embedded.go
+++ b/src/encoding/json/v2/arshal_embedded.go
@@ -172,6 +172,9 @@ func unmarshalEmbeddedFallbackNext(dec *jsontext.Decoder, va addressableValue, u
 		v = v.fieldByIndex(f.index, true)
 	}
 	v = v.indirect(true)
+	if !v.IsValid() {
+		return nil // implies a nil embedded field
+	}
 
 	if v.Type() == jsontextValueType {
 		b, _ := reflect.TypeAssert[*jsontext.Value](v.Addr())


### PR DESCRIPTION
## 修复 golang/go issue #81297

### 问题描述
当 Unmarshal JSON 到带有以下特征的结构体时 panic：
- 带有 `map[string]any` 类型和 `,embed` tag 的未导出指针字段
- 当有 JSON 字段路由到该 embedded fallback 时 panic
- `GOEXPERIMENT=nojsonv2` 不 panic

### 根本原因
在 `unmarshalEmbeddedFallbackNext` 函数中，当处理 embedded fallback map 时：
1. 如果 embedded pointer 是 nil 且不可分配（例如 unexported 字段），`indirect(true)` 返回一个无效的 addressableValue
2. 但 unmarshal 路径没有检查有效性就直接调用 `v.Type()` 或 `m.IsNil()`，导致 panic

Marshal 路径 (`marshalEmbeddedFallbackAll`) 已有这个检查，但 unmarshal 路径缺失。

### 修复内容
在 `indirect(true)` 调用后添加有效性检查，与 marshal 路径保持一致：

```go
v = v.indirect(true)
if !v.IsValid() {
    return nil // implies a nil embedded field
}
```

### 修复文件
- `src/encoding/json/v2/arshal_embedded.go`

Fixes #81297