### PR TITLE
net/http/httputil: remove hop-by-hop headers from forwarded 1xx responses

### DIFF
--- a/src/net/http/httputil/reverseproxy.go
+++ b/src/net/http/httputil/reverseproxy.go
@@ -573,7 +573,18 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 				orig = h.Clone()
 			}
 
-			copyHeader(h, http.Header(header))
+			// Hop-by-hop headers apply to a single transport-level
+			// connection and must be removed by an intermediary before a
+			// message is forwarded (RFC 9110, section 7.6.1). This applies
+			// to informational responses as well as to the final response,
+			// which is handled by removeHopByHopHeaders below.
+			//
+			// Copy the backend's header before modifying it: it belongs to
+			// the transport, not to us.
+			h1xx := http.Header(header).Clone()
+			removeHopByHopHeaders(h1xx)
+
+			copyHeader(h, h1xx)
 			rw.WriteHeader(code)
 
 			// Restore the original headers (which may include headers added

--- a/src/net/http/httputil/reverseproxy_test.go
+++ b/src/net/http/httputil/reverseproxy_test.go
@@ -2346,3 +2346,59 @@ func TestReverseProxy1xx(t *testing.T) {
 		}
 	})
 }
+
+// Issue: hop-by-hop headers must be removed from 1xx informational responses
+// before they are forwarded, per RFC 9110, section 7.6.1.
+func TestReverseProxy1xxRemovesHopByHopHeaders(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Add("Link", "</style.css>; rel=preload")
+		h.Set("Connection", "X-Nominated")
+		h.Set("X-Nominated", "should-be-stripped")
+		h.Set("Keep-Alive", "timeout=5")
+		h.Set("Proxy-Authenticate", "Basic realm=backend")
+		w.WriteHeader(http.StatusEarlyHints)
+
+		h.Del("Connection")
+		h.Del("X-Nominated")
+		h.Del("Keep-Alive")
+		h.Del("Proxy-Authenticate")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "done")
+	}))
+	defer backend.Close()
+
+	backendURL, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frontend := httptest.NewServer(NewSingleHostReverseProxy(backendURL))
+	defer frontend.Close()
+
+	var got1xx http.Header
+	req, _ := http.NewRequest("GET", frontend.URL, nil)
+	trace := &httptrace.ClientTrace{
+		Got1xxResponse: func(code int, header textproto.MIMEHeader) error {
+			got1xx = http.Header(header).Clone()
+			return nil
+		},
+	}
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+	res, err := frontend.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+
+	if got1xx == nil {
+		t.Fatal("did not receive a 1xx response")
+	}
+	if got := got1xx.Get("Link"); got == "" {
+		t.Errorf("1xx Link header was dropped; want it preserved")
+	}
+	for _, k := range []string{"Connection", "X-Nominated", "Keep-Alive", "Proxy-Authenticate"} {
+		if got := got1xx.Get(k); got != "" {
+			t.Errorf("1xx response forwarded hop-by-hop header %q = %q; want it removed", k, got)
+		}
+	}
+}


### PR DESCRIPTION
ReverseProxy forwards 1xx informational responses to the client, but only
the final response passes through removeHopByHopHeaders. A backend can
therefore have Connection-nominated headers, Keep-Alive, Proxy-Authenticate
and Upgrade relayed verbatim inside a 103 Early Hints block, while the same
headers are correctly stripped from the final response.

RFC 9110, section 7.6.1 requires an intermediary to parse a received
Connection header field before a message is forwarded and, for each
connection-option, remove any header field with that name and then remove
the Connection field itself. "a message" is not qualified by status class.

Strip hop-by-hop headers from the backend's informational response before
copying it to the ResponseWriter. The received header is cloned rather than
modified in place, since it belongs to the transport, and headers the
proxy's own middleware placed on the ResponseWriter are left untouched.
Whether the latter should also be stripped is the one open design question;
the CL deliberately does not, so it cannot disturb operator-set headers.

Tested against tip ef00dcff01 with a toolchain built from that tree.
TestReverseProxy1xxRemovesHopByHopHeaders fails before the change, one
assertion per hop-by-hop header, and passes after. The full package suite
passes and the existing TestReverseProxy1xx is unaffected.

This is a spec-conformance fix, not a security fix. I could not demonstrate
a security impact and said so in the issue: Content-Length and
Transfer-Encoding are never emitted on a 1xx, Connection: close is consumed
by the Transport before reaching the callback, CR/LF is rejected, browsers
have no plumbing for these fields on a 103, and RFC 8297 section 2 says 103
header evaluation must not affect how the final response is processed.

Fixes #81319
