### PR TITLE
all: make package comments begin with "Package <name>"

### DIFF
--- a/src/arena/arena.go
+++ b/src/arena/arena.go
@@ -5,7 +5,7 @@
 //go:build goexperiment.arenas
 
 /*
-The arena package provides the ability to allocate memory for a collection
+Package arena provides the ability to allocate memory for a collection
 of Go values and free that space manually all at once, safely. The purpose
 of this functionality is to improve efficiency: manually freeing memory
 before a garbage collection delays that cycle. Less frequent cycles means

--- a/src/cmd/cgo/internal/test/issue6997_linux.go
+++ b/src/cmd/cgo/internal/test/issue6997_linux.go
@@ -7,6 +7,7 @@
 // Test that pthread_cancel works as expected
 // (NPTL uses SIGRTMIN to implement thread cancellation)
 // See https://golang.org/issue/6997
+
 package cgotest
 
 /*

--- a/src/cmd/compile/internal/deadlocals/deadlocals.go
+++ b/src/cmd/compile/internal/deadlocals/deadlocals.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// The deadlocals pass removes assignments to unused local variables.
+// Package deadlocals implements a pass that removes assignments to
+// unused local variables.
 package deadlocals
 
 import (

--- a/src/cmd/compile/internal/importer/ureader.go
+++ b/src/cmd/compile/internal/importer/ureader.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// package importer implements package reading for gc-generated object files.
+// Package importer implements package reading for gc-generated object files.
 package importer
 
 import (

--- a/src/cmd/go/internal/fips140/fips140.go
+++ b/src/cmd/go/internal/fips140/fips140.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package fips implements support for the GOFIPS140 build setting.
+// Package fips140 implements support for the GOFIPS140 build setting.
 //
 // The GOFIPS140 build setting controls two aspects of the build:
 //

--- a/src/cmd/go/internal/mmap/mmap.go
+++ b/src/cmd/go/internal/mmap/mmap.go
@@ -5,7 +5,7 @@
 // This package is a lightly modified version of the mmap code
 // in github.com/google/codesearch/index.
 
-// The mmap package provides an abstraction for memory mapping files
+// Package mmap provides an abstraction for memory mapping files
 // on different platforms.
 package mmap
 

--- a/src/crypto/internal/boring/syso/syso.go
+++ b/src/crypto/internal/boring/syso/syso.go
@@ -4,6 +4,6 @@
 
 //go:build boringcrypto
 
-// This package only exists with GOEXPERIMENT=boringcrypto.
+// Package syso only exists with GOEXPERIMENT=boringcrypto.
 // It provides the actual syso file.
 package syso

--- a/src/crypto/internal/sysrand/rand.go
+++ b/src/crypto/internal/sysrand/rand.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package rand provides cryptographically secure random bytes from the
+// Package sysrand provides cryptographically secure random bytes from the
 // operating system.
 package sysrand
 

--- a/src/encoding/json/internal/jsonflags/flags.go
+++ b/src/encoding/json/internal/jsonflags/flags.go
@@ -4,7 +4,7 @@
 
 //go:build goexperiment.jsonv2
 
-// jsonflags implements all the optional boolean flags.
+// Package jsonflags implements all the optional boolean flags.
 // These flags are shared across both "json", "jsontext", and "jsonopts".
 package jsonflags
 

--- a/src/internal/goarch/goarch.go
+++ b/src/internal/goarch/goarch.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// package goarch contains GOARCH-specific constants.
+// Package goarch contains GOARCH-specific constants.
 package goarch
 
 // The next line makes 'go generate' write the zgoarch*.go files with

--- a/src/internal/goos/goos.go
+++ b/src/internal/goos/goos.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// package goos contains GOOS-specific constants.
+// Package goos contains GOOS-specific constants.
 package goos
 
 // The next line makes 'go generate' write the zgoos*.go files with

--- a/src/internal/runtime/sys/sys.go
+++ b/src/internal/runtime/sys/sys.go
@@ -2,6 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// package sys contains system- and configuration- and architecture-specific
+// Package sys contains system- and configuration- and architecture-specific
 // constants used by the runtime.
 package sys

--- a/src/internal/trace/traceviewer/format/format.go
+++ b/src/internal/trace/traceviewer/format/format.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package traceviewer provides definitions of the JSON data structures
+// Package format provides definitions of the JSON data structures
 // used by the Chrome trace viewer.
 //
 // The official description of the format is in this file:

--- a/src/math/big/internal/asmgen/main.go
+++ b/src/math/big/internal/asmgen/main.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Asmgen generates math/big assembly.
+// Package asmgen generates math/big assembly.
 //
 // Usage:
 //

--- a/src/unique/doc.go
+++ b/src/unique/doc.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 /*
-The unique package provides facilities for canonicalizing ("interning")
+Package unique provides facilities for canonicalizing ("interning")
 comparable values.
 */
 package unique


### PR DESCRIPTION
Go doc comments for a package conventionally begin with "Package <name>"
(see https://go.dev/doc/comment#package). A handful of packages instead
start with a lowercase "package", name a different package than the one
they document, or use command-style or free-form wording. Fix them, and
separate a file comment in cmd/cgo/internal/test from the package clause
so that it is no longer picked up as the package's doc comment.

This covers every package comment in the tree that does not follow the
convention, except for vendored packages and generated files.
