### PR TITLE
keep gofmt composite-literal key alignment across Go 1.26/1.27

### DIFF
--- a/src/go/printer/math.go
+++ b/src/go/printer/math.go
@@ -13,7 +13,13 @@ import "math"
 // across all architectures.
 func log2ish(x float64) float64 {
 	f, e := math.Frexp(x)
-	return float64(e) + 2*(f-1)
+	// 0.5 ≤ f < 1, so t = 2f-1 is in [0, 1) and x = 2^{e-1}·(1+t).
+	// log₂(1+t) ≈ t(4-t)/3 interpolates log₂(1)=0 and log₂(2)=1 exactly
+	// (max error on [1,2) is about 0.01 bits). The previous 2(f-1) fit
+	// was piecewise-linear and could push the 2.5 alignment threshold
+	// the other way from math.Log/math.Exp.
+	t := 2*f - 1
+	return float64(e-1) + t*(4-t)/3
 }
 
 // exp2ish returns a crude approximation to 2**x.
@@ -24,5 +30,6 @@ func log2ish(x float64) float64 {
 func exp2ish(x float64) float64 {
 	n := math.Floor(x)
 	f := x - n
-	return math.Ldexp(1+f, int(n))
+	// 2^f ≈ 1 + f(2+f)/3 interpolates 2^0=1 and 2^1=2 exactly.
+	return math.Ldexp(1+f*(2+f)/3, int(n))
 }

--- a/src/go/printer/testdata/alignment.golden
+++ b/src/go/printer/testdata/alignment.golden
@@ -177,3 +177,15 @@ var _ = []any{
 	(expr_size_38_xxxxxxxxxxxxxxxxxxxx)(0),	// 1
 	(*expr_size_126_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)(nil),	// 2
 }
+
+// Quoted key sizes 14,7,12,31,34 then 41. Go 1.26 keeps one aligned
+// column (41/geomean ≈ 2.478 < 2.5). The log₂ approximation must not
+// cross the 2.5 threshold the other way.
+var m = map[string]int{
+	"execution_id":					1,
+	"topic":					2,
+	"partitions":					3,
+	"kafka_broker_version_inferred":		4,
+	"kafka_reassignment_api_supported":		5,
+	"kafka_reassignment_api_required_version":	6,
+}

--- a/src/go/printer/testdata/alignment.input
+++ b/src/go/printer/testdata/alignment.input
@@ -184,3 +184,15 @@ var _ = []any{
 	(expr_size_38_xxxxxxxxxxxxxxxxxxxx)(0), // 1
 	(*expr_size_126_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)(nil), // 2
 }
+
+// Quoted key sizes 14,7,12,31,34 then 41. Go 1.26 keeps one aligned
+// column (41/geomean ≈ 2.478 < 2.5). The log₂ approximation must not
+// cross the 2.5 threshold the other way.
+var m = map[string]int{
+	"execution_id":                            1,
+	"topic":                                   2,
+	"partitions":                              3,
+	"kafka_broker_version_inferred":           4,
+	"kafka_reassignment_api_supported":        5,
+	"kafka_reassignment_api_required_version": 6,
+}


### PR DESCRIPTION
The piecewise-linear log2ish (2(f-1)) could push 41/geomean over 2.5 while math.Log/math.Exp stayed under it, splitting a column that Go 1.26 kept. Use the quadratic interpolant that still only needs Frexp/Ldexp/Floor.

closed: https://github.com/golang/go/issues/81375