### PR TITLE
runtime: skip async preemption during Windows exception handling

### DIFF
--- a/src/internal/runtime/syscall/windows/defs_windows.go
+++ b/src/internal/runtime/syscall/windows/defs_windows.go
@@ -161,3 +161,15 @@ type OSVERSIONINFOW struct {
 	PlatformID        uint32
 	CSDVersion        [128]uint16
 }
+
+// ContextFlags bits for GetThreadContext. CONTEXT_EXCEPTION_REQUEST asks the
+// kernel to report, in the returned ContextFlags, whether the thread is
+// inside an exception dispatch (CONTEXT_EXCEPTION_ACTIVE) or a system call
+// (CONTEXT_SERVICE_ACTIVE). CONTEXT_EXCEPTION_REPORTING is set when the
+// request was honored.
+const (
+	CONTEXT_EXCEPTION_ACTIVE    = 0x08000000
+	CONTEXT_SERVICE_ACTIVE      = 0x10000000
+	CONTEXT_EXCEPTION_REQUEST   = 0x40000000
+	CONTEXT_EXCEPTION_REPORTING = 0x80000000
+)

--- a/src/runtime/os_windows.go
+++ b/src/runtime/os_windows.go
@@ -6,6 +6,7 @@ package runtime
 
 import (
 	"internal/abi"
+	"internal/goarch"
 	"internal/runtime/atomic"
 	"internal/runtime/sys"
 	"internal/runtime/syscall/windows"
@@ -1226,7 +1227,9 @@ func preemptM(mp *m) {
 	var c *windows.Context
 	var cbuf [unsafe.Sizeof(*c) + 15]byte
 	c = (*windows.Context)(unsafe.Pointer((uintptr(unsafe.Pointer(&cbuf[15]))) &^ 15))
-	c.ContextFlags = windows.CONTEXT_CONTROL
+	// Also ask the kernel whether the thread is inside an exception
+	// dispatch or a system call; see below.
+	c.ContextFlags = windows.CONTEXT_CONTROL | windows.CONTEXT_EXCEPTION_REQUEST
 
 	// Serialize thread suspension. SuspendThread is asynchronous,
 	// so it's otherwise possible for two threads to suspend each
@@ -1263,9 +1266,27 @@ func preemptM(mp *m) {
 
 	unlock(&suspendLock)
 
+	// A context read while the thread is in kernel mode, inside an
+	// exception dispatch (typically a hard page fault) or a system call,
+	// must not be modified: Windows does not reliably apply such a context
+	// in SetThreadContext. On AMD Zen machines the register state of the
+	// resulting crashes is consistent with the injected call taking effect
+	// at a later kernel entry, so that asyncPreempt returns to a stale PC
+	// and the instruction there runs a second time (#67108, #79249); where
+	// exactly the kernel goes wrong is not established. Follow .NET's
+	// IsContextSafeToRedirect: an active exception or system call is
+	// unsafe, and so is a missing reporting bit, which Windows omits at
+	// times while the thread is in kernel mode, except on 386 where the
+	// bit is not dependable. sysmon retries on its next tick.
+	safe := c.ContextFlags&(windows.CONTEXT_EXCEPTION_ACTIVE|windows.CONTEXT_SERVICE_ACTIVE) == 0
+	if goarch.GOARCH != "386" && c.ContextFlags&windows.CONTEXT_EXCEPTION_REPORTING == 0 {
+		safe = false
+	}
+	c.ContextFlags = windows.CONTEXT_CONTROL
+
 	// Does it want a preemption and is it safe to preempt?
 	gp := gFromSP(mp, c.SP())
-	if gp != nil && wantAsyncPreempt(gp) {
+	if gp != nil && safe && wantAsyncPreempt(gp) {
 		if ok, resumePC := isAsyncSafePoint(gp, c.PC(), c.SP(), c.LR()); ok {
 			// Inject call to asyncPreempt
 			targetPC := abi.FuncPCABI0(asyncPreempt)


### PR DESCRIPTION
A Windows thread's context may be unsafe to modify while the thread is in
kernel mode, during exception handling (including page faults) or a system
call. Injecting asyncPreempt in this state can lead to crashes.

Request exception-state reporting from GetThreadContext and skip
asyncPreempt injection when CONTEXT_EXCEPTION_ACTIVE or
CONTEXT_SERVICE_ACTIVE is set, or when the reporting bit is missing
(except on 386, where it is not dependable). Resume the thread normally
so preemption can be retried later.

Updates #67108
Fixes #79249
